### PR TITLE
hitagS fix sim + write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -420,6 +420,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Added `hf mf mad` and `hf mfp mad` MAD decode, check and print commands (@merlokk)
  - Added `script run luxeodump` (@0xdrrb)
  - Fix `lf hitag reader 02` - print all bytes (@bosb)
+ - Fix hitag S simulation (still not working), write, add example HITAG S 256  (@bosb)
 
 
 ### Fixed

--- a/armsrc/hitagS.c
+++ b/armsrc/hitagS.c
@@ -940,7 +940,7 @@ void SimulateHitagSTag(bool tag_mem_supplied, uint8_t *data) {
         memcpy((uint8_t *)tag.pages, data, 4 * 64);
     }
 
-    tag.uid = (uint32_t)tag.pages[0];
+    tag.uid = (tag.pages[0][3] << 24 | tag.pages[0][2] << 16 | tag.pages[0][1] << 8 | tag.pages[0][0]);
     tag.key = (intptr_t)tag.pages[3];
     tag.key <<= 16;
     tag.key += ((tag.pages[2][0]) << 8) + tag.pages[2][1];
@@ -1555,6 +1555,7 @@ void WritePageHitagS(hitag_function htf, hitag_data *htd, int page) {
     AT91C_BASE_TC1->TC_CCR = AT91C_TC_CLKDIS;
 
     // Capture mode, defaul timer source = MCK/2 (TIMER_CLOCK1), TIOA is external trigger,
+    AT91C_BASE_TC0->TC_CMR = AT91C_TC_CLKS_TIMER_DIV1_CLOCK;
     // external trigger rising edge, load RA on falling edge of TIOA.
     AT91C_BASE_TC1->TC_CMR = AT91C_TC_CLKS_TIMER_DIV1_CLOCK
                              | AT91C_TC_ETRGEDG_FALLING


### PR DESCRIPTION
I'm trying to get hitag S simulation to work.
Only partial success :-( and now stuck.

UID is D4 8E 09 8E ;   D4: 11010100 ; advanced mode 3 bits SOF
triggering for now with another proxmark by: lf cmdread d 50 z 116 o 166 c 011001
(but also via: lf hitag read 01)
I have a real tag with this id also to compare.
Any hints where I can influence 1+2 are appreciated...

Tag simulation sending UID:
![hitags-sim-0](https://user-images.githubusercontent.com/12600404/75280481-cd46a680-580d-11ea-9df2-0924b71a9678.png)

1. In the beginning the first half period is too long, and one period is missing
I can add the period in hitag_send_frame as a workaround by inserting at the beginning:

```
          AT91C_BASE_TC0->TC_CCR = AT91C_TC_SWTRG;
                // AC coding -_
                HIGH(GPIO_SSC_DOUT);
                while (AT91C_BASE_TC0->TC_CV < T0 * 16) {};
                
               LOW(GPIO_SSC_DOUT);
                while (AT91C_BASE_TC0->TC_CV < T0 * 32) {};
```
but it does not solve the length of the first period, for now it might not be that much of a problem, just looks not right.

2. I have no clue where that one comes from and I suspect it a problem, since the reader sends out a select, after it recieved the UID right, which the tag does not receive or recognize...