### PR TITLE
Removed ErrorAction

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -276,7 +276,7 @@ build_script:
     
     ExecCheck "PS cmake Tests"
     
-    Receive-Job -Wait -Job $WSLjob -ErrorAction Stop
+    Receive-Job -Wait -Job $WSLjob
 
     
 test_script:


### PR DESCRIPTION
ErrorAction will remove the error from the log and store it in a variable. ErrorAction Stop is not needed anyways.