### PR TITLE
Fix. More flexible anti-collision frame check (hf_mf_sim)

### DIFF
--- a/armsrc/mifaresim.c
+++ b/armsrc/mifaresim.c
@@ -625,7 +625,8 @@ void Mifare1ksim(uint16_t flags, uint8_t exitAfterNReads, uint8_t *datain) {
                 }
 
                 // Incoming anti-collision frame
-                if (receivedCmd_len >= 2 && receivedCmd_len <= 6 && receivedCmd[1] == 0x50) {
+                // receivedCmd[1] indicates number of byte and bit collision, supports only for bit collision is zero
+                if (receivedCmd_len >= 3 && receivedCmd_len <= 6 && (receivedCmd[1] & 0x0f) == 0) {
                     // we can process only full-byte frame anti-collision procedure
                     if (memcmp(&receivedCmd[2], responses[uid_index].response, receivedCmd_len - 2) == 0) {
                         // response missing part of UID via relative array index


### PR DESCRIPTION
Removed hard coded check for anti-collision during selection of emulated Mifare Classic tag