### PR TITLE
 EM4x50 missing functions 4x50_info, 4x50_ write, 4x50_write_password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Added lf em functions: 4x50_info, 4x50_write, 4x50_write_password (@tharexde)
  - Fix em4x50 demodulation error (@tharexde)  
  - Fix `hf mfdes` authentification issues, DES working (@bkerler)
  - Add Android cross-compilation to client cmake (@dxl, @doegox)

--- a/armsrc/Makefile
+++ b/armsrc/Makefile
@@ -63,6 +63,12 @@ else
     SRC_HITAG =
 endif
 
+ifneq (,$(findstring WITH_EM4x50,$(APP_CFLAGS)))
+	SRC_EM4x50 = em4x50.c
+else
+	SRC_EM4x50 =
+endif
+
 ifneq (,$(findstring WITH_LCD,$(APP_CFLAGS)))
     SRC_LCD = fonts.c LCD.c
 else
@@ -99,6 +105,7 @@ THUMBSRC = start.c \
     $(SRC_SMARTCARD) \
     $(SRC_FPC) \
     $(SRC_HITAG) \
+	$(SRC_EM4x50) \
     $(SRC_SPIFFS) \
     $(SRC_ISO14443a) \
     $(SRC_ISO14443b) \

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -29,6 +29,7 @@
 #include "felica.h"
 #include "hitag2.h"
 #include "hitagS.h"
+#include "em4x50.h"
 #include "iclass.h"
 #include "legicrfsim.h"
 #include "epa.h"
@@ -447,6 +448,11 @@ static void SendCapabilities(void) {
     capabilities.compiled_with_hitag = true;
 #else
     capabilities.compiled_with_hitag = false;
+#endif
+#ifdef WITH_EM4x50
+    capabilities.compiled_with_em4x50 = true;
+#else
+    capabilities.compiled_with_em4x50 = false;
 #endif
 #ifdef WITH_HFSNIFF
     capabilities.compiled_with_hfsniff = true;
@@ -979,6 +985,13 @@ static void PacketReceived(PacketCommandNG *packet) {
             } else {
                 WriterHitag((hitag_function)packet->oldarg[0], (hitag_data *)packet->data.asBytes, packet->oldarg[2]);
             }
+            break;
+        }
+#endif
+
+#ifdef WITH_EM4x50
+        case CMD_LF_EM4X50_INFO: {
+            em4x50_info((em4x50_data_t *)packet->data.asBytes);
             break;
         }
 #endif

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -994,6 +994,14 @@ static void PacketReceived(PacketCommandNG *packet) {
             em4x50_info((em4x50_data_t *)packet->data.asBytes);
             break;
         }
+        case CMD_LF_EM4X50_WRITE: {
+            em4x50_write((em4x50_data_t *)packet->data.asBytes);
+            break;
+        }
+        case CMD_LF_EM4X50_WRITE_PASSWORD: {
+            em4x50_write_password((em4x50_data_t *)packet->data.asBytes);
+            break;
+        }
 #endif
 
 #ifdef WITH_ISO15693

--- a/armsrc/em4x50.c
+++ b/armsrc/em4x50.c
@@ -584,7 +584,8 @@ static bool login(uint8_t password[4]) {
             return true;
     
     } else {
-        Dbprintf("error in command request");
+         if (DBGLEVEL >= DBG_ERROR)
+             Dbprintf("error in command request");
     }
     
     return false;
@@ -605,7 +606,8 @@ static bool reset(void) {
             return true;
 
     } else {
-        Dbprintf("error in command request");
+         if (DBGLEVEL >= DBG_ERROR)
+             Dbprintf("error in command request");
     }
 
     return false;
@@ -634,7 +636,8 @@ static bool standard_read(int *now) {
         return true;
 
     } else {
-        Dbprintf("didn't find a listen window");
+         if (DBGLEVEL >= DBG_ERROR)
+             Dbprintf("didn't find a listen window");
     }
 
     return false;
@@ -667,7 +670,8 @@ static bool selective_read(uint8_t addresses[4]) {
                     return true;
         
     } else {
-        Dbprintf("error in command request");
+         if (DBGLEVEL >= DBG_ERROR)
+             Dbprintf("error in command request");
     }
 
     return false;
@@ -736,7 +740,8 @@ static bool write(uint8_t word[4], uint8_t address) {
         }
 
     } else {
-        Dbprintf("error in command request");
+         if (DBGLEVEL >= DBG_ERROR)
+             Dbprintf("error in command request");
     }
 
     return false;
@@ -774,7 +779,8 @@ static bool write_password(uint8_t password[4], uint8_t new_password[4]) {
         }
 
     } else {
-        Dbprintf("error in command request");
+         if (DBGLEVEL >= DBG_ERROR)
+             Dbprintf("error in command request");
     }
 
     return false;

--- a/armsrc/em4x50.c
+++ b/armsrc/em4x50.c
@@ -12,6 +12,7 @@
 #include "ticks.h"
 #include "dbprint.h"
 #include "lfadc.h"
+#include "commonutil.h"
 #include "em4x50.h"
 
 // 4 data bytes
@@ -118,28 +119,16 @@ static uint8_t bits2byte(uint8_t bits[8], int length) {
     return byte;
 }
 
-static uint8_t msb2lsb(uint8_t byte) {
-
-    // returns byte with bit positions in reverse order
-    
-    uint8_t tmp = 0;
-    
-    for (int i = 0; i < 8; i++)
-        tmp |= ((byte >> (7-i)) & 1) << i;
-    
-    return tmp;
-}
-
 static void msb2lsb_word(uint8_t *word) {
     
     // reorders given <word> according to EM4x50 datasheet (msb -> lsb)
     
     uint8_t buff[4];
     
-    buff[0] = msb2lsb(word[3]);
-    buff[1] = msb2lsb(word[2]);
-    buff[2] = msb2lsb(word[1]);
-    buff[3] = msb2lsb(word[0]);
+    buff[0] = reflect8(word[3]);
+    buff[1] = reflect8(word[2]);
+    buff[2] = reflect8(word[1]);
+    buff[3] = reflect8(word[0]);
 
     word[0] = buff[0];
     word[1] = buff[1];

--- a/armsrc/em4x50.c
+++ b/armsrc/em4x50.c
@@ -717,7 +717,7 @@ static bool write(uint8_t word[4], uint8_t address) {
     
     if (request_receive_mode()) {
 
-        // send selective read command
+        // send write command
         em4x50_send_byte_with_parity(EM4X50_COMMAND_WRITE);
 
         // send address data
@@ -753,7 +753,7 @@ static bool write_password(uint8_t password[4], uint8_t new_password[4]) {
     
     if (request_receive_mode()) {
 
-        // send selective read command
+        // send write password command
         em4x50_send_byte_with_parity(EM4X50_COMMAND_WRITE_PASSWORD);
 
         // send address data

--- a/armsrc/em4x50.c
+++ b/armsrc/em4x50.c
@@ -791,7 +791,7 @@ void em4x50_write(em4x50_data_t *etd) {
     // write operation process for EM4x50 tag,
     // single word is written to given address, verified by selective read operation
     
-    bool bsuccess = true, blogin = false;
+    bool bsuccess = false, blogin = false;
     uint8_t word[4] = {0x00, 0x00, 0x00, 0x00};
     uint8_t addresses[4] = {0x00, 0x00, 0x00, 0x00};
     
@@ -826,6 +826,7 @@ void em4x50_write(em4x50_data_t *etd) {
                 word[3] = tag.sectors[etd->address][3];
                 msb2lsb_word(word);
                 
+                bsuccess = true;
                 for (int i = 0; i < 4; i++)
                     bsuccess &= (word[i] == etd->word[i]) ? true : false;
 

--- a/armsrc/em4x50.c
+++ b/armsrc/em4x50.c
@@ -220,7 +220,7 @@ static void em4x50_setup_read(void) {
     //   TIMER_CLOCK0, used to measure exact timing before answering
     //   TIMER_CLOCK1, used to capture edges of the tag frames
     AT91C_BASE_PMC->PMC_PCER |= (1 << AT91C_ID_TC0) | (1 << AT91C_ID_TC1);
-    AT91C_BASE_PIOA->PIO_BSR = GPIO_SSC_FRAME; // wofür ist das?
+    AT91C_BASE_PIOA->PIO_BSR = GPIO_SSC_FRAME;
 
     // Disable timer during configuration
     AT91C_BASE_TC0->TC_CCR = AT91C_TC_CLKDIS;

--- a/armsrc/em4x50.c
+++ b/armsrc/em4x50.c
@@ -102,7 +102,7 @@ static void init_tag(void) {
             tag.sectors[i][j] = 0x00;
 }
 
-static uint8_t bits2byte(uint8_t bits[8], int length) {
+static uint8_t bits2byte(uint8_t *bits, int length) {
 
     // converts <length> separate bits into a single "byte"
     

--- a/armsrc/em4x50.c
+++ b/armsrc/em4x50.c
@@ -341,39 +341,23 @@ static void em4x50_send_byte(uint8_t byte) {
 
     // send byte (without parity)
     
-    int mask = 0x80;
+    for (int i = 0; i < 8; i++)
+        em4x50_send_bit((byte >> (7-i)) & 1);
 
-    for (int i = 0; i < 8; i++) {
-
-        if ((byte & mask) == 0)
-            em4x50_send_bit(0);
-        else
-            em4x50_send_bit(1);
-        
-        mask >>= 1;
-    }
 }
 
 static void em4x50_send_byte_with_parity(uint8_t byte) {
 
     // send byte followed by its (equal) parity bit
     
-    int parity = 0;
-    int mask = 0x80;
-
-    for (int i = 0; i < 8; i++) {
-        
-        if ((byte & mask) == 0) {
-            em4x50_send_bit(0);
-            parity ^= 0;
-        } else {
-            em4x50_send_bit(1);
-            parity ^= 1;
-        }
-        
-        mask >>= 1;
-    }
+    int parity = 0, bit = 0;
     
+    for (int i = 0; i < 8; i++) {
+        bit = (byte >> (7-i)) & 1;
+        em4x50_send_bit(bit);
+        parity ^= bit;
+    }
+
     em4x50_send_bit(parity);
 }
 

--- a/armsrc/em4x50.c
+++ b/armsrc/em4x50.c
@@ -684,6 +684,7 @@ void em4x50_info(em4x50_data_t *etd) {
     // otherwise continue without login
     
     bool bsuccess = false, blogin = false;
+    uint8_t status = 0;
     uint8_t addresses[] = {0x00, 0x00, 0x21, 0x00}; // fwr = 0, lwr = 33
     uint8_t password[] = {0x00, 0x00, 0x00, 0x00};  // default password
 
@@ -705,8 +706,10 @@ void em4x50_info(em4x50_data_t *etd) {
     
     bsuccess = selective_read(addresses);
     
+    status = (bsuccess << 1) + blogin;
+    
     lf_finalize();
-    reply_mix(CMD_ACK, bsuccess, blogin, 0, (uint8_t *)tag.sectors, 238);
+    reply_ng(CMD_ACK, status, (uint8_t *)tag.sectors, 238);
 }
 
 // write functions
@@ -792,6 +795,7 @@ void em4x50_write(em4x50_data_t *etd) {
     // single word is written to given address, verified by selective read operation
     
     bool bsuccess = false, blogin = false;
+    uint8_t status = 0;
     uint8_t word[4] = {0x00, 0x00, 0x00, 0x00};
     uint8_t addresses[4] = {0x00, 0x00, 0x00, 0x00};
     
@@ -834,8 +838,10 @@ void em4x50_write(em4x50_data_t *etd) {
         }
     }
 
+    status = (bsuccess << 1) + blogin;
+    
     lf_finalize();
-    reply_mix(CMD_ACK, bsuccess, blogin, 0, (uint8_t *)tag.sectors, 238);
+    reply_ng(CMD_ACK, status, (uint8_t *)tag.sectors, 238);
 }
 
 void em4x50_write_password(em4x50_data_t *etd) {
@@ -853,5 +859,5 @@ void em4x50_write_password(em4x50_data_t *etd) {
     }
 
     lf_finalize();
-    reply_mix(CMD_ACK, bsuccess, 0, 0, 0, 0);
+    reply_ng(CMD_ACK, bsuccess, 0, 0);
 }

--- a/armsrc/em4x50.c
+++ b/armsrc/em4x50.c
@@ -1,0 +1,672 @@
+//-----------------------------------------------------------------------------
+// Copyright (C) 2020 tharexde
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// Low frequency EM4x50 commands
+//-----------------------------------------------------------------------------
+
+#include "fpgaloader.h"
+#include "ticks.h"
+#include "dbprint.h"
+#include "lfadc.h"
+#include "em4x50.h"
+
+// 4 data bytes
+// + byte with row parities
+// + column parity byte
+// + byte with stop bit
+
+static em4x50_tag_t tag = {
+    .sectors = {
+        [0]  = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // password
+        [1]  = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // protection word
+        [2]  = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // control word
+        [3]  = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [4]  = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [5]  = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [6]  = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [7]  = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [8]  = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [9]  = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [10] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [11] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [12] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [13] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [14] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [15] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [16] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [17] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [18] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [19] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [20] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [21] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [22] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [23] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [24] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [25] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [26] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [27] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [28] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [29] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [30] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [31] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // user
+        [32] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // device serial number
+        [33] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // device identification
+    },
+};
+
+// Sam7s has several timers, we will use the source TIMER_CLOCK1 (aka AT91C_TC_CLKS_TIMER_DIV1_CLOCK)
+// TIMER_CLOCK1 = MCK/2, MCK is running at 48 MHz, Timer is running at 48/2 = 24 MHz
+// EM4x50 units (T0) have duration of 8 microseconds (us), which is 1/125000 per second (carrier)
+// T0 = TIMER_CLOCK1 / 125000 = 192
+
+#ifndef T0
+#define T0                                  192
+#endif
+
+#define EM4X50_T_TAG_QUARTER_PERIOD         16
+#define EM4X50_T_TAG_HALF_PERIOD            32
+#define EM4X50_T_TAG_THREE_QUARTER_PERIOD   48
+#define EM4X50_T_TAG_FULL_PERIOD            64
+#define EM4X50_T_WAITING_FOR_LIW            500
+
+#define EM4X50_TAG_TOLERANCE                8
+#define EM4X50_TAG_WORD                     45
+
+#define EM4X50_BIT_0                        0
+#define EM4X50_BIT_1                        1
+#define EM4X50_BIT_OTHER                    2
+
+#define EM4X50_COMMAND_LOGIN                0x01
+#define EM4X50_COMMAND_WRITE                0x12
+#define EM4X50_COMMAND_SELECTIVE_READ       0x0A
+
+#define FPGA_TIMER_0                        0
+
+// auxiliary functions
+
+static void init_tag(void) {
+
+    // initialize global tag structure
+    
+    for (int i = 0; i < 34; i++)
+        for (int j = 0; j < 7; j++)
+            tag.sectors[i][j] = 0x00;
+}
+
+static uint8_t bits2byte(uint8_t bits[8], int length) {
+
+    // converts <length> separate bits into a single "byte"
+    
+    uint8_t byte = 0;
+    
+    for (int i = 0; i < length; i++) {
+
+        byte |= bits[i];
+
+        if (i != length-1)
+            byte <<= 1;
+    }
+
+    return byte;
+}
+
+static void save_word(int pos, uint8_t bits[EM4X50_TAG_WORD]) {
+    
+    // split "raw" word into data, row and column parity bits and stop bit and
+    // save them in global tag structure
+    
+    uint8_t row_parity[4];
+    uint8_t col_parity[8];
+    
+    // data and row parities
+    for (int i = 0; i < 4; i++) {
+        tag.sectors[pos][i] = bits2byte(&bits[9*i],8);
+        row_parity[i] = bits[9*i+8];
+    }
+
+    tag.sectors[pos][4] = bits2byte(row_parity,4);
+
+    // column parities
+    for (int i = 0; i < 8; i++)
+        col_parity[i] = bits[36+i];
+
+    tag.sectors[pos][5] = bits2byte(col_parity,8);
+    
+    // stop bit
+    tag.sectors[pos][6] = bits[44];
+}
+
+static void wait_timer(int timer, uint32_t period) {
+
+    // do nothing for <period> using timer <timer>
+    
+    if (timer == FPGA_TIMER_0) {
+
+        AT91C_BASE_TC0->TC_CCR = AT91C_TC_SWTRG;
+        while (AT91C_BASE_TC0->TC_CV < period);
+
+    } else {
+
+        AT91C_BASE_TC1->TC_CCR = AT91C_TC_SWTRG;
+        while (AT91C_BASE_TC1->TC_CV < period);
+
+    }
+}
+
+static void em4x50_setup_read(void) {
+ 
+    FpgaDownloadAndGo(FPGA_BITSTREAM_LF);
+    
+    FpgaWriteConfWord(FPGA_MAJOR_MODE_LF_ADC | FPGA_LF_ADC_READER_FIELD);
+
+    // 50ms for the resonant antenna to settle.
+    SpinDelay(50);
+    // Now set up the SSC to get the ADC samples that are now streaming at us.
+    FpgaSetupSsc();
+    // start a 1.5ticks is 1us
+    StartTicks();
+ 
+    FpgaSendCommand(FPGA_CMD_SET_DIVISOR, LF_DIVISOR_125);
+
+    // Connect the A/D to the peak-detected low-frequency path.
+    SetAdcMuxFor(GPIO_MUXSEL_LOPKD);
+    
+    // Steal this pin from the SSP (SPI communication channel with fpga) and
+    // use it to control the modulation
+    AT91C_BASE_PIOA->PIO_PER = GPIO_SSC_DOUT;
+    AT91C_BASE_PIOA->PIO_OER = GPIO_SSC_DOUT;
+
+    // Disable modulation at default, which means enable the field
+    LOW(GPIO_SSC_DOUT);
+    
+    // Enable Peripheral Clock for
+    //   TIMER_CLOCK0, used to measure exact timing before answering
+    //   TIMER_CLOCK1, used to capture edges of the tag frames
+    AT91C_BASE_PMC->PMC_PCER |= (1 << AT91C_ID_TC0) | (1 << AT91C_ID_TC1);
+    AT91C_BASE_PIOA->PIO_BSR = GPIO_SSC_FRAME; // wofür ist das?
+
+    // Disable timer during configuration
+    AT91C_BASE_TC0->TC_CCR = AT91C_TC_CLKDIS;
+    AT91C_BASE_TC1->TC_CCR = AT91C_TC_CLKDIS;
+
+    // TC0: Capture mode, default timer source = MCK/2 (TIMER_CLOCK1), no triggers
+    AT91C_BASE_TC0->TC_CMR = AT91C_TC_CLKS_TIMER_DIV1_CLOCK;
+    
+    // TC1: Capture mode, default timer source = MCK/2 (TIMER_CLOCK1), no triggers
+    AT91C_BASE_TC1->TC_CMR = AT91C_TC_CLKS_TIMER_DIV1_CLOCK;
+      
+    // Enable and reset counters
+    AT91C_BASE_TC0->TC_CCR = AT91C_TC_CLKEN | AT91C_TC_SWTRG;
+    AT91C_BASE_TC1->TC_CCR = AT91C_TC_CLKEN | AT91C_TC_SWTRG;
+    
+    // synchronized startup procedure
+    while (AT91C_BASE_TC0->TC_CV > 0) {}; // wait until TC1 returned to zero
+    
+    // Watchdog hit
+    WDT_HIT();
+}
+
+// functions for "reader" use case
+
+static int get_next_bit(void) {
+    
+    // returns bit value (or EM4X50_BIT_OTHER -> no bit pattern) by evaluating
+    // a single sample within a bit period (given there is no LIW, ACK or NAK)
+    // This function is not used for decoding, it is only used for identifying
+    // a listen window (return value = EM4X50_BIT_OTHER) in functions
+    // "find_double_listen_window" and "check_ack"
+  
+    int dhigh = 230;    // 90% of maximum sample value (255)
+    int dlow = 25;      // 10% of maximum sample value (255)
+    uint8_t sample;
+
+    // get sample at 3/4 of bit period
+    wait_timer(0, T0 * EM4X50_T_TAG_THREE_QUARTER_PERIOD);
+    sample = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
+
+    // wait until end of bit period
+    wait_timer(0, T0 * EM4X50_T_TAG_QUARTER_PERIOD);
+
+    // decide wether "0" or "1"
+    if (sample > dhigh)
+        return EM4X50_BIT_0;
+    else if (sample < dlow)
+        return EM4X50_BIT_1;
+    
+    return EM4X50_BIT_OTHER;
+}
+
+static uint32_t get_pulse_length(void) {
+    
+    //
+    
+    uint8_t sample = 0, high = 192, low = 64;
+
+    sample = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
+    
+    while (sample > low)
+        sample = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
+
+    AT91C_BASE_TC1->TC_CCR = AT91C_TC_SWTRG;
+
+    while (sample < high)
+        sample = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
+
+    while (sample > low)
+        sample = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
+
+    return (uint32_t)AT91C_BASE_TC1->TC_CV;
+}
+
+static bool check_pulse_length(uint32_t pl, int length) {
+    
+    // check if pulse length <pl> corresponds to given length <length>
+    
+    if ((pl >= T0 * (length - EM4X50_TAG_TOLERANCE)) &
+        (pl <= T0 * (length + EM4X50_TAG_TOLERANCE)))
+        return true;
+    else
+        return false;
+}
+
+static void em4x50_send_bit(int bit) {
+    
+    // send single bit according to EM4x50 application note and datasheet
+    
+    // reset clock for the next bit
+    AT91C_BASE_TC0->TC_CCR = AT91C_TC_SWTRG;
+
+    if (bit == 0) {
+
+        // disable modulation (drop the field) for 7 cycles of carrier
+        // period (Opt64)
+        LOW(GPIO_SSC_DOUT);
+        while (AT91C_BASE_TC0->TC_CV < T0 * 7);
+
+        // enable modulation (activates the field) for remaining first
+        // half of bit period
+        HIGH(GPIO_SSC_DOUT);
+        while (AT91C_BASE_TC0->TC_CV < T0 * EM4X50_T_TAG_HALF_PERIOD);
+        
+        // disable modulation for second half of bit period
+        LOW(GPIO_SSC_DOUT);
+        while (AT91C_BASE_TC0->TC_CV < T0 * EM4X50_T_TAG_FULL_PERIOD);
+
+    } else {
+        
+        // bit = "1" means disable modulation for full bit period
+        LOW(GPIO_SSC_DOUT);
+        while (AT91C_BASE_TC0->TC_CV < T0 * EM4X50_T_TAG_FULL_PERIOD);
+    }
+}
+
+static void em4x50_send_byte(uint8_t byte) {
+
+    // send byte (without parity)
+    
+    int mask = 0x80;
+
+    for (int i = 0; i < 8; i++) {
+
+        if ((byte & mask) == 0)
+            em4x50_send_bit(0);
+        else
+            em4x50_send_bit(1);
+        
+        mask >>= 1;
+    }
+}
+
+static void em4x50_send_byte_with_parity(uint8_t byte) {
+
+    // send byte followed by its (equal) parity bit
+    
+    int parity = 0;
+    int mask = 0x80;
+
+    for (int i = 0; i < 8; i++) {
+        
+        if ((byte & mask) == 0) {
+            em4x50_send_bit(0);
+            parity ^= 0;
+        } else {
+            em4x50_send_bit(1);
+            parity ^= 1;
+        }
+        
+        mask >>= 1;
+    }
+    
+    em4x50_send_bit(parity);
+}
+
+static void em4x50_send_word(const uint8_t bytes[4]) {
+    
+    // send 32 bit word with parity bits according to EM4x50 datasheet
+    
+    for (int i = 0; i < 4; i++)
+        em4x50_send_byte_with_parity(bytes[i]);
+    
+    // send column parities
+    em4x50_send_byte(bytes[0] ^ bytes[1] ^ bytes[2] ^ bytes[3]);
+
+    // send final stop bit (always "0")
+    em4x50_send_bit(0);
+}
+
+static bool find_double_listen_window(bool bcommand) {
+    
+    // find two successive listen windows that indicate the beginning of
+    // data transmission
+    
+    AT91C_BASE_TC0->TC_CCR = AT91C_TC_SWTRG;
+    while (AT91C_BASE_TC0->TC_CV < T0 * EM4X50_T_WAITING_FOR_LIW) {
+
+        // identification of listen window is done via evaluation of
+        // pulse lengths
+        if (check_pulse_length(get_pulse_length(), 3 * EM4X50_T_TAG_FULL_PERIOD)) {
+            
+            if (check_pulse_length(get_pulse_length(), 2 * EM4X50_T_TAG_FULL_PERIOD)) {
+                
+                // first listen window found
+                
+                if (bcommand) {
+
+                    // data transmission from card has to be stopped, because
+                    // a commamd shall be issued
+                    
+                    // unfortunately the posititon in listen window (where
+                    // command request has to be sent) has gone, so if a
+                    // second window follows - sync on this to issue a command
+                    
+                    // skip the next bit...
+                    wait_timer(FPGA_TIMER_0, T0 * EM4X50_T_TAG_FULL_PERIOD);
+                    
+                    // ...and check if the following bit does make sense
+                    // (if not it is the correct position within the second
+                    // listen window)
+                    if (get_next_bit() == EM4X50_BIT_OTHER) {
+                    
+                        // send RM for request mode
+                        em4x50_send_bit(0);
+                        em4x50_send_bit(0);
+
+                        return true;
+                    }
+
+                }
+
+                if (check_pulse_length(get_pulse_length(), 3 * EM4X50_T_TAG_FULL_PERIOD)) {
+
+                    // return although second listen window consists of one
+                    // more bit period but this period is necessary for
+                    // evaluating further pulse lengths
+                    return true;
+                }
+            }
+        }
+    }
+    
+    return false;
+}
+
+static bool request_receive_mode(void) {
+    
+    // To issue a command we have to find a listen window first.
+    // Because identification and sychronization at the same time is not
+    // possible when using pulse lengths a double listen window is used.
+
+    bool bcommand = true;
+    
+    return find_double_listen_window(bcommand);
+}
+
+static bool check_ack(bool bliw) {
+    
+    // returns true if signal structue corresponds to ACK, anything else is
+    // counted as NAK (-> false)
+    // Only relevant for pasword writing function:
+    // If <bliw> is true then within the single listen window right after the
+    // ack signal a RM request has to be sent.
+    
+    AT91C_BASE_TC0->TC_CCR = AT91C_TC_SWTRG;
+    while (AT91C_BASE_TC0->TC_CV < T0 * 4 * EM4X50_T_TAG_FULL_PERIOD) {
+        
+        if (check_pulse_length(get_pulse_length(), 2 * EM4X50_T_TAG_FULL_PERIOD)) {
+            
+            // The received signal is either ACK or NAK.
+        
+            if (check_pulse_length(get_pulse_length(), 2 * EM4X50_T_TAG_FULL_PERIOD)) {
+                
+                // Now the signal must be ACK.
+
+                if (!bliw) {
+
+                    return true;
+
+                } else {
+                    
+                    // send RM request after ack signal
+
+                    // wait for 2 bits (remaining "bit" of ACK signal + first
+                    // "bit" of listen window)
+                    wait_timer(FPGA_TIMER_0, T0 * 2 * EM4X50_T_TAG_FULL_PERIOD);
+                        
+                    // check for listen window (if first bit cannot be inerpreted
+                    // as a valid bit it must belong to a listen window)
+                    if (get_next_bit() == EM4X50_BIT_OTHER) {
+                        
+                        // send RM for request mode
+                        em4x50_send_bit(0);
+                        em4x50_send_bit(0);
+
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+static int get_word_from_bitstream(uint8_t bits[EM4X50_TAG_WORD]) {
+
+    // decodes one word by evaluating pulse lengths and previous bit;
+    // word must have 45 bits in total:
+    // 32 data bits + 4 row parity bits + 8 column parity bits + 1 stop bit
+    
+    bool bbitchange = false;
+    int i = 0;
+    uint32_t pl = 0;
+
+    // initial bit value depends on last pulse length of listen window
+    pl = get_pulse_length();
+    if (check_pulse_length(pl, 3 * EM4X50_T_TAG_HALF_PERIOD)) {
+
+        // pulse length = 1.5
+        bits[0] = 1;
+
+    } else if (check_pulse_length(pl, 2 * EM4X50_T_TAG_FULL_PERIOD)) {
+
+        // pulse length = 2
+        bits[0] = 0;
+        bbitchange = true;
+
+    } else {
+        
+        // pulse length = 2.5
+        bits[0] = 0;
+        bits[1] = 1;
+        i++;
+    }
+
+    // identify remaining bits based on pulse lengths
+    // between two listen windows only pulse lengths of 1, 1.5 and 2 are possible
+    while (true) {
+               
+        i++;
+        pl = get_pulse_length();
+        
+        if (check_pulse_length(pl, EM4X50_T_TAG_FULL_PERIOD)) {
+
+            // pulse length = 1 -> keep former bit value
+            bits[i] = bits[i-1];
+
+        } else if (check_pulse_length(pl, 3 * EM4X50_T_TAG_HALF_PERIOD)) {
+
+            // pulse length = 1.5 -> decision on bit change
+            
+            if (bbitchange) {
+
+                // if number of pulse lengths with 1.5 periods is even -> add bit
+                bits[i] = (bits[i-1] == 1) ? 1 : 0;
+
+                // pulse length of 1.5 changes bit value
+                bits[i+1] = (bits[i] == 1) ? 0 : 1;
+                i++;
+                
+                // next time add only one bit
+                bbitchange = false;
+                
+            } else {
+
+                bits[i] = (bits[i-1] == 1) ? 0 : 1;
+                
+                // next time two bits have to be added
+                bbitchange = true;
+            }
+
+        } else if (check_pulse_length(pl, 2 * EM4X50_T_TAG_FULL_PERIOD)) {
+
+            // pulse length of 2 means: adding 2 bits "01"
+            bits[i] = 0;
+            bits[i+1] = 1;
+            i++;
+
+        } else if (check_pulse_length(pl, 3 * EM4X50_T_TAG_FULL_PERIOD)) {
+
+            // pulse length of 3 indicates listen window -> clear last
+            // bit (= 0) and return
+            return --i;
+            
+        }
+    }
+}
+
+// login function
+
+static bool login(uint8_t password[4]) {
+
+    if (request_receive_mode ()) {
+
+        // send login command
+        em4x50_send_byte_with_parity(EM4X50_COMMAND_LOGIN);
+
+        // send password
+        em4x50_send_word(password);
+
+        // check if ACK is returned
+        if (check_ack(false))
+            return true;
+    
+    } else {
+        Dbprintf("error in command request");
+    }
+    
+    return false;
+}
+
+// read functions
+
+static bool standard_read(int *now) {
+    
+    // reads data that tag transmits when exposed to reader field
+    // (standard read mode); number of read words is saved in <now>
+    
+    uint8_t bits[EM4X50_TAG_WORD] = {0};
+
+    // start with the identification of two succsessive listening windows
+    if (find_double_listen_window(false)) {
+
+        // read and save words until following double listen window is detected
+        while (get_word_from_bitstream(bits) == EM4X50_TAG_WORD)
+            save_word((*now)++, bits);
+
+        return true;
+
+    } else {
+        Dbprintf("didn't find a listen window");
+    }
+
+    return false;
+}
+
+static bool selective_read(uint8_t addresses[4]) {
+    
+    // reads from "first word read" (fwr = addresses[3]) to "last word read"
+    // (lwr = addresses[2])
+    // result is verified by "standard read mode" result
+    
+    int fwr = addresses[3];     // first word read
+    int lwr = addresses[2];     // last word read
+    int now = 0;                // number of words
+
+    if (request_receive_mode()) {
+
+        // send selective read command
+        em4x50_send_byte_with_parity(EM4X50_COMMAND_SELECTIVE_READ);
+
+        // send address data
+        em4x50_send_word(addresses);
+
+        // look for ACK sequence
+        if (check_ack(false))
+            
+            // save and verifiy via standard read mode (compare number of words)
+            if (standard_read(&now))
+                if (now == (lwr - fwr + 1))
+                    return true;
+
+    } else {
+        Dbprintf("error in command request");
+    }
+
+    return false;
+}
+
+void em4x50_info(em4x50_data_t *etd) {
+    
+    // collects as much information as possible via selective read mode
+    // if no password is given -> try with standard password "0x00000000"
+    // otherwise continue without login
+    
+    bool bsuccess = false, blogin = false;
+    uint8_t addresses[] = {0x00, 0x00, 0x21, 0x00}; // fwr = 0, lwr = 33
+    uint8_t password[] = {0x00, 0x00, 0x00, 0x00};  // default password
+
+    init_tag();
+    em4x50_setup_read();
+
+    
+    if (etd->pwd_given) {
+
+        // try to login with given password
+        blogin = login(etd->password);
+
+    } else {
+    
+        // if no password is given, try to login with "0x00000000"
+        blogin = login(password);
+
+    }
+    
+    bsuccess = selective_read(addresses);
+    
+    lf_finalize();
+    reply_mix(CMD_ACK, bsuccess, blogin, 0, (uint8_t *)tag.sectors, 238);
+}

--- a/armsrc/em4x50.h
+++ b/armsrc/em4x50.h
@@ -18,5 +18,7 @@ typedef struct {
 } em4x50_tag_t;
 
 void em4x50_info(em4x50_data_t *etd);
+void em4x50_write(em4x50_data_t *etd);
+void em4x50_write_password(em4x50_data_t *etd);
 
 #endif /* EM4X50_H */

--- a/armsrc/em4x50.h
+++ b/armsrc/em4x50.h
@@ -1,0 +1,22 @@
+//-----------------------------------------------------------------------------
+// Copyright (C) 2020 tharexde
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// Low frequency EM4x50 commands
+//-----------------------------------------------------------------------------
+
+#ifndef EM4X50_H
+#define EM4X50_H
+
+#include "../include/em4x50.h"
+
+typedef struct {
+    uint8_t sectors[34][7];
+} em4x50_tag_t;
+
+void em4x50_info(em4x50_data_t *etd);
+
+#endif /* EM4X50_H */

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -214,6 +214,7 @@ set (TARGET_SOURCES
         ${PM3_ROOT}/client/src/cmdlfawid.c
         ${PM3_ROOT}/client/src/cmdlfcotag.c
         ${PM3_ROOT}/client/src/cmdlfem4x.c
+        ${PM3_ROOT}/client/src/cmdlfem4x50.c
         ${PM3_ROOT}/client/src/cmdlffdx.c
         ${PM3_ROOT}/client/src/cmdlfgallagher.c
         ${PM3_ROOT}/client/src/cmdlfguard.c

--- a/client/Makefile
+++ b/client/Makefile
@@ -439,6 +439,7 @@ SRCS =  aidsearch.c \
 		cmdlfawid.c \
 		cmdlfcotag.c \
 		cmdlfem4x.c \
+		cmdlfem4x50.c \
 		cmdlffdx.c \
 		cmdlfguard.c \
 		cmdlfgallagher.c \

--- a/client/src/cmdlfem4x.c
+++ b/client/src/cmdlfem4x.c
@@ -9,6 +9,7 @@
 //-----------------------------------------------------------------------------
 
 #include "cmdlfem4x.h"
+#include "cmdlfem4x50.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -1765,6 +1766,7 @@ static command_t CommandTable[] = {
     {"4x50_dump",   CmdEM4x50Dump,        IfPm3Lf,         "dump EM4x50 tag"},
     {"4x50_read",   CmdEM4x50Read,        IfPm3Lf,         "read word data from EM4x50"},
     {"4x50_write",  CmdEM4x50Write,       IfPm3Lf,         "write word data to EM4x50"},
+    {"4x50_info",   CmdEM4x50Info,        IfPm3Lf,         "read complete data from EM4x50"},
     {NULL, NULL, NULL, NULL}
 };
 

--- a/client/src/cmdlfem4x.c
+++ b/client/src/cmdlfem4x.c
@@ -139,20 +139,6 @@ static int usage_lf_em4x50_read(void) {
     PrintAndLogEx(NORMAL, "      lf em 4x50_read 1 11223344");
     return PM3_SUCCESS;
 }
-static int usage_lf_em4x50_write(void) {
-    PrintAndLogEx(NORMAL, "Write EM 4x50/4x69.  Tag must be on antenna. ");
-    PrintAndLogEx(NORMAL, "");
-    PrintAndLogEx(NORMAL, "Usage:  lf em 4x50_write [h] <address> <data> <pwd>");
-    PrintAndLogEx(NORMAL, "Options:");
-    PrintAndLogEx(NORMAL, "       h         - this help");
-    PrintAndLogEx(NORMAL, "       address   - memory address to write to. (0-15)");
-    PrintAndLogEx(NORMAL, "       data      - data to write (hex)");
-    PrintAndLogEx(NORMAL, "       pwd       - password (hex) (optional)");
-    PrintAndLogEx(NORMAL, "Examples:");
-    PrintAndLogEx(NORMAL, "      lf em 4x50_write 1 deadc0de");
-    PrintAndLogEx(NORMAL, "      lf em 4x50_write 1 deadc0de 11223344");
-    return PM3_SUCCESS;
-}
 
 //////////////// 4205 / 4305 commands
 static int usage_lf_em4x05_dump(void) {
@@ -1039,16 +1025,6 @@ static int CmdEM4x50Read(const char *Cmd) {
     return EM4x50Read(Cmd, true);
 }
 
-static int CmdEM4x50Write(const char *Cmd) {
-    uint8_t ctmp = tolower(param_getchar(Cmd, 0));
-    if (ctmp == 'h') return usage_lf_em4x50_write();
-    PrintAndLogEx(NORMAL, "no implemented yet");
-//
-//    PrintAndLogEx(SUCCESS, "Done");
-//    PrintAndLogEx(HINT, "Hint: try " _YELLOW_("`lf em 4x50_read`") " to verify");
-    return PM3_SUCCESS;
-}
-
 static int CmdEM4x50Dump(const char *Cmd) {
     uint8_t ctmp = tolower(param_getchar(Cmd, 0));
     if (ctmp == 'h') return usage_lf_em4x50_dump();
@@ -1765,8 +1741,9 @@ static command_t CommandTable[] = {
     {"4x50_demod",  CmdEM4x50Demod,       AlwaysAvailable, "demodulate a EM4x50 tag from the GraphBuffer"},
     {"4x50_dump",   CmdEM4x50Dump,        IfPm3Lf,         "dump EM4x50 tag"},
     {"4x50_read",   CmdEM4x50Read,        IfPm3Lf,         "read word data from EM4x50"},
-    {"4x50_write",  CmdEM4x50Write,       IfPm3Lf,         "write word data to EM4x50"},
     {"4x50_info",   CmdEM4x50Info,        IfPm3Lf,         "read complete data from EM4x50"},
+    {"4x50_write",  CmdEM4x50Write,       IfPm3Lf,         "write word data to EM4x50"},
+    {"4x50_write_password", CmdEM4x50WritePassword, IfPm3Lf, "change passwword of EM4x50 tag"},
     {NULL, NULL, NULL, NULL}
 };
 

--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -12,6 +12,7 @@
 #include <ctype.h>
 #include "fileutils.h"
 #include "comms.h"
+#include "commonutil.h"
 #include "em4x50.h"
 
 #define EM4x50_FCT_STDREAD  0
@@ -58,6 +59,7 @@ int usage_lf_em4x50_write_password(void) {
     return PM3_SUCCESS;
 }
 
+/*
 static uint8_t msb2lsb(uint8_t byte) {
 
     // convert given byte (msb) into lsb format
@@ -69,7 +71,7 @@ static uint8_t msb2lsb(uint8_t byte) {
     
     return tmp;
 }
-
+*/
 static bool check_bit_in_byte(uint8_t pos, uint8_t byte) {
     
     // return true if bit at position <pos> is "1"
@@ -163,9 +165,9 @@ static void print_bit_table(const em4x50_word_t word) {
         strcat(string, pstring);
         
         if (j == 0)
-            sprintf(pstring, "  msb: 0x%02x  lsb: 0x%02x", word.byte[j], msb2lsb(word.byte[j]));
+            sprintf(pstring, "  msb: 0x%02x  lsb: 0x%02x", word.byte[j], reflect8(word.byte[j]));
         else
-            sprintf(pstring, "       0x%02x       0x%02x", word.byte[j], msb2lsb(word.byte[j]));
+            sprintf(pstring, "       0x%02x       0x%02x", word.byte[j], reflect8(word.byte[j]));
         
         strcat(string, pstring);
         PrintAndLogEx(NORMAL,string);
@@ -229,7 +231,7 @@ static void print_result(const em4x50_word_t *words,  int fwr,  int lwr) {
         strcat(string, pstring);
 
         for (int j = 0; j < 4; j++) {
-            sprintf(pstring, _GREEN_("%02x"), msb2lsb(words[i].byte[3-j]));
+            sprintf(pstring, _GREEN_("%02x"), reflect8(words[i].byte[3-j]));
             strcat(string, pstring);
         }
         
@@ -257,12 +259,12 @@ static void print_info_result(PacketResponseNG *resp, const em4x50_data_t *etd, 
 
     bpwc = check_bit_in_byte(7, words[2].byte[2]);   // password check
     braw = check_bit_in_byte(6, words[2].byte[2]);   // read after write
-    fwr = msb2lsb(words[2].byte[0]);    // first word read
-    lwr = msb2lsb(words[2].byte[1]);    // last word read
-    fwrp = msb2lsb(words[1].byte[0]);   // first word read protected
-    lwrp = msb2lsb(words[1].byte[1]);   // last word read protected
-    fwwi = msb2lsb(words[1].byte[2]);   // first word write inhibited
-    lwwi = msb2lsb(words[1].byte[3]);   // last word write inhibited
+    fwr = reflect8(words[2].byte[0]);    // first word read
+    lwr = reflect8(words[2].byte[1]);    // last word read
+    fwrp = reflect8(words[1].byte[0]);   // first word read protected
+    lwrp = reflect8(words[1].byte[1]);   // last word read protected
+    fwwi = reflect8(words[1].byte[2]);   // first word write inhibited
+    lwwi = reflect8(words[1].byte[3]);   // last word write inhibited
     
     // data section
     PrintAndLogEx(NORMAL, _YELLOW_("\n  em4x50 data:"));

--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -1,0 +1,441 @@
+//-----------------------------------------------------------------------------
+// Copyright (C) 2020 tharexde
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// Low frequency EM4x50 commands
+//-----------------------------------------------------------------------------
+
+#include "cmdlfem4x50.h"
+#include <ctype.h>
+#include "fileutils.h"
+#include "comms.h"
+#include "em4x50.h"
+
+#define EM4x50_FCT_STDREAD  0
+#define EM4x50_FCT_LOGIN    1
+#define EM4x50_FCT_WRITE    2
+
+int usage_lf_em4x50_info(void) {
+    PrintAndLogEx(NORMAL, "Read all information of EM4x50. Tag nust be on antenna.");
+    PrintAndLogEx(NORMAL, "");
+    PrintAndLogEx(NORMAL, "Usage:  lf em 4x50_info [h] [v] [p <pwd>]");
+    PrintAndLogEx(NORMAL, "Options:");
+    PrintAndLogEx(NORMAL, "       h         - this help");
+    PrintAndLogEx(NORMAL, "       v         - verbose output");
+    PrintAndLogEx(NORMAL, "       p <pwd>   - password (hex) (optional)");
+    PrintAndLogEx(NORMAL, "Examples:");
+    PrintAndLogEx(NORMAL, "      lf em 4x50_info");
+    PrintAndLogEx(NORMAL, "      lf em 4x50_info p fa225de1\n");
+    PrintAndLogEx(NORMAL, "      lf em 4x50_info v p fa225de1\n");
+    return PM3_SUCCESS;
+}
+
+static uint8_t msb2lsb(uint8_t byte) {
+
+    // convert given byte (msb) into lsb format
+    
+    uint8_t tmp = 0;
+    
+    for (int i = 0; i < 8; i++)
+        tmp |= ((byte >> (7-i)) & 1) << i;
+    
+    return tmp;
+}
+
+static bool check_bit_in_byte(uint8_t pos, uint8_t byte) {
+    
+    // return true if bit at position <pos> is "1"
+    
+    return (((byte >> pos) & 1) == 1) ? true : false;
+}
+
+static void prepare_result(const uint8_t *byte, int fwr, int lwr, em4x50_word_t *words) {
+
+    // restructure received result in "em4x50_word_t" structure and check all
+    // parities including stop bit; result of each check is stored in structure
+    
+    int p = 0, c[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    
+    for (int i = fwr; i <= lwr; i++) {
+    
+        words[i].stopparity = true;
+        words[i].parity = true;
+ 
+        for (int j = 0; j < 8; j++)
+            c[j] = 0;
+
+        for (int j = 0; j < 4; j++) {
+            words[i].byte[j] = byte[i*7+j];
+            words[i].row_parity[j] = (byte[i*7+4] >> (3-j)) & 1;
+            
+            // collect parities
+            p = 0;
+
+            for (int k = 0; k < 8; k++) {
+               
+                // row parity
+                p ^= (words[i].byte[j] >> k) & 1;
+                
+                // column parity
+                c[k] ^= (words[i].byte[j] >> (7-k)) & 1;
+            }
+            
+            // check row parities
+            words[i].rparity[j] = (words[i].row_parity[j] == p) ? true : false;
+
+            if (!words[i].rparity[j])
+                words[i].parity = false;
+        }
+        
+        // check column parities
+        words[i].col_parity = byte[i*7+5] ;
+        
+        for (int j = 0; j < 8; j++) {
+            words[i].cparity[j] = (((words[i].col_parity >> (7-j)) & 1) == c[j]) ? true : false;
+
+            if (!words[i].cparity[j])
+                words[i].parity = false;
+        }
+
+        // check stop bit
+        words[i].stopbit = byte[i*7+6] & 1;
+        
+        if (words[i].stopbit == 1)
+            words[i].stopparity = false;
+        
+    }
+}
+
+static void print_bit_table(const em4x50_word_t word) {
+    
+    // generate output in table form for each word including parities, stop
+    // bit, result of parity checks and hex notation of each row in msb/lsb
+    // notation
+    // individual parity errors will be highlighted in red
+        
+    int bit = 0;
+    char string[400] = {0};
+    char pstring[100] = {0};
+
+    // print binary data
+    for (int j = 0; j < 4; j++) {
+        
+        strcat(string, "  ");
+
+        // lsb notation
+        for (int k = 0; k < 8; k++) {
+            sprintf(pstring, "%i", (word.byte[j] >> (7-k)) & 1);
+            strcat(string, pstring);
+        }
+
+        strcat(string, " | ");
+
+        // binary row parities + hex bytes of word
+        sprintf(pstring, (word.rparity[j]) ? "%i" : _RED_("%i"), word.row_parity[j]);
+        strcat(string, pstring);
+        
+        if (j == 0)
+            sprintf(pstring, "  msb: 0x%02x  lsb: 0x%02x", word.byte[j], msb2lsb(word.byte[j]));
+        else
+            sprintf(pstring, "       0x%02x       0x%02x", word.byte[j], msb2lsb(word.byte[j]));
+        
+        strcat(string, pstring);
+        PrintAndLogEx(NORMAL,string);
+
+        string[0] = '\0';
+    }
+
+    strcat(string, "  ------------  --------------------\n  ");
+
+    // binary column parities
+    for (int k = 0; k < 8; k++) {
+        
+        bit = (word.col_parity >> (7-k)) & 1;
+        
+        // if column parity is false -> highlight bit in red
+        sprintf(pstring, (word.cparity[k]) ? "%i" : _RED_("%i"), bit);
+        strcat(string, pstring);
+    }
+
+    // binary stop bit
+    strcat(string, " | ");
+    sprintf(pstring, (word.stopparity) ? "%i" : _RED_("%i"), word.stopbit);
+    strcat(pstring, "  parities ");
+    strcat(string, pstring);
+    
+    // parities passed/failed
+    sprintf(pstring, (word.parity) ? _GREEN_("passed") : _RED_("failed"));
+    strcat(string, pstring);
+
+    PrintAndLogEx(NORMAL,string);
+   
+    string[0] = '\0';
+}
+
+static void print_result(const em4x50_word_t *words,  int fwr,  int lwr) {
+    
+    // print available information for given word from fwr to lwr, i.e.
+    // bit table + summary lines with hex notation of word (msb + lsb)
+    
+    char string[400] = {0};
+    char pstring[100] = {0};
+
+    for (int i = fwr; i <= lwr; i++) {
+
+        // blank line before each bit table
+        PrintAndLogEx(NORMAL, "");
+
+        // print bit table
+        print_bit_table(words[i]);
+         
+        // final result
+        sprintf(pstring, "\n  word[%i] msb: " _BLUE_("0x"), i);
+        strcat(string, pstring);
+
+        for (int j = 0; j < 4; j++) {
+            sprintf(pstring, _BLUE_("%02x"), words[i].byte[j]);
+            strcat(string, pstring);
+        }
+        
+        sprintf(pstring, "\n  word[%i] lsb: " _BLUE_("0x"), i);
+        strcat(string, pstring);
+
+        for (int j = 0; j < 4; j++) {
+            sprintf(pstring, _BLUE_("%02x"), msb2lsb(words[i].byte[3-j]));
+            strcat(string, pstring);
+        }
+        
+        PrintAndLogEx(NORMAL,string);
+
+        string[0] = '\0';
+    }
+}
+
+static void print_info_result(PacketResponseNG *resp, const em4x50_data_t *etd, bool bverbose) {
+
+    // displays all information info result in structured format
+    
+    bool bpwd_given = etd->pwd_given;
+    bool bsuccess = (bool)resp->oldarg[0];
+    bool blogin = (bool)resp->oldarg[1];
+    bool bpwc, braw;
+    int fwr, lwr, fwrp, lwrp, fwwi, lwwi;
+    uint8_t *data = resp->data.asBytes;
+    em4x50_word_t words[34];
+    char pstring[100] = {0};
+    char string[200] = {0};
+
+    prepare_result(data, 0, 33, words);
+
+    bpwc = check_bit_in_byte(7, words[2].byte[2]);   // password check
+    braw = check_bit_in_byte(6, words[2].byte[2]);   // read after write
+    fwr = msb2lsb(words[2].byte[0]);    // first word read
+    lwr = msb2lsb(words[2].byte[1]);    // last word read
+    fwrp = msb2lsb(words[1].byte[0]);   // first word read protected
+    lwrp = msb2lsb(words[1].byte[1]);   // last word read protected
+    fwwi = msb2lsb(words[1].byte[2]);   // first word write inhibited
+    lwwi = msb2lsb(words[1].byte[3]);   // last word write inhibited
+    
+    // data section
+    PrintAndLogEx(NORMAL, _YELLOW_("\n  em4x50 data:"));
+
+    if (bverbose) {
+
+        // detailed data section
+        print_result(words, 0, 33);
+        
+    } else {
+
+        // condensed data section
+        for (int i = 0; i <= 33; i++) {
+     
+            sprintf(pstring, "  word[%2i]:  ", i);
+            strcat(string, pstring);
+
+            for (int j = 0; j < 4; j++) {
+                sprintf(pstring, "%02x", words[i].byte[j]);
+                strcat(string, pstring);
+            }
+            
+            switch(i) {
+                case 0:
+                    sprintf(pstring, _BLUE_("  password, write only"));
+                    break;
+                case 1:
+                    sprintf(pstring, _BLUE_("  protection word, write inhibited"));
+                    break;
+                case 2:
+                    sprintf(pstring, _BLUE_("  control word, write inhibited"));
+                    break;
+                case 32:
+                    sprintf(pstring, _BLUE_("  device serial number, read only"));
+                    break;
+                case 33:
+                    sprintf(pstring, _BLUE_("  device identification, read only"));
+                    break;
+                default:
+                    sprintf(pstring, "  user data");
+                    break;
+            }
+
+            strcat(string, pstring);
+            PrintAndLogEx(NORMAL,"%s", string);
+            string[0] = '\0';
+        }
+    }
+    
+    // configuration section
+    PrintAndLogEx(NORMAL, _YELLOW_("\n  em4x50 configuration"));
+    PrintAndLogEx(NORMAL,"  control:                 |  protection:");
+
+    sprintf(pstring, "    first word read:  %3i  |", fwr);
+    strcat(string, pstring);
+    sprintf(pstring, "    first word read protected:  %3i", fwrp);
+    strcat(string, pstring);
+    PrintAndLogEx(NORMAL,"%s", string);
+    string[0] = '\0';
+
+    sprintf(pstring, "    last word read:   %3i  |", lwr);
+    strcat(string, pstring);
+    sprintf(pstring, "    last word read protected:   %3i", lwrp);
+    strcat(string, pstring);
+    PrintAndLogEx(NORMAL,"%s", string);
+    string[0] = '\0';
+
+    sprintf(pstring, "    password check:   %3s  |", (bpwc) ? "on" : "off");
+    strcat(string, pstring);
+    sprintf(pstring, "    first word write inhibited: %3i", fwwi);
+    strcat(string, pstring);
+    PrintAndLogEx(NORMAL,"%s", string);
+    string[0] = '\0';
+
+    sprintf(pstring, "    read after write: %3s  |", (braw) ? "on" : "off");
+    strcat(string, pstring);
+    sprintf(pstring, "    last word write inhibited:  %3i", lwwi);
+    strcat(string, pstring);
+    PrintAndLogEx(NORMAL,"%s", string);
+    string[0] = '\0';
+
+    PrintAndLogEx(NORMAL, "\n  Zero values may indicate read protection!");
+    
+    // status line
+    sprintf(pstring, "\n  reading ");
+    strcat(string, pstring);
+
+    if (!bsuccess) {
+        
+        sprintf(pstring, _RED_("failed"));
+        strcat(string, pstring);
+
+    } else {
+            
+        sprintf(pstring, _GREEN_("successful "));
+        strcat(string, pstring);
+
+        if (blogin) {
+
+            if (bpwd_given) {
+
+                sprintf(pstring, "(login with 0x%02x%02x%02x%02x)",
+                                    etd->password[0], etd->password[1],
+                                    etd->password[2], etd->password[3]);
+                strcat(string, pstring);
+            
+            } else {
+
+                sprintf(pstring, "(login with default password)");
+                strcat(string, pstring);
+
+            }
+
+        } else {
+
+            if (bpwd_given) {
+
+                sprintf(pstring, "(login failed)");
+                strcat(string, pstring);
+            
+            } else {
+
+                sprintf(pstring, "(no login)");
+                strcat(string, pstring);
+
+            }
+        }
+
+    }
+
+    PrintAndLogEx(NORMAL,"%s\n", string);
+}
+
+int CmdEM4x50Info(const char *Cmd) {
+
+    // envokes reading of a EM4x50 tag which has to be on the antenna because
+    // decoding is done by the device (not on client side)
+
+    bool errors = false, verbose = false;
+    char password[20] = {0x00}, tmpbuff[3];
+    uint8_t cmdp = 0;
+    em4x50_data_t etd;
+    PacketResponseNG resp;
+
+    while (param_getchar(Cmd, cmdp) != 0x00 && !errors) {
+        switch (tolower(param_getchar(Cmd, cmdp))) {
+
+            case 'h':
+                return usage_lf_em4x50_info();
+
+            case 'p':
+                param_getstr(Cmd, cmdp + 1, password, sizeof(password));
+                
+                // validation
+                if (strlen(password) != 8) {
+    
+                    PrintAndLogEx(WARNING, "\n  error, password has to be 4 bytes\n");
+                    errors = true;
+                    break;
+                }
+                
+                // prepare given password
+                etd.pwd_given = true;
+                for (int i = 0; i < 4; i++)
+                    sscanf(strncpy(tmpbuff, password+2*i, 2), "%2hhx", &etd.password[i]);
+                    
+                cmdp += 2;
+                break;
+
+            case 'v':
+                verbose = true;
+                cmdp += 1;
+                break;
+                
+            default:
+                PrintAndLogEx(WARNING, "  Unknown parameter '%c'", param_getchar(Cmd, cmdp));
+                errors = true;
+                break;
+        }
+    }
+
+    // validation
+     if (errors) {
+         return usage_lf_em4x50_info();
+    }
+
+    // call info command
+    clearCommandBuffer();
+    SendCommandMIX(CMD_LF_EM4X50_INFO, 0, 0, 0, &etd, sizeof(etd));
+
+    // get result
+    if (!WaitForResponse(CMD_ACK, &resp)) {
+        PrintAndLogEx(WARNING, "  timeout while waiting for reply.");
+        return PM3_ESOFT;
+    }
+    
+    // prepare result
+    print_info_result(&resp, &etd, verbose);
+
+    return ((bool)resp.oldarg[0]) ? PM3_SUCCESS : PM3_ESOFT;
+}

--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -217,19 +217,19 @@ static void print_result(const em4x50_word_t *words,  int fwr,  int lwr) {
         print_bit_table(words[i]);
          
         // final result
-        sprintf(pstring, "\n  word[%i] msb: " _BLUE_("0x"), i);
+        sprintf(pstring, "\n  word[%i] msb: " _GREEN_("0x"), i);
         strcat(string, pstring);
 
         for (int j = 0; j < 4; j++) {
-            sprintf(pstring, _BLUE_("%02x"), words[i].byte[j]);
+            sprintf(pstring, _GREEN_("%02x"), words[i].byte[j]);
             strcat(string, pstring);
         }
         
-        sprintf(pstring, "\n  word[%i] lsb: " _BLUE_("0x"), i);
+        sprintf(pstring, "\n  word[%i] lsb: " _GREEN_("0x"), i);
         strcat(string, pstring);
 
         for (int j = 0; j < 4; j++) {
-            sprintf(pstring, _BLUE_("%02x"), msb2lsb(words[i].byte[3-j]));
+            sprintf(pstring, _GREEN_("%02x"), msb2lsb(words[i].byte[3-j]));
             strcat(string, pstring);
         }
         
@@ -287,19 +287,19 @@ static void print_info_result(PacketResponseNG *resp, const em4x50_data_t *etd, 
             
             switch(i) {
                 case 0:
-                    sprintf(pstring, _BLUE_("  password, write only"));
+                    sprintf(pstring, _YELLOW_("  password, write only"));
                     break;
                 case 1:
-                    sprintf(pstring, _BLUE_("  protection word, write inhibited"));
+                    sprintf(pstring, _YELLOW_("  protection word, write inhibited"));
                     break;
                 case 2:
-                    sprintf(pstring, _BLUE_("  control word, write inhibited"));
+                    sprintf(pstring, _YELLOW_("  control word, write inhibited"));
                     break;
                 case 32:
-                    sprintf(pstring, _BLUE_("  device serial number, read only"));
+                    sprintf(pstring, _YELLOW_("  device serial number, read only"));
                     break;
                 case 33:
-                    sprintf(pstring, _BLUE_("  device identification, read only"));
+                    sprintf(pstring, _YELLOW_("  device identification, read only"));
                     break;
                 default:
                     sprintf(pstring, "  user data");

--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -459,7 +459,7 @@ int CmdEM4x50Info(const char *Cmd) {
     // get result
     if (!WaitForResponse(CMD_ACK, &resp)) {
         PrintAndLogEx(WARNING, "  timeout while waiting for reply.");
-        return PM3_ESOFT;
+        return PM3_ETIMEOUT;
     }
     
     // prepare result
@@ -604,7 +604,7 @@ int CmdEM4x50Write(const char *Cmd) {
 
     if (!WaitForResponse(CMD_ACK, &resp)) {
         PrintAndLogEx(WARNING, "\n  timeout while waiting for reply.\n");
-        return PM3_ESOFT;
+        return PM3_ETIMEOUT;
     }
     
     // get, prepare and print response
@@ -710,7 +710,7 @@ int CmdEM4x50WritePassword(const char *Cmd) {
 
     if (!WaitForResponse(CMD_ACK, &resp)) {
         PrintAndLogEx(WARNING, "\n  timeout while waiting for reply.\n");
-        return PM3_ESOFT;
+        return PM3_ETIMEOUT;
     }
     
     // get, prepare and print response

--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -59,19 +59,6 @@ int usage_lf_em4x50_write_password(void) {
     return PM3_SUCCESS;
 }
 
-/*
-static uint8_t msb2lsb(uint8_t byte) {
-
-    // convert given byte (msb) into lsb format
-    
-    uint8_t tmp = 0;
-    
-    for (int i = 0; i < 8; i++)
-        tmp |= ((byte >> (7-i)) & 1) << i;
-    
-    return tmp;
-}
-*/
 static bool check_bit_in_byte(uint8_t pos, uint8_t byte) {
     
     // return true if bit at position <pos> is "1"

--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -456,7 +456,8 @@ int CmdEM4x50Info(const char *Cmd) {
 
     // call info command
     clearCommandBuffer();
-    SendCommandMIX(CMD_LF_EM4X50_INFO, 0, 0, 0, &etd, sizeof(etd));
+    SendCommandNG(CMD_LF_EM4X50_INFO, (uint8_t *)&etd, sizeof(etd));
+
 
     // get result
     if (!WaitForResponse(CMD_ACK, &resp)) {
@@ -602,7 +603,8 @@ int CmdEM4x50Write(const char *Cmd) {
          return usage_lf_em4x50_write();
 
     clearCommandBuffer();
-    SendCommandMIX(CMD_LF_EM4X50_WRITE, 0, 0, 0, &etd, sizeof(etd));
+    SendCommandNG(CMD_LF_EM4X50_WRITE, (uint8_t *)&etd, sizeof(etd));
+
 
     if (!WaitForResponse(CMD_ACK, &resp)) {
         PrintAndLogEx(WARNING, "\n  timeout while waiting for reply.\n");
@@ -708,7 +710,7 @@ int CmdEM4x50WritePassword(const char *Cmd) {
          return usage_lf_em4x50_write_password();
 
     clearCommandBuffer();
-    SendCommandMIX(CMD_LF_EM4X50_WRITE_PASSWORD, 0, 0, 0, &etd, sizeof(etd));
+    SendCommandNG(CMD_LF_EM4X50_WRITE_PASSWORD, (uint8_t *)&etd, sizeof(etd));
 
     if (!WaitForResponse(CMD_ACK, &resp)) {
         PrintAndLogEx(WARNING, "\n  timeout while waiting for reply.\n");

--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -192,7 +192,7 @@ static void print_bit_table(const em4x50_word_t word) {
     strcat(string, pstring);
     
     // parities passed/failed
-    sprintf(pstring, (word.parity) ? _GREEN_("passed") : _RED_("failed"));
+    sprintf(pstring, (word.parity) ? _GREEN_("ok") : _RED_("failed"));
     strcat(string, pstring);
 
     PrintAndLogEx(NORMAL,string);

--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -59,13 +59,6 @@ int usage_lf_em4x50_write_password(void) {
     return PM3_SUCCESS;
 }
 
-static bool check_bit_in_byte(uint8_t pos, uint8_t byte) {
-    
-    // return true if bit at position <pos> is "1"
-    
-    return (((byte >> pos) & 1) == 1) ? true : false;
-}
-
 static void prepare_result(const uint8_t *byte, int fwr, int lwr, em4x50_word_t *words) {
 
     // restructure received result in "em4x50_word_t" structure and check all
@@ -244,14 +237,14 @@ static void print_info_result(PacketResponseNG *resp, const em4x50_data_t *etd, 
 
     prepare_result(data, 0, 33, words);
 
-    bpwc = check_bit_in_byte(7, words[2].byte[2]);   // password check
-    braw = check_bit_in_byte(6, words[2].byte[2]);   // read after write
-    fwr = reflect8(words[2].byte[0]);    // first word read
-    lwr = reflect8(words[2].byte[1]);    // last word read
-    fwrp = reflect8(words[1].byte[0]);   // first word read protected
-    lwrp = reflect8(words[1].byte[1]);   // last word read protected
-    fwwi = reflect8(words[1].byte[2]);   // first word write inhibited
-    lwwi = reflect8(words[1].byte[3]);   // last word write inhibited
+    bpwc = (bool)(words[2].byte[2] & 128);  // password check (bit 7)
+    braw = (bool)(words[2].byte[2] & 64);   // read after write (bit 6)
+    fwr = reflect8(words[2].byte[0]);       // first word read
+    lwr = reflect8(words[2].byte[1]);       // last word read
+    fwrp = reflect8(words[1].byte[0]);      // first word read protected
+    lwrp = reflect8(words[1].byte[1]);      // last word read protected
+    fwwi = reflect8(words[1].byte[2]);      // first word write inhibited
+    lwwi = reflect8(words[1].byte[3]);      // last word write inhibited
     
     // data section
     PrintAndLogEx(NORMAL, _YELLOW_("\n  em4x50 data:"));

--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -214,11 +214,11 @@ static void print_result(const em4x50_word_t *words,  int fwr,  int lwr) {
             strcat(string, pstring);
         }
         
-        sprintf(pstring, "\n  word[%i] lsb: " _GREEN_("0x"), i);
+        sprintf(pstring, "\n  word[%i] lsb: 0x", i);
         strcat(string, pstring);
 
         for (int j = 0; j < 4; j++) {
-            sprintf(pstring, _GREEN_("%02x"), reflect8(words[i].byte[3-j]));
+            sprintf(pstring, "%02x", reflect8(words[i].byte[3-j]));
             strcat(string, pstring);
         }
         
@@ -346,14 +346,14 @@ static void print_info_result(PacketResponseNG *resp, const em4x50_data_t *etd, 
 
     } else {
             
-        sprintf(pstring, _GREEN_("successful "));
+        sprintf(pstring, _GREEN_("ok "));
         strcat(string, pstring);
 
         if (blogin) {
 
             if (bpwd_given) {
 
-                sprintf(pstring, "(login with 0x%02x%02x%02x%02x)",
+                sprintf(pstring, "(login with password 0x%02x%02x%02x%02x)",
                                     etd->password[0], etd->password[1],
                                     etd->password[2], etd->password[3]);
                 strcat(string, pstring);
@@ -469,13 +469,13 @@ static void print_write_result(PacketResponseNG *resp, const em4x50_data_t *etd)
         prepare_result(data, etd->address, etd->address, &word[0]);
         print_result(word, etd->address, etd->address);
 
-        sprintf(pstring, "\n  writing " _GREEN_("successful "));
+        sprintf(pstring, "\n  writing " _GREEN_("ok "));
         strcat(string, pstring);
 
         if (pwd_given) {
 
             if (login) {
-                sprintf(pstring, "(login with 0x%02x%02x%02x%02x)",
+                sprintf(pstring, "(login with password 0x%02x%02x%02x%02x)",
                                     etd->password[0], etd->password[1],
                                     etd->password[2], etd->password[3]);
                 strcat(string, pstring);
@@ -582,7 +582,7 @@ static void print_write_password_result(PacketResponseNG *resp, const em4x50_dat
 
     } else {
         
-        sprintf(pstring, "\n  writing new password " _GREEN_("successful"));
+        sprintf(pstring, "\n  writing new password " _GREEN_("ok"));
         strcat(string, pstring);
     }
 

--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -233,8 +233,8 @@ static void print_info_result(PacketResponseNG *resp, const em4x50_data_t *etd, 
     // display all information info result in structured format
     
     bool bpwd_given = etd->pwd_given;
-    bool bsuccess = (bool)resp->oldarg[0];
-    bool blogin = (bool)resp->oldarg[1];
+    bool bsuccess = (bool)(resp->status & 0x2);
+    bool blogin = (bool)(resp->status & 0x1);
     bool bpwc, braw;
     int fwr, lwr, fwrp, lwrp, fwwi, lwwi;
     uint8_t *data = resp->data.asBytes;
@@ -390,7 +390,7 @@ int CmdEM4x50Info(const char *Cmd) {
     // envoke reading of a EM4x50 tag which has to be on the antenna because
     // decoding is done by the device (not on client side)
 
-    bool errors = false, verbose = false;
+    bool errors = false, verbose = false, success = false;
     uint8_t cmdp = 0;
     em4x50_data_t etd;
     PacketResponseNG resp;
@@ -440,10 +440,11 @@ int CmdEM4x50Info(const char *Cmd) {
         return PM3_ETIMEOUT;
     }
     
-    // prepare result
+    // print result
     print_info_result(&resp, &etd, verbose);
-
-    return ((bool)resp.oldarg[0]) ? PM3_SUCCESS : PM3_ESOFT;
+    
+    success = resp.status & 0x2;
+    return (success) ? PM3_SUCCESS : PM3_ESOFT;
 }
 
 static void print_write_result(PacketResponseNG *resp, const em4x50_data_t *etd) {
@@ -451,8 +452,8 @@ static void print_write_result(PacketResponseNG *resp, const em4x50_data_t *etd)
     // display result of writing operation in structured format
 
     bool pwd_given = etd->pwd_given;
-    bool success = (bool)resp->oldarg[0];
-    bool login = (bool)resp->oldarg[1];
+    bool success = (bool)(resp->status & 0x2);
+    bool login = (bool)(resp->status & 0x1);
     uint8_t *data = resp->data.asBytes;
     char string[400] = {0};
     char pstring[100] = {0};
@@ -496,7 +497,7 @@ int CmdEM4x50Write(const char *Cmd) {
 
     // envoke writing a single word (32 bit) to a EM4x50 tag
 
-    bool errors = false, bword = false, baddr = false;
+    bool errors = false, bword = false, baddr = false, success = false;
     uint8_t cmdp = 0;
     em4x50_data_t etd;
     PacketResponseNG resp;
@@ -562,14 +563,15 @@ int CmdEM4x50Write(const char *Cmd) {
     // get, prepare and print response
     print_write_result(&resp, &etd);
     
-    return ((bool)resp.oldarg[0]) ? PM3_SUCCESS : PM3_ESOFT;
+    success = (bool)(resp.status & 0x2);
+    return (success) ? PM3_SUCCESS : PM3_ESOFT;
 }
 
 static void print_write_password_result(PacketResponseNG *resp, const em4x50_data_t *etd) {
     
     // display result of password changing operation
 
-    bool success = (bool)resp->oldarg[0];
+    bool success = (bool)resp->status;
     char string[400] = {0};
     char pstring[100] = {0};
 
@@ -647,5 +649,5 @@ int CmdEM4x50WritePassword(const char *Cmd) {
     // get, prepare and print response
     print_write_password_result(&resp, &etd);
     
-    return ((bool)resp.oldarg[0]) ? PM3_SUCCESS : PM3_ESOFT;
+    return ((bool)resp.status) ? PM3_SUCCESS : PM3_ESOFT;
 }

--- a/client/src/cmdlfem4x50.h
+++ b/client/src/cmdlfem4x50.h
@@ -1,0 +1,18 @@
+//-----------------------------------------------------------------------------
+// Copyright (C) 2020 tharexde
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// Low frequency EM4x50 commands
+//-----------------------------------------------------------------------------
+
+#ifndef CMDLFEM4X50_H__
+#define CMDLFEM4X50_H__
+
+int usage_lf_em4x50_info(void);
+
+int CmdEM4x50Info(const char *Cmd);
+
+#endif

--- a/client/src/cmdlfem4x50.h
+++ b/client/src/cmdlfem4x50.h
@@ -12,7 +12,11 @@
 #define CMDLFEM4X50_H__
 
 int usage_lf_em4x50_info(void);
+int usage_lf_em4x50_write(void);
+int usage_lf_em4x50_write_password(void);
 
 int CmdEM4x50Info(const char *Cmd);
+int CmdEM4x50Write(const char *Cmd);
+int CmdEM4x50WritePassword(const char *Cmd);
 
 #endif

--- a/common_arm/Makefile.hal
+++ b/common_arm/Makefile.hal
@@ -81,7 +81,8 @@ endif
 # common LF support
 PLATFORM_DEFS += \
     -DWITH_LF \
-    -DWITH_HITAG
+    -DWITH_HITAG \
+    -DWITH_EM4x50
 
 # common HF support
 PLATFORM_DEFS += \

--- a/include/em4x50.h
+++ b/include/em4x50.h
@@ -1,0 +1,37 @@
+//-----------------------------------------------------------------------------
+// Copyright (C) 2020 tharexde
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// Low frequency EM4x50 structs
+//-----------------------------------------------------------------------------
+
+#ifndef EM4X50_H__
+#define EM4X50_H__
+
+typedef struct {
+    bool fwr_given;
+    bool lwr_given;
+    bool pwd_given;
+    bool newpwd_given;
+    uint8_t password[4];
+    uint8_t new_password[4];
+    uint8_t addresses[4];
+    uint8_t address;
+    uint8_t word[4];
+} em4x50_data_t;
+
+typedef struct {
+    uint8_t byte[4];
+    uint8_t row_parity[4];
+    uint8_t col_parity;
+    uint8_t stopbit;
+    bool rparity[4];
+    bool cparity[8];
+    bool stopparity;
+    bool parity;
+} em4x50_word_t;
+
+#endif /* EM4X50_H__ */

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -187,6 +187,7 @@ typedef struct {
     // lf
     bool compiled_with_lf              : 1;
     bool compiled_with_hitag           : 1;
+    bool compiled_with_em4x50          : 1;
     // hf
     bool compiled_with_hfsniff         : 1;
     bool compiled_with_hfplot          : 1;
@@ -401,6 +402,7 @@ typedef struct {
 #define CMD_LF_EM4X_WRITEWORD                                             0x0219
 #define CMD_LF_IO_DEMOD                                                   0x021A
 #define CMD_LF_EM410X_DEMOD                                               0x021C
+#define CMD_LF_EM4X50_INFO                                                0x0240
 // Sampling configuration for LF reader/sniffer
 #define CMD_LF_SAMPLING_SET_CONFIG                                        0x021D
 #define CMD_LF_FSK_SIMULATE                                               0x021E

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -403,6 +403,8 @@ typedef struct {
 #define CMD_LF_IO_DEMOD                                                   0x021A
 #define CMD_LF_EM410X_DEMOD                                               0x021C
 #define CMD_LF_EM4X50_INFO                                                0x0240
+#define CMD_LF_EM4X50_WRITE                                               0x0241
+#define CMD_LF_EM4X50_WRITE_PASSWORD                                      0x0242
 // Sampling configuration for LF reader/sniffer
 #define CMD_LF_SAMPLING_SET_CONFIG                                        0x021D
 #define CMD_LF_FSK_SIMULATE                                               0x021E


### PR DESCRIPTION
Added lf functions for EM4x50:
	1. 4x50_info (displays all available info of EM4x50 tag)
	2. 4x50_write (writes a single word to a specified address of EM4x50 tag)
	3. 4x50_write_password (changes password of EM4x50 tag)
	
Decoding is done on the fly on device side (by directly interpreting pulse lengths, no GraphBuffer)
	- no memory limitations (a tag with 33 words is fully readable)
	- can be used in standalone mode
	
Functions currently only work for Opt64 data rate because I don't have any Opt32 EM4x50 tags. 
Implementation is heavily based on EM4450 datasheet and EM4150 application note (AppNote 406) with ideas from hitag2 code.