### PR TITLE
subtle change for clarity in comment

### DIFF
--- a/tools/jtag_openocd/interface-raspberrypi2.cfg
+++ b/tools/jtag_openocd/interface-raspberrypi2.cfg
@@ -17,7 +17,7 @@ interface bcm2835gpio
 # This file is meant for recent versions of Raspberry Pi
 # You can check yours with:
 # dd if=/proc/device-tree/soc/ranges bs=4 skip=1 count=1 2>/dev/null|xxd -p
-# if it returns 20000000, use interface-raspberrypi2.cfg
+# if it returns 20000000, use interface-raspberrypi.cfg
 # if it returns 3F000000, you're fine
 bcm2835gpio_peripheral_base 0x3F000000
 


### PR DESCRIPTION
Both interface-raspberrypi.cfg and interface-raspberrypi2.cfg gave conflicting instructions for the dd return value. This should clear that up.