### PR TITLE
Add missing i2c init in sc upgrade

### DIFF
--- a/common/i2c.c
+++ b/common/i2c.c
@@ -124,6 +124,8 @@ void I2C_Reset_EnterMainProgram(void) {
 // Reset the SIM_Adapter, then enter the bootloader program
 // Reserve for firmware update.
 void I2C_Reset_EnterBootloader(void) {
+	StartTicks();
+	I2C_init();
 	I2C_SetResetStatus(0, 1, 1);
 	WaitMS(100);
 	I2C_SetResetStatus(1, 1, 1);


### PR DESCRIPTION
Running sc upgrade was failing if we didn't run other sc command first because some init was missing