### PR TITLE
Added paged moving to the plot GUI

### DIFF
--- a/client/proxguiqt.cpp
+++ b/client/proxguiqt.cpp
@@ -33,8 +33,8 @@ extern "C" {
 
 bool g_useOverlays = false;
 int g_absVMax = 0;
-uint32_t startMax;
-int PageWidth;
+uint32_t startMax; // Maximum offset in the graph (right side of graph)
+uint32_t PageWidth; // How many samples are currently visible on this 'page' / graph
 int unlockStart = 0;
 
 void ProxGuiQT::ShowGraphWindow(void) {
@@ -483,6 +483,7 @@ void Plot::paintEvent(QPaintEvent *event) {
 
     QRect plotRect(WIDTH_AXES, 0, width() - WIDTH_AXES, height() - HEIGHT_INFO);
     QRect infoRect(0, height() - HEIGHT_INFO, width(), HEIGHT_INFO);
+    PageWidth = plotRect.width() / GraphPixelsPerPoint;
 
     //Grey background
     painter.fillRect(rect(), QColor(60, 60, 60));
@@ -586,7 +587,7 @@ void Plot::mouseMoveEvent(QMouseEvent *event) {
 }
 
 void Plot::keyPressEvent(QKeyEvent *event) {
-    uint32_t offset;
+    uint32_t offset; // Left/right movement offset (in sample size)
 
     if (event->modifiers() & Qt::ShiftModifier) {
         if (PlotGridX)
@@ -651,7 +652,6 @@ void Plot::keyPressEvent(QKeyEvent *event) {
             break;
 
         case Qt::Key_H:
-
             puts("\n-----------------------------------------------------------------------");
             puts("PLOT window keystrokes");
             puts("\tKey                      Action");
@@ -662,6 +662,10 @@ void Plot::keyPressEvent(QKeyEvent *event) {
             puts("\tH                        Show help");
             puts("\tL                        Toggle lock grid relative to samples");
             puts("\tQ                        Hide window");
+            puts("\tHOME                     Move to the start of the graph");
+            puts("\tEND                      Move to the end of the graph");
+            puts("\tPGUP                     Page left");
+            puts("\tPGDOWN                   Page right");
             puts("\tLEFT                     Move left");
             puts("\t<CTLR> LEFT              Move left 1 sample");
             puts("\t<SHIFT> LEFT             Page left");
@@ -683,6 +687,26 @@ void Plot::keyPressEvent(QKeyEvent *event) {
 
         case Qt::Key_Q:
             master->hide();
+            break;
+
+        case Qt::Key_Home:
+            GraphStart = 0;
+            break;
+
+        case Qt::Key_End:
+            GraphStart = startMax;
+            break;
+
+        case Qt::Key_PageUp:
+            if (GraphStart >= PageWidth) {
+                GraphStart -= PageWidth;
+            } else {
+                GraphStart = 0;
+            }
+            break;
+
+        case Qt::Key_PageDown:
+            GraphStart += PageWidth;
             break;
 
         default:

--- a/client/proxguiqt.h
+++ b/client/proxguiqt.h
@@ -31,8 +31,8 @@ class ProxWidget;
 class Plot: public QWidget {
   private:
     QWidget *master;
-    uint32_t GraphStart;
-    double GraphPixelsPerPoint;
+    uint32_t GraphStart; // Starting point/offset for the left side of the graph
+    double GraphPixelsPerPoint; // How many visual pixels are between each sample point (x axis)
     uint32_t CursorAPos;
     uint32_t CursorBPos;
     void PlotGraph(int *buffer, size_t len, QRect r, QRect r2, QPainter *painter, int graphNum);


### PR DESCRIPTION
Adds bindings for HOME and END to jump to the start or end of the graph.
Adds bindings for PGUP and PGDOWN to move a page left or right on the graph.
Sets the PageWidth variable (wasn't set before) to contain the number of samples on the current page. (Fixes shift+arrow pagination)