### PR TITLE
Add hitag2 write password auth

### DIFF
--- a/client/cmdlfhitag.c
+++ b/client/cmdlfhitag.c
@@ -106,6 +106,7 @@ static int usage_hitag_writer(void) {
     PrintAndLogEx(NORMAL, "   Hitag1 (1*)");
     PrintAndLogEx(NORMAL, "   Hitag2 (2*)");
     PrintAndLogEx(NORMAL, "      24  <key> (set to 0 if no authentication is needed) <page> <byte0...byte3> write page on a Hitag2 tag");
+    PrintAndLogEx(NORMAL, "      27  <password> <page> <byte0...byte3> write page on a Hitag2 tag");
     return 0;
 }
 static int usage_hitag_checkchallenges(void) {
@@ -655,6 +656,12 @@ static int CmdLFHitagWriter(const char *Cmd) {
         case WHTSF_KEY:
         case WHT2F_CRYPTO: {
             num_to_bytes(param_get64ex(Cmd, 1, 0, 16), 6, htd.crypto.key);
+            arg2 = param_get32ex(Cmd, 2, 0, 10);
+            num_to_bytes(param_get32ex(Cmd, 3, 0, 16), 4, htd.crypto.data);
+            break;
+        }
+        case WHT2F_PASSWORD: {
+            num_to_bytes(param_get64ex(Cmd, 1, 0, 16), 4, htd.pwd.password);
             arg2 = param_get32ex(Cmd, 2, 0, 10);
             num_to_bytes(param_get32ex(Cmd, 3, 0, 16), 4, htd.crypto.data);
             break;

--- a/include/hitag.h
+++ b/include/hitag.h
@@ -31,6 +31,7 @@ typedef enum {
     WHT2F_CRYPTO              = 24,
     RHT2F_TEST_AUTH_ATTEMPTS  = 25,
     RHT2F_UID_ONLY            = 26,
+    WHT2F_PASSWORD            = 27,
 } hitag_function;
 
 typedef struct {


### PR DESCRIPTION
**Tested and working.**

My only concern is the following write in crypto mode:
https://github.com/RfidResearchGroup/proxmark3/blob/cb453139813a7b1b5ff17e6bd66d3e80075ead35/armsrc/hitag2.c#L506-L511

Unless I'm missing something, this is useless since the write at the top of the method:
https://github.com/RfidResearchGroup/proxmark3/blob/cb453139813a7b1b5ff17e6bd66d3e80075ead35/armsrc/hitag2.c#L449-L453
will be called long before this one is reached.

For that reason I added only the top write in password mode.