### PR TITLE
Client: fixed build on osx

### DIFF
--- a/client/cmdhflegic.c
+++ b/client/cmdhflegic.c
@@ -9,6 +9,7 @@
 //-----------------------------------------------------------------------------
 #include "cmdhflegic.h"
 
+#include <ctype.h>
 #include <stdio.h> // for Mingw readline
 #include <readline/readline.h>
 

--- a/client/proxmark3.c
+++ b/client/proxmark3.c
@@ -13,8 +13,10 @@
 #include <limits.h>
 
 #include <stdio.h> // for Mingw readline
+#include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <ctype.h>
 #include <readline/readline.h>
 #include <readline/history.h>
 

--- a/client/ui.c
+++ b/client/ui.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h> // for Mingw readline
 #include <stdarg.h>
+#include <string.h>
 #include <stdlib.h>
 #include <readline/readline.h>
 #include <complex.h>
@@ -155,8 +156,10 @@ void PrintAndLogEx(logLevel_t level, const char *fmt, ...) {
 }
 
 static void fPrintAndLog(FILE *stream, const char *fmt, ...) {
+#ifdef RL_STATE_READCMD
     char *saved_line;
     int saved_point;
+#endif
     va_list argptr;
     static FILE *logfile = NULL;
     static int logging = 1;


### PR DESCRIPTION
On my system the build of the latest version failed with implicit declaration errors. Including `ctype.h` fixed the error for me.