### PR TITLE
Add keys for hardenested Mifare Classic card

### DIFF
--- a/client/dictionaries/mfc_default_keys.dic
+++ b/client/dictionaries/mfc_default_keys.dic
@@ -1018,3 +1018,5 @@ e6849fcc324b
 #
 0b83797a9c64
 39ad2963d3d1
+34b16cd59ff8 # Hotel Berlin Classic room A KEY
+bb2c0007d022 # Hotel Berlin Classic room B KEY


### PR DESCRIPTION
Add keys found from an hardenested mifare classic card of an Hotel in Berlin.