### PR TITLE
Fixing filenames for "hf mf dump" command

### DIFF
--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -963,9 +963,11 @@ static int CmdHF14AMfDump(const char *Cmd) {
     PrintAndLogEx(SUCCESS, "\nSucceded in dumping all blocks");
 
     if (strlen(dataFilename) < 1) {
-        fptr = dataFilename;
-        fptr += sprintf(fptr, "hf-mf-");
-        FillFileNameByUID(fptr, (uint8_t *)carddata, "-data", 4);
+        fptr = GenerateFilename("hf-mf-", "-data");
+        if (fptr == NULL)
+            return PM3_ESOFT;
+
+        strcpy(dataFilename, fptr);
     }
 
     uint16_t bytes = 16 * (FirstBlockOfSector(numSectors - 1) + NumBlocksPerSector(numSectors - 1));


### PR DESCRIPTION
It's not convenient that "hf mf dump" creates files with only the first 4 bytes of a card UID, but "hf mf restore" requires files with the full UID of the card or manual argument transmission.