### PR TITLE
lf em 4x05_dump - print output for each block read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,6 +355,8 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Added T55x7 downlink mode support r <mode> 0 Default, 1 Long Leading 0, 2 Leading 0, 3 1 of 4 and 4 (in some commands) try all. (@mwalker33)
  - Added T55x7 downlink mode auto usage via mode detected (lf t55 detect) (@mwalker33)
  - Fix T55xx config getting displayed when using password when no password needed on read. (@mwalker33)
+ - Fix `em 4x05_dump` to print all blocks read (@mwalker33)
+ - Added save to .eml and .bin for `em 4x05_dump` (@mwalker33)
 
 ### Fixed
  - Changed driver file proxmark3.inf to support both old and new Product/Vendor IDs (@pwpiwi)

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -1204,6 +1204,8 @@ static int CmdEM4x05Dump(const char *Cmd) {
     uint32_t pwd = 0;
     bool usePwd = false;
     uint8_t ctmp = tolower(param_getchar(Cmd, 0));
+    uint8_t bytes[4] = {0};
+
     if (ctmp == 'h') return usage_lf_em4x05_dump();
 
     // for now use default input of 1 as invalid (unlikely 1 will be a valid password...)
@@ -1215,7 +1217,7 @@ static int CmdEM4x05Dump(const char *Cmd) {
     int success = PM3_SUCCESS;
     int status;
     uint32_t word = 0;
-    PrintAndLogEx(NORMAL, "Addr | data     | info");
+    PrintAndLogEx(NORMAL, "Addr | data     | ascii");
     PrintAndLogEx(NORMAL, "-----+----------+-------");
     for (; addr < 16; addr++) {
 
@@ -1230,10 +1232,12 @@ static int CmdEM4x05Dump(const char *Cmd) {
             status = EM4x05ReadWord_ext(addr, pwd, usePwd, &word); // Get status for single read
             success &= status; // Update status to match previous return
             
-            if (status == PM3_SUCCESS)
-                PrintAndLogEx(NORMAL, "  %02d | %08X | %s", addr, word, (addr > 13) ? "Lock" : "");
+            if (status == PM3_SUCCESS) {
+                num_to_bytes(word, 4, bytes);
+                PrintAndLogEx(NORMAL, "  %02d | %08X | %s", addr, word, (addr > 13) ? "Lock" : sprint_ascii(bytes, 4));
+            }
             else
-                PrintAndLogEx(NORMAL, "  %02d | " _RED_("Fail"), addr);
+                PrintAndLogEx(NORMAL, "  %02d |          | " _RED_("Fail"), addr);
         }
     }
 
@@ -1244,6 +1248,7 @@ static int CmdEM4x05Read(const char *Cmd) {
     uint8_t addr;
     uint32_t pwd;
     bool usePwd = false;
+
     uint8_t ctmp = tolower(param_getchar(Cmd, 0));
     if (strlen(Cmd) == 0 || ctmp == 'h') return usage_lf_em4x05_read();
 

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -1213,19 +1213,27 @@ static int CmdEM4x05Dump(const char *Cmd) {
         usePwd = true;
 
     int success = PM3_SUCCESS;
+    int status;
     uint32_t word = 0;
-    PrintAndLogEx(NORMAL, "Addr | data   | ascii");
-    PrintAndLogEx(NORMAL, "-----+--------+------");
+    PrintAndLogEx(NORMAL, "Addr | data     | info");
+    PrintAndLogEx(NORMAL, "-----+----------+-------");
     for (; addr < 16; addr++) {
 
         if (addr == 2) {
             if (usePwd) {
-                PrintAndLogEx(NORMAL, " %02u | %08X", addr, pwd, word);
+                PrintAndLogEx(NORMAL, "  %02u | %08X |", addr, pwd, word);
             } else {
-                PrintAndLogEx(NORMAL, " 02 | " _RED_("cannot read"));
+                PrintAndLogEx(NORMAL, "  02 |          | " _RED_("cannot read"));
             }
         } else {
-            success &= EM4x05ReadWord_ext(addr, pwd, usePwd, &word);
+            // success &= EM4x05ReadWord_ext(addr, pwd, usePwd, &word);
+            status = EM4x05ReadWord_ext(addr, pwd, usePwd, &word); // Get status for single read
+            success &= status; // Update status to match previous return
+            
+            if (status == PM3_SUCCESS)
+                PrintAndLogEx(NORMAL, "  %02d | %08X | %s", addr, word, (addr > 13) ? "Lock" : "");
+            else
+                PrintAndLogEx(NORMAL, "  %02d | " _RED_("Fail"), addr);
         }
     }
 


### PR DESCRIPTION
The lf em 4x05_dump was missing the code to print the data for the dump.
It was only showing the "special purpose" block 2 - password.
Now shows all 16 blocks of data.