### PR TITLE
added `hf lto restore` and fix filename for dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Added `hf lto restore` - restore LTO cartridge memory from dump file [.bin|.eml] (@Kevin-Nakamoto)
  - Added `LF_ICEHID` standalone mode which searches for lf HID credentials and store to RDV4 flashmem (@iceman1001)
  - Added `HF_14ASNIFF` standalone mode with storing trace to RDV4 flashmem (@micolous)
  - Added `hf lto dump` - dump 8160 bytes of data from LTO cartridge memory and save to file (@Kevin-Nakamoto)

--- a/client/cmdhflto.c
+++ b/client/cmdhflto.c
@@ -509,7 +509,7 @@ static int CmdHfLTODump(const char *Cmd) {
 
     // save to file 
     if (filename[0] == '\0') {
-        memcpy(serial_number, sprint_hex_inrow(dump, sizeof(serial_number)), sizeof(serial_number) * 2);
+        memcpy(serial_number, sprint_hex_inrow(dump, sizeof(serial_number)), sizeof(serial_number));
         char tmp_name[17] = "hf_lto_";
         strcat(tmp_name, serial_number);
         memcpy(filename, tmp_name, sizeof(tmp_name));
@@ -549,7 +549,9 @@ int restoreLTO(uint8_t *dump_data, bool verbose) {
 
         ret_val = lto_wrbl(blk, blkData, verbose);
 
-        if (ret_val != PM3_SUCCESS) {
+        if (ret_val == PM3_SUCCESS) {
+             PrintAndLogEx(SUCCESS, "BLK %03d: " _YELLOW_("write success"), blk);
+        } else {
             lto_switch_off_field();
             return ret_val;
         }

--- a/client/cmdhflto.h
+++ b/client/cmdhflto.h
@@ -14,7 +14,8 @@
 #include "common.h"
 
 int infoLTO(bool verbose);
-int dumpLTO(uint8_t *serial_number, uint8_t serial_len, uint8_t *dump, bool verbose);
+int dumpLTO(uint8_t *dump, bool verbose);
+int restoreLTO(uint8_t *dump, bool verbose);
 int rdblLTO(uint8_t st_blk, uint8_t end_blk, bool verbose);
 int wrblLTO(uint8_t blk, uint8_t *data, bool verbose);
 int CmdHFLTO(const char *Cmd);


### PR DESCRIPTION
Fix filename for `hf lto dump`.
Before
~~~
[usb] pm3 --> hf lto dump
[+] saved 8160  bytes to binary file xxxxxxxxxx.bin
[+] saved 255  blocks to text file xxxxxxxxxx.eml
~~~
After
~~~
[usb] pm3 --> hf lto dump
[+] saved 8160  bytes to binary file hf_lto_xxxxxxxxxx.bin
[+] saved 255  blocks to text file hf_lto_xxxxxxxxxx.eml
~~~
where xxxxxxxxxx is a UID.
***
Add `hf lto restore`.

Dump data from tag.A
~~~
[usb] pm3 --> hf lto dump
[+] saved 8160  bytes to binary file hf_lto_xxxxxxxxxx.bin
[+] saved 255  blocks to text file hf_lto_xxxxxxxxxx.eml
~~~
Then, restore this file to different tag.B
~~~
[usb] pm3 --> hf lto restore f hf_lto_xxxxxxxxxx.bin
~~~
Then, dump data from tag.B
~~~
[usb] pm3 --> hf lto dump
[+] saved 8160  bytes to binary file hf_lto_yyyyyyyyyy.bin
[+] saved 255  blocks to text file hf_lto_yyyyyyyyyy.eml
~~~
Compare these two dump files (hf_lto_xxxxxxxxxx.bin and hf_lto_yyyyyyyyyy.bin) with hexdump command. I could verify that both are the same data besides block 0 and 1 where read-only block.