### PR TITLE
Additional CharlieCard Key

### DIFF
--- a/client/dictionaries/mfc_default_keys.dic
+++ b/client/dictionaries/mfc_default_keys.dic
@@ -605,6 +605,7 @@ d58023ba2bdc # charlie
 62ced42a6d87 # charlie
 2548a443df28 # charlie
 2ed3b15e7c0f # charlie
+f66224ee1e89 # charlie
 #
 60012e9ba3fa
 #


### PR DESCRIPTION
Found another CharlieCard key, so I figured I'd contribute. Found using the mf hardnested attack. Was originally [here](https://github.com/iceman1001/proxmark3/pull/299) before I realized this dictionary existed.