### PR TITLE
Fix 2 issues in proxendian.h, see details:

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -51,8 +51,6 @@ DEFCFLAGS += -Wbad-function-cast -Wredundant-decls -Wmissing-prototypes -Wchar-s
 # Some more warnings we need first to eliminate, so temporarely tolerated:
 DEFCFLAGS += -Wcast-align -Wno-error=cast-align
 DEFCFLAGS += -Wswitch-enum -Wno-error=switch-enum
-# Termux on-device __BYTE_ORDER and __LITTLE_ENDIAN undef in src/proxendian.h, see #730
-DEFCFLAGS += -Wno-error=undef
 
 ifeq ($(platform),Darwin)
 # their readline has strict-prototype issues

--- a/client/src/proxendian.h
+++ b/client/src/proxendian.h
@@ -16,17 +16,22 @@
 #ifdef _WIN32
 # define HOST_LITTLE_ENDIAN
 #else
-# include <sys/types.h>
-# ifndef BYTE_ORDER
-#  define BYTE_ORDER __BYTE_ORDER
-#  define LITTLE_ENDIAN __LITTLE_ENDIAN
-#  define BIG_ENDIAN __BIG_ENDIAN
-# endif
-# if !defined(BYTE_ORDER) || (BYTE_ORDER != LITTLE_ENDIAN && BYTE_ORDER != BIG_ENDIAN)
-#  error Define BYTE_ORDER to be equal to either LITTLE_ENDIAN or BIG_ENDIAN
-# endif
-# if BYTE_ORDER == LITTLE_ENDIAN
-#  define HOST_LITTLE_ENDIAN
+// Only some OSes include endian.h from sys/types.h, not Termux, so let's include endian.h directly
+# include <endian.h>
+# if !defined(BYTE_ORDER)
+#  if !defined(__BYTE_ORDER) || (__BYTE_ORDER != __LITTLE_ENDIAN && __BYTE_ORDER != __BIG_ENDIAN)
+#   error Define BYTE_ORDER to be equal to either LITTLE_ENDIAN or BIG_ENDIAN
+#  endif
+#  if __BYTE_ORDER == __LITTLE_ENDIAN
+#   define HOST_LITTLE_ENDIAN
+#  endif
+# else
+#  if BYTE_ORDER != LITTLE_ENDIAN && BYTE_ORDER != BIG_ENDIAN
+#   error Define BYTE_ORDER to be equal to either LITTLE_ENDIAN or BIG_ENDIAN
+#  endif
+#  if BYTE_ORDER == LITTLE_ENDIAN
+#   define HOST_LITTLE_ENDIAN
+#  endif
 # endif
 #endif
 


### PR DESCRIPTION
Only some OSes include endian.h from sys/types.h, not Termux, so let's include endian.h directly.
Moreover the past logic defined BYTE_ORDER to an undef macro, so BYTE_ORDER was not undef but def to 0
and BYTE_ORDER != LITTLE_ENDIAN && BYTE_ORDER != BIG_ENDIAN was always false as (0!=0 && 0!=0)