### PR TITLE
Modified install.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
-## [unreleased][unreleased]						
+## [unreleased][unreleased]		
+ - Improved 'install.sh' to install dependencies for Ubuntu 18.04 and using max number of processors during compilation (@joanbono)				
  - Modified 'install.sh' script to work in macOS and Linux + added the 'update.sh' and 'proxmark3.sh' from joanbono (@TomHarkness)	 
  - Fix 'hf emv' - some cards need to have Le=0x00, some need to not to have (@merlokk)
  - Fix 'hf legic'  enhancement of rx / tx in legic commands (@drandreas)

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,12 @@ function installProxmark_Linux {
   sudo apt-get autoclean -y
   sudo apt-get clean -y
   sudo apt-get update
+
+  # Install libcanberragtk in Ubuntu 18.04
+  if [[ $(cat /etc/issue | awk '{print $2}') = *"18.04"* ]]; then 
+    apt-get install libcanberra-gtk-module
+  fi
+
 # install RDV40 - proxmark3
   git clone https://github.com/RfidResearchGroup/proxmark3.git
   (
@@ -18,7 +24,7 @@ function installProxmark_Linux {
       git reset --hard
       git clean -dfx
       make clean
-      make all
+      make -j$(nproc) all 
       # Copy blacklist rules into /etc/udev/rules.d
       # check the Makefile for details
       sudo make udev
@@ -46,7 +52,7 @@ local qt5Core=$(find /usr -name Qt5Core.pc 2>/dev/null)
         git reset --hard
         git clean -dfx
         make clean
-        make
+        make -j$(sysctl -n hw.physicalcpu)
       )
   }
 # Where is my device?


### PR DESCRIPTION
Added Ubuntu 18.04 detection, which needs `libcanberra-gtk-module` to compile the code as mentioned in #6  :

```bash
  # Install libcanberragtk in Ubuntu 18.04
  if [[ $(cat /etc/issue | awk '{print $2}') = *"18.04"* ]]; then 
    apt-get install libcanberra-gtk-module
  fi
```

Also, improved compilation times using max number of processors available on each machine:

+ Linux: `make all -j$(nproc)`
+ macOS: `make -j$(sysctl -n hw.physicalcpu)` 
