### PR TITLE
Removed an status check that was blocking command 'hf 14b dump', …

### DIFF
--- a/client/src/cmdhf14b.c
+++ b/client/src/cmdhf14b.c
@@ -880,11 +880,11 @@ static int CmdHF14BDump(const char *Cmd) {
     if (fileNameLen < 1) {
         PrintAndLogEx(INFO, "Using UID as filename");
         fptr += sprintf(fptr, "hf-14b-");
-        FillFileNameByUID(fptr, card.uid, "-dump", card.uidlen);
+        FillFileNameByUID(fptr, SwapEndian64(card.uid, 8, 8), "-dump", card.uidlen);
     }
 
     // detect blocksize from card :)
-    PrintAndLogEx(NORMAL, "Reading memory from tag UID %s", sprint_hex(card.uid, card.uidlen));
+    PrintAndLogEx(NORMAL, "Reading memory from tag UID %s", sprint_hex(SwapEndian64(card.uid, 8, 8), card.uidlen));
 
     uint8_t data[cardsize];
     memset(data, 0, sizeof(data));
@@ -915,10 +915,10 @@ static int CmdHF14BDump(const char *Cmd) {
 
         if (WaitForResponseTimeout(CMD_HF_ISO14443B_COMMAND, &resp, 2000)) {
 
-            uint8_t status = resp.oldarg[0] & 0xFF;
-            if (status > 0) {
-                continue;
-            }
+            //uint8_t status = resp.oldarg[0] & 0xFF;
+            //if (status > 0) {
+            //    continue;
+            //}
 
             uint16_t len = (resp.oldarg[1] & 0xFFFF);
             recv = resp.data.asBytes;


### PR DESCRIPTION
…added SwapEndian64 to generated filename to be consistent with UID

First I added a missing "SwapEndian64" in the filename generation for the DUMP command _(hf 14b dump f)_ as without it the UID was "inverted" for what I call the "Endian-Effect".

Secondly I remove a status check from the DUMP command itself. The status check was always failing in my testing as the command was always returning "06" instead of the expected "00". I tried removing this check and the DUMP was successful. I'm not 100% sure this is correct, so I hope someone could do some testing. I own only one Srix4k _(one with Chip: 00, SRIX4K (Special))_ so I cannot test the code with other models.
