### PR TITLE
Fix sizes for GCC 8.2 string truncation warnings

### DIFF
--- a/client/cmdhf15.c
+++ b/client/cmdhf15.c
@@ -781,7 +781,7 @@ int CmdHF15Restore(const char *Cmd) {
     char buff[255] = {0x00};
     size_t blocksize = 4;
     uint8_t cmdp = 0;
-    char newCmdPrefix[255] = {0x00}, tmpCmd[255] = {0x00};
+    char newCmdPrefix[FILE_PATH_SIZE + 1] = {0x00}, tmpCmd[FILE_PATH_SIZE + 262] = {0x00};
     char param[FILE_PATH_SIZE] = "";
     char hex[255] = "";
     uint8_t retries = 3, tried = 0, i = 0;


### PR DESCRIPTION
Fix for:
```
cmdhf15.c: In function ‘CmdHF15Restore’:
cmdhf15.c:876:45: warning: ‘ u ’ directive output may be truncated writing 3 bytes into a region of size between 1 and 255 [-Wformat-truncation=]
         snprintf(tmpCmd, sizeof(tmpCmd), "%s u %u %s", newCmdPrefix, i, hex);
                                             ^~~
cmdhf15.c:876:42: note: directive argument in the range [0, 255]
         snprintf(tmpCmd, sizeof(tmpCmd), "%s u %u %s", newCmdPrefix, i, hex);
                                          ^~~~~~~~~~~~
cmdhf15.c:876:9: note: ‘snprintf’ output between 6 and 516 bytes into a destination of size 255
         snprintf(tmpCmd, sizeof(tmpCmd), "%s u %u %s", newCmdPrefix, i, hex);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cmdhf15.c:799:25: warning: ‘strncat’ output may be truncated copying between 0 and 254 bytes from a string of length 999 [-Wstringop-truncation]
                         strncat(newCmdPrefix, param, sizeof(newCmdPrefix) - strlen(newCmdPrefix) - 1);
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
