### PR TITLE
 Gitignore more linux profile related files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@
 
 .history
 .bash_history
+.bash_profile
+.bash_logout
+.bashrc
+.inputrc
+.profile
 *.log
 *.eml
 *.o


### PR DESCRIPTION
May help for people launching manually afterwards. It will also help if people have more than one proxmark connected, as they will know which one was selected.