### PR TITLE
fix: make libsndfile optional

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -22,7 +22,7 @@ vpath %.dic dictionaries
 OBJDIR = obj
 
 LDLIBS ?= -L/usr/local/lib
-LDLIBS += -lreadline -lsndfile -lpthread -lm
+LDLIBS += -lreadline -lpthread -lm
 
 # RPi Zero gcc requires -latomic
 # but MacOSX /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld
@@ -116,6 +116,16 @@ else
     QTGUISRCS = guidummy.cpp
     QTGUIOBJS = $(OBJDIR)/guidummy.o
 endif
+
+ifneq ($(SKIPSNDFILE),1)
+    # Check for libsndfile
+    SNDFILELDLIBS = $(shell pkg-config --libs sndfile 2>/dev/null)
+    ifneq ($(SNDFILELDLIBS), )
+        CFLAGS += -DUSE_SNDFILE
+        LDLIBS += $(SNDFILELDLIBS)
+    endif
+endif
+
 
 # Flags to generate temporary dependency files
 DEPFLAGS = -MT $@ -MMD -MP -MF $(OBJDIR)/$*.Td

--- a/client/fileutils.c
+++ b/client/fileutils.c
@@ -41,7 +41,9 @@
 
 #include <dirent.h>
 #include <ctype.h>
+#ifdef USE_SNDFILE
 #include <sndfile.h>
+#endif
 
 #include "pm3_cmd.h"
 #include "commonutil.h"
@@ -401,7 +403,7 @@ out:
 }
 
 int saveFileWAVE(const char *preferredName, int *data, size_t datalen) {
-
+#ifdef USE_SNDFILE
     if (data == NULL) return PM3_EINVARG;
     char *fileName = newfilenamemcopy(preferredName, ".wav");
     if (fileName == NULL) return PM3_EMALLOC;
@@ -434,6 +436,10 @@ int saveFileWAVE(const char *preferredName, int *data, size_t datalen) {
 out:
     free(fileName);
     return retval;
+#else
+    PrintAndLogEx(WARNING, "PM3 was built without sndfile, cannot write wave files!");
+    return PM3_EINVARG;
+#endif
 }
 
 int saveFilePM3(const char *preferredName, int *data, size_t datalen) {

--- a/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md
+++ b/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md
@@ -19,6 +19,13 @@ make clean
 make SKIPQT=1
 ```
 
+Here are all the client compliation options:
+
+| OPTION          | DESCRIPTION                                                              |
+|-----------------|--------------------------------------------------------------------------|
+| `SKIPQT=1`      | Don't use Qt, even if installed. Graphs will not work.                   |
+| `SKIPSNDFILE=1` | Don't use `sndfile`, even if installed. Saving WAVE files will not work. |
+
 ## Firmware
 
 By default, the firmware is of course tuned for the Proxmark3 Rdv4.0 device, which has built-in support for 256kb onboard flash SPI memory, Sim module (smart card support), FPC connector.


### PR DESCRIPTION
This makes `libsndfile` an optional dependency, in the same way as Qt (`SKIPQT`).

It is only used for one feature, and `libsndfile` depends on a number of other libraries.