### PR TITLE
Refactor demodParadox()

### DIFF
--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -598,9 +598,8 @@ int lf_read(bool verbose, uint32_t samples) {
     struct p {
         uint8_t verbose;
         uint32_t samples;
-    } PACKED;
+    } payload;
 
-    struct p payload;
     payload.verbose = verbose;
     payload.samples = samples;
 

--- a/client/src/cmdlfparadox.h
+++ b/client/src/cmdlfparadox.h
@@ -14,5 +14,4 @@
 int CmdLFParadox(const char *Cmd);
 
 int demodParadox(void);
-int detectParadox(uint8_t *dest, size_t *size, int *wave_start_idx);
 #endif

--- a/client/src/cmdparser.c
+++ b/client/src/cmdparser.c
@@ -187,17 +187,17 @@ int CmdsParse(const command_t Commands[], const char *Cmd) {
         return PM3_SUCCESS;
     }
 
-    char cmd_name[128];
-    memset(cmd_name, 0, sizeof(cmd_name));
+    char cmd_name[128] = { 0 };
 
     int len = 0;
     // %n == receives an integer of value equal to the number of chars read so far.
     // len = max 127
     sscanf(Cmd, "%127s%n", cmd_name, &len);
 
+    // Convert commands to lower case
     str_lower(cmd_name);
 
-    // Comment
+    // Ignore comment
     if (cmd_name[0] == '#')
         return PM3_SUCCESS;
 
@@ -243,7 +243,7 @@ int CmdsParse(const command_t Commands[], const char *Cmd) {
 static char pparent[512] = {0};
 static char *parent = pparent;
 
-void dumpCommandsRecursive(const command_t cmds[], int markdown) {
+void dumpCommandsRecursive(const command_t cmds[], bool markdown) {
     if (cmds[0].Name == NULL) return;
 
     int i = 0;

--- a/client/src/cmdparser.h
+++ b/client/src/cmdparser.h
@@ -52,6 +52,6 @@ void CmdsHelp(const command_t Commands[]);
 void CmdsLS(const command_t Commands[]);
 // Parse a command line
 int CmdsParse(const command_t Commands[], const char *Cmd);
-void dumpCommandsRecursive(const command_t cmds[], int markdown);
+void dumpCommandsRecursive(const command_t cmds[], bool markdown);
 
 #endif

--- a/client/src/wiegand_formats.c
+++ b/client/src/wiegand_formats.c
@@ -591,7 +591,7 @@ static const cardformat_t FormatTable[] = {
     {"H10306",  Pack_H10306,  Unpack_H10306,  "HID H10306 34-bit",          {1, 1, 0, 0, 1}}, // imported from old pack/unpack
     {"N10002",  Pack_N10002,  Unpack_N10002,  "HID N10002 34-bit",          {1, 1, 0, 0, 1}}, // from cardinfo.barkweb.com.au
     {"C1k35s",  Pack_C1k35s,  Unpack_C1k35s,  "HID Corporate 1000 35-bit standard layout", {1, 1, 0, 0, 1}}, // imported from old pack/unpack
-    {"C15001",  Pack_C15001,  Unpack_C15001,  "HID KeySpan 36-bit",         {1, 1, 0, 1, 1}}, // from Proxmark forums
+    {"C15001",  Pack_C15001,  Unpack_C15001,  "HID Keyscan 36-bit",         {1, 1, 0, 1, 1}}, // from Proxmark forums
     {"S12906",  Pack_S12906,  Unpack_S12906,  "HID Simplex 36-bit",         {1, 1, 1, 0, 1}}, // from cardinfo.barkweb.com.au
     {"Sie36",   Pack_Sie36,   Unpack_Sie36,   "HID 36-bit Siemens",         {1, 1, 0, 0, 1}}, // from cardinfo.barkweb.com.au
     {"H10320",  Pack_H10320,  Unpack_H10320,  "HID H10320 36-bit BCD",      {1, 0, 0, 0, 1}}, // from Proxmark forums

--- a/common/lfdemod.h
+++ b/common/lfdemod.h
@@ -77,7 +77,8 @@ size_t   removeParity(uint8_t *bits, size_t startIdx, uint8_t pLen, uint8_t pTyp
 //tag specific
 int detectAWID(uint8_t *dest, size_t *size, int *waveStartIdx);
 int Em410xDecode(uint8_t *bits, size_t *size, size_t *start_idx, uint32_t *hi, uint64_t *lo);
-int HIDdemodFSK(uint8_t *dest, size_t *size, uint32_t *hi2, uint32_t *hi, uint32_t *lo, int *waveStartIdx);
+int DemodManchesterFSK(uint8_t *dest, size_t *size, uint64_t *demod_id_hi, uint64_t *demod_id_lo, int *waveStartIdx,
+                       uint8_t *preamble, uint8_t raw_full_len, uint8_t raw_pre_len);
 int detectIdteck(uint8_t *dest, size_t *size);
 int detectIOProx(uint8_t *dest, size_t *size, int *waveStartIdx);
 


### PR DESCRIPTION
1. Fixed the bug of Paradox ID, now the ID is 32 bits in length, first 8 bits is FC, next 16 bits is CN, last 8 bits is CRC;
2. Made code easier to read, code is much simpler now and fixed the color output;
3. Removed doegox's code on attempting to reverse engineering the 8 bit CRC value. I think new CRC reverse engineering needs to be based on the first 24 bits of the Paradox ID, so new codes to be written;
4. Added instruction in the header to allow other developers to easily understand Paradox.