### PR TITLE
Corrected ProxSpace installation.

### DIFF
--- a/doc/md/Installation_Instructions/Windows-Installation-Instructions.md
+++ b/doc/md/Installation_Instructions/Windows-Installation-Instructions.md
@@ -17,11 +17,9 @@ There are two ways to install, build and use Proxmark3 on Windows:
 Install required drivers for your Windows installation. You may need admin privileges to do this.  
 Step by step guides are online such as [RyscCorps](https://store.ryscc.com/blogs/news/how-to-install-a-proxmark3-driver-on-windows-10).
 
-## Download / clone ProxSpace repo
+## Download ProxSpace repo
 
 Download the Gator96100 ProxSpace package from https://github.com/Gator96100/ProxSpace/releases
-
-If you prefer, you can clone it, provided that you installed Github for Windows https://desktop.github.com/.
 
 Extract 'ProxSpace' to a location path without spaces.  
 For example D:\OneDrive\Documents\GitHub is ok whereas C:\My Documents\My Projects\proxspace is not.
@@ -30,7 +28,7 @@ If you're running Windows in a Virtualbox guest, make sure not to install ProxSp
 
 ## Launch ProxSpace
 
-Run `runme.bat` or `runme64.bat` depending on your Windows architecture.
+Run `runme64.bat`.
 
 You'll get a Bash prompt and your home directory should become the ProxSpace `pm3` sub-directory.
 


### PR DESCRIPTION
ProxSpace can not be cloned, as this causes errors during the installation.
runme.bat does no longer exist.