### PR TITLE
remove termcap and use pkg-config for ncurses

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -90,7 +90,7 @@ else
     LIBS := -I/usr/local/opt/readline/include $(LIBS)
 else
     LUALIB +=  -ldl
-    LDLIBS +=  -ltermcap -lncurses
+    LDLIBS +=  `pkg-config --libs ncurses`
     LUAPLATFORM = linux
 endif
 endif


### PR DESCRIPTION
termcap has been deprecated for over a decade, remove it.

ncurses *can* be split into two libs, ncurses and tinfo, most distros do this and the standard way of dealing with it is to just ask pkg-config for the right libs to link.