### PR TITLE
Mifare Desfire DF Name display support and hf mfdes enum output improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Add Mifare Desfire GetDFNames and improve HF MFDES Enum output (@bkerler)
+ - Fix Mifare Desfire select appid handling (@bkerler)
  - Improved `hf 14a info` - card detection handling (@bkerler)
  - Updated helptext layout in all luascripts (@iceman1001)
  - Change `hf mfdes info` - output and logging (@bkerler)

--- a/armsrc/desfire.h
+++ b/armsrc/desfire.h
@@ -150,6 +150,7 @@ enum DESFIRE_CMD {
     GET_FREE_MEMORY                     = 0x6e,
     GET_FILE_IDS                        = 0x6f,
     GET_FILE_SETTINGS                   = 0xf5,
+    GET_DF_NAMES                        = 0x6d,
     CHANGE_FILE_SETTINGS                = 0x5f,
     CREATE_STD_DATA_FILE                = 0xcd,
     CREATE_BACKUP_DATA_FILE             = 0xcb,

--- a/client/cmdhflist.c
+++ b/client/cmdhflist.c
@@ -768,6 +768,9 @@ void annotateMfDesfire(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize) {
                     case MFDES_GET_FILE_IDS:
                         snprintf(exp, size, "GET FILE IDS");
                         break;
+                    case MFDES_GET_DF_NAMES:
+                        snprintf(exp, size, "GET DF NAMES");
+                        break;
                     case MFDES_GET_ISOFILE_IDS:
                         snprintf(exp, size, "GET ISOFILE IDS");
                         break;

--- a/include/protocols.h
+++ b/include/protocols.h
@@ -387,6 +387,7 @@ ISO 7816-4 Basic interindustry commands. For command APDU's.
 #define MFDES_AUTHENTICATION_FRAME      0xAF
 #define MFDES_ADDITIONAL_FRAME          0xAF
 #define MFDES_READSIG                   0x3C
+#define MFDES_GET_DF_NAMES              0x6D
 
 // LEGIC Commands
 #define LEGIC_MIM_22                    0x0D


### PR DESCRIPTION
### Add Mifare Desfire GetDFNames and improve HF MFDES Enum output.

If a Mifare Desfire card supports the GetDFNames command, it will print out the 
corresponding DF name for the app id.

#### Example:
```
[con] pm3 --> hf mfdes enum          
          
[=] -- Mifare DESFire Enumerate applications --------------------          
[=] -------------------------------------------------------------          
[+]  Tag report 2 applications          
          
[+] --- AMK - Application Master Key settings           
[+]   AID : 00 83 80           
[+]   -  DF 00 83  Name : OWOK light           
[+]   AID Key settings           : 0b          
[+]   Max number of keys in AID  : 142          
[=] -------------------------------------------------------------          
[+]   Changekey Access rights          
[+]   -- AMK authentication is necessary to change any key (default)          
[+]    [0x08] Configuration changeable       : YES           
[+]    [0x04] AMK required for create/delete : YES          
[+]    [0x02] Directory list access with AMK : NO          
[+]    [0x01] AMK is changeable              : YES           
[=] -------------------------------------------------------------          
[=]   Application keys          
[+]    Key [0]  Version : 0 (0x00)          
[+]    Key [1]  Version : 0 (0x00)          
[+]    Key [2]  Version : 0 (0x00)          
[+]    Key [3]  Version : 0 (0x00)          
[+]    Key [4]  Version : 0 (0x00)          
[+]    Key [5]  Version : 0 (0x00)          
[+]    Key [6]  Version : 0 (0x00)          
[+]    Key [7]  Version : 0 (0x00)          
[+]    Key [8]  Version : 0 (0x00)          
[+]    Key [9]  Version : 0 (0x00)          
[+]    Key [10]  Version : 0 (0x00)          
[+]    Key [11]  Version : 0 (0x00)          
[+]    Key [12]  Version : 0 (0x00)          
[+]    Key [13]  Version : 0 (0x00)          
[+]  Tag report 0 files          
          
[+] --- AMK - Application Master Key settings           
[+]   AID : 01 83 80           
[+]   -  DF 01 83  Name : OWOK offline           
[+]   AID Key settings           : eb          
[+]   Max number of keys in AID  : 132          
[=] -------------------------------------------------------------          
[+]   Changekey Access rights          
[+]   -- Authentication with the key to be changed (same KeyNo) is necessary to change a key          
[+]    [0x08] Configuration changeable       : YES           
[+]    [0x04] AMK required for create/delete : YES          
[+]    [0x02] Directory list access with AMK : NO          
[+]    [0x01] AMK is changeable              : YES           
[=] -------------------------------------------------------------          
[=]   Application keys          
[+]    Key [0]  Version : 0 (0x00)          
[+]    Key [1]  Version : 0 (0x00)          
[+]    Key [2]  Version : 0 (0x00)          
[+]    Key [3]  Version : 0 (0x00)          
[+]  Tag report 0 files          
[=] -------------------------------------------------------------
```    