### PR TITLE
convert python2 mfd2eml and eml2mfd scripts to python3

### DIFF
--- a/tools/pm3_eml2mfd.py
+++ b/tools/pm3_eml2mfd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 # Andrei Costin <zveriu@gmail.com>, 2011
@@ -6,20 +6,20 @@
 # Converts PM3 Mifare Classic emulator EML text file to MFD binary dump file
 '''
 
-from __future__ import with_statement
+
 import sys
 import binascii
 
 def main(argv):
     argc = len(argv)
     if argc < 3:
-        print 'Usage:', argv[0], 'input.eml output.mfd'
+        print('Usage:', argv[0], 'input.eml output.mfd')
         sys.exit(1)
 
-    with file(argv[1], "r") as file_inp, file(argv[2], "wb") as file_out:
+    with open(argv[1], "r") as file_inp, open(argv[2], "wb") as file_out:
         for line in file_inp:
             line = line.rstrip('\n').rstrip('\r')
-            print line
+            print(line)
             data = binascii.unhexlify(line)
             file_out.write(data)
 

--- a/tools/pm3_eml_mfd_test.py
+++ b/tools/pm3_eml_mfd_test.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import with_statement
+
 from tempfile import mkdtemp
 from shutil import rmtree
-from itertools import imap
+
 from string import hexdigits
 import unittest, os
 import pm3_eml2mfd, pm3_mfd2eml
@@ -24,18 +24,18 @@ class TestEmlMfd(unittest.TestCase):
 
     def test_mfd2eml(self):
         self.three_argument_test(pm3_mfd2eml.main,
-                imap(reversed, self.EML2MFD_TESTCASES), c14n=hex_c14n)
+                map(reversed, self.EML2MFD_TESTCASES), c14n=hex_c14n)
 
     def three_argument_test(self, operation, cases, c14n=str):
         for case_input, case_output in cases:
             try:
                 inp_name = os.path.join(self.tmpdir, 'input')
                 out_name = os.path.join(self.tmpdir, 'output')
-                with file(inp_name, 'wb') as in_file:
+                with open(inp_name, 'w') as in_file:
                     in_file.write(case_input)
                 operation(['', inp_name, out_name])
-                with file(out_name, 'rb') as out_file:
-                    self.assertEquals(c14n(case_output), c14n(out_file.read()))
+                with open(out_name, 'r') as out_file:
+                    self.assertEqual(c14n(case_output), c14n(out_file.read()))
             finally:
                 for file_name in inp_name, out_name:
                     if os.path.exists(file_name):

--- a/tools/pm3_mfd2eml.py
+++ b/tools/pm3_mfd2eml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 # Andrei Costin <zveriu@gmail.com>, 2011
@@ -6,24 +6,23 @@
 # Converts PM3 Mifare Classic MFD binary dump file to emulator EML text file
 '''
 
-from __future__ import with_statement
+
 import sys
-import binascii
 
 READ_BLOCKSIZE = 16
 
 def main(argv):
     argc = len(argv)
     if argc < 3:
-        print 'Usage:', argv[0], 'input.mfd output.eml'
+        print('Usage:', argv[0], 'input.mfd output.eml')
         sys.exit(1)
 
-    with file(argv[1], "rb") as file_inp, file(argv[2], "w") as file_out:
+    with open(argv[1], "rb") as file_inp, open(argv[2], "w") as file_out:
         while True:
             byte_s = file_inp.read(READ_BLOCKSIZE)
             if not byte_s:
                 break
-            hex_char_repr = binascii.hexlify(byte_s)
+            hex_char_repr = byte_s.hex()
             file_out.write(hex_char_repr)
             file_out.write("\n")
 


### PR DESCRIPTION
Works towards #564 

Need someone to check my bytes<->string stuff is okay in python3, to make sure I'm not testing _nothing_ here.