### PR TITLE
FIXes # 174 and more (OSX > 10.4 num_Cpus) the good way

### DIFF
--- a/client/util.c
+++ b/client/util.c
@@ -9,7 +9,7 @@
 //-----------------------------------------------------------------------------
 
 // ensure gmtime_r is available even with -std=c99; must be included before
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__APPLE__)
 #define _POSIX_C_SOURCE 200112L
 #endif
 
@@ -807,24 +807,12 @@ int num_CPUs(void) {
     SYSTEM_INFO sysinfo;
     GetSystemInfo(&sysinfo);
     return sysinfo.dwNumberOfProcessors;
-#elif defined(__linux__) && defined(_SC_NPROCESSORS_ONLN)
+#else
 #include <unistd.h>
     int count = sysconf(_SC_NPROCESSORS_ONLN);
     if (count <= 0)
         count = 1;
     return count;
-#elif defined(__APPLE__)
-    /*
-       TODO ICEMAN 2019, its commented out until someone finds a better solution
-#include "sys/sysctl.h"
-        uint32_t logicalcores = 0;
-        size_t size = sizeof( logicalcores );
-        sysctlbyname( "hw.logicalcpu", &logicalcores, &size, NULL, 0 );
-        return logicalcores;
-        */
-    return 1;
-#else
-    return 1;
 #endif
 }
 


### PR DESCRIPTION
sysconf() is  part of IEEE Std 1003.1-1988 (POSIX.1).
Fortunately, it *is* available to OSX `>=10.5`.
At least on `~10.14`, the old unposix `sysctl` osx way was lost, at least in portable environments.
This fixes it, but will not be compatible with OSX > 10.4. 
So i'm sorry but here we loose compatibility with Macs olders than 2005. (🤣)