### PR TITLE
lf config s <samples to skip> option added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,7 +357,8 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Fix T55xx config getting displayed when using password when no password needed on read. (@mwalker33)
  - Fix `em 4x05_dump` to print all blocks read (@mwalker33)
  - Added save to .eml and .bin for `em 4x05_dump` (@mwalker33)
-
+ - Added `s` <samples to skip> to `lf config` / `lf sniff` to skip samples when sniffing (@mwalker33)
+ 
 ### Fixed
  - Changed driver file proxmark3.inf to support both old and new Product/Vendor IDs (@pwpiwi)
  - Changed start sequence in Qt mode (fix: short commands hangs main Qt thread) (@merlokk)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,7 +357,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Fix T55xx config getting displayed when using password when no password needed on read. (@mwalker33)
  - Fix `em 4x05_dump` to print all blocks read (@mwalker33)
  - Added save to .eml and .bin for `em 4x05_dump` (@mwalker33)
- - Added `s` <samples to skip> to `lf config` / `lf sniff` to skip samples when sniffing (@mwalker33)
+ - Added `s` <samples to skip> to `lf config` / `lf sniff` to skip samples when sniffing based on same option in Proxmark/proxmark3 by @marshmellow42. (@mwalker33)
  
 ### Fixed
  - Changed driver file proxmark3.inf to support both old and new Product/Vendor IDs (@pwpiwi)

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -147,7 +147,6 @@ uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averag
     uint32_t sample_total_numbers = 0;
     uint32_t sample_total_saved = 0;
     uint32_t cancel_counter = 0;
-    uint32_t samples_skipped = 0;
 
     uint16_t checker = 0;
 
@@ -181,8 +180,8 @@ uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averag
 
             trigger_threshold = 0;
 
-            if (samples_to_skip > samples_skipped) {
-                samples_skipped++;
+            if (samples_to_skip > 0) {
+                samples_to_skip--;
                 continue;
             }
 
@@ -249,7 +248,7 @@ uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averag
  * @return number of bits sampled
  */
 uint32_t DoAcquisition_default(int trigger_threshold, bool silent) {
-    return DoAcquisition(1, 8, 0, trigger_threshold, silent, 0, 0,0);
+    return DoAcquisition(1, 8, 0, trigger_threshold, silent, 0, 0, 0);
 }
 uint32_t DoAcquisition_config(bool silent, int sample_size) {
     return DoAcquisition(config.decimation
@@ -263,7 +262,7 @@ uint32_t DoAcquisition_config(bool silent, int sample_size) {
 }
 
 uint32_t DoPartialAcquisition(int trigger_threshold, bool silent, int sample_size, uint32_t cancel_after) {
-    return DoAcquisition(1, 8, 0, trigger_threshold, silent, sample_size, cancel_after,0);
+    return DoAcquisition(1, 8, 0, trigger_threshold, silent, sample_size, cancel_after, 0);
 }
 
 uint32_t ReadLF(bool activeField, bool silent, int sample_size) {

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -24,7 +24,7 @@ Default LF config is set to:
     divisor = 95 (125kHz)
     trigger_threshold = 0
     */
-sample_config config = { 1, 8, 1, 95, 0 } ;
+sample_config config = { 1, 8, 1, 95, 0, 0 } ;
 
 void printConfig() {
     DbpString(_BLUE_("LF Sampling config"));

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -51,8 +51,9 @@ void setSamplingConfig(sample_config *sc) {
     if (sc->divisor != 0) config.divisor = sc->divisor;
     if (sc->bits_per_sample != 0) config.bits_per_sample = sc->bits_per_sample;
     if (sc->trigger_threshold != -1) config.trigger_threshold = sc->trigger_threshold;
-    if (sc->samples_to_skip != -1) config.samples_to_skip = sc->samples_to_skip;
+//    if (sc->samples_to_skip == 0xffffffff) // if needed to not update if not supplied 
 
+    config.samples_to_skip = sc->samples_to_skip;
     config.decimation = (sc->decimation != 0) ? sc->decimation : 1;
     config.averaging = sc->averaging;
     if (config.bits_per_sample > 8) config.bits_per_sample = 8;
@@ -126,7 +127,7 @@ void LFSetupFPGAForADC(int divisor, bool lf_field) {
  * @param silent - is true, now outputs are made. If false, dbprints the status
  * @return the number of bits occupied by the samples.
  */
-uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averaging, int trigger_threshold, bool silent, int bufsize, uint32_t cancel_after, int samples_to_skip) {
+uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averaging, int trigger_threshold, bool silent, int bufsize, uint32_t cancel_after, uint32_t samples_to_skip) {
 
     uint8_t *dest = BigBuf_get_addr();
     bufsize = (bufsize > 0 && bufsize < BigBuf_max_traceLen()) ? bufsize : BigBuf_max_traceLen();

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -33,6 +33,7 @@ void printConfig() {
     Dbprintf("  [d] decimation..........%d", config.decimation);
     Dbprintf("  [a] averaging...........%s", (config.averaging) ? "Yes" : "No");
     Dbprintf("  [t] trigger threshold...%d", config.trigger_threshold);
+    Dbprintf("  [s] samples to skip.....%d ", config.samples_to_skip);
 }
 
 /**
@@ -50,6 +51,7 @@ void setSamplingConfig(sample_config *sc) {
     if (sc->divisor != 0) config.divisor = sc->divisor;
     if (sc->bits_per_sample != 0) config.bits_per_sample = sc->bits_per_sample;
     if (sc->trigger_threshold != -1) config.trigger_threshold = sc->trigger_threshold;
+    if (sc->samples_to_skip != -1) config.samples_to_skip = sc->samples_to_skip;
 
     config.decimation = (sc->decimation != 0) ? sc->decimation : 1;
     config.averaging = sc->averaging;
@@ -124,7 +126,7 @@ void LFSetupFPGAForADC(int divisor, bool lf_field) {
  * @param silent - is true, now outputs are made. If false, dbprints the status
  * @return the number of bits occupied by the samples.
  */
-uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averaging, int trigger_threshold, bool silent, int bufsize, uint32_t cancel_after) {
+uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averaging, int trigger_threshold, bool silent, int bufsize, uint32_t cancel_after, int samples_to_skip) {
 
     uint8_t *dest = BigBuf_get_addr();
     bufsize = (bufsize > 0 && bufsize < BigBuf_max_traceLen()) ? bufsize : BigBuf_max_traceLen();
@@ -144,6 +146,7 @@ uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averag
     uint32_t sample_total_numbers = 0;
     uint32_t sample_total_saved = 0;
     uint32_t cancel_counter = 0;
+    uint32_t samples_skipped = 0;
 
     uint16_t checker = 0;
 
@@ -176,6 +179,12 @@ uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averag
             }
 
             trigger_threshold = 0;
+
+            if (samples_to_skip > samples_skipped) {
+                samples_skipped++;
+                continue;
+            }
+
             sample_total_numbers++;
 
             if (averaging)
@@ -196,6 +205,7 @@ uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averag
 
             // store the sample
             sample_total_saved ++;
+
             if (bits_per_sample == 8) {
                 dest[sample_total_saved - 1] = sample;
 
@@ -238,7 +248,7 @@ uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averag
  * @return number of bits sampled
  */
 uint32_t DoAcquisition_default(int trigger_threshold, bool silent) {
-    return DoAcquisition(1, 8, 0, trigger_threshold, silent, 0, 0);
+    return DoAcquisition(1, 8, 0, trigger_threshold, silent, 0, 0,0);
 }
 uint32_t DoAcquisition_config(bool silent, int sample_size) {
     return DoAcquisition(config.decimation
@@ -247,11 +257,12 @@ uint32_t DoAcquisition_config(bool silent, int sample_size) {
                          , config.trigger_threshold
                          , silent
                          , sample_size
-                         , 0);
+                         , 0
+                         , config.samples_to_skip);
 }
 
 uint32_t DoPartialAcquisition(int trigger_threshold, bool silent, int sample_size, uint32_t cancel_after) {
-    return DoAcquisition(1, 8, 0, trigger_threshold, silent, sample_size, cancel_after);
+    return DoAcquisition(1, 8, 0, trigger_threshold, silent, sample_size, cancel_after,0);
 }
 
 uint32_t ReadLF(bool activeField, bool silent, int sample_size) {

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -400,7 +400,7 @@ int CmdLFSetConfig(const char *Cmd) {
     bool errors = false;
     int trigger_threshold = -1;//Means no change
     uint8_t unsigned_trigg = 0;
-    int samples_to_skip = -1;
+    uint32_t samples_to_skip = 0; // will return offset to 0 if not supplied.  Could set to 0xffffffff if needed to not update
 
 
     uint8_t cmdp = 0;

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -441,7 +441,7 @@ int CmdLFSetConfig(const char *Cmd) {
                 cmdp += 2;
                 break;
             case 's':
-                samples_to_skip = param_get32ex(Cmd,cmdp+1,0,10);
+                samples_to_skip = param_get32ex(Cmd, cmdp + 1, 0, 10);
                 cmdp+=2;
                 break;
             default:
@@ -457,7 +457,7 @@ int CmdLFSetConfig(const char *Cmd) {
     //Bps is limited to 8
     if (bps >> 4) bps = 8;
 
-    sample_config config = { decimation, bps, averaging, divisor, trigger_threshold,samples_to_skip };
+    sample_config config = { decimation, bps, averaging, divisor, trigger_threshold, samples_to_skip };
 
     clearCommandBuffer();
     SendCommandNG(CMD_LF_SAMPLING_SET_CONFIG, (uint8_t *)&config, sizeof(sample_config));

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -105,14 +105,15 @@ static int usage_lf_sniff(void) {
 static int usage_lf_config(void) {
     PrintAndLogEx(NORMAL, "Usage: lf config [h] [H|<divisor>] [b <bps>] [d <decim>] [a 0|1]");
     PrintAndLogEx(NORMAL, "Options:");
-    PrintAndLogEx(NORMAL, "       h             This help");
-    PrintAndLogEx(NORMAL, "       L             Low frequency (125 kHz)");
-    PrintAndLogEx(NORMAL, "       H             High frequency (134 kHz)");
-    PrintAndLogEx(NORMAL, "       q <divisor>   Manually set divisor. 88-> 134 kHz, 95-> 125 kHz");
-    PrintAndLogEx(NORMAL, "       b <bps>       Sets resolution of bits per sample. Default (max): 8");
-    PrintAndLogEx(NORMAL, "       d <decim>     Sets decimation. A value of N saves only 1 in N samples. Default: 1");
-    PrintAndLogEx(NORMAL, "       a [0|1]       Averaging - if set, will average the stored sample value when decimating. Default: 1");
-    PrintAndLogEx(NORMAL, "       t <threshold> Sets trigger threshold. 0 means no threshold (range: 0-128)");
+    PrintAndLogEx(NORMAL, "       h                 This help");
+    PrintAndLogEx(NORMAL, "       L                 Low frequency (125 kHz)");
+    PrintAndLogEx(NORMAL, "       H                 High frequency (134 kHz)");
+    PrintAndLogEx(NORMAL, "       q <divisor>       Manually set divisor. 88-> 134 kHz, 95-> 125 kHz");
+    PrintAndLogEx(NORMAL, "       b <bps>           Sets resolution of bits per sample. Default (max): 8");
+    PrintAndLogEx(NORMAL, "       d <decim>         Sets decimation. A value of N saves only 1 in N samples. Default: 1");
+    PrintAndLogEx(NORMAL, "       a [0|1]           Averaging - if set, will average the stored sample value when decimating. Default: 1");
+    PrintAndLogEx(NORMAL, "       t <threshold>     Sets trigger threshold. 0 means no threshold (range: 0-128)");
+    PrintAndLogEx(NORMAL, "       s <samplestoskip> Sets a number of samples to skip before capture. Default: 0");
     PrintAndLogEx(NORMAL, "Examples:");
     PrintAndLogEx(NORMAL, "      lf config b 8 L");
     PrintAndLogEx(NORMAL, "                    Samples at 125 kHz, 8bps.");
@@ -399,6 +400,8 @@ int CmdLFSetConfig(const char *Cmd) {
     bool errors = false;
     int trigger_threshold = -1;//Means no change
     uint8_t unsigned_trigg = 0;
+    int samples_to_skip = -1;
+
 
     uint8_t cmdp = 0;
     while (param_getchar(Cmd, cmdp) != 0x00 && !errors) {
@@ -437,6 +440,10 @@ int CmdLFSetConfig(const char *Cmd) {
                 averaging = param_getchar(Cmd, cmdp + 1) == '1';
                 cmdp += 2;
                 break;
+            case 's':
+                samples_to_skip = param_get32ex(Cmd,cmdp+1,0,10);
+                cmdp+=2;
+                break;
             default:
                 PrintAndLogEx(WARNING, "Unknown parameter '%c'", param_getchar(Cmd, cmdp));
                 errors = 1;
@@ -450,7 +457,7 @@ int CmdLFSetConfig(const char *Cmd) {
     //Bps is limited to 8
     if (bps >> 4) bps = 8;
 
-    sample_config config = { decimation, bps, averaging, divisor, trigger_threshold };
+    sample_config config = { decimation, bps, averaging, divisor, trigger_threshold,samples_to_skip };
 
     clearCommandBuffer();
     SendCommandNG(CMD_LF_SAMPLING_SET_CONFIG, (uint8_t *)&config, sizeof(sample_config));

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -118,6 +118,7 @@ typedef struct {
     bool averaging;
     int divisor;
     int trigger_threshold;
+    int samples_to_skip;
 } PACKED sample_config;
 /*
 typedef struct {

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -118,7 +118,7 @@ typedef struct {
     bool averaging;
     int divisor;
     int trigger_threshold;
-    int samples_to_skip;
+    uint32_t samples_to_skip;
 } PACKED sample_config;
 /*
 typedef struct {


### PR DESCRIPTION
This will allow the lf sniff to skip over x samples to allow capture of larger signals (e.g. cloners)

With the unint_32 for the samples to skip, the s <value> will be reset to 0 if not supplied on the lf config command.  If needed to retain the last value set, we could use 0xffffffff as the "default" to mean don't change from last set value set (comment lines left in code).


