### PR TITLE
New features and fixes for the autopwn command

### DIFF
--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -1773,7 +1773,7 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
     // Load the dictionary
     if (strlen(filename) != 0) {
         keyBlock = loadFileDICTIONARY_safe(filename, 6, &key_cnt);
-        if (keyBlock == NULL) {
+        if (keyBlock == NULL || key_cnt == 0) {
             PrintAndLogEx(FAILED, "An error occurred while parsing the dictionary!");
             goto useDefaultKeys;
         }

--- a/client/cmdlft55xx.c
+++ b/client/cmdlft55xx.c
@@ -2127,19 +2127,10 @@ static int CmdT55xxChkPwds(const char *Cmd) {
 
     if (use_pwd_file) {
         uint16_t keycount = 0;
-        size_t datalen = 0;
 
-        // TODO, a way of reallocating memory if file was larger
-        keyBlock = calloc(4 * 200, sizeof(uint8_t));
-        if (keyBlock == NULL) {
-            PrintAndLogEx(ERR, "error, cannot allocate memory ");
-            return PM3_ESOFT;
-        }
-
-        int res = loadFileDICTIONARY(filename, keyBlock, &datalen, 4, &keycount);
-        if (res || keycount == 0) {
-            PrintAndLogEx(WARNING, "No keys found in file");
-            free(keyBlock);
+        keyBlock = loadFileDICTIONARY_safe(filename, 4, &keycount);
+        if (keyBlock == NULL || keycount == 0) {
+            PrintAndLogEx(ERR, "An error occurred while parsing the dictionary");
             return PM3_ESOFT;
         }
 

--- a/client/dictionaries/mfc_default_keys.dic
+++ b/client/dictionaries/mfc_default_keys.dic
@@ -982,3 +982,36 @@ ef4c5a7ac6fc
 b47058139187
 8268046cd154
 67cc03b7d577
+#
+# From the HTL Mödling, NÖ, AT
+#
+a5524645cd91
+d964406e67b4
+99858a49c119
+7b7e752b6a2d
+c27d999912ea
+66a163ba82b4
+4c60f4b15ba8
+#
+# CAFE + CO, AT
+#
+35d850d10a24
+4b511f4d28dd
+e45230e7a9e8
+535f47d35e39
+fb6c88b7e279
+#
+# Metro Card, AT
+#
+223C3427108A
+#
+# Unknown, AT
+#
+23d4cdff8da3
+e6849fcc324b
+12fd3a94df0e
+#
+# Unknown, AT
+#
+0b83797a9c64
+39ad2963d3d1

--- a/client/fileutils.c
+++ b/client/fileutils.c
@@ -649,6 +649,78 @@ out:
     return retval;
 }
 
+uint8_t* loadFileDICTIONARY_safe(const char *preferredName, uint8_t keylen, uint16_t *keycnt) {
+
+    int block_size = 512;
+    int allocation_size = block_size;
+    size_t counter = 0;
+    uint8_t* data;
+    char *path;
+    if (searchFile(&path, DICTIONARIES_SUBDIR, preferredName, ".dic") != PM3_SUCCESS)
+        return NULL;
+
+    // t5577 == 4bytes
+    // mifare == 6 bytes
+    // iclass == 8 bytes
+    // default to 6 bytes.
+    if (keylen != 4 && keylen != 6 && keylen != 8) {
+        keylen = 6;
+    }
+
+    // double up since its chars
+    keylen <<= 1;
+
+    char line[255];
+
+    // allocate some space for the dictionary
+    data = (uint8_t*) malloc(keylen * allocation_size * sizeof(uint8_t));
+    if (data == NULL) return NULL;
+
+    FILE *f = fopen(path, "r");
+    if (!f) {
+        PrintAndLogEx(WARNING, "file not found or locked. '" _YELLOW_("%s")"'", path);
+        return NULL;
+    }
+
+    // read file
+    while (fgets(line, sizeof(line), f)) {
+        // check if we have enough space (if not allocate more)
+        if ((*keycnt) >= allocation_size) {
+            allocation_size += block_size;
+            data = (uint8_t*) realloc((void*) data, keylen * allocation_size * sizeof(uint8_t));
+            if (data == NULL) return NULL;
+        }
+
+        // add null terminator
+        line[keylen] = 0;
+
+        // smaller keys than expected is skipped
+        if (strlen(line) < keylen)
+            continue;
+
+        // The line start with # is comment, skip
+        if (line[0] == '#')
+            continue;
+
+        if (!isxdigit(line[0])) {
+            PrintAndLogEx(FAILED, "file content error. '%s' must include " _BLUE_("%2d") "HEX symbols", line, keylen);
+            continue;
+        }
+
+        uint64_t key = strtoull(line, NULL, 16);
+
+        num_to_bytes(key, keylen >> 1, data + counter);
+        (*keycnt)++;
+        memset(line, 0, sizeof(line));
+        counter += (keylen >> 1);
+    }
+    fclose(f);
+    PrintAndLogEx(SUCCESS, "loaded " _GREEN_("%2d") "keys from dictionary file " _YELLOW_("%s"), *keycnt, path);
+
+    free(path);
+    return data;
+}
+
 int convertOldMfuDump(uint8_t **dump, size_t *dumplen) {
     if (!dump || !dumplen || *dumplen < OLD_MFU_DUMP_PREFIX_LENGTH)
         return 1;

--- a/client/fileutils.h
+++ b/client/fileutils.h
@@ -163,6 +163,17 @@ int loadFileJSON(const char *preferredName, void *data, size_t maxdatalen, size_
 */
 int loadFileDICTIONARY(const char *preferredName, void *data, size_t *datalen, uint8_t keylen, uint16_t *keycnt);
 
+
+/**
+ * @brief  Utility function to load data safely from a DICTIONARY textfile (no more heap overflows). This method takes a preferred name.
+ * E.g. mfc_default_keys.dic
+ *
+ * @param preferredName
+ * @param keylen  the number of bytes a key per row is
+ * @return pointer to the dictionary data for ok, NULL for failz
+*/
+uint8_t* loadFileDICTIONARY_safe(const char *preferredName, uint8_t keylen, uint16_t *keycnt);
+
 /**
  * @brief  Utility function to check and convert old mfu dump format to new
  *


### PR DESCRIPTION
Add feature to extract the B keys with known A keys (I couldn't verify if this is working correct, so someone should please try it first)
Add some of my found keys in the dictionary
Add a safer function to load dictionaries from the filesystem
Add fast key check for nested keys (I have no idea why this works there and not in the key reuse detection loop above...)