### PR TITLE
Fix em4x50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fix em4x50 demodulation error (@tharexde)  
  - Fix `hf mfdes` authentification issues, DES working (@bkerler)
  - Add Android cross-compilation to client cmake (@dxl, @doegox)
  - Fix `emv scan` - now saves in current folder and uses unique names (@iceman1001)

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -1537,6 +1537,11 @@ static uint16_t cleanAskRawDemod(uint8_t *bits, size_t *size, int clk, int inver
     getNextHigh(bits, *size, high, &pos);
 //    getNextLow(bits, *size, low, &pos);
 
+    // do not skip first transition
+    if ((pos > cl_2 - cl_4 - 1) && (pos <= clk + cl_4 + 1)) {
+        bits[bitCnt++] = invert ^ 1;
+    }
+    
     // sample counts,   like clock = 32.. it tries to find  32/4 = 8,  32/2 = 16
     for (size_t i = pos; i < *size; i++) {
         if (bits[i] >= high && waveHigh) {


### PR DESCRIPTION
Fixed the following problem:
`lf search´ with an em4x50 tag placed on the device may result in `no known tags found´ and `lf em 4x50_read´ shows parity errors. The problem only occurs if the first bit of an em4x50 word is `0´. If it’s `1´ everything works as expected.

Reason: When performing the raw Manchester decoding in function `cleanAskRawDemod(…)´ the first transition of the signal is not evaluated due to the function call `getNextHigh(…)´. 

I tested the modification against the v4.9237 release by comparing the demodulation results with the available traces in the proxmark `traces´ directory. Doublecheck has been done with numerous available lf cards (em4x50, em41x, em42x, hid, …).
So far I couldn’t observe any differences…