### PR TITLE
added 4x50_wipe

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1023,7 +1023,10 @@ static void PacketReceived(PacketCommandNG *packet) {
             em4x50_read((em4x50_data_t *)packet->data.asBytes);
             break;
         }
-            
+        case CMD_LF_EM4X50_WIPE: {
+            em4x50_wipe((em4x50_data_t *)packet->data.asBytes);
+            break;
+        }
 #endif
 
 #ifdef WITH_ISO15693

--- a/armsrc/em4x50.h
+++ b/armsrc/em4x50.h
@@ -21,5 +21,6 @@ void em4x50_info(em4x50_data_t *etd);
 void em4x50_write(em4x50_data_t *etd);
 void em4x50_write_password(em4x50_data_t *etd);
 void em4x50_read(em4x50_data_t *etd);
+void em4x50_wipe(em4x50_data_t *etd);
 
 #endif /* EM4X50_H */

--- a/client/src/cmdlfem4x.c
+++ b/client/src/cmdlfem4x.c
@@ -1400,6 +1400,7 @@ static command_t CommandTable[] = {
     {"4x50_write",  CmdEM4x50Write,       IfPm3EM4x50,     "write word data to EM4x50"},
     {"4x50_write_password", CmdEM4x50WritePassword, IfPm3EM4x50, "change passwword of EM4x50 tag"},
     {"4x50_read",   CmdEM4x50Read,        IfPm3EM4x50,     "read word data from EM4x50"},
+    {"4x50_wipe",   CmdEM4x50Wipe,        IfPm3EM4x50,     "wipe data from EM4x50"},
     {NULL, NULL, NULL, NULL}
 };
 

--- a/client/src/cmdlfem4x50.h
+++ b/client/src/cmdlfem4x50.h
@@ -23,4 +23,6 @@ int CmdEM4x50Write(const char *Cmd);
 int CmdEM4x50WritePassword(const char *Cmd);
 int CmdEM4x50Read(const char *Cmd);
 int CmdEM4x50Dump(const char *Cmd);
+int CmdEM4x50Wipe(const char *Cmd);
+
 #endif

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -406,6 +406,7 @@ typedef struct {
 #define CMD_LF_EM4X50_WRITE                                               0x0241
 #define CMD_LF_EM4X50_WRITE_PASSWORD                                      0x0242
 #define CMD_LF_EM4X50_READ                                                0x0243
+#define CMD_LF_EM4X50_WIPE                                                0x0244
 // Sampling configuration for LF reader/sniffer
 #define CMD_LF_SAMPLING_SET_CONFIG                                        0x021D
 #define CMD_LF_FSK_SIMULATE                                               0x021E


### PR DESCRIPTION
Added function "4x50_wipe" to clear an EM4x50 tag, i.e. fill/overwrite everything with "0" (including password);
UID and serial can not be changed! 