### PR TITLE
Add support for new "Mikron JSC Russia" UL tag.

### DIFF
--- a/client/src/cmdhfmfu.c
+++ b/client/src/cmdhfmfu.c
@@ -1088,8 +1088,8 @@ uint32_t GetHF14AMfU_Type(void) {
                 MF0UNH1001DUx 0004030203000B03
                 NT2L1001G0DUx 0004040102000B03
                 NT2H1001G0DUx 0004040202000B03
+                Micron UL 0034210101000E03
                 */
-
                 if (memcmp(version, "\x00\x04\x03\x01\x01\x00\x0B", 7) == 0)      { tagtype = UL_EV1_48; break; }
                 else if (memcmp(version, "\x00\x04\x03\x01\x02\x00\x0B", 7) == 0) { tagtype = UL_NANO_40; break; }
                 else if (memcmp(version, "\x00\x04\x03\x02\x01\x00\x0B", 7) == 0) { tagtype = UL_EV1_48; break; }
@@ -1106,6 +1106,7 @@ uint32_t GetHF14AMfU_Type(void) {
                 else if (memcmp(version, "\x00\x04\x04\x05\x02\x01\x15", 7) == 0) { tagtype = NTAG_I2C_2K; break; }
                 else if (memcmp(version, "\x00\x04\x04\x05\x02\x02\x13", 7) == 0) { tagtype = NTAG_I2C_1K_PLUS; break; }
                 else if (memcmp(version, "\x00\x04\x04\x05\x02\x02\x15", 7) == 0) { tagtype = NTAG_I2C_2K_PLUS; break; }
+                else if (memcmp(version, "\x00\x34\x21\x01\x01\x00\x0E", 7) == 0) { tagtype = UL; break; }
                 else if (version[2] == 0x04) { tagtype = NTAG; break; }
                 else if (version[2] == 0x03) { tagtype = UL_EV1; }
                 break;


### PR DESCRIPTION
I have new russian Mikron Ultralight tag.
Dump command compleates with error, but dump file is created.
But i got an error while trying to read/write blocks, beacuse we think that card have only 0 block.
I assume that I need to add version detection to hf_mfu command =)

```
[usb] pm3 --> hf mfu dump
TYPE: Unknown 000000
[+] Reading tag memory...
[!] Authentication Failed UL-EV1/NTAG
[=] MFU dump file information
[=] -------------------------------------------------------------
[=]       Version | 00 34 21 01 01 00 0E 03
[=]         TBD 0 | 00 00
[=]         TBD 1 | 00
[=]     Signature | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[=]     Counter 0 | 00 00 00
[=]     Tearing 0 | 00
[=]     Counter 1 | 00 00 00
[=]     Tearing 1 | 00
[=]     Counter 2 | 00 00 00
[=]     Tearing 2 | 00
[=] Max data page | 14 (60 bytes)
[=]   Header size | 56
[=] -------------------------------------------------------------
[=] block#   | data        |lck| ascii
[=] ---------+-------------+---+------
[=]   0/0x00 | 34 73 45 8A |   | 4sE.
[=]   1/0x01 | 41 13 17 E6 |   | A...
[=]   2/0x02 | A3 00 70 08 |   | ..p.
[=]   3/0x03 | 00 00 00 00 | 0 | ....
[=]   4/0x04 | 45 D9 BB CB | 1 | E...
[=]   5/0x05 | DB DA 4A 00 | 1 | ..J.
[=]   6/0x06 | 66 60 38 40 | 1 | f`8@
[=]   7/0x07 | 00 00 00 00 | 0 | ....
[=]   8/0x08 | 01 00 00 00 | 0 | ....
[=]   9/0x09 | 00 00 00 00 | 0 | ....
[=]  10/0x0A | 88 95 F6 50 | 0 | ...P
[=]  11/0x0B | 66 60 38 40 | 1 | f`8@
[=]  12/0x0C | 00 00 00 00 | 0 | ....
[=]  13/0x0D | 01 00 00 00 | 0 | ....
[=]  14/0x0E | 00 00 00 00 | 0 | ....
[=]  15/0x0F | 88 95 F6 50 | 0 | ...P
[=] ---------------------------------
[=] Using UID as filename
[+] saved 120 bytes to binary file hf-mfu-347345411317E6-dump-3.bin
[+] saved to json file hf-mfu-347345411317E6-dump-3.json
```

```
[usb] pm3 --> hf mfu info

[=] --- Tag Information --------------------------
[=] -------------------------------------------------------------
      TYPE: Unknown 000000
[+]        UID: 34 73 45 41 13 17 E6
[+]     UID[0]: 34, Mikron JSC Russia
[+]       BCC0: 8A (ok)
[+]       BCC1: A3 (ok)
[+]   Internal: 00 (not default)
[+]       Lock: 70 08  - 18
[+] OneTimePad: 00 00 00 00  - 0000
```


```
[usb] pm3 --> hf mfu rdbl b 3
[!] block number to large. Max block is 0/0x00

Read a block and print. It autodetects card type.

Usage:  hf mfu rdbl b <block number> k <key> l

Options:
  b <no>  : block to read
  k <key> : (optional) key for authentication [UL-C 16bytes, EV1/NTAG 4bytes]
  l       : (optional) swap entered key's endianness

Examples:
       hf mfu rdbl b 0
       hf mfu rdbl b 0 k 00112233445566778899AABBCCDDEEFF
       hf mfu rdbl b 0 k AABBCCDD
```