### PR TITLE
Keri ms clone support with fc and cardid

### DIFF
--- a/client/cmdlfkeri.c
+++ b/client/cmdlfkeri.c
@@ -38,11 +38,11 @@ static int usage_lf_keri_clone(void) {
     // New format
     PrintAndLogEx(NORMAL, "      <t> [m|i]    : Type. m - MS, i - Internal ID");
     PrintAndLogEx(NORMAL, "      <f> <fc>     : Facility Code");
-    PrintAndLogEx(NORMAL, "      <c> <cardid> : Card ID");
+    PrintAndLogEx(NORMAL, "      <c> <cn>     : Card Number");
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(NORMAL, "Examples:");
     PrintAndLogEx(NORMAL, "       lf keri clone 112233");
-    PrintAndLogEx(NORMAL, "       lf keri clone type ms fc 6 cardid 12345");
+    PrintAndLogEx(NORMAL, "       lf keri clone type ms fc 6 cn 12345");
     PrintAndLogEx(NORMAL, "       lf keri clone t m f 6 c 12345");
     
     return PM3_SUCCESS;
@@ -130,7 +130,7 @@ static int CmdKeriMSScramble (KeriMSScramble_t Action, uint32_t *FC, uint32_t *I
         // Bit 31 was fixed but not in check/parity bits
         *CardID |= (1 << 31); 
 
-        PrintAndLogEx(SUCCESS, "Scrambled MS : FC %d - Card ID %d to RAW : E0000000%08X",*FC,*ID,*CardID);
+        PrintAndLogEx(SUCCESS, "Scrambled MS : FC %d - CN %d to RAW : E0000000%08X",*FC,*ID,*CardID);
     }
     return PM3_SUCCESS;
 }
@@ -196,7 +196,7 @@ static int CmdKeriDemod(const char *Cmd) {
     // Just need to the low 32 bits without the 111 trailer
     CmdKeriMSScramble (Descramble,&fc,&cardid,&raw2);
 
-    PrintAndLogEx (SUCCESS,"Descrambled MS : FC %d - Card ID %d\n",fc,cardid);
+    PrintAndLogEx (SUCCESS,"Descrambled MS : FC %d - CN %d\n",fc,cardid);
 
     if (invert) {
         PrintAndLogEx(INFO, "Had to Invert - probably KERI");

--- a/client/cmdlfkeri.c
+++ b/client/cmdlfkeri.c
@@ -32,18 +32,18 @@ static int usage_lf_keri_clone(void) {
     PrintAndLogEx(NORMAL, "Usage: lf keri clone [h] <id> <Q5>");
     PrintAndLogEx(NORMAL, "Usage extended: lf keri clone [h] t <m|i> [f <fc>] c <cardid> [Q5]");
     PrintAndLogEx(NORMAL, "Options:");
-    PrintAndLogEx(NORMAL, "      h          : This help");
-    PrintAndLogEx(NORMAL, "      <id>       : Keri Internal ID");
-    PrintAndLogEx(NORMAL, "      <Q5>       : specify write to Q5 (t5555 instead of t55x7)");
+    PrintAndLogEx(NORMAL, "      h            : This help");
+    PrintAndLogEx(NORMAL, "      <id>         : Keri Internal ID");
+    PrintAndLogEx(NORMAL, "      <Q5>         : specify write to Q5 (t5555 instead of t55x7)");
     // New format
-    PrintAndLogEx(NORMAL, "      <t> [m|i]  : Type. m - MS, i - Internal ID");
-    PrintAndLogEx(NORMAL, "      <f> <fc>   : Facility Code");
-    PrintAndLogEx(NORMAL, "      <c> <cid>  : Card ID");
+    PrintAndLogEx(NORMAL, "      <t> [m|i]    : Type. m - MS, i - Internal ID");
+    PrintAndLogEx(NORMAL, "      <f> <fc>     : Facility Code");
+    PrintAndLogEx(NORMAL, "      <c> <cardid> : Card ID");
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(NORMAL, "Examples:");
     PrintAndLogEx(NORMAL, "       lf keri clone 112233");
-    PrintAndLogEx(NORMAL, "       lf keri clone type ms fc 6 id 12345");
-    PrintAndLogEx(NORMAL, "       lf keri clone t m f 6 i 12345");
+    PrintAndLogEx(NORMAL, "       lf keri clone type ms fc 6 cardid 12345");
+    PrintAndLogEx(NORMAL, "       lf keri clone t m f 6 c 12345");
     
     return PM3_SUCCESS;
 }

--- a/client/cmdlfkeri.c
+++ b/client/cmdlfkeri.c
@@ -30,7 +30,7 @@ static int CmdHelp(const char *Cmd);
 static int usage_lf_keri_clone(void) {
     PrintAndLogEx(NORMAL, "clone a KERI tag to a T55x7 tag.");
     PrintAndLogEx(NORMAL, "Usage: lf keri clone [h] <id> <Q5>");
-    PrintAndLogEx(NORMAL, "Usage extended: lf keri clone [h] t <m|i> [f <fc>] i <id> [Q5]");
+    PrintAndLogEx(NORMAL, "Usage extended: lf keri clone [h] t <m|i> [f <fc>] c <cardid> [Q5]");
     PrintAndLogEx(NORMAL, "Options:");
     PrintAndLogEx(NORMAL, "      h          : This help");
     PrintAndLogEx(NORMAL, "      <id>       : Keri Internal ID");
@@ -225,7 +225,7 @@ static int CmdKeriRead(const char *Cmd) {
 static int CmdKeriClone(const char *Cmd) {
 
     uint8_t cmdptr = 0;
-    char format = 'r'; // default to raw
+    char format = 'i'; // default to raw
     uint32_t fc = 0;
     uint32_t cid = 0;
     uint32_t cardid = 0;
@@ -294,7 +294,7 @@ static int CmdKeriClone(const char *Cmd) {
             2 << T5555_MAXBLOCK_SHIFT;
     }
 */
-    // Setup card data
+    // Setup card data/build internal id
     switch (format) { 
         case 'i' : // Internal ID
             // MSB is ONE


### PR DESCRIPTION
As well as the original 
lf keri clone <internal cardid> 
it now supports
lf keri clone type ms fc 7 cardid 35423

Note: each command line option is based on the first letter (e.g. t for type, m for ms, f for fc etc)
so supports both readable and short version.

I have left the original command line options in tact, as such left the original help line as well.

let me know if I have missed something.