### PR TITLE
(OSX) Fix build failure and all build warnings

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -31,7 +31,12 @@ platform = $(shell uname)
 VPATH = ../common ../zlib ../uart
 OBJDIR = obj
 
-LDLIBS = -L/opt/local/lib -L/usr/local/lib -lreadline -lpthread -lm
+LDLIBS =
+ifneq ($(platform),Darwin)
+    LDLIBS += -L/opt/local/lib
+endif
+LDLIBS += -L/usr/local/lib -lreadline -lpthread -lm
+
 # RPi Zero gcc requires -latomic
 # but MacOSX /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld
 # doesn't recognize option --as-needed

--- a/client/emv/cmdemv.c
+++ b/client/emv/cmdemv.c
@@ -287,8 +287,8 @@ static int CmdEMVGPO(const char *Cmd) {
         PrintAndLogEx(ERR, "Can't create PDOL data.");
         tlvdb_free(tmp_ext);
         tlvdb_free(tlvRoot);
-        if (pdol_data_tlv != &data_tlv);
-        free(pdol_data_tlv);
+        if (pdol_data_tlv != &data_tlv)
+          free(pdol_data_tlv);
         return PM3_ESOFT;
     }
     PrintAndLogEx(INFO, "PDOL data[%d]: %s", pdol_data_tlv_data_len, sprint_hex(pdol_data_tlv_data, pdol_data_tlv_data_len));

--- a/client/jansson/Makefile
+++ b/client/jansson/Makefile
@@ -36,15 +36,26 @@ CFILES = $(filter %.c, $(libjansson_la_SOURCES))
 CMDOBJS = $(CFILES:%.c=%.o)
 CLEAN = $(CMDOBJS)
 
+platform = $(shell uname)
+
 CC= gcc
-CFLAGS= -O2 -Wall -Wno-unused-variable -Wno-unused-function -Wno-format-truncation
+CFLAGS= -O2 -Wall -Wno-unused-variable -Wno-unused-function
+ifneq ($(platform),Darwin)
+CFLAGS += -Wno-format-truncation
+endif
+
 LDFLAGS= $(SYSLDFLAGS) $(libjansson_la_LDFLAGS)
 LIBS= $(SYSLIBS) $(MYLIBS)
 DEFAULT_INCLUDES = -I.
 DEFS = -DHAVE_STDINT_H
 
+ifeq ($(platform),Darwin)
+AR= /usr/bin/ar rcs
+RANLIB= /usr/bin/ranlib
+else
 AR= ar rcs
 RANLIB= ranlib
+endif
 RM= rm -f
 TST= echo
 

--- a/client/proxguiqt.h
+++ b/client/proxguiqt.h
@@ -97,8 +97,8 @@ class WorkerThread : public QThread {
     ~WorkerThread();
     void run();
   private:
-    char *script_cmds_file = NULL;
-    char *script_cmd = NULL;
+    char *script_cmds_file;
+    char *script_cmd;
 };
 
 class ProxGuiQT : public QObject {

--- a/client/proxmark3.c
+++ b/client/proxmark3.c
@@ -388,7 +388,7 @@ int main(int argc, char *argv[]) {
                 show_help(false, exec_name);
                 return 1;
             }
-            uint32_t tmpspeed = strtoul(argv[i + 1], NULL, 10);
+            unsigned long tmpspeed = strtoul(argv[i + 1], NULL, 10);
             if ((tmpspeed == ULONG_MAX) || (tmpspeed == 0)) {
                 PrintAndLogEx(ERR, _RED_("ERROR:") "invalid baudrate: -b " _YELLOW_("%s") "\n", argv[i + 1]);
                 return 1;

--- a/client/tinycbor/Makefile
+++ b/client/tinycbor/Makefile
@@ -19,14 +19,21 @@ CFILES = $(filter %.c, $(tinycbor_SOURCES))
 CMDOBJS = $(CFILES:%.c=%.o)
 CLEAN = $(CMDOBJS)
 
+platform = $(shell uname)
+
 CC= gcc
 CFLAGS= -O2 -Wall -Wno-unused-variable -Wno-unused-function
 LIBS=  $(SYSLIBS) $(MYLIBS)
 DEFAULT_INCLUDES = -I. -I..
 DEFS = -DHAVE_STDINT_H
 
+ifeq ($(platform),Darwin)
+AR= /usr/bin/ar rcs
+RANLIB= /usr/bin/ranlib
+else
 AR= ar rcs
 RANLIB= ranlib
+endif
 RM= rm -f
 TST= echo
 

--- a/common/Makefile.common
+++ b/common/Makefile.common
@@ -43,15 +43,13 @@ TARFLAGS = -C .. -rvf
 #  amount of shell command line parsing going on. echo "" on 
 #  Windows yields literal "", on Linux yields an empty line
 ifeq ($(shell echo ""),)
-
-# This is probably a proper system, so we can use uname
-UNAME := $(shell uname)
 DELETE=rm -rf
 MOVE=mv
 COPY=cp
 PATHSEP=/
 FLASH_TOOL=client/flasher
-DETECTED_OS=$(UNAME)
+# This is probably a proper system, so we can use uname
+DETECTED_OS=$(platform)
 else
 
 # Assume that we are running on Windows.

--- a/common/mbedtls/Makefile
+++ b/common/mbedtls/Makefile
@@ -59,6 +59,8 @@ CFILES = $(filter %.c, $(mbedtls_SOURCES))
 CMDOBJS = $(CFILES:%.c=%.o)
 CLEAN = $(CMDOBJS)
 
+platform = $(shell uname)
+
 CC= gcc
 CFLAGS= -O2 -Wall -Wno-unused-variable -Wno-unused-function
 LDFLAGS= $(SYSLDFLAGS) $(mbedtls_LDFLAGS)
@@ -66,8 +68,13 @@ LIBS=  $(SYSLIBS) $(MYLIBS)
 DEFAULT_INCLUDES = -I. -I..
 DEFS = -DHAVE_STDINT_H
 
+ifeq ($(platform),Darwin)
+AR= /usr/bin/ar rcs
+RANLIB= /usr/bin/ranlib
+else
 AR= ar rcs
 RANLIB= ranlib
+endif
 RM= rm -f
 TST= echo
 

--- a/liblua/Makefile
+++ b/liblua/Makefile
@@ -12,13 +12,20 @@ endif
 # Your platform. See PLATS for possible values.
 PLAT= none
 
+platform= $(shell uname)
+
 CC= gcc
 CFLAGS= -O3 -Wall -DLUA_COMPAT_ALL $(SYSCFLAGS) $(MYCFLAGS)
 LDFLAGS= $(SYSLDFLAGS) $(MYLDFLAGS)
 LIBS= -lm $(SYSLIBS) $(MYLIBS)
 
+ifeq ($(platform),Darwin)
+AR= /usr/bin/ar rc
+RANLIB= /usr/bin/ranlib
+else
 AR= ar rc
 RANLIB= ranlib
+endif
 RM= rm -f
 
 SYSCFLAGS=


### PR DESCRIPTION
Hi,
I'm my OSX environment the build process fail. This issue is related to the "binutils" package installed by brew:

```
$ ls -al $(which ar) $(which ranlib)
[...] /usr/local/bin/ar -> /usr/local/Cellar/binutils/2.32/bin/ar
[...] /usr/local/bin/ranlib -> ../Cellar/binutils/2.32/bin/ranlib
```

With the following patch I switch the "ar" and "ranlib" binaries to the working ones: "/usr/bin/ar" and "/usr/bin/ranlib".

Moreover I solved all the build warning on OSX and I found a little bug here:

```
[-] CC emv/cmdemv.c
emv/cmdemv.c:290:40: warning: if statement has empty body [-Wempty-body]
        if (pdol_data_tlv != &data_tlv);
                                       ^
emv/cmdemv.c:290:40: note: put the semicolon on a separate line to silence this warning
1 warning generated.
```

and I solved in this way:

```
--- a/client/emv/cmdemv.c
+++ b/client/emv/cmdemv.c
@@ -287,8 +287,8 @@ static int CmdEMVGPO(const char *Cmd) {
         PrintAndLogEx(ERR, "Can't create PDOL data.");
         tlvdb_free(tmp_ext);
         tlvdb_free(tlvRoot);
-        if (pdol_data_tlv != &data_tlv);
-        free(pdol_data_tlv);
+        if (pdol_data_tlv != &data_tlv)
+          free(pdol_data_tlv);
         return PM3_ESOFT;
     }
     PrintAndLogEx(INFO, "PDOL data[%d]: %s", pdol_data_tlv_data_len, sprint_hex(pdol_data_tlv_data, pdol_data_tlv_data_len));

```

using as reference the proxmark3 original source code [here](https://github.com/Proxmark/proxmark3/blob/master/client/emv/cmdemv.c#L330) 

Thanks,
matrix
 