### PR TITLE
'hf 14b dump' without params now calls help and corrected a typo

### DIFF
--- a/client/src/cmdhf14b.c
+++ b/client/src/cmdhf14b.c
@@ -105,10 +105,10 @@ static int usage_hf_14b_write_srx(void) {
 static int usage_hf_14b_dump(void) {
     PrintAndLogEx(NORMAL, "This command dumps the contents of a ISO-14443-B tag and save it to file\n"
                   "\n"
-                  "Usage: hf 14b dump [h] [card memory] <f filname> \n"
+                  "Usage: hf 14b dump [h] [card memory] <f filename> \n"
                   "Options:\n"
                   "\th             this help\n"
-                  "\t[card memory] 1 = SRIX4K (default), 2 = SRI512"
+                  "\t[card memory] 1 = SRIX4K (default), 2 = SRI512\n"
                   "\tf <name>      filename,  if no <name> UID will be used as filename\n"
                   "\n"
                   "Example:\n"
@@ -834,6 +834,8 @@ static int CmdHF14BDump(const char *Cmd) {
     uint16_t cardsize = 0;
     uint8_t blocks = 0;
     iso14b_card_select_t card;
+
+    if (strlen(Cmd) < 1) return usage_hf_14b_dump();
 
     while (param_getchar(Cmd, cmdp) != 0x00 && !errors) {
         switch (tolower(param_getchar(Cmd, cmdp))) {


### PR DESCRIPTION
I found out that if I use the command "hf 14b dump" without any parameters instead of getting the help like other commands it tries to dump to file. I corrected this behavior so that calling the command without parameter the help will be shown.
I fixed also a couple of typo in the help itself. 
