### PR TITLE
Add 36bit HID format, extend calcWiegand() to include oem bits

### DIFF
--- a/client/cmdlfhid.c
+++ b/client/cmdlfhid.c
@@ -217,7 +217,7 @@ int CmdHIDDemod(const char *Cmd) {
         if (fmtLen == 32 && (lo & 0x40000000)) { //if 32 bit and Kastle bit set
             PrintAndLogEx(SUCCESS, "HID Prox TAG (Kastle format) ID: %08x (%u) - Format Len: 32bit - CC: %u - FC: %u - Card: %u", lo, (lo >> 1) & 0xFFFF, cc, fc, cardnum);
         } else {
-            PrintAndLogEx(NORMAL, "HID Prox TAG ID: %x%08x (%u) - Format Len: %ubit - OEM: %03u - FC: %u - Card: %u",
+            PrintAndLogEx(SUCCESS, "HID Prox TAG ID: %x%08x (%u) - Format Len: %ubit - OEM: %03u - FC: %u - Card: %u",
                                   hi, lo, cardnum, fmtLen, oem, fc, cardnum);
         }
     }

--- a/client/cmdlfhid.h
+++ b/client/cmdlfhid.h
@@ -33,5 +33,5 @@ int CmdHIDWiegand(const char *Cmd);
 int CmdHIDBrute(const char *Cmd);
 
 //void calc26(uint16_t fc, uint32_t cardno, uint8_t *out);
-void calcWiegand(uint8_t fmtlen, uint16_t fc, uint64_t cardno, uint8_t *bits);
+void calcWiegand(uint8_t fmtlen, uint16_t fc, uint64_t cardno, uint8_t *bits, uint8_t oem);
 #endif

--- a/client/util.c
+++ b/client/util.c
@@ -751,6 +751,15 @@ void wiegand_add_parity(uint8_t *target, uint8_t *source, uint8_t length) {
     *(target) = GetParity(source + length / 2, ODD, length / 2);
 }
 
+// add HID parity to binary array: ODD prefix for 1st half of ID, EVEN suffix for 2nd half
+void wiegand_add_parity_swapped(uint8_t *target, uint8_t *source, uint8_t length)
+{
+    *(target++)= GetParity(source, ODD, length / 2);
+    memcpy(target, source, length);
+    target += length;
+    *(target)= GetParity(source + length / 2, EVEN, length / 2);
+}
+
 // xor two arrays together for len items.  The dst array contains the new xored values.
 void xor(unsigned char *dst, unsigned char *src, size_t len) {
     for (; len > 0; len--, dst++, src++)

--- a/client/util.h
+++ b/client/util.h
@@ -245,6 +245,7 @@ int binarraytohex(char *target, const size_t targetlen, char *source, size_t src
 void binarraytobinstring(char *target,  char *source, int length);
 uint8_t GetParity(uint8_t *bits, uint8_t type, int length);
 void wiegand_add_parity(uint8_t *target, uint8_t *source, uint8_t length);
+void wiegand_add_parity_swapped(uint8_t *target, uint8_t *source, uint8_t length);
 
 void xor(unsigned char *dst, unsigned char *src, size_t len);
 int32_t le24toh(uint8_t data[3]);


### PR DESCRIPTION
As requested by @iceman1001 here https://github.com/iceman1001/proxmark3/pull/285, notes below copied for convenience.

I came across a bag full of HID tags using this format that I couldn't find documented anywhere. After some poking and prodding at the bits I worked out the format and figured I would contribute the addition. I added support to the demoudulator, tested reading, cloning, wiegand output, and simulation. I did not add support for this format to the brute forcer as it would require refactoring to support the OEM segment, and just hard coded a 0 into the OEM parameter added to `clacWiegand` inside the brute forcing code.

This format is backwards in that the parity logic is swapped, so I duplicated the existing function to do this. Plenty of head scratching to finally figure that out as none of the other HID formats seem to be encoded this way.

Format Details:
```
FC     1  - 16  - 16 bit
cardno 17 - 33  - 16 bit
oem    34 - 35  -  2 bit
Odd  Parity  0th bit  1-17
Even Parity 36th bit 18-35
```
Some example bitstreams, card number is printed on tag along with sales order number from original purchase:
```
1 1011000000010000 0101101110100000 00 1 FC = 45072, Card = 23456, OEM = 0
1 1011000000010000 0101101111000001 00 0 FC = 45072, Card = 23489, OEM = 0
1 1011000000010000 0101101111100111 00 1 FC = 45072, Card = 23527, OEM = 0
1 1011000000010000 0110000100000100 00 0 FC = 45072, Card = 24836, OEM = 0
1 1011000000010000 0110000000110001 00 1 FC = 45072, Card = 24625, OEM = 0
```