### PR TITLE
EM4x50 function "sread" (standard/selective read)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 |[Notes on external flash](/doc/ext_flash_notes.md)|[Notes on loclass](/doc/loclass_notes.md)|[Notes on Coverity Scan Config & Run](/doc/md/Development/Coverity-Scan-Config-%26-Run.md)|
 |[Notes on file formats used with Proxmark3](/doc/extensions_notes.md)|[Notes on MFU binary format](/doc/mfu_binary_format_notes.md)|[Notes on FPGA & ARM](/doc/fpga_arm_notes.md)|
 |[Developing standalone mode](/armsrc/Standalone/readme.md)|[Wiki about standalone mode](https://github.com/RfidResearchGroup/proxmark3/wiki/Standalone-mode)||
-|[Notes on Color usage](/doc/colors_notes.md)||
+|[Notes on Color usage](/doc/colors_notes.md)|[Makefile vs CMake](/doc/md/Development/Makefile-vs-CMake.md)|
 
 
 ## Build for non-RDV4 Proxmark3 platforms

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1019,6 +1019,11 @@ static void PacketReceived(PacketCommandNG *packet) {
             em4x50_write_password((em4x50_data_t *)packet->data.asBytes);
             break;
         }
+        case CMD_LF_EM4X50_SREAD: {
+            em4x50_sread((em4x50_data_t *)packet->data.asBytes);
+            break;
+        }
+            
 #endif
 
 #ifdef WITH_ISO15693

--- a/armsrc/em4x50.c
+++ b/armsrc/em4x50.c
@@ -604,7 +604,9 @@ static int get_word_from_bitstream(uint8_t bits[EM4X50_TAG_WORD]) {
     }
 }
 
+//==============================================================================
 // login function
+//==============================================================================
 
 static bool login(uint8_t password[4]) {
 
@@ -631,7 +633,9 @@ static bool login(uint8_t password[4]) {
     return false;
 }
 
+//==============================================================================
 // reset function
+//==============================================================================
 
 static bool reset(void) {
 
@@ -653,7 +657,9 @@ static bool reset(void) {
     return false;
 }
 
+//==============================================================================
 // read functions
+//==============================================================================
 
 static bool standard_read(int *now) {
     
@@ -756,7 +762,7 @@ void em4x50_info(em4x50_data_t *etd) {
 
 void em4x50_sread(em4x50_data_t *etd) {
     
-    // reads single word in two alternative ways:
+    // reads in two different ways:
     // - using "selective read mode" -> bidirectional communication
     // - using "standard read mode" -> unidirectional communication (read
     //   data that tag transmits "voluntarily")
@@ -764,7 +770,7 @@ void em4x50_sread(em4x50_data_t *etd) {
     bool bsuccess = false, blogin = false;
     int now = 0;
     uint8_t status = 0;
-    uint8_t addresses[] = {0x00, 0x00, 0x00, 0x00}; // fwr = 0, lwr = 33
+    uint8_t addresses[] = {0x00, 0x00, 0x00, 0x00};
 
     init_tag();
     em4x50_setup_read();
@@ -790,14 +796,16 @@ void em4x50_sread(em4x50_data_t *etd) {
         bsuccess = standard_read(&now);
         
     }
+    
     status = (now << 2) + (bsuccess << 1) + blogin;
     
     lf_finalize();
     reply_ng(CMD_ACK, status, (uint8_t *)tag.sectors, 238);
 }
 
-
+//==============================================================================
 // write functions
+//==============================================================================
 
 static bool write(uint8_t word[4], uint8_t address) {
 

--- a/armsrc/em4x50.h
+++ b/armsrc/em4x50.h
@@ -20,5 +20,6 @@ typedef struct {
 void em4x50_info(em4x50_data_t *etd);
 void em4x50_write(em4x50_data_t *etd);
 void em4x50_write_password(em4x50_data_t *etd);
+void em4x50_sread(em4x50_data_t *etd);
 
 #endif /* EM4X50_H */

--- a/client/src/cmdlfem4x.c
+++ b/client/src/cmdlfem4x.c
@@ -1759,6 +1759,7 @@ static command_t CommandTable[] = {
     {"4x50_info",   CmdEM4x50Info,        IfPm3Lf,         "read complete data from EM4x50"},
     {"4x50_write",  CmdEM4x50Write,       IfPm3Lf,         "write word data to EM4x50"},
     {"4x50_write_password", CmdEM4x50WritePassword, IfPm3Lf, "change passwword of EM4x50 tag"},
+    {"4x50_sread",  CmdEM4x50SRead,       IfPm3Lf,         "read word data from EM4x50 on device"},
     {NULL, NULL, NULL, NULL}
 };
 

--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -206,6 +206,7 @@ static void print_result(const em4x50_word_t *words, int fwr, int lwr) {
         print_bit_table(words[i]);
          
         // final result
+        string[0] = '\0';
         sprintf(pstring, "\n  word[%i] msb: " _GREEN_("0x"), i);
         strcat(string, pstring);
 
@@ -223,8 +224,6 @@ static void print_result(const em4x50_word_t *words, int fwr, int lwr) {
         }
         
         PrintAndLogEx(NORMAL,string);
-
-        string[0] = '\0';
     }
 }
 
@@ -677,6 +676,7 @@ static void print_sread_result(PacketResponseNG *resp, const em4x50_data_t *etd)
             prepare_result(data, etd->address, etd->address, &word);
             print_result(&word, etd->address, etd->address);
             
+            string[0] = '\0';
             sprintf(pstring, "\n  reading " _GREEN_("ok "));
             strcat(string, pstring);
             
@@ -702,6 +702,7 @@ static void print_sread_result(PacketResponseNG *resp, const em4x50_data_t *etd)
             prepare_result(data, 0, now - 1, &word);
             print_result(&word, 0, now - 1);
 
+            string[0] = '\0';
             sprintf(pstring, "\n  reading " _GREEN_("ok "));
             strcat(string, pstring);
 

--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -723,8 +723,8 @@ int CmdEM4x50SRead(const char *Cmd) {
 
     // envoke reading
     // - without option -> standard read mode
-    // - with given address (option a) and optional password if address is
-    //   read protected -> selective read mode
+    // - with given address (option a) (and optional password if address is
+    //   read protected) -> selective read mode
 
     bool errors = false, success = false;
     uint8_t cmdp = 0;

--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -15,33 +15,6 @@
 #include "commonutil.h"
 #include "em4x50.h"
 
-#define EM4X50_NO_WORDS             34
-
-// special words
-#define EM4X50_DEVICE_PASSWORD      0
-#define EM4X50_PROTECTION           1
-#define EM4X50_CONTROL        2
-#define EM4X50_DEVICE_SERIAL        32
-#define EM4X50_DEVICE_ID            33
-
-// control word (word = 4 bytes)
-#define FIRST_WORD_READ             0       // first byte
-#define LAST_WORD_READ              1       // second byte
-#define CONFIG_BLOCK                2       // third byte
-#define PASSWORD_CHECK              0x80    // first bit in third byte
-#define READ_AFTER_WRITE            0x40    // second bit in third byte
-
-// protection word
-#define FIRST_WORD_READ_PROTECTED   0       // first byte
-#define LAST_WORD_READ_PROTECTED    1       // second byte
-#define FIRST_WORD_WRITE_INHIBITED  2       // third byte
-#define LAST_WORD_WRITE_INHIBITED   3       // fourth byte
-
-// misc
-#define STATUS_SUCCESS              0x2
-#define STATUS_LOGIN                0x1
-#define NO_CHARS_MAX                400
-
 int usage_lf_em4x50_info(void) {
     PrintAndLogEx(NORMAL, "Read all information of EM4x50. Tag nust be on antenna.");
     PrintAndLogEx(NORMAL, "");
@@ -79,6 +52,19 @@ int usage_lf_em4x50_write_password(void) {
     PrintAndLogEx(NORMAL, "       n <pwd>   - new password (hex)");
     PrintAndLogEx(NORMAL, "Examples:");
     PrintAndLogEx(NORMAL, "      lf em 4x50_write_password p 11223344 n 01020304");
+    return PM3_SUCCESS;
+}
+int usage_lf_em4x50_sread(void) {
+    PrintAndLogEx(NORMAL, "Read EM4x50 word(s). Tag must be on antenna. ");
+    PrintAndLogEx(NORMAL, "");
+    PrintAndLogEx(NORMAL, "Usage:  lf em 4x50_sread [h] a <address> p <pwd>");
+    PrintAndLogEx(NORMAL, "Options:");
+    PrintAndLogEx(NORMAL, "       h         - this help");
+    PrintAndLogEx(NORMAL, "       a <addr>  - memory address to read (dec) (optional)");
+    PrintAndLogEx(NORMAL, "       p <pwd>   - password (hex) (optional)");
+    PrintAndLogEx(NORMAL, "Examples:");
+    PrintAndLogEx(NORMAL, "      lf em 4x50_sread");
+    PrintAndLogEx(NORMAL, "      lf em 4x50_sread a 2 p 00000000");
     return PM3_SUCCESS;
 }
 
@@ -121,13 +107,13 @@ static void prepare_result(const uint8_t *byte, int fwr, int lwr, em4x50_word_t 
         }
         
         // check column parities
-        words[i].col_parity = byte[i*7+5] ;
+        words[i].col_parity = byte[i*7+5];
         
         for (int j = 0; j < 8; j++) {
             words[i].cparity[j] = (((words[i].col_parity >> (7-j)) & 1) == c[j]) ? true : false;
 
             if (!words[i].cparity[j])
-                words[i].parity = false;
+               words[i].parity = false;
         }
 
         // check stop bit
@@ -204,7 +190,7 @@ static void print_bit_table(const em4x50_word_t word) {
     string[0] = '\0';
 }
 
-static void print_result(const em4x50_word_t *words,  int fwr,  int lwr) {
+static void print_result(const em4x50_word_t *words, int fwr, int lwr) {
     
     // print available information for given word from fwr to lwr, i.e.
     // bit table + summary lines with hex notation of word (msb + lsb)
@@ -251,7 +237,7 @@ static void print_info_result(PacketResponseNG *resp, const em4x50_data_t *etd, 
     char pstring[NO_CHARS_MAX] = {0}, string[NO_CHARS_MAX] = {0};
 
     bool bpwd_given = etd->pwd_given;
-    bool bsuccess = resp->status & STATUS_SUCCESS;
+    bool bsuccess = (resp->status & STATUS_SUCCESS) >> 1;
     bool blogin = resp->status & STATUS_LOGIN;
 
     prepare_result(data, 0, EM4X50_NO_WORDS - 1, words);
@@ -455,7 +441,7 @@ int CmdEM4x50Info(const char *Cmd) {
     // print result
     print_info_result(&resp, &etd, verbose);
     
-    success = resp.status & STATUS_SUCCESS;
+    success = (resp.status & STATUS_SUCCESS) >> 1;
     return (success) ? PM3_SUCCESS : PM3_ESOFT;
 }
 
@@ -464,7 +450,7 @@ static void print_write_result(PacketResponseNG *resp, const em4x50_data_t *etd)
     // display result of writing operation in structured format
 
     bool pwd_given = etd->pwd_given;
-    bool success = resp->status & STATUS_SUCCESS;
+    bool success = (resp->status & STATUS_SUCCESS) >> 1;
     bool login = resp->status & STATUS_LOGIN;
     uint8_t *data = resp->data.asBytes;
     char string[NO_CHARS_MAX] = {0}, pstring[NO_CHARS_MAX] = {0};
@@ -574,7 +560,7 @@ int CmdEM4x50Write(const char *Cmd) {
     // get, prepare and print response
     print_write_result(&resp, &etd);
     
-    success = resp.status & STATUS_SUCCESS;
+    success = (resp.status & STATUS_SUCCESS) >> 1;
     return (success) ? PM3_SUCCESS : PM3_ESOFT;
 }
 
@@ -660,4 +646,143 @@ int CmdEM4x50WritePassword(const char *Cmd) {
     print_write_password_result(&resp, &etd);
     
     return ((bool)resp.status) ? PM3_SUCCESS : PM3_ESOFT;
+}
+
+static void print_sread_result(PacketResponseNG *resp, const em4x50_data_t *etd) {
+    
+    // display result of writing operation in structured format
+
+    bool addr_given = etd->addr_given;
+    bool pwd_given = etd->pwd_given;
+    bool login = resp->status & STATUS_LOGIN;
+    bool success = (resp->status & STATUS_SUCCESS) >> 1;
+    int now = (resp->status & STATUS_NO_WORDS) >> 2;
+    char string[NO_CHARS_MAX] = {0}, pstring[NO_CHARS_MAX] = {0};
+    uint8_t *data = resp->data.asBytes;
+    em4x50_word_t word;
+
+    if (!success) {
+        
+        sprintf(pstring, "\n  reading " _RED_("failed"));
+        strcat(string, pstring);
+
+        PrintAndLogEx(NORMAL,"%s\n", string);
+
+    } else {
+
+        if (addr_given) {
+            
+            // selective read mode
+
+            prepare_result(data, etd->address, etd->address, &word);
+            print_result(&word, etd->address, etd->address);
+            
+            sprintf(pstring, "\n  reading " _GREEN_("ok "));
+            strcat(string, pstring);
+            
+            if (pwd_given) {
+                if (login) {
+                    sprintf(pstring, "(login with password 0x%02x%02x%02x%02x)",
+                            etd->password[0], etd->password[1],
+                            etd->password[2], etd->password[3]);
+                    strcat(string, pstring);
+                } else {
+                    sprintf(pstring, "(login failed)");
+                    strcat(string, pstring);
+                }
+            } else {
+                sprintf(pstring, "(no login)");
+                strcat(string, pstring);
+            }
+
+        } else {
+            
+            //standard read mode
+
+            prepare_result(data, 0, now - 1, &word);
+            print_result(&word, 0, now - 1);
+
+            sprintf(pstring, "\n  reading " _GREEN_("ok "));
+            strcat(string, pstring);
+
+            if (pwd_given) {
+                sprintf(pstring, "(standard read mode, password ignored)");
+                strcat(string, pstring);
+            } else {
+                sprintf(pstring, "(standard read mode)");
+                strcat(string, pstring);
+            }
+        }
+
+        PrintAndLogEx(NORMAL,"%s\n", string);
+    }
+}
+
+int CmdEM4x50SRead(const char *Cmd) {
+
+    // envoke reading
+    // - without option -> standard read mode
+    // - with given address (option a) and optional password if address is
+    //   read protected -> selective read mode
+
+    bool errors = false, success = false;
+    uint8_t cmdp = 0;
+    em4x50_data_t etd;
+    PacketResponseNG resp;
+
+    // init
+    etd.pwd_given = false;
+    etd.addr_given = false;
+
+    while (param_getchar(Cmd, cmdp) != 0x00 && !errors) {
+
+        switch (tolower(param_getchar(Cmd, cmdp))) {
+            case 'h':
+                return usage_lf_em4x50_sread();
+
+            case 'p':
+                if (param_gethex(Cmd, cmdp + 1, etd.password, 8)) {
+                     PrintAndLogEx(FAILED, "\n  password has to be 8 hex symbols\n");
+                     return PM3_EINVARG;
+                 }
+                etd.pwd_given = true;
+                cmdp += 2;
+                break;
+
+            case 'a':
+                param_getdec(Cmd, cmdp + 1, &etd.address);
+
+                // validation
+                if (etd.address <= 0 || etd.address >= EM4X50_NO_WORDS) {
+                    PrintAndLogEx(FAILED, "\n  error, address has to be in range [1-33]\n");
+                    return PM3_EINVARG;
+                }
+                etd.addr_given = true;
+                cmdp += 2;
+                break;
+
+            default:
+                PrintAndLogEx(WARNING, "\n  Unknown parameter '%c'\n", param_getchar(Cmd, cmdp));
+                errors = true;
+                break;
+        }
+    }
+
+    if (errors)
+         return usage_lf_em4x50_sread();
+
+    clearCommandBuffer();
+    SendCommandNG(CMD_LF_EM4X50_SREAD, (uint8_t *)&etd, sizeof(etd));
+
+
+    if (!WaitForResponse(CMD_ACK, &resp)) {
+        PrintAndLogEx(WARNING, "\n  timeout while waiting for reply.\n");
+        return PM3_ETIMEOUT;
+    }
+    
+    // get, prepare and print response
+    print_sread_result(&resp, &etd);
+    
+    success = (resp.status & STATUS_SUCCESS) >> 1;
+    return (success) ? PM3_SUCCESS : PM3_ESOFT;
 }

--- a/client/src/cmdlfem4x50.h
+++ b/client/src/cmdlfem4x50.h
@@ -14,9 +14,11 @@
 int usage_lf_em4x50_info(void);
 int usage_lf_em4x50_write(void);
 int usage_lf_em4x50_write_password(void);
+int usage_lf_em4x50_sread(void);
 
 int CmdEM4x50Info(const char *Cmd);
 int CmdEM4x50Write(const char *Cmd);
 int CmdEM4x50WritePassword(const char *Cmd);
+int CmdEM4x50SRead(const char *Cmd);
 
 #endif

--- a/include/em4x50.h
+++ b/include/em4x50.h
@@ -11,9 +11,36 @@
 #ifndef EM4X50_H__
 #define EM4X50_H__
 
+#define EM4X50_NO_WORDS             34
+
+// special words
+#define EM4X50_DEVICE_PASSWORD      0
+#define EM4X50_PROTECTION           1
+#define EM4X50_CONTROL              2
+#define EM4X50_DEVICE_SERIAL        32
+#define EM4X50_DEVICE_ID            33
+
+// control word (word = 4 bytes)
+#define FIRST_WORD_READ             0       // first byte
+#define LAST_WORD_READ              1       // second byte
+#define CONFIG_BLOCK                2       // third byte
+#define PASSWORD_CHECK              0x80    // first bit in third byte
+#define READ_AFTER_WRITE            0x40    // second bit in third byte
+
+// protection word
+#define FIRST_WORD_READ_PROTECTED   0       // first byte
+#define LAST_WORD_READ_PROTECTED    1       // second byte
+#define FIRST_WORD_WRITE_INHIBITED  2       // third byte
+#define LAST_WORD_WRITE_INHIBITED   3       // fourth byte
+
+// misc
+#define STATUS_NO_WORDS             0xfc
+#define STATUS_SUCCESS              0x2
+#define STATUS_LOGIN                0x1
+#define NO_CHARS_MAX                400
+
 typedef struct {
-    bool fwr_given;
-    bool lwr_given;
+    bool addr_given;
     bool pwd_given;
     bool newpwd_given;
     uint8_t password[4];

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -405,6 +405,7 @@ typedef struct {
 #define CMD_LF_EM4X50_INFO                                                0x0240
 #define CMD_LF_EM4X50_WRITE                                               0x0241
 #define CMD_LF_EM4X50_WRITE_PASSWORD                                      0x0242
+#define CMD_LF_EM4X50_SREAD                                               0x0243
 // Sampling configuration for LF reader/sniffer
 #define CMD_LF_SAMPLING_SET_CONFIG                                        0x021D
 #define CMD_LF_FSK_SIMULATE                                               0x021E


### PR DESCRIPTION
Added new read function "sread" for EM4x50 (device side): 
 
- If no option is given „em4x50_sread“ carries out a „standard read“, i.e. the data transmitted by tag voluntarily is catched and decoded.
- If a dedicated address is given (option a) „em4x50_sread“ carries out a „selective read“, i.e. data stored at this address is requested and decoded.