### PR TITLE
BL versionning

### DIFF
--- a/bootrom/bootrom.c
+++ b/bootrom/bootrom.c
@@ -126,6 +126,7 @@ void UsbPacketReceived(uint8_t *packet, int len) {
                    DEVICE_INFO_FLAG_CURRENT_MODE_BOOTROM |
                    DEVICE_INFO_FLAG_UNDERSTANDS_START_FLASH |
                    DEVICE_INFO_FLAG_UNDERSTANDS_CHIP_INFO;
+                   //to add later: DEVICE_INFO_FLAG_UNDERSTANDS_VERSION
             if (common_area.flags.osimage_present)
                 arg0 |= DEVICE_INFO_FLAG_OSIMAGE_PRESENT;
 
@@ -139,6 +140,12 @@ void UsbPacketReceived(uint8_t *packet, int len) {
             reply_old(CMD_CHIP_INFO, arg0, 0, 0, 0, 0);
         }
         break;
+
+        case CMD_BL_VERSION: {
+            dont_ack = 1;
+            arg0 = VERSION_1_0_0;
+            reply_old(CMD_BL_VERSION, arg0, 0, 0, 0, 0);
+        }
 
         case CMD_SETUP_WRITE: {
             /* The temporary write buffer of the embedded flash controller is mapped to the

--- a/bootrom/bootrom.c
+++ b/bootrom/bootrom.c
@@ -143,7 +143,7 @@ void UsbPacketReceived(uint8_t *packet, int len) {
 
         case CMD_BL_VERSION: {
             dont_ack = 1;
-            arg0 = VERSION_1_0_0;
+            arg0 = BL_VERSION_1_0_0;
             reply_old(CMD_BL_VERSION, arg0, 0, 0, 0, 0);
         }
 

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -208,6 +208,7 @@ typedef struct {
 #define CMD_HARDWARE_RESET                                                0x0004
 #define CMD_START_FLASH                                                   0x0005
 #define CMD_CHIP_INFO                                                     0x0006
+#define CMD_BL_VERSION                                                    0x0007
 #define CMD_NACK                                                          0x00fe
 #define CMD_ACK                                                           0x00ff
 
@@ -535,6 +536,12 @@ typedef struct {
 
 /* Set if this device understands the chip info command */
 #define DEVICE_INFO_FLAG_UNDERSTANDS_CHIP_INFO       (1<<5)
+
+/* Set if this device understands the version command */
+#define DEVICE_INFO_FLAG_UNDERSTANDS_VERSION         (1<<6)
+
+// Different versions here. Each version should increse the number
+#define VERSION_1_0_0 1
 
 /* CMD_START_FLASH may have three arguments: start of area to flash,
    end of area to flash, optional magic.

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -541,7 +541,10 @@ typedef struct {
 #define DEVICE_INFO_FLAG_UNDERSTANDS_VERSION         (1<<6)
 
 // Different versions here. Each version should increse the number
-#define VERSION_1_0_0 1
+#define BL_VERSION_INVALID  0
+#define BL_VERSION_1_0_0    1
+#define BL_VERSION_FIRST    BL_VERSION_1_0_0
+#define BL_VERSION_LAST     BL_VERSION_1_0_0
 
 /* CMD_START_FLASH may have three arguments: start of area to flash,
    end of area to flash, optional magic.


### PR DESCRIPTION
This pull request adds basic bootloader versioning to help with migration. For now, the bootloader does not reports it understand the versionning and thus the flasher restricts the flashable area to 256k.