### PR TITLE
UL/NTAG new dump file format. Added counters support, simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Change/Add new dump format for Ultralight/NTAG, counters support, simulation (@mceloff)
  - Fix/Add 'hf mf sim' bugs fix, RATS support, etc (@mceloff)
  - Fix serial of FPC. (@ryan)
  - Fix 'data shiftgraphzero' corrupting end of GraphBuffer (@doegox)

--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -1318,6 +1318,9 @@ void SimulateIso14443aTag(int tagType, int flags, uint8_t *data) {
                     p_response = NULL;
                 }
             }
+        } else if (receivedCmd[0] == MIFARE_ULEV1_VCSL) {
+            EmSend4bit(CARD_NACK_NA);
+            p_response = NULL;
         } else {
             // Check for ISO 14443A-4 compliant commands, look at left nibble
             switch (receivedCmd[0]) {
@@ -1371,8 +1374,10 @@ void SimulateIso14443aTag(int tagType, int flags, uint8_t *data) {
                 default: {
                     // Never seen this command before
                     LogTrace(receivedCmd, Uart.len, Uart.startTime * 16 - DELAY_AIR2ARM_AS_TAG, Uart.endTime * 16 - DELAY_AIR2ARM_AS_TAG, Uart.parity, true);
-                    Dbprintf("Received unknown command (len=%d):", len);
-                    Dbhexdump(len, receivedCmd, false);
+                    if (MF_DBGLEVEL >= 3) {
+                        Dbprintf("Received unknown command (len=%d):", len);
+                        Dbhexdump(len, receivedCmd, false);
+                    }
                     // Do not respond
                     dynamic_response_info.response_n = 0;
                 }
@@ -1388,7 +1393,7 @@ void SimulateIso14443aTag(int tagType, int flags, uint8_t *data) {
                 dynamic_response_info.response_n += 2;
 
                 if (prepare_tag_modulation(&dynamic_response_info, DYNAMIC_MODULATION_BUFFER_SIZE) == false) {
-                    DbpString("Error preparing tag response");
+                    if (MF_DBGLEVEL >= 3) DbpString("Error preparing tag response");
                     LogTrace(receivedCmd, Uart.len, Uart.startTime * 16 - DELAY_AIR2ARM_AS_TAG, Uart.endTime * 16 - DELAY_AIR2ARM_AS_TAG, Uart.parity, true);
                     break;
                 }

--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -832,8 +832,6 @@ void SimulateIso14443aTag(int tagType, int flags, uint8_t *data) {
 
     // PACK response to PWD AUTH for EV1/NTAG
     uint8_t response8[4] = {0, 0, 0, 0};
-    // Counter for EV1/NTAG
-    uint32_t counters[] = {0, 0, 0};
 
     // The first response contains the ATQA (note: bytes are transmitted in reverse order).
     uint8_t response1[] = {0, 0};
@@ -847,6 +845,9 @@ void SimulateIso14443aTag(int tagType, int flags, uint8_t *data) {
     nonces_t ar_nr_nonces[ATTACK_KEY_COUNT]; // for attack types moebius
     memset(ar_nr_nonces, 0x00, sizeof(ar_nr_nonces));
     uint8_t    moebius_count = 0;
+
+    // some first pages of UL/NTAG dump is special data
+    mfu_dump_prefix_t *mfu_header =  tagType == 2 || tagType == 7 ? (mfu_dump_prefix_t *) BigBuf_get_EM_addr() : NULL;
 
     switch (tagType) {
         case 1: { // MIFARE Classic 1k
@@ -884,13 +885,12 @@ void SimulateIso14443aTag(int tagType, int flags, uint8_t *data) {
         case 7: { // NTAG
             response1[0] = 0x44;
             sak = 0x00;
-            // PACK
-            response8[0] = 0x80;
-            response8[1] = 0x80;
+            // PACK, from last page of dump
+            emlGetMemBt(response8, MFU_DUMP_PREFIX_LENGTH + mfu_header->pages * 4, 2);
             compute_crc(CRC_14443_A, response8, 2, &response8[2], &response8[3]);
             // uid not supplied then get from emulator memory
             if (data[0] == 0) {
-                uint16_t start = 4 * (0 + 12);
+                uint16_t start = MFU_DUMP_PREFIX_LENGTH;
                 uint8_t emdata[8];
                 emlGetMemBt(emdata, start, sizeof(emdata));
                 memcpy(data, emdata, 3); // uid bytes 0-2
@@ -1086,12 +1086,17 @@ void SimulateIso14443aTag(int tagType, int flags, uint8_t *data) {
             uint8_t block = receivedCmd[1];
             // if Ultralight or NTAG (4 byte blocks)
             if (tagType == 7 || tagType == 2) {
-                // first 12 blocks of emu are [getversion answer - check tearing - pack - 0x00 - signature]
-                uint16_t start = 4 * (block + 12);
-                uint8_t emdata[MAX_MIFARE_FRAME_SIZE];
-                emlGetMemBt(emdata, start, 16);
-                AddCrc14A(emdata, 16);
-                EmSendCmd(emdata, sizeof(emdata));
+                if (block > mfu_header->pages) {
+                    // send NACK 0x0 == invalid argument
+                    EmSend4bit(CARD_NACK_IV);
+                } else {
+                    // first blocks of emu are header
+                    uint16_t start = block * 4 + MFU_DUMP_PREFIX_LENGTH;
+                    uint8_t emdata[MAX_MIFARE_FRAME_SIZE];
+                    emlGetMemBt(emdata, start, 16);
+                    AddCrc14A(emdata, 16);
+                    EmSendCmd(emdata, sizeof(emdata));
+                }
                 // We already responded, do not send anything with the EmSendCmd14443aRaw() that is called below
                 p_response = NULL;
             } else if (tagType == 9 && block == 1) {
@@ -1110,23 +1115,36 @@ void SimulateIso14443aTag(int tagType, int flags, uint8_t *data) {
                 p_response = NULL;
             }
         } else if (receivedCmd[0] == MIFARE_ULEV1_FASTREAD) {    // Received a FAST READ (ranged read)
-            uint8_t emdata[MAX_FRAME_SIZE];
-            // first 12 blocks of emu are [getversion answer - check tearing - pack - 0x00 - signature]
-            int start = (receivedCmd[1] + 12) * 4;
-            len   = (receivedCmd[2] - receivedCmd[1] + 1) * 4;
-            emlGetMemBt(emdata, start, len);
-            AddCrc14A(emdata, len);
-            EmSendCmd(emdata, len + 2);
+            uint8_t block1 = receivedCmd[1];
+            uint8_t block2 = receivedCmd[2];
+            if (block1 > mfu_header->pages) {
+                // send NACK 0x0 == invalid argument
+                EmSend4bit(CARD_NACK_IV);
+            } else {
+                uint8_t emdata[MAX_FRAME_SIZE];
+                // first blocks of emu are header
+                int start = block1 * 4 + MFU_DUMP_PREFIX_LENGTH;
+                len   = (block2 - block1 + 1) * 4;
+                emlGetMemBt(emdata, start, len);
+                AddCrc14A(emdata, len);
+                EmSendCmd(emdata, len + 2);
+            }
             p_response = NULL;
         } else if ((receivedCmd[0] == MIFARE_ULC_WRITE || receivedCmd[0] == MIFARE_ULC_COMP_WRITE) && (tagType == 2 || tagType == 7)) {        // Received a WRITE
             // cmd + block + 4/16 bytes data + 2 bytes crc
             if (len == 8 || len == 20) {
                 bool isCrcCorrect = CheckCrc14A(receivedCmd, len);
                 if (isCrcCorrect) {
-                    int block = receivedCmd[1] + 12; // first 12 blocks of emu are [getversion answer - check tearing - pack - 0x00 - signature]
-                    emlSetMem_xt(&receivedCmd[2], block, 1, 4);
-                    // send ACK
-                    EmSend4bit(CARD_ACK);
+                    uint8_t block = receivedCmd[1];
+                    if (block > mfu_header->pages) {
+                        // send NACK 0x0 == invalid argument
+                        EmSend4bit(CARD_NACK_IV);
+                    } else {
+                        // first blocks of emu are header
+                        emlSetMem_xt(&receivedCmd[2], block + MFU_DUMP_PREFIX_LENGTH / 4, 1, 4);
+                        // send ACK
+                        EmSend4bit(CARD_ACK);
+                    }
                 } else {
                     // send NACK 0x1 == crc/parity error
                     EmSend4bit(CARD_NACK_PA);
@@ -1137,10 +1155,9 @@ void SimulateIso14443aTag(int tagType, int flags, uint8_t *data) {
             }
             p_response = NULL;
         } else if (receivedCmd[0] == MIFARE_ULEV1_READSIG && tagType == 7) {    // Received a READ SIGNATURE --
-            // first 12 blocks of emu are [getversion answer - check tearing - pack - 0x00 - signature]
-            uint16_t start = 4 * 4;
+            // first blocks of emu are header
             uint8_t emdata[34];
-            emlGetMemBt(emdata, start, 32);
+            memcpy(emdata, mfu_header->signature, 32);
             AddCrc14A(emdata, 32);
             EmSendCmd(emdata, sizeof(emdata));
             p_response = NULL;
@@ -1151,7 +1168,7 @@ void SimulateIso14443aTag(int tagType, int flags, uint8_t *data) {
                 EmSend4bit(0x00);
             } else {
                 uint8_t cmd[] =  {0x00, 0x00, 0x00, 0x14, 0xa5};
-                num_to_bytes(counters[index], 3, cmd);
+                memcpy(cmd, mfu_header->counter_tearing[index], 3);
                 AddCrc14A(cmd, sizeof(cmd) - 2);
                 EmSendCmd(cmd, sizeof(cmd));
             }
@@ -1162,15 +1179,13 @@ void SimulateIso14443aTag(int tagType, int flags, uint8_t *data) {
                 // send NACK 0x0 == invalid argument
                 EmSend4bit(0x00);
             } else {
-
-                uint32_t val = bytes_to_num(receivedCmd + 2, 4);
-
+                uint32_t val = le24toh(receivedCmd + 2) + le24toh(mfu_header->counter_tearing[index]);
                 // if new value + old value is bigger 24bits,  fail
-                if (val + counters[index] > 0xFFFFFF) {
+                if (val > 0xFFFFFF) {
                     // send NACK 0x4 == counter overflow
                     EmSend4bit(CARD_NACK_NA);
                 } else {
-                    counters[index] = val;
+                    htole24(val, mfu_header->counter_tearing[index]);
                     // send ACK
                     EmSend4bit(CARD_ACK);
                 }
@@ -1184,7 +1199,7 @@ void SimulateIso14443aTag(int tagType, int flags, uint8_t *data) {
                 // send NACK 0x0 == invalid argument
                 EmSend4bit(0x00);
             } else {
-                emlGetMemBt(emdata, 10 + index, 1);
+                emdata[0] = mfu_header->counter_tearing[index][3];
                 AddCrc14A(emdata, sizeof(emdata) - 2);
                 EmSendCmd(emdata, sizeof(emdata));
             }
@@ -1195,7 +1210,7 @@ void SimulateIso14443aTag(int tagType, int flags, uint8_t *data) {
         } else if (receivedCmd[0] == MIFARE_AUTH_KEYA || receivedCmd[0] == MIFARE_AUTH_KEYB) {    // Received an authentication request
             if (tagType == 7) {     // IF NTAG /EV1  0x60 == GET_VERSION, not a authentication request.
                 uint8_t emdata[10];
-                emlGetMemBt(emdata, 0, 8);
+                memcpy(emdata, mfu_header->version, 8);
                 AddCrc14A(emdata, sizeof(emdata) - 2);
                 EmSendCmd(emdata, sizeof(emdata));
                 p_response = NULL;
@@ -1291,15 +1306,17 @@ void SimulateIso14443aTag(int tagType, int flags, uint8_t *data) {
         } else if (receivedCmd[0] == MIFARE_ULC_AUTH_1) {  // ULC authentication, or Desfire Authentication
         } else if (receivedCmd[0] == MIFARE_ULEV1_AUTH) { // NTAG / EV-1 authentication
             if (tagType == 7) {
-                uint16_t start = 13; // first 4 blocks of emu are [getversion answer - check tearing - pack - 0x00]
-                uint8_t emdata[4];
-                emlGetMemBt(emdata, start, 2);
-                AddCrc14A(emdata, 2);
-                EmSendCmd(emdata, sizeof(emdata));
-                p_response = NULL;
-                uint32_t pwd = bytes_to_num(receivedCmd + 1, 4);
-
-                if (MF_DBGLEVEL >= 3) Dbprintf("Auth attempt: %08x", pwd);
+                // PWD stored in dump now
+                uint8_t pwd[4];
+                emlGetMemBt(pwd, (mfu_header->pages - 1) * 4 + MFU_DUMP_PREFIX_LENGTH, sizeof(pwd));
+                if (memcmp(receivedCmd + 1, pwd, 4) == 0) {
+                    p_response = &responses[7]; // precompiled PACK
+                } else {
+                    EmSend4bit(CARD_NACK_NA);
+                    uint32_t pwd = bytes_to_num(receivedCmd + 1, 4);
+                    if (MF_DBGLEVEL >= 3) Dbprintf("Auth attempt: %08x", pwd);
+                    p_response = NULL;
+                }
             }
         } else {
             // Check for ISO 14443A-4 compliant commands, look at left nibble

--- a/armsrc/iso14443a.h
+++ b/armsrc/iso14443a.h
@@ -95,18 +95,6 @@ typedef struct {
     uint8_t *parity;
 } tUart;
 
-// Length must be aligned to 4 bytes (UL/NTAG page)
-#define MFU_DUMP_PREFIX_LENGTH 56
-
-typedef struct {
-    uint8_t version[8];
-    uint8_t tbo[2];
-    uint8_t tbo1[1];
-    uint8_t pages;                  // max page number in dump
-    uint8_t signature[32];
-    uint8_t counter_tearing[3][4];  // 3 bytes counter, 1 byte tearing flag
-} mfu_dump_prefix_t;
-
 #ifndef AddCrc14A
 # define AddCrc14A(data, len) compute_crc(CRC_14443_A, (data), (len), (data)+(len), (data)+(len)+1)
 #endif

--- a/armsrc/iso14443a.h
+++ b/armsrc/iso14443a.h
@@ -95,6 +95,18 @@ typedef struct {
     uint8_t *parity;
 } tUart;
 
+// Length must be aligned to 4 bytes (UL/NTAG page)
+#define MFU_DUMP_PREFIX_LENGTH 56
+
+typedef struct {
+    uint8_t version[8];
+    uint8_t tbo[2];
+    uint8_t tbo1[1];
+    uint8_t pages;                  // max page number in dump
+    uint8_t signature[32];
+    uint8_t counter_tearing[3][4];  // 3 bytes counter, 1 byte tearing flag
+} mfu_dump_prefix_t;
+
 #ifndef AddCrc14A
 # define AddCrc14A(data, len) compute_crc(CRC_14443_A, (data), (len), (data)+(len), (data)+(len)+1)
 #endif

--- a/armsrc/util.c
+++ b/armsrc/util.c
@@ -91,6 +91,12 @@ int32_t le24toh(uint8_t data[3]) {
     return (data[2] << 16) | (data[1] << 8) | data[0];
 }
 
+void htole24(uint32_t val, uint8_t data[3]) {
+    data[0] = (uint8_t) val;
+    data[1] = (uint8_t)(val >> 8);
+    data[2] = (uint8_t)(val >> 16);
+}
+
 //convert hex digit to integer
 uint8_t hex2int(char hexchar) {
     switch (hexchar) {

--- a/armsrc/util.h
+++ b/armsrc/util.h
@@ -93,6 +93,7 @@ uint64_t bytes_to_num(uint8_t *src, size_t len);
 void rol(uint8_t *data, const size_t len);
 void lsl(uint8_t *data, size_t len);
 int32_t le24toh(uint8_t data[3]);
+void htole24(uint32_t val, uint8_t data[3]);
 uint8_t hex2int(char hexchar);
 
 void LED(int led, int ms);

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -2590,6 +2590,16 @@ int CmdHF14AMfELoad(const char *Cmd) {
         return 2;
     }
 
+    // convert old mfu format to new
+    if (blockWidth == 4) {
+        res = convertOldMfuDump(&data, &datalen);
+        if (res) {
+            PrintAndLogEx(FAILED, "Failed convert on load to new Ultralight/NTAG format");
+            free(data);
+            return res;
+        }
+    }
+
     PrintAndLogEx(INFO, "Copying to emulator memory");
 
     blockNum = 0;

--- a/client/cmdhfmfu.c
+++ b/client/cmdhfmfu.c
@@ -1622,12 +1622,10 @@ void printMFUdumpEx(mfu_dump_t *card, uint16_t pages, uint8_t startpage) {
     PrintAndLogEx(NORMAL, "TBD       | %-24s| %s", sprint_hex(card->tbo1, sizeof(card->tbo1)), sprint_ascii(card->tbo1, sizeof(card->tbo1)));
     PrintAndLogEx(NORMAL, "Signature1| %s| %s", sprint_hex(card->signature, 16), sprint_ascii(card->signature, 16));
     PrintAndLogEx(NORMAL, "Signature2| %s| %s", sprint_hex(card->signature + 16, 16), sprint_ascii(card->signature + 16, 16));
-    PrintAndLogEx(NORMAL, "Counter0  | %-24s| %s", sprint_hex(card->counter_tearing[0],     3), sprint_ascii(card->counter_tearing[0],     3));
-    PrintAndLogEx(NORMAL, "Tearing0  | %-24s| %s", sprint_hex(card->counter_tearing[0] + 3, 1), sprint_ascii(card->counter_tearing[0] + 3, 1));
-    PrintAndLogEx(NORMAL, "Counter1  | %-24s| %s", sprint_hex(card->counter_tearing[1],     3), sprint_ascii(card->counter_tearing[1],     3));
-    PrintAndLogEx(NORMAL, "Tearing1  | %-24s| %s", sprint_hex(card->counter_tearing[1] + 3, 1), sprint_ascii(card->counter_tearing[1] + 3, 1));
-    PrintAndLogEx(NORMAL, "Counter2  | %-24s| %s", sprint_hex(card->counter_tearing[2],     3), sprint_ascii(card->counter_tearing[2],     3));
-    PrintAndLogEx(NORMAL, "Tearing3  | %-24s| %s", sprint_hex(card->counter_tearing[2] + 3, 1), sprint_ascii(card->counter_tearing[2] + 3, 1));
+    for (uint8_t i = 0; i < 3; i ++) {
+        PrintAndLogEx(NORMAL, "Counter%d  | %-24s| %s", i, sprint_hex(card->counter_tearing[i],     3), sprint_ascii(card->counter_tearing[i],     3));
+        PrintAndLogEx(NORMAL, "Tearing%d  | %-24s| %s", i, sprint_hex(card->counter_tearing[i] + 3, 1), sprint_ascii(card->counter_tearing[i] + 3, 1));
+    }
     PrintAndLogEx(NORMAL, "-------------------------------------------------------------");
     PrintAndLogEx(NORMAL, "\nBlock#   | Data        |lck| Ascii");
     PrintAndLogEx(NORMAL, "---------+-------------+---+------");

--- a/client/cmdhfmfu.h
+++ b/client/cmdhfmfu.h
@@ -13,20 +13,6 @@
 #include "loclass/fileutils.h"
 
 
-// New Ultralight/NTAG dump file format
-// Length must be aligned to 4 bytes (UL/NTAG page)
-#define MFU_DUMP_PREFIX_LENGTH 56
-
-typedef struct {
-    uint8_t version[8];
-    uint8_t tbo[2];
-    uint8_t tbo1[1];
-    uint8_t pages;                  // max page number in dump
-    uint8_t signature[32];
-    uint8_t counter_tearing[3][4];  // 3 bytes counter, 1 byte tearing flag
-    uint8_t data[1024];
-} mfu_dump_t;
-
 // Old Ultralight/NTAG dump file format
 // It is used only for converting
 #define OLD_MFU_DUMP_PREFIX_LENGTH 48

--- a/client/cmdhfmfu.h
+++ b/client/cmdhfmfu.h
@@ -12,8 +12,10 @@
 #include "comms.h"
 #include "loclass/fileutils.h"
 
+
+// New Ultralight/NTAG dump file format
 // Length must be aligned to 4 bytes (UL/NTAG page)
-#define DUMP_PREFIX_LENGTH 56
+#define MFU_DUMP_PREFIX_LENGTH 56
 
 typedef struct {
     uint8_t version[8];
@@ -24,6 +26,22 @@ typedef struct {
     uint8_t counter_tearing[3][4];  // 3 bytes counter, 1 byte tearing flag
     uint8_t data[1024];
 } mfu_dump_t;
+
+// Old Ultralight/NTAG dump file format
+// It is used only for converting
+#define OLD_MFU_DUMP_PREFIX_LENGTH 48
+
+typedef struct {
+    uint8_t version[8];
+    uint8_t tbo[2];
+    uint8_t tearing[3];
+    uint8_t pack[2];
+    uint8_t tbo1[1];
+    uint8_t signature[32];
+    //uint8_t counter[3];
+    uint8_t data[1024];
+} old_mfu_dump_t;
+
 
 uint32_t GetHF14AMfU_Type(void);
 int ul_print_type(uint32_t tagtype, uint8_t spaces);

--- a/client/cmdhfmfu.h
+++ b/client/cmdhfmfu.h
@@ -12,16 +12,16 @@
 #include "comms.h"
 #include "loclass/fileutils.h"
 
-#define DUMP_PREFIX_LENGTH 48
+// Length must be aligned to 4 bytes (UL/NTAG page)
+#define DUMP_PREFIX_LENGTH 56
 
 typedef struct {
     uint8_t version[8];
     uint8_t tbo[2];
-    uint8_t tearing[3];
-    uint8_t pack[2];
     uint8_t tbo1[1];
+    uint8_t pages;                  // max page number in dump
     uint8_t signature[32];
-    //uint8_t counter[3];
+    uint8_t counter_tearing[3][4];  // 3 bytes counter, 1 byte tearing flag
     uint8_t data[1024];
 } mfu_dump_t;
 

--- a/client/loclass/fileutils.c
+++ b/client/loclass/fileutils.c
@@ -218,23 +218,24 @@ int saveFileJSON(const char *preferredName, const char *suffix, JSONFileType fty
             memcpy(uid, tmp->data, 3);
             memcpy(uid + 3, tmp->data + 4, 4);
 
+            char path[PATH_MAX_LENGTH] = {0};
+
             JsonSaveBufAsHexCompact(root, "$.Card.UID", uid, sizeof(uid));
             JsonSaveBufAsHexCompact(root, "$.Card.Version", tmp->version, sizeof(tmp->version));
             JsonSaveBufAsHexCompact(root, "$.Card.TBO_0", tmp->tbo, sizeof(tmp->tbo));
             JsonSaveBufAsHexCompact(root, "$.Card.TBO_1", tmp->tbo1, sizeof(tmp->tbo1));
             JsonSaveBufAsHexCompact(root, "$.Card.Signature", tmp->signature, sizeof(tmp->signature));
-            JsonSaveBufAsHexCompact(root, "$.Card.Counter0", tmp->counter_tearing[0], 3);
-            JsonSaveBufAsHexCompact(root, "$.Card.Tearing0", tmp->counter_tearing[0] + 3, 1);
-            JsonSaveBufAsHexCompact(root, "$.Card.Counter1", tmp->counter_tearing[1], 3);
-            JsonSaveBufAsHexCompact(root, "$.Card.Tearing1", tmp->counter_tearing[1] + 3, 1);
-            JsonSaveBufAsHexCompact(root, "$.Card.Counter2", tmp->counter_tearing[2], 3);
-            JsonSaveBufAsHexCompact(root, "$.Card.Tearing2", tmp->counter_tearing[2] + 3, 1);
+            for (uint8_t i = 0; i < 3; i ++) {
+                sprintf(path, "$.Card.Counter%d", i);
+                JsonSaveBufAsHexCompact(root, path, tmp->counter_tearing[i], 3);
+                sprintf(path, "$.Card.Tearing%d", i);
+                JsonSaveBufAsHexCompact(root, path, tmp->counter_tearing[i] + 3, 1);
+            }
 
             // size of header 56b
             size_t len = (datalen - DUMP_PREFIX_LENGTH) / 4;
 
             for (size_t i = 0; i < len; i++) {
-                char path[PATH_MAX_LENGTH] = {0};
                 sprintf(path, "$.blocks.%zu", i);
                 JsonSaveBufAsHexCompact(root, path, tmp->data + (i * 4), 4);
             }

--- a/client/loclass/fileutils.c
+++ b/client/loclass/fileutils.c
@@ -221,13 +221,16 @@ int saveFileJSON(const char *preferredName, const char *suffix, JSONFileType fty
             JsonSaveBufAsHexCompact(root, "$.Card.UID", uid, sizeof(uid));
             JsonSaveBufAsHexCompact(root, "$.Card.Version", tmp->version, sizeof(tmp->version));
             JsonSaveBufAsHexCompact(root, "$.Card.TBO_0", tmp->tbo, sizeof(tmp->tbo));
-            JsonSaveBufAsHexCompact(root, "$.Card.Tearing", tmp->tearing, sizeof(tmp->tearing));
-            JsonSaveBufAsHexCompact(root, "$.Card.Pack",  tmp->pack, sizeof(tmp->pack));
             JsonSaveBufAsHexCompact(root, "$.Card.TBO_1", tmp->tbo1, sizeof(tmp->tbo1));
             JsonSaveBufAsHexCompact(root, "$.Card.Signature", tmp->signature, sizeof(tmp->signature));
-            JsonSaveStr(root, "$.Card.Counter", "N/A");
+            JsonSaveBufAsHexCompact(root, "$.Card.Counter0", tmp->counter_tearing[0], 3);
+            JsonSaveBufAsHexCompact(root, "$.Card.Tearing0", tmp->counter_tearing[0] + 3, 1);
+            JsonSaveBufAsHexCompact(root, "$.Card.Counter1", tmp->counter_tearing[1], 3);
+            JsonSaveBufAsHexCompact(root, "$.Card.Tearing1", tmp->counter_tearing[1] + 3, 1);
+            JsonSaveBufAsHexCompact(root, "$.Card.Counter2", tmp->counter_tearing[2], 3);
+            JsonSaveBufAsHexCompact(root, "$.Card.Tearing2", tmp->counter_tearing[2] + 3, 1);
 
-            // size of header 48b
+            // size of header 56b
             size_t len = (datalen - DUMP_PREFIX_LENGTH) / 4;
 
             for (size_t i = 0; i < len; i++) {

--- a/client/loclass/fileutils.c
+++ b/client/loclass/fileutils.c
@@ -584,13 +584,11 @@ int convertOldMfuDump(uint8_t **dump, size_t *dumplen) {
     mfu_dump = (mfu_dump_t *) calloc(new_dump_len, sizeof(uint8_t));
 
     memcpy(mfu_dump->version, old_mfu_dump->version, 8);
-    mfu_dump->tbo[0] = old_mfu_dump->tbo[0];
-    mfu_dump->tbo[1] = old_mfu_dump->tbo[1];
+    memcpy(mfu_dump->tbo, old_mfu_dump->tbo, 2);
     mfu_dump->tbo1[0] = old_mfu_dump->tbo1[0];
     memcpy(mfu_dump->signature, old_mfu_dump->signature, 32);
-    mfu_dump->counter_tearing[0][3] = old_mfu_dump->tearing[0];
-    mfu_dump->counter_tearing[1][3] = old_mfu_dump->tearing[1];
-    mfu_dump->counter_tearing[2][3] = old_mfu_dump->tearing[2];
+    for (int i = 0; i < 3; i++)
+        mfu_dump->counter_tearing[i][3] = old_mfu_dump->tearing[i];
 
     memcpy(mfu_dump->data, old_mfu_dump->data, old_data_len);
     mfu_dump->pages = old_data_len / 4 - 1;

--- a/client/loclass/fileutils.h
+++ b/client/loclass/fileutils.h
@@ -158,6 +158,15 @@ int loadFileJSON(const char *preferredName, const char *suffix, void *data, size
 */
 int loadFileDICTIONARY(const char *preferredName, const char *suffix, void *data, size_t *datalen, uint8_t keylen, uint16_t *keycnt);
 
+/**
+ * @brief  Utility function to check and convert old mfu dump format to new
+ *
+ * @param dump pointer to loaded dump to check and convert format
+ * @param dumplen the number of bytes loaded dump and converted
+ * @return 0 for ok, 1 for fails
+*/
+int convertOldMfuDump(uint8_t **dump, size_t *dumplen);
+
 #define PrintAndLogDevice(level, format, args...)  PrintAndLogEx(level, format , ## args)
 #else
 
@@ -169,6 +178,7 @@ int loadFileDICTIONARY(const char *preferredName, const char *suffix, void *data
 * @param fmt
 */
 #define PrintAndLogDevice(level, format, args...) { }
+
 
 
 #endif //ON_DEVICE

--- a/client/scripts/dumptoemul-mfu.lua
+++ b/client/scripts/dumptoemul-mfu.lua
@@ -104,11 +104,11 @@ local function main(args)
     -- lua uses start index and endindex,  not count.
     -- UID is  3three skip bcc0 then 4bytes.
     -- 1 lua is one-index.
-    -- 1 + 96 (48*2)  new dump format has version/signature/counter data here
-    -- 97,98,99,100,101,102   UID first three bytes
-    -- 103,104 bcc0
-    -- 105---  UID last four bytes
-    local uid = string.sub(dumpdata, 97, 97+5)..string.sub(dumpdata, 97+8, 97+8+7)
+    -- 1 + 112 (56*2)  new dump format has version/signature/counter data here
+    -- 113,114,115,116,117,118   UID first three bytes
+    -- 119,120 bcc0
+    -- 121---  UID last four bytes
+    local uid = string.sub(dumpdata, 113, 113+5)..string.sub(dumpdata, 113+8, 113+8+7)
     output = output or (uid .. ".eml")
 
     -- Format some linebreaks

--- a/include/mifare.h
+++ b/include/mifare.h
@@ -20,6 +20,23 @@
 #define MF_MAD2_SECTOR 0x10
 
 //-----------------------------------------------------------------------------
+// Common types, used by client and ARM
+//-----------------------------------------------------------------------------
+// New Ultralight/NTAG dump file format
+// Length must be aligned to 4 bytes (UL/NTAG page)
+#define MFU_DUMP_PREFIX_LENGTH 56
+
+typedef struct {
+    uint8_t version[8];
+    uint8_t tbo[2];
+    uint8_t tbo1[1];
+    uint8_t pages;                  // max page number in dump
+    uint8_t signature[32];
+    uint8_t counter_tearing[3][4];  // 3 bytes counter, 1 byte tearing flag
+    uint8_t data[1024];
+} mfu_dump_t;
+
+//-----------------------------------------------------------------------------
 // ISO 14443A
 //-----------------------------------------------------------------------------
 typedef struct {


### PR DESCRIPTION
1) New header format of dump files for Ultralight/NTAG. Added counters to header, removed PACK from header, because PACK and PWD for EV1 stores into dump.
2) Fix EV1/NTAG simulation.