### PR TITLE
Add key to default_iclass_keys.dic

### DIFF
--- a/client/default_iclass_keys.dic
+++ b/client/default_iclass_keys.dic
@@ -8,3 +8,4 @@ AEA684A6DAB23278 -- AA1
 5b7c62c491c11b39 -- from loclass demo file.
 F0E1D2C3B4A59687 -- Kd from PicoPass 2k documentation
 5CBCF1DA45D5FB4F -- PicoPass Default Exchange Key
+31ad7ebd2f282168 -- From HID multiclassSE reader


### PR DESCRIPTION
Key from HID multiclassSE reader has been added