### PR TITLE
client/comms.c: fix buffer overflow

### DIFF
--- a/client/comms.c
+++ b/client/comms.c
@@ -613,7 +613,7 @@ int TestProxmark(void) {
 
         SendCommandNG(CMD_CAPABILITIES, NULL, 0);
         if (WaitForResponseTimeoutW(CMD_CAPABILITIES, &resp, 1000, false)) {
-            memcpy(&pm3_capabilities, resp.data.asBytes, resp.length);
+            memcpy(&pm3_capabilities, resp.data.asBytes, MIN(sizeof(capabilities_t), resp.length));
             conn.send_via_fpc_usart = pm3_capabilities.via_fpc;
             conn.uart_speed = pm3_capabilities.baudrate;
             PrintAndLogEx(INFO, "Communicating with PM3 over %s", conn.send_via_fpc_usart ? _YELLOW_("FPC UART") : _YELLOW_("USB-CDC"));


### PR DESCRIPTION
Don't copy more bytes into pm3_capabilities as its size.

Fix: RfidResearchGroup/proxmark3#189