### PR TITLE
Update CHANGELOG.md for Kastle HID high bit change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Display high bit for detected Kastle HIDs to allow `lf hid clone [id]` to work properly (@swg0101)
  - Add option `-n` to scripts pm3* (@doegox)
  - Add `wiegand list/encode/decode` - wiegand format manipulation. Adapted to fit here. (@grauerfuchs)
  - Add `lf t55xx protect` - sets password and enables password protection on t55x7 tag (@iceman1001)


### PR DESCRIPTION
Display high bit for detected Kastle HIDs to allow `lf hid clone [id]` to work properly