### PR TITLE
Fixed the url for smartcard ATR lookup

### DIFF
--- a/client/cmdsmartcard.c
+++ b/client/cmdsmartcard.c
@@ -740,7 +740,7 @@ static int CmdSmartInfo(const char *Cmd) {
     PrintAndLogEx(INFO, "--- Smartcard Information ---------");
     PrintAndLogEx(INFO, "-------------------------------------------------------------");
     PrintAndLogEx(INFO, "ISO7618-3 ATR : %s", sprint_hex(card.atr, card.atr_len));
-    PrintAndLogEx(INFO, "\nhttp://smartcard-atr.appspot.com/parse?ATR=%s", sprint_hex_inrow(card.atr, card.atr_len));
+    PrintAndLogEx(INFO, "\nhttp://smartcard-atr.apdu.fr/parse?ATR=%s", sprint_hex_inrow(card.atr, card.atr_len));
 
     // print ATR
     PrintAndLogEx(NORMAL, "");


### PR DESCRIPTION
A small change that just follows the redirect on the page as it was apparently moved. 