### PR TITLE
include machine/endian.h for os x

### DIFF
--- a/client/src/proxendian.h
+++ b/client/src/proxendian.h
@@ -17,7 +17,11 @@
 # define HOST_LITTLE_ENDIAN
 #else
 // Only some OSes include endian.h from sys/types.h, not Termux, so let's include endian.h directly
-# include <endian.h>
+# if defined(__APPLE__)
+#  include <machine/endian.h>
+# else
+#  include <endian.h>
+# endif
 # if !defined(BYTE_ORDER)
 #  if !defined(__BYTE_ORDER) || (__BYTE_ORDER != __LITTLE_ENDIAN && __BYTE_ORDER != __BIG_ENDIAN)
 #   error Define BYTE_ORDER to be equal to either LITTLE_ENDIAN or BIG_ENDIAN


### PR DESCRIPTION
referencing issue #730 / PR #731 
platform check is needed if bypassing <sys/types.h> on os x.
include <machine/endian.h> instead of <endian.h> to avoid the error below.

```
In file included from src/flash.c:20:
./src/proxendian.h:20:11: fatal error: 'endian.h' file not found
# include <endian.h>
          ^~~~~~~~~~
1 error generated.
```