### PR TITLE
autopwn: fix card detection

### DIFF
--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -1660,7 +1660,7 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
     // Settings
     bool slow = false;
     bool legacy_mfchk = false;
-    int prng_type = 0;
+    int prng_type = PM3_EUNDEF;
     bool verbose = false;
     bool has_filename = false;
     bool errors = false;
@@ -1776,11 +1776,12 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
         }
     }
 
-    // card prng type (weak=1 / hard=0 / select/card comm error fail = -vaule)
+    // card prng type (weak=1 / hard=0 / select/card comm error = negative value)
     prng_type = detect_classic_prng();
     if (prng_type < 0){
         PrintAndLogEx(FAILED, "\nNo tag detected or other tag communication error");
-        goto noValidKeyFound;
+        free(e_sector);
+        return prng_type;
     }
 
     // print parameters

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -1660,7 +1660,7 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
     // Settings
     bool slow = false;
     bool legacy_mfchk = false;
-    bool prng_type = false;
+    int prng_type = 0;
     bool verbose = false;
     bool has_filename = false;
     bool errors = false;
@@ -1776,8 +1776,12 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
         }
     }
 
-    // card prng type (weak=true / hard=false)
+    // card prng type (weak=1 / hard=0 / select/card comm error fail = -vaule)
     prng_type = detect_classic_prng();
+    if (prng_type < 0){
+        PrintAndLogEx(FAILED, "\nNo tag detected or other tag communication error");
+        goto noValidKeyFound;
+    }
 
     // print parameters
     if (verbose) {


### PR DESCRIPTION
There is false assumption in autopwn code that function `detect_classic_prng()` returns only vaules 1 or 0 so its interpreted as boolean. So if there is no tag on the device - autopwn runs cracking procedure printing a LOTS of errors.