### PR TITLE
Remove potentially undefined exit behaviour from analyzesize tool

### DIFF
--- a/tools/analyzesize.py
+++ b/tools/analyzesize.py
@@ -17,7 +17,7 @@ except FileNotFoundError:
 
 if len(sys.argv) < 3:
     print("Usage: analyzesize.py <info|add|diff> <datasetname>")
-    exit(-1)
+    exit(2)
 action, name = sys.argv[1:3]
 currentdata = subprocess.run(["arm-none-eabi-size","armsrc/obj/fullimage.stage1.elf"], stdout=subprocess.PIPE).stdout
 currentdata = currentdata.split(b"\n")[1].strip()


### PR DESCRIPTION
Python2.7 doc for `sys` module states that "Most systems require [the
exit code] to be in the range 0-127, and produce undefined results
otherwise".

https://docs.python.org/2/library/sys.html#sys.exit

Currently, modern Linux-based systems will exit with code 255, while
msys2-based systems such as Proxspace will exit with code 127.

Instead, explicitly exit with non-zero exit code of 2.
Encountered while testing #561 on Proxspace.