### PR TITLE
Add standalone mode hf_aveful: Mifare ultralight read/simulation

### DIFF
--- a/armsrc/Standalone/Makefile.hal
+++ b/armsrc/Standalone/Makefile.hal
@@ -38,6 +38,9 @@ define KNOWN_STANDALONE_DEFINITIONS
 | HF_14ASNIFF     | 14a sniff to flashmem                  |
 | (RDV4 only)     |                                        |
 +----------------------------------------------------------+
+| HF_AVEFUL       | Mifare ultralight read/simulation      |
+|                 | - Ave Ozkal                            |
++----------------------------------------------------------+
 | HF_BOG          | 14a sniff with ULC/ULEV1/NTAG auth     |
 | (RDV4 only)     | storing in flashmem - Bogito           |
 +----------------------------------------------------------+
@@ -59,13 +62,10 @@ define KNOWN_STANDALONE_DEFINITIONS
 | HF_YOUNG        | Mifare sniff/simulation                |
 |                 | - Craig Young                          |
 +----------------------------------------------------------+
-| HF_AVEFUL       | Mifare ultralight read/simulation      |
-|                 | - Ave Ozkal                            |
-+----------------------------------------------------------+
 endef
 
 STANDALONE_MODES := LF_SKELETON LF_EM4100EMUL LF_EM4100RSWB LF_EM4100RWC LF_HIDBRUTE LF_ICEHID LF_PROXBRUTE LF_SAMYRUN
-STANDALONE_MODES += HF_14ASNIFF HF_BOG HF_COLIN HF_ICECLASS HF_LEGIC HF_MATTYRUN HF_MSDSAL HF_YOUNG HF_AVEFUL
+STANDALONE_MODES += HF_14ASNIFF HF_AVEFUL HF_BOG HF_COLIN HF_ICECLASS HF_LEGIC HF_MATTYRUN HF_MSDSAL HF_YOUNG
 STANDALONE_MODES_REQ_SMARTCARD :=
 STANDALONE_MODES_REQ_FLASH := LF_ICEHID HF_14ASNIFF HF_BOG HF_COLIN HF_ICECLASS
 ifneq ($(filter $(STANDALONE),$(STANDALONE_MODES)),)

--- a/armsrc/Standalone/Makefile.hal
+++ b/armsrc/Standalone/Makefile.hal
@@ -59,13 +59,13 @@ define KNOWN_STANDALONE_DEFINITIONS
 | HF_YOUNG        | Mifare sniff/simulation                |
 |                 | - Craig Young                          |
 +----------------------------------------------------------+
-| HF_AVEUL        | Mifare ultralight read/simulation      |
+| HF_AVEFUL       | Mifare ultralight read/simulation      |
 |                 | - Ave Ozkal                            |
 +----------------------------------------------------------+
 endef
 
 STANDALONE_MODES := LF_SKELETON LF_EM4100EMUL LF_EM4100RSWB LF_EM4100RWC LF_HIDBRUTE LF_ICEHID LF_PROXBRUTE LF_SAMYRUN
-STANDALONE_MODES += HF_14ASNIFF HF_BOG HF_COLIN HF_ICECLASS HF_LEGIC HF_MATTYRUN HF_MSDSAL HF_YOUNG HF_AVEUL
+STANDALONE_MODES += HF_14ASNIFF HF_BOG HF_COLIN HF_ICECLASS HF_LEGIC HF_MATTYRUN HF_MSDSAL HF_YOUNG HF_AVEFUL
 STANDALONE_MODES_REQ_SMARTCARD :=
 STANDALONE_MODES_REQ_FLASH := LF_ICEHID HF_14ASNIFF HF_BOG HF_COLIN HF_ICECLASS
 ifneq ($(filter $(STANDALONE),$(STANDALONE_MODES)),)

--- a/armsrc/Standalone/Makefile.hal
+++ b/armsrc/Standalone/Makefile.hal
@@ -59,10 +59,13 @@ define KNOWN_STANDALONE_DEFINITIONS
 | HF_YOUNG        | Mifare sniff/simulation                |
 |                 | - Craig Young                          |
 +----------------------------------------------------------+
+| HF_AVEUL        | Mifare ultralight read/simulation      |
+|                 | - Ave Ozkal                            |
++----------------------------------------------------------+
 endef
 
 STANDALONE_MODES := LF_SKELETON LF_EM4100EMUL LF_EM4100RSWB LF_EM4100RWC LF_HIDBRUTE LF_ICEHID LF_PROXBRUTE LF_SAMYRUN
-STANDALONE_MODES += HF_14ASNIFF HF_BOG HF_COLIN HF_ICECLASS HF_LEGIC HF_MATTYRUN HF_MSDSAL HF_YOUNG 
+STANDALONE_MODES += HF_14ASNIFF HF_BOG HF_COLIN HF_ICECLASS HF_LEGIC HF_MATTYRUN HF_MSDSAL HF_YOUNG HF_AVEUL
 STANDALONE_MODES_REQ_SMARTCARD :=
 STANDALONE_MODES_REQ_FLASH := LF_ICEHID HF_14ASNIFF HF_BOG HF_COLIN HF_ICECLASS
 ifneq ($(filter $(STANDALONE),$(STANDALONE_MODES)),)

--- a/armsrc/Standalone/Makefile.inc
+++ b/armsrc/Standalone/Makefile.inc
@@ -37,9 +37,9 @@ endif
 ifneq (,$(findstring WITH_STANDALONE_HF_14ASNIFF,$(APP_CFLAGS)))
     SRC_STANDALONE = hf_14asniff.c
 endif
-# WITH_STANDALONE_HF_AVEUL
-ifneq (,$(findstring WITH_STANDALONE_HF_AVEUL,$(APP_CFLAGS)))
-    SRC_STANDALONE = hf_aveul.c
+# WITH_STANDALONE_HF_AVEFUL
+ifneq (,$(findstring WITH_STANDALONE_HF_AVEFUL,$(APP_CFLAGS)))
+    SRC_STANDALONE = hf_aveful.c
 endif
 # WITH_STANDALONE_LF_ICEHID
 ifneq (,$(findstring WITH_STANDALONE_LF_ICEHID,$(APP_CFLAGS)))

--- a/armsrc/Standalone/Makefile.inc
+++ b/armsrc/Standalone/Makefile.inc
@@ -37,6 +37,10 @@ endif
 ifneq (,$(findstring WITH_STANDALONE_HF_14ASNIFF,$(APP_CFLAGS)))
     SRC_STANDALONE = hf_14asniff.c
 endif
+# WITH_STANDALONE_HF_AVEUL
+ifneq (,$(findstring WITH_STANDALONE_HF_AVEUL,$(APP_CFLAGS)))
+    SRC_STANDALONE = hf_aveul.c
+endif
 # WITH_STANDALONE_LF_ICEHID
 ifneq (,$(findstring WITH_STANDALONE_LF_ICEHID,$(APP_CFLAGS)))
     SRC_STANDALONE = lf_icehid.c

--- a/armsrc/Standalone/hf_aveful.c
+++ b/armsrc/Standalone/hf_aveful.c
@@ -8,11 +8,11 @@
 // main code for HF Mifare Ultralight read/simulation by Ave Ozkal
 //-----------------------------------------------------------------------------
 
-/* Several parts of this code is based on code by Craig Young from HF_YOUNG */
+// Several parts of this code is based on code by Craig Young from HF_YOUNG
 
-/* This code does not:
-- Account for cards with authentication (MFU EV1 etc)
-- Determine if cards have block count that's not the same as the BLOCKS def */
+// This code does not:
+// - Account for cards with authentication (MFU EV1 etc)
+// - Determine if cards have block count that's not the same as the BLOCKS def
 
 #include "standalone.h" // standalone definitions
 #include "proxmark3_arm.h"
@@ -80,20 +80,17 @@ void RunMod(void) {
                         DbpString("Found ultralight with UID: ");
                         Dbhexdump(card.uidlen, card.uid, 0);
                         state = STATE_READ;
-                    }
-                    else {
+                    } else {
                         DbpString("Found non-ultralight card, ignoring.");
                     }
                 }
-            }
-            else if (state == STATE_READ) {
+            } else if (state == STATE_READ) {
                 iso14443a_setup(FPGA_HF_ISO14443A_READER_LISTEN);
                 iso14443a_select_card(NULL, NULL, NULL, true, 0, true);
                 bool read_successful = true;
                 Dbprintf("Contents:");
 
-                for (int i = 0; i < BLOCKS; i++)
-                {
+                for (int i = 0; i < BLOCKS; i++) {
                     uint8_t dataout[4] = {0x00};
                     if (mifare_ultra_readblock(i, dataout)) {
                         // If there's an error reading, go back to search state
@@ -113,8 +110,7 @@ void RunMod(void) {
                     Dbprintf("Read failure, going back to search state.");
                     state = STATE_SEARCH;
                 }
-            }
-            else if (state == 2) {
+            } else if (state == 2) {
                 uint8_t flags = FLAG_7B_UID_IN_DATA;
 
                 Dbprintf("Starting simulation, press pm3-button to stop and go back to search state.");

--- a/armsrc/Standalone/hf_aveful.c
+++ b/armsrc/Standalone/hf_aveful.c
@@ -47,7 +47,7 @@ void ModInfo(void) {
 
 void RunMod(void) {
     StandAloneMode();
-    Dbprintf("AveUL (MF Ultralight read/emul) started");
+    Dbprintf("AveFUL (MF Ultralight read/emul) started");
     FpgaDownloadAndGo(FPGA_BITSTREAM_HF);
 
     // the main loop for your standalone mode

--- a/armsrc/Standalone/hf_aveul.c
+++ b/armsrc/Standalone/hf_aveul.c
@@ -1,0 +1,119 @@
+//-----------------------------------------------------------------------------
+// A. Ozkal, 2020
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// main code for HF Mifare Ultralight read/simulation by Ave Ozkal
+//-----------------------------------------------------------------------------
+
+/* Several parts of this code is based on code by Craig Young from HF_YOUNG */
+
+#include "standalone.h" // standalone definitions
+#include "proxmark3_arm.h"
+#include "appmain.h"
+#include "fpgaloader.h"
+#include "util.h"
+#include "dbprint.h"
+
+#include "ticks.h"  // SpinDelay
+#include "mifareutil.h"
+#include "iso14443a.h"
+
+typedef struct {
+    uint8_t uid[10];
+    uint8_t uidlen;
+    uint8_t atqa[2];
+    uint8_t sak;
+} PACKED card_clone_t;
+
+void ModInfo(void) {
+    DbpString("  HF Mifare Ultralight read/simulation by Ave Ozkal");
+}
+
+void RunMod(void) {
+    StandAloneMode();
+    Dbprintf("[=] AveUL (MF Ultralight read/emul) started");
+    FpgaDownloadAndGo(FPGA_BITSTREAM_HF);
+
+    // the main loop for your standalone mode
+    for (;;) {
+        WDT_HIT();
+
+        // exit from RunMod,   send a usbcommand.
+        if (data_available()) break;
+
+        iso14a_card_select_t card;
+
+        SpinDelay(500);
+        iso14443a_setup(FPGA_HF_ISO14443A_READER_MOD);
+
+        // 0 = search, 1 = read, 2 = emul
+        int stage = 0;
+
+        DbpString("Scanning...");
+        for (;;) {
+            // Was our button held down or pressed?
+            int button_pressed = BUTTON_HELD(1000);
+
+            if (button_pressed != BUTTON_NO_CLICK || data_available())
+                break;
+            else if (stage == 0) {
+                if (!iso14443a_select_card(NULL, &card, NULL, true, 0, true)) {
+                    continue;
+                } else {
+                    if (card.sak == 0x00 && card.atqa[0] == 0x44 && card.atqa[1] == 0 && card.uidlen == 7) {
+                        DbpString("Found ultralight with UID: ");
+                        Dbhexdump(7, card.uid, 0);
+                        stage = 1;
+                    }
+                    else {
+                        DbpString("Found non-ultralight card, ignoring");
+                    }
+                }
+            }
+            else if (stage == 1) {
+                iso14443a_setup(FPGA_HF_ISO14443A_READER_LISTEN);
+                iso14443a_select_card(NULL, NULL, NULL, true, 0, true);
+                int i;
+                bool read_successful = true;
+                Dbprintf("Contents:");
+
+                for (i = 0; i < 16; ++i)
+                {
+                    uint8_t dataout[4] = {0x00};
+                    if (mifare_ultra_readblock(i, dataout)) {
+                        // If there's an error reading, go back to stage 0
+                        read_successful = false;
+                        break;
+                    }
+                    // TODO: I'm not 100% on why I need to do + 14. The bin->eml results have 14 blocks of almost all 0 at start.
+                    // and the bins just don't, so I'll admit that I am a little confused, but it works, so I won't question it much.
+                    emlSetMem_xt(dataout, 14 + i, 1, 4);
+                    Dbhexdump(4, dataout, 0);
+                }
+
+                if (read_successful) {
+                    Dbprintf("Successfully loaded into emulator memory");
+                    stage = 2;
+                } else {
+                    Dbprintf("Read failure, going back to stage 0.");
+                    stage = 0;
+                }
+            }
+            else if (stage == 2) {
+                uint8_t flags = FLAG_7B_UID_IN_DATA;
+
+                Dbprintf("Starting simulation, press pm3-button to stop and go back to scan");
+                SimulateIso14443aTag(2, flags, card.uid);
+
+                // Go back to stage 0 if user presses pm3-button
+                stage = 0;
+            }
+        }
+    }
+
+    DbpString("[=] exiting");
+    LEDsoff();
+}

--- a/armsrc/Standalone/hf_aveul.c
+++ b/armsrc/Standalone/hf_aveul.c
@@ -10,6 +10,10 @@
 
 /* Several parts of this code is based on code by Craig Young from HF_YOUNG */
 
+/* This code does not account for:
+- Cards with block counts other than 16
+- Cards with authentication (MFU EV1 etc) */
+
 #include "standalone.h" // standalone definitions
 #include "proxmark3_arm.h"
 #include "appmain.h"
@@ -34,7 +38,7 @@ void ModInfo(void) {
 
 void RunMod(void) {
     StandAloneMode();
-    Dbprintf("[=] AveUL (MF Ultralight read/emul) started");
+    Dbprintf("AveUL (MF Ultralight read/emul) started");
     FpgaDownloadAndGo(FPGA_BITSTREAM_HF);
 
     // the main loop for your standalone mode
@@ -88,8 +92,8 @@ void RunMod(void) {
                         read_successful = false;
                         break;
                     }
-                    // TODO: I'm not 100% on why I need to do + 14. The bin->eml results have 14 blocks of almost all 0 at start.
-                    // and the bins just don't, so I'll admit that I am a little confused, but it works, so I won't question it much.
+                    // We're skipping 14 blocks (56 bytes) here, as that "[...] has version/signature/counter data here" according to comments on dumptoemul-mfu
+                    // When converting a bin, it's almost all 0 other than one 0x0F byte, and functionality seems to be unaffected if that byte is set to 0x00.
                     emlSetMem_xt(dataout, 14 + i, 1, 4);
                     Dbhexdump(4, dataout, 0);
                 }
@@ -114,6 +118,6 @@ void RunMod(void) {
         }
     }
 
-    DbpString("[=] exiting");
+    DbpString("exiting");
     LEDsoff();
 }


### PR DESCRIPTION
This PR adds `hf_aveful`, which is a standalone mode that aims to read and simulate Mifare Ultralights (and Ultralight clones) on the go, with the process for reading a card taking less than a second. This doesn't include EV1, C etc.

C is not really a language I use a lot, so there may be potential improvements that can be done to a bunch of the code. Input welcome :)

Right now I am only accounting for Ultralights/clones with 16 blocks/pages, though I've supplied `define` options, so users that want to modify the code to work with other stuff (My-d move, my-d NFC, and Mifare Ultralight Nanos etc) can easily do so.

If anyone's interested in using this but aren't using master due to MERGEHELL: I've confirmed that the code works fine on both master and the latest stable release at the time of me writing this (v4.9237).