### PR TITLE
fix: logic inversion in loadFileDICTIONARY_safe use of CheckStringIsHEXValue

### DIFF
--- a/client/fileutils.c
+++ b/client/fileutils.c
@@ -1016,7 +1016,7 @@ int loadFileDICTIONARY_safe(const char *preferredName, void **pdata, uint8_t key
         if (line[0] == '#')
             continue;
 
-        if (CheckStringIsHEXValue(line))
+        if (!CheckStringIsHEXValue(line))
             continue;
 
         uint64_t key = strtoull(line, NULL, 16);


### PR DESCRIPTION
Before this patch:

```
[usb] pm3 --> hf iclass chk f client/dictionaries/iclass_default_keys.dic
[+] loaded  0 keys from dictionary file client/dictionaries/iclass_default_keys.dic
[usb] pm3 -->
```

After this patch:

```
[usb] pm3 --> hf iclass chk f client/dictionaries/iclass_default_keys.dic
[+] loaded  7 keys from dictionary file client/dictionaries/iclass_default_keys.dic
[+] Reading tag CSN
(further communication continues)
```

It looks like the regression came from #484; it was fixed in 94eb741a4 for `loadFileDICTIONARYEx`, but not `loadFileDICTIONARY_safe`.