### PR TITLE
Fix last block of dumps on my-d move/move lean

### DIFF
--- a/client/src/cmdhfmfu.c
+++ b/client/src/cmdhfmfu.c
@@ -1983,7 +1983,7 @@ static int CmdHF14AMfUDump(const char *Cmd) {
 
     // not ul_c and not std ul then attempt to collect info like
     //  VERSION, SIGNATURE, COUNTERS, TEARING, PACK,
-    if (!(tagtype & UL_C || tagtype & UL)) {
+    if (!(tagtype & UL_C || tagtype & UL || tagtype & MY_D_MOVE || tagtype & MY_D_MOVE_LEAN)) {
         //attempt to read pack
         uint8_t get_pack[] = {0, 0};
         if (ul_auth_select(&card, tagtype, true, authKeyPtr, get_pack, sizeof(get_pack)) != PM3_SUCCESS) {


### PR DESCRIPTION
As discussed on Discord, the code adding pack (`memcpy(data + (pages * 4) - 4, get_pack, sizeof(get_pack));`) to the last page ends up causing dumps that (incorrectly) have 0x00 0x00 as first 2 bytes of the last page on dump, which is incorrect:

![](https://lasagna.cat/t/m06xdoc8e.png)

![](https://lasagna.cat/t/m7rmz7bqq.png)

![](https://lasagna.cat/t/m4xy0l87e.png)

This PR adds my-d move and my-d move leans to the lists of card types where this behavior is not applied, which in turn results in proper dumps.

I don't have a my-d or my-d NFC to test with (and I cannot seem to find their datasheets), so I chose to not exclude them. Let me know if you need any changes.