### PR TITLE
Display high bit for Kastle HID to allow for lf hid clone

### DIFF
--- a/client/cmdlfhid.c
+++ b/client/cmdlfhid.c
@@ -239,7 +239,7 @@ static int CmdHIDDemod(const char *Cmd) {
             fc = ((hi & 0xF) << 12) | (lo >> 20);
         }
         if (fmtLen == 32 && (lo & 0x40000000)) { //if 32 bit and Kastle bit set
-            PrintAndLogEx(SUCCESS, "HID Prox TAG (Kastle format) ID: %08x (%u) - Format Len: 32bit - CC: %u - FC: %u - Card: %u", lo, (lo >> 1) & 0xFFFF, cc, fc, cardnum);
+            PrintAndLogEx(SUCCESS, "HID Prox TAG (Kastle format) ID: %x%08x (%u) - Format Len: 32bit - CC: %u - FC: %u - Card: %u", hi, lo, (lo >> 1) & 0xFFFF, cc, fc, cardnum);
         } else {
             PrintAndLogEx(SUCCESS, "HID Prox TAG ID: %x%08x (%u) - Format Len: %ubit - OEM: %03u - FC: %u - Card: %u",
                           hi, lo, cardnum, fmtLen, oem, fc, cardnum);


### PR DESCRIPTION
Currently, the high bit for Kastle HID is omitted from the output, which results in an invalid clone ID when lf hid clone [id] is used. Displaying the high bit along with the rest of the ID would allow these ID cards to be cloned properly.