### PR TITLE
Add missing header

### DIFF
--- a/client/mifare/mad.h
+++ b/client/mifare/mad.h
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 typedef struct {
 	uint16_t AID;


### PR DESCRIPTION
Latest merge (hf mf* mad) didn't compile due to a missing header.