### PR TITLE
Missing b on Example

### DIFF
--- a/client/cmdlfparadox.c
+++ b/client/cmdlfparadox.c
@@ -36,7 +36,7 @@ static int usage_lf_paradox_clone(void) {
     PrintAndLogEx(NORMAL, "  b <raw hex>     : raw hex data. 12 bytes max");
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(NORMAL, "Examples:");
-    PrintAndLogEx(NORMAL, "       lf paradox clone 0f55555695596a6a9999a59a");
+    PrintAndLogEx(NORMAL, "       lf paradox clone b 0f55555695596a6a9999a59a");
     return PM3_SUCCESS;
 }
 


### PR DESCRIPTION
Hi guys I was playing with a Paradox tag and saw the following:

```
[usb] pm3 --> lf paradox clone
clone a Paradox tag to a T55x7 tag.

Usage: lf paradox clone [h] [b <raw hex>]
Options:
  h               : this help
  b <raw hex>     : raw hex data. 12 bytes max

Examples:
       lf paradox clone 0f55555695596a6a9999a59a
```

In the Examples, I think the correct command is:

```
 lf paradox clone b 0f55555695596a6a9999a59a
```

Otherwise shows the help over and over. Basically, just a missing `b`.