### PR TITLE
LF_EM4100RSWB - How I can add HF Mode?

### DIFF
--- a/armsrc/Standalone/lf_em4100rswb.c
+++ b/armsrc/Standalone/lf_em4100rswb.c
@@ -395,7 +395,6 @@ void RunMod() {
     StandAloneMode();
     FpgaDownloadAndGo(FPGA_BITSTREAM_LF);
     Dbprintf("[=] >>  LF EM4100 read/write/clone/brute started  <<");
-    int slots_count = 4;
     int mode_count[] = {4, 2}; //LF, HF
 
     int mode = 0;
@@ -434,7 +433,7 @@ void RunMod() {
             mode = SwitchMode(mode, slot, tag_mode);
         } else if (button_pressed == BUTTON_HOLD) {
             Dbprintf("[=] >>  Button hold  <<");
-            slot = (slot + 1) % slots_count;
+            slot = (slot + 1) % SLOT_COUNT;
             SpinUp(100);
             SpinDelay(300);
 


### PR DESCRIPTION
I have idea to make standalone mode that will allow me to bypass simple locks in standalone mode.
I have already done with LF tags(EMs are most used in my place), but for now I also have some UID-based HF locks (mine is Xiaomi Aqara lock).

I am not pretty sure how to make dual-frequency standalone mode. Do I need to add HF to name or it is ok that "LF_xxx" mode can operate on HF or maybe we can add "DF_xxx" (dual frequency prefix)?
I need some help with naming - because (I think) it didn't fit current naming convention =)