### PR TITLE
Bosch Solution 6000 Key Sector 0 Key A&B

### DIFF
--- a/client/dictionaries/mfc_default_keys.dic
+++ b/client/dictionaries/mfc_default_keys.dic
@@ -1108,3 +1108,5 @@ fe04ecfe5577
 # 
 # unknown hotel key
 6d9b485a4845
+#
+5a7a52d5e20d # Bosch Solution 6000


### PR DESCRIPTION
Works with any Bosch Solution 6000 PR11xB reader.