### PR TITLE
client/Makefile: use brew libreadline on macOS

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -72,6 +72,8 @@ else
     LUAPLATFORM = macosx
     OBJCSRCS = util_darwin.m
     LDFLAGS += -framework Foundation -framework AppKit
+    LDLIBS := -L/usr/local/opt/readline/lib $(LDLIBS)
+    LIBS := -I/usr/local/opt/readline/include $(LIBS)
 else
     LUALIB +=  -ldl
     LDLIBS +=  -ltermcap -lncurses


### PR DESCRIPTION
Make sure we use libreadline from brew and not the default macOS shipped one.
Otherwise compilation fails for undefined rl_event_hook