### PR TITLE
Fixed gen_pm3mfsim_script.sh

### DIFF
--- a/client/gen_pm3mfsim_script.sh
+++ b/client/gen_pm3mfsim_script.sh
@@ -32,4 +32,4 @@ rm $2
 echo "hf mf eclr" >> $2
 echo "hf mf eload" $1 >> $2
 echo "hf mf ekeyprn" >> $2
-echo "hf mf sim" `cat $1.eml | (read -n 8 uid; echo $uid)` >> $2
+echo "hf mf sim u" `cat $1.eml | (read -n 8 uid; echo $uid)` >> $2

--- a/client/gen_pm3mfsim_script.sh
+++ b/client/gen_pm3mfsim_script.sh
@@ -11,7 +11,7 @@ show_usage()
 {
     echo
     echo "Usage:"
-    echo "${0##/} input_eml_without_extension output.pm3scr"
+    echo "${0##/} input_eml_without_extension output.cmd"
     exit
 }
 


### PR DESCRIPTION
The script for generating a MiFare Classic emulation script (located at `client/gen_pm3mfsim_script.sh`) was missing a parameter in the script generation process. This pull request adds the missing parameter.