### PR TITLE
Documentation: changed the `sc` command to `smart`

### DIFF
--- a/doc/cheatsheet.md
+++ b/doc/cheatsheet.md
@@ -574,7 +574,7 @@ pm3 --> mem load f iclass_default_keys i
 
 Upgrade Sim Module firmware
 ```
-pm3 --> sc upgrade f ../tools/simmodule/sim011.bin
+pm3 --> smart upgrade f ../tools/simmodule/sim011.bin
 ```
 
 ## Smart Card
@@ -582,12 +582,12 @@ pm3 --> sc upgrade f ../tools/simmodule/sim011.bin
 
 Get Smart Card Information
 ```
-pm3 --> sc info
+pm3 --> smart info
 ```
 
 Act like an IS07816 reader
 ```
-pm3 --> sc reader
+pm3 --> smart reader
 ```
 
 Set clock speed
@@ -596,7 +596,7 @@ Options
 ---
 c <speed>       : clockspeed (0 = 16MHz, 1=8MHz, 2=4MHz)
 
-pm3 --> sc setclock c 2
+pm3 --> smart setclock c 2
 ```
 
 Send raw hex data
@@ -604,16 +604,16 @@ Send raw hex data
 Options
 ---
 r           : do not read response
-a           : active smartcard without select (reset sc module)
+a           : active smartcard without select (reset smart module)
 s           : active smartcard with select (get ATR)
 t           : executes TLV decoder if it possible
 0           : use protocol T=0
 d <bytes>   : bytes to send
 
-pm3 --> sc raw s 0 d 00a404000e315041592e5359532e4444463031 : 1PAY.SYS.DDF01 PPSE directory with get ATR
-pm3 --> sc raw 0 d 00a404000e325041592e5359532e4444463031   : 2PAY.SYS.DDF01 PPSE directory
-pm3 --> sc raw 0 t d 00a4040007a0000000041010               : Mastercard
-pm3 --> sc raw 0 t d 00a4040007a0000000031010               : Visa
+pm3 --> smart raw s 0 d 00a404000e315041592e5359532e4444463031 : 1PAY.SYS.DDF01 PPSE directory with get ATR
+pm3 --> smart raw 0 d 00a404000e325041592e5359532e4444463031   : 2PAY.SYS.DDF01 PPSE directory
+pm3 --> smart raw 0 t d 00a4040007a0000000041010               : Mastercard
+pm3 --> smart raw 0 t d 00a4040007a0000000031010               : Visa
 ````
 
 Bruteforce SPI
@@ -622,6 +622,6 @@ Options
 ---
 t          : executes TLV decoder if it possible
 
-pm3 --> sc brute
-pm3 --> sc brute t
+pm3 --> smart brute
+pm3 --> smart brute t
 ```

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -845,14 +845,14 @@ Check column "offline" for their availability.
           
 |command                  |offline |description          
 |-------                  |------- |-----------          
-|`sc help                `|Y       |`This help`          
-|`sc list                `|N       |`List ISO 7816 history`          
-|`sc info                `|N       |`Tag information`          
-|`sc reader              `|N       |`Act like an IS07816 reader`          
-|`sc raw                 `|N       |`Send raw hex data to tag`          
-|`sc upgrade             `|Y       |`Upgrade sim module firmware`          
-|`sc setclock            `|N       |`Set clock speed`          
-|`sc brute               `|N       |`Bruteforce SFI`          
+|`smart help             `|Y       |`This help`          
+|`smart list             `|N       |`List ISO 7816 history`          
+|`smart info             `|N       |`Tag information`          
+|`smart reader           `|N       |`Act like an IS07816 reader`          
+|`smart raw              `|N       |`Send raw hex data to tag`          
+|`smart upgrade          `|Y       |`Upgrade sim module firmware`          
+|`smart setclock         `|N       |`Set clock speed`          
+|`smart brute            `|N       |`Bruteforce SFI`          
 
           
 ### script

--- a/doc/md/Installation_Instructions/Troubleshooting.md
+++ b/doc/md/Installation_Instructions/Troubleshooting.md
@@ -127,9 +127,9 @@ proxmark3 <YOUR_PORT_HERE> --flash --image /usr/local/share/proxmark3/firmware/f
 <>
 proxmark3 <YOUR_PORT_HERE> --flash --image /usr/share/proxmark3/firmware/fullimage.elf
 
-pm3 --> sc upgrade f /usr/local/share/proxmark3/firmware/sim011.bin
+pm3 --> smart upgrade f /usr/local/share/proxmark3/firmware/sim011.bin
 <>
-pm3 --> sc upgrade f /usr/share/proxmark3/firmware/sim011.bin
+pm3 --> smart upgrade f /usr/share/proxmark3/firmware/sim011.bin
 ```
 
 If you didn't install the PRoxmark but you're working from the sources directory and depending how you launch the client, your working directory might be the root of the repository:
@@ -152,9 +152,9 @@ client/proxmark3 <YOUR_PORT_HERE> --flash --image armsrc/obj/fullimage.elf
 <>
 ./proxmark3 <YOUR_PORT_HERE> --flash --image ../armsrc/obj/fullimage.elf
 
-pm3 --> sc upgrade f tools/simmodule/sim011.bin
+pm3 --> smart upgrade f tools/simmodule/sim011.bin
 <>
-pm3 --> sc upgrade f ../tools/simmodule/sim011.bin
+pm3 --> smart upgrade f ../tools/simmodule/sim011.bin
 ```
 
 etc.

--- a/doc/md/Use_of_Proxmark/2_Configuration-and-Verification.md
+++ b/doc/md/Use_of_Proxmark/2_Configuration-and-Verification.md
@@ -46,9 +46,9 @@ Don't not turn off your device during the execution of this command!!
 Even its a quite fast command you should be warned.  You may brick it if you interrupt it.
 
 ```
-[usb] pm3 --> sc upgrade f /usr/local/share/proxmark3/firmware/sim011.bin
+[usb] pm3 --> smart upgrade f /usr/local/share/proxmark3/firmware/sim011.bin
 # or if from local repo
-[usb] pm3 --> sc upgrade f tools/simmodule/sim011.bin
+[usb] pm3 --> smart upgrade f tools/simmodule/sim011.bin
 ```
 
 You get the following output if the execution was successful:


### PR DESCRIPTION
The documentation was refering to the command related to Smart Card as `sc` while it is instead the `smart` command.
Entering `sc` in the proxmark3 client runs the `script` command.

```
[usb] pm3 --> sc
help             Usage info
list             List available scripts
run              <name> -- execute a script
[usb] pm3 --> script
help             Usage info
list             List available scripts
run              <name> -- execute a script
[usb] pm3 --> smart
help             This help
list             List ISO 7816 history
info             Tag information
reader           Act like an IS07816 reader
raw              Send raw hex data to tag
upgrade          Upgrade sim module firmware
setclock         Set clock speed
brute            Bruteforce SFI
```

```
[usb] pm3 --> help
--------         ----------------------- Technology -----------------------
[...]
smart            { Smart card ISO-7816 commands... }
[...]
```