### PR TITLE
Felica support: Add new commands

### DIFF
--- a/client/cmdhffelica.c
+++ b/client/cmdhffelica.c
@@ -246,6 +246,7 @@ static bool waitCmdFelica(uint8_t iSelect, PacketResponseNG *resp, bool verbose)
             PrintAndLogEx(NORMAL, "Client Received %i octets", len);
             if (!len || len < 2) {
                 PrintAndLogEx(ERR, "Could not receive data correctly!");
+                return false;
             }
             PrintAndLogEx(NORMAL, "%s", sprint_hex(resp->data.asBytes, len));
             if (!check_crc(CRC_FELICA, resp->data.asBytes + 2, len - 2)) {

--- a/include/mifare.h
+++ b/include/mifare.h
@@ -205,6 +205,21 @@ typedef struct {
     felica_status_flags_t status_flags;
 } PACKED felica_status_response_t;
 
+typedef struct {
+    felica_frame_response_t frame_response;
+    uint8_t number_of_systems[1];
+    uint8_t system_code_list[32];
+} PACKED felica_syscode_response_t;
+
+typedef struct {
+    felica_frame_response_t frame_response;
+    felica_status_flags_t status_flags;
+    uint8_t format_version[1];
+    uint8_t basic_version[2];
+    uint8_t number_of_option[1];
+    uint8_t option_version_list[4];
+} PACKED felica_request_spec_response_t;
+
 typedef enum FELICA_COMMAND {
     FELICA_CONNECT = (1 << 0),
     FELICA_NO_DISCONNECT = (1 << 1),


### PR DESCRIPTION
Adds three new FeliCa commands:
Request Specification Version: Gives the Card OS information.
Reset Mode: Sets the Auth Mode back to 00h.
Request System Code: Gives a list of all system codes.

Bug-fix:
Fix a segmentation fault in the raw command when no card is on the reader.