### PR TITLE
'hf mf sim' bugs fix, RATS support, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fix/Add 'hf mf sim' bugs fix, RATS support, etc (@mceloff)
  - Fix serial of FPC. (@ryan)
  - Fix 'data shiftgraphzero' corrupting end of GraphBuffer (@doegox)
  - Fix 'hf legic info' - unsegmented card now uses card size to calc remaining length (@iceman)

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -2140,7 +2140,7 @@ static int CmdHF14AMf1kSim(const char *Cmd) {
 
     uint8_t uid[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     uint8_t exitAfterNReads = 0;
-    uint16_t flags = (FLAG_UID_IN_EMUL | FLAG_4B_UID_IN_DATA);
+    uint16_t flags = 0;
     int uidlen = 0;
     uint8_t cmdp = 0;
     bool errors = false, verbose = false, setEmulatorMem = false;
@@ -2191,13 +2191,13 @@ static int CmdHF14AMf1kSim(const char *Cmd) {
                 param_gethex_ex(Cmd, cmdp + 1, uid, &uidlen);
                 switch (uidlen) {
                     case 20:
-                        flags = FLAG_10B_UID_IN_DATA;
+                        flags |= FLAG_10B_UID_IN_DATA;
                         break;
                     case 14:
-                        flags = FLAG_7B_UID_IN_DATA;
+                        flags |= FLAG_7B_UID_IN_DATA;
                         break;
                     case  8:
-                        flags = FLAG_4B_UID_IN_DATA;
+                        flags |= FLAG_4B_UID_IN_DATA;
                         break;
                     default:
                         return usage_hf14_mf1ksim();
@@ -2220,6 +2220,10 @@ static int CmdHF14AMf1kSim(const char *Cmd) {
     }
     //Validations
     if (errors) return usage_hf14_mf1ksim();
+
+    // Use UID, SAK, ATQA from EMUL, if uid not defined
+    if ((flags & (FLAG_4B_UID_IN_DATA | FLAG_7B_UID_IN_DATA | FLAG_10B_UID_IN_DATA)) == 0)
+        flags |= FLAG_UID_IN_EMUL;
 
     PrintAndLogEx(NORMAL, " uid:%s, numreads:%d, flags:%d (0x%02x) "
                   , (uidlen == 0) ? "N/A" : sprint_hex(uid, uidlen >> 1)

--- a/common/protocols.h
+++ b/common/protocols.h
@@ -151,6 +151,7 @@ ISO 7816-4 Basic interindustry commands. For command APDU's.
 #define ISO14443A_CMD_WRITEBLOCK    0xA0
 #define ISO14443A_CMD_HALT          0x50
 #define ISO14443A_CMD_RATS          0xE0
+#define ISO14443A_CMD_NXP_DESELECT  0xC2
 
 #define MIFARE_SELECT_CT            0x88
 #define MIFARE_AUTH_KEYA            0x60
@@ -167,7 +168,7 @@ ISO 7816-4 Basic interindustry commands. For command APDU's.
 #define MIFARE_EV1_SETMODE          0x43
 
 #define MIFARE_ULC_WRITE            0xA2
-#define MIFARE_ULC_COMP_WRITE      0xA0
+#define MIFARE_ULC_COMP_WRITE       0xA0
 #define MIFARE_ULC_AUTH_1           0x1A
 #define MIFARE_ULC_AUTH_2           0xAF
 


### PR DESCRIPTION
1. Bug. Tag type missing if 'u <uid>' option place at the end of command line 'hf mf sim...'
2. Bug. Wrong ATQA used for single/double/triple uid sizes
3. Add. Possible to extract 4/7 uid, sak, atqa from emulator memory to exactly simulate loaded tag dump - 'hf mf sim' without parameters
4. Add. Support RATS+DESELECT responses for mifare NXP 2K tags simulation.