### PR TITLE
cmake macOS: use brew installed readline

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -418,7 +418,8 @@ add_executable(
 )
 
 if (APPLE)
-    set_target_properties(proxmark3 PROPERTIES LINK_FLAGS "-Wl,-F/Library/Frameworks")
+    set_target_properties(proxmark3 PROPERTIES LINK_FLAGS "-Wl,-F/Library/Frameworks, -L/usr/local/opt/readline/lib")
+    set_target_properties(proxmark3 PROPERTIES COMPILE_FLAGS "-I/usr/local/opt/readline/include")
 endif (APPLE)
 
 


### PR DESCRIPTION
I guess it is ugly and not how it should be made with cmake but it works.