### PR TITLE
Add libpcsclite-dev to package install list

### DIFF
--- a/Installation_Instructions/Ubuntu-Installation-Instructions.md
+++ b/Installation_Instructions/Ubuntu-Installation-Instructions.md
@@ -22,7 +22,7 @@ sudo apt-get update
 ### Requirements
 
 ```sh
-sudo apt-get install p7zip git build-essential libreadline5 libreadline-dev libusb-0.1-4 libusb-dev libqt4-dev perl pkg-config wget libncurses5-dev gcc-arm-none-eabi
+sudo apt-get install p7zip git build-essential libreadline5 libreadline-dev libusb-0.1-4 libusb-dev libqt4-dev perl pkg-config wget libncurses5-dev gcc-arm-none-eabi libpcsclite-dev
 ```
 
 ### Clone Fork 


### PR DESCRIPTION
Build fails on new Lubuntu install, same error and solution as here: https://github.com/Proxmark/proxmark3/issues/774