### PR TITLE
added write block command for LTO-CM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Added `hf lto wrbl` - write block support for LTO Cartridge memory (@Kevin-Nakamoto)
  - Fix compilation under openSUSE (@hsanjuan)
  - Added `lf nexwatch sim` - use raw hex to simulate (@iceman1001)
  - Fix `lf indala read` - long id 224bits preamble identification less strict (@iceman1001)

--- a/client/cmdhflto.h
+++ b/client/cmdhflto.h
@@ -15,6 +15,7 @@
 
 int infoLTO(bool verbose);
 int rdblLTO(uint8_t st_blk, uint8_t end_blk, bool verbose);
+int wrblLTO(uint8_t blk, uint8_t *data, bool verbose);
 int CmdHFLTO(const char *Cmd);
 
 #endif


### PR DESCRIPTION
Test results: 

Write: 
`[usb] pm3 --> hf lto wrbl b 128 d0001020304050607080910111213141516171819202122232425262728293031`
`[+] BLK128: Write Success`

Verify:
`[usb] pm3 --> hf lto rdbl s 128 e 128`
`[+] BLK128: 0001020304050607080910111213141516171819202122232425262728293031`

Also checked `hf lto list` after the write command. Everything looks good. 