### PR TITLE
Use /usr/bin/env in shebangs

### DIFF
--- a/client/gen_pm3mfsim_script.sh
+++ b/client/gen_pm3mfsim_script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Andrei Costin <zveriu@gmail.com>, 2011
 # gen_pm3mfsim_script.sh

--- a/covbuild.sh
+++ b/covbuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 . .coverity.conf || exit 1

--- a/covconfig.sh
+++ b/covconfig.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 . .coverity.conf || exit 1

--- a/covsubmit.sh
+++ b/covsubmit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 . .coverity.conf || exit 1

--- a/pm3
+++ b/pm3
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: run option -h to get help
 

--- a/pm3-flash
+++ b/pm3-flash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PM3PATH=$(dirname "$0")
 . "$PM3PATH/pm3"

--- a/pm3-flash-all
+++ b/pm3-flash-all
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PM3PATH=$(dirname "$0")
 . "$PM3PATH/pm3"

--- a/pm3-flash-bootrom
+++ b/pm3-flash-bootrom
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PM3PATH=$(dirname "$0")
 . "$PM3PATH/pm3"

--- a/pm3-flash-fullimage
+++ b/pm3-flash-fullimage
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PM3PATH=$(dirname "$0")
 . "$PM3PATH/pm3"

--- a/pm3test.sh
+++ b/pm3test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PM3PATH=$(dirname "$0")
 cd "$PM3PATH" || exit 1

--- a/tools/analyzesize.py
+++ b/tools/analyzesize.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 
 import json
 import subprocess

--- a/tools/findbits.py
+++ b/tools/findbits.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 #  findbits.py - find Binary, Octal, Decimal or Hex number in bitstream
 #

--- a/tools/findbits_test.py
+++ b/tools/findbits_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from itertools import imap
 import unittest, sys, findbits

--- a/tools/hitag2crack/crack2/runtest.sh
+++ b/tools/hitag2crack/crack2/runtest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$1" == "" ]; then
 echo "runtest.sh testfile"

--- a/tools/jtag_openocd/openocd_flash_dump.sh
+++ b/tools/jtag_openocd/openocd_flash_dump.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $(dirname "$0")
 . openocd_configuration || exit 1

--- a/tools/jtag_openocd/openocd_flash_recovery.sh
+++ b/tools/jtag_openocd/openocd_flash_recovery.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $(dirname "$0")
 . openocd_configuration || exit 1

--- a/tools/jtag_openocd/openocd_interactive.sh
+++ b/tools/jtag_openocd/openocd_interactive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $(dirname "$0")
 . openocd_configuration || exit 1

--- a/tools/mkversion.pl
+++ b/tools/mkversion.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 # Output a version.c file that includes information about the current build
 # Normally a couple of lines of bash would be enough (see openpcd project, original firmware by Harald Welte and Milosch Meriac)

--- a/tools/pm3_amii_bin2eml.pl
+++ b/tools/pm3_amii_bin2eml.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Read Amiibo data, decrypt, and produce EML file
 # Convert proxmark MFU (MIFARE Ultralight) .bin to .eml format

--- a/tools/pm3_cs8.pl
+++ b/tools/pm3_cs8.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Convert proxmark3 trace or wav files to formats to be used by Inspectrum
 #

--- a/tools/pm3_eml2lower.sh
+++ b/tools/pm3_eml2lower.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Andrei Costin <zveriu@gmail.com>, 2011
 # pm3_eml2lower.sh

--- a/tools/pm3_eml2mfd.py
+++ b/tools/pm3_eml2mfd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 '''
 # Andrei Costin <zveriu@gmail.com>, 2011

--- a/tools/pm3_eml2upper.sh
+++ b/tools/pm3_eml2upper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Andrei Costin <zveriu@gmail.com>, 2011
 # pm3_eml2upper.sh

--- a/tools/pm3_eml_mfd_test.py
+++ b/tools/pm3_eml_mfd_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import with_statement
 from tempfile import mkdtemp

--- a/tools/pm3_mfd2eml.py
+++ b/tools/pm3_mfd2eml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 '''
 # Andrei Costin <zveriu@gmail.com>, 2011

--- a/tools/rfidtest.pl
+++ b/tools/rfidtest.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # -samy kamkar, rfid@samy.pl
 
 use strict;

--- a/tools/xorcheck.py
+++ b/tools/xorcheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 #  xorcheck.py - find xor values for 8-bit LRC
 #


### PR DESCRIPTION
Use the `env` command in shebangs to find the correct interpreter instead of hard-coding paths.

Fixes #560 