### PR TITLE
Little optimization for hitag2hell attack

### DIFF
--- a/tools/hitag2crack/crack5/ht2crack5.c
+++ b/tools/hitag2crack/crack5/ht2crack5.c
@@ -330,7 +330,6 @@ static void *find_state(void *thread_d) {
                         const bitslice_value_t filter4 = f_c_bs(filter4_0, filter4_1, filter4_2, filter4_3, filter4_4);
                         bitslice_t results4;
                         results4.value = results3.value & (filter4 ^ keystream[4].value);
-
                         if (results4.bytes64[0] == 0
                                 && results4.bytes64[1] == 0
                                 && results4.bytes64[2] == 0
@@ -339,7 +338,9 @@ static void *find_state(void *thread_d) {
                             continue;
                         }
 
+                        state[-2 + 56].value = lfsr_bs(8);
                         const bitslice_value_t filter5_3 = f_b_bs(state[-2 + 33].value, state[-2 + 34].value, state[-2 + 36].value, state[-2 + 38].value);
+                        const bitslice_value_t filter10_4 = f_a_bs(state[-2 + 44].value, state[-2 + 53].value, state[-2 + 54].value, state[-2 + 56].value);
                         const bitslice_value_t filter12_2 = f_b_bs(state[-2 + 29].value, state[-2 + 33].value, state[-2 + 35].value, state[-2 + 38].value);
 
                         for (uint8_t i5 = 0; i5 < (1 << bits[5]); i5++) {
@@ -358,8 +359,9 @@ static void *find_state(void *thread_d) {
                                 continue;
                             }
 
+                            state[-2 + 57].value = lfsr_bs(9);
                             const bitslice_value_t filter6_3 = f_b_bs(state[-2 + 34].value, state[-2 + 35].value, state[-2 + 37].value, state[-2 + 39].value);
-
+                            const bitslice_value_t filter11_4 = f_a_bs(state[-2 + 45].value, state[-2 + 54].value, state[-2 + 55].value, state[-2 + 57].value);
                             for (uint8_t i6 = 0; i6 < (1 << bits[6]); i6++) {
                                 state[-2 + 40].value = ((bool)(i6 & 0x1)) ? bs_ones.value : bs_zeroes.value;
                                 // 0xffe7ffffffff
@@ -376,8 +378,9 @@ static void *find_state(void *thread_d) {
                                     continue;
                                 }
 
+                                state[-2 + 58].value = lfsr_bs(10);
                                 const bitslice_value_t filter7_3 = f_b_bs(state[-2 + 35].value, state[-2 + 36].value, state[-2 + 38].value, state[-2 + 40].value);
-
+                                const bitslice_value_t filter12_4 = f_a_bs(state[-2 + 46].value, state[-2 + 55].value, state[-2 + 56].value, state[-2 + 58].value);
                                 for (uint8_t i7 = 0; i7 < (1 << bits[7]); i7++) {
                                     state[-2 + 41].value = ((bool)(i7 & 0x1)) ? bs_ones.value : bs_zeroes.value;
                                     // 0xfff7ffffffff
@@ -393,16 +396,14 @@ static void *find_state(void *thread_d) {
                                         continue;
                                     }
 
+                                    state[-2 + 59].value = lfsr_bs(11);
                                     const bitslice_value_t filter8_3 = f_b_bs(state[-2 + 36].value, state[-2 + 37].value, state[-2 + 39].value, state[-2 + 41].value);
                                     const bitslice_value_t filter10_3 = f_b_bs(state[-2 + 38].value, state[-2 + 39].value, state[-2 + 41].value, state[-2 + 43].value);
                                     const bitslice_value_t filter12_3 = f_b_bs(state[-2 + 40].value, state[-2 + 41].value, state[-2 + 43].value, state[-2 + 45].value);
-
                                     for (uint8_t i8 = 0; i8 < (1 << bits[8]); i8++) {
                                         state[-2 + 42].value = ((bool)(i8 & 0x1)) ? bs_ones.value : bs_zeroes.value;
                                         // 0xffffffffffff
                                         const bitslice_value_t filter8_4 = f_a_bs(state[-2 + 42].value, state[-2 + 51].value, state[-2 + 52].value, state[-2 + 54].value);
-                                        const bitslice_value_t filter9_3 = f_b_bs(state[-2 + 37].value, state[-2 + 38].value, state[-2 + 40].value, state[-2 + 42].value);
-                                        const bitslice_value_t filter11_3 = f_b_bs(state[-2 + 39].value, state[-2 + 40].value, state[-2 + 42].value, state[-2 + 44].value);
                                         const bitslice_value_t filter8 = f_c_bs(filter8_0, filter8_1, filter8_2, filter8_3, filter8_4);
                                         bitslice_t results8;
                                         results8.value = results7.value & (filter8 ^ keystream[8].value);
@@ -415,6 +416,7 @@ static void *find_state(void *thread_d) {
                                             continue;
                                         }
 
+                                        const bitslice_value_t filter9_3 = f_b_bs(state[-2 + 37].value, state[-2 + 38].value, state[-2 + 40].value, state[-2 + 42].value);
                                         const bitslice_value_t filter9 = f_c_bs(filter9_0, filter9_1, filter9_2, filter9_3, filter9_4);
                                         results8.value &= (filter9 ^ keystream[9].value);
 
@@ -425,8 +427,7 @@ static void *find_state(void *thread_d) {
                                            ) {
                                             continue;
                                         }
-                                        state[-2 + 56].value = lfsr_bs(8);
-                                        const bitslice_value_t filter10_4 = f_a_bs(state[-2 + 44].value, state[-2 + 53].value, state[-2 + 54].value, state[-2 + 56].value);
+
                                         const bitslice_value_t filter10 = f_c_bs(filter10_0, filter10_1, filter10_2, filter10_3, filter10_4);
                                         results8.value &= (filter10 ^ keystream[10].value);
 
@@ -438,8 +439,7 @@ static void *find_state(void *thread_d) {
                                             continue;
                                         }
 
-                                        state[-2 + 57].value = lfsr_bs(9);
-                                        const bitslice_value_t filter11_4 = f_a_bs(state[-2 + 45].value, state[-2 + 54].value, state[-2 + 55].value, state[-2 + 57].value);
+                                        const bitslice_value_t filter11_3 = f_b_bs(state[-2 + 39].value, state[-2 + 40].value, state[-2 + 42].value, state[-2 + 44].value);
                                         const bitslice_value_t filter11 = f_c_bs(filter11_0, filter11_1, filter11_2, filter11_3, filter11_4);
                                         results8.value &= (filter11 ^ keystream[11].value);
 
@@ -451,8 +451,6 @@ static void *find_state(void *thread_d) {
                                             continue;
                                         }
 
-                                        state[-2 + 58].value = lfsr_bs(10);
-                                        const bitslice_value_t filter12_4 = f_a_bs(state[-2 + 46].value, state[-2 + 55].value, state[-2 + 56].value, state[-2 + 58].value);
                                         const bitslice_value_t filter12 = f_c_bs(filter12_0, filter12_1, filter12_2, filter12_3, filter12_4);
                                         results8.value &= (filter12 ^ keystream[12].value);
 
@@ -464,7 +462,6 @@ static void *find_state(void *thread_d) {
                                             continue;
                                         }
 
-                                        state[-2 + 59].value = lfsr_bs(11);
                                         const bitslice_value_t filter13_0 = f_a_bs(state[-2 + 15].value, state[-2 + 16].value, state[-2 + 18].value, state[-2 + 19].value);
                                         const bitslice_value_t filter13_1 = f_b_bs(state[-2 + 21].value, state[-2 + 25].value, state[-2 + 27].value, state[-2 + 28].value);
                                         const bitslice_value_t filter13_2 = f_b_bs(state[-2 + 30].value, state[-2 + 34].value, state[-2 + 36].value, state[-2 + 39].value);


### PR DESCRIPTION
Thank you for including the hitag2hell attack code in the project. I noticed that the version of the code published during the WOOT proceedings was not generated using the very latest version of the memoization algorithm. The fixes in this PR make the CPU implementation about 10% faster in practice according to my benchmark. The published GPU version is not affected by this oversight.

Please let me know if you have plans to develop this implementation further, for example to add support for smaller or larger vector machines as was done for the crypto1 hardnested attack. I would like to point out in advance that such a modification would work better when the vector size is taken into account in the cracker code itself, because the work per layer is distributed differently as a consequence of the word size according to the memoization algorithm.