### PR TITLE
Mifare Ultralight/NTAG simulation. Add WRITE and COMPATIBLE_WRITE support

### DIFF
--- a/armsrc/iso14443a.h
+++ b/armsrc/iso14443a.h
@@ -93,6 +93,10 @@ typedef struct {
 # define AddCrc14B(data, len) compute_crc(CRC_14443_B, (data), (len), (data)+(len), (data)+(len)+1)
 #endif
 
+#ifndef CheckCrc14A
+# define	CheckCrc14A(data, len)	check_crc(CRC_14443_A, (data), (len))
+#endif 
+
 extern void GetParity(const uint8_t *pbtCmd, uint16_t len, uint8_t *par);
 
 extern tDemod *GetDemod(void);

--- a/common/protocols.h
+++ b/common/protocols.h
@@ -166,7 +166,7 @@ ISO 7816-4 Basic interindustry commands. For command APDU's.
 #define MIFARE_EV1_SETMODE          0x43
 
 #define MIFARE_ULC_WRITE            0xA2
-//#define MIFARE_ULC__COMP_WRITE      0xA0
+#define MIFARE_ULC_COMP_WRITE      0xA0
 #define MIFARE_ULC_AUTH_1           0x1A
 #define MIFARE_ULC_AUTH_2           0xAF
 


### PR DESCRIPTION
New feature to store data from reader to 'hf 14a sim' Ultralight/NTAG emulator memory