### PR TITLE
added hf lto dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Added `hf lto dump` - dump 8160 bytes of data from LTO cartridge memory and save to file (@Kevin-Nakamoto)
  - Change `data plot` - write serial port name in window title for plot / slider window (@iceman1001)
  - Added `hf lto wrbl` - write block support for LTO Cartridge memory (@Kevin-Nakamoto)
  - Fix compilation under openSUSE (@hsanjuan)

--- a/client/cmdhflto.h
+++ b/client/cmdhflto.h
@@ -14,6 +14,7 @@
 #include "common.h"
 
 int infoLTO(bool verbose);
+int dumpLTO(uint8_t *serial_number, uint8_t serial_len, uint8_t *dump, bool verbose);
 int rdblLTO(uint8_t st_blk, uint8_t end_blk, bool verbose);
 int wrblLTO(uint8_t blk, uint8_t *data, bool verbose);
 int CmdHFLTO(const char *Cmd);


### PR DESCRIPTION
Tested commands:

- No file name specified:  
`[usb] pm3 --> hf lto dump`
`[+] saved 8160  bytes to binary file XXXXXXXXXX.bin`
`[+] saved 255  blocks to text file XXXXXXXXXX.eml`
where XXXXXXXXXX = UID of the tag in hex.

- File name specified by f option: 
`[usb] pm3 --> hf lto dump f test`
`[+] saved 8160  bytes to binary file test.bin`
`[+] saved 255  blocks to text file test.eml`
