### PR TITLE
add *.tmp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ client/lualibs/pm3_cmd.lua
 fpga_version_info.c
 
 .proxmark3/*
+
+# .tmp files are created during compilation
+*.tmp


### PR DESCRIPTION
My git client goes insane during compilation seeing new `*.tmp` files popping up and disappearing. I think it doesn't hurt anything to add it to `.gitignore`