### PR TITLE
Allow writes up to 256 bytes with mfdes writedata

### DIFF
--- a/client/deps/cliparser/cliparser.c
+++ b/client/deps/cliparser/cliparser.c
@@ -152,7 +152,7 @@ int CLIParamHexToBuf(struct arg_str *argstr, uint8_t *data, int maxdatalen, int 
     *datalen = 0;
 
     int ibuf = 0;
-    uint8_t tmp_buf[256] = {0};
+    uint8_t tmp_buf[512] = {0};
     int res = CLIParamStrToBuf(argstr, tmp_buf, maxdatalen * 2, &ibuf); // *2 because here HEX
     if (res) {
         printf("Parameter error: buffer overflow.\n");
@@ -186,7 +186,7 @@ int CLIParamStrToBuf(struct arg_str *argstr, uint8_t *data, int maxdatalen, int 
     if (!argstr->count)
         return 0;
 
-    uint8_t tmp_buf[256] = {0};
+    uint8_t tmp_buf[512] = {0};
     int ibuf = 0;
 
     for (int i = 0; i < argstr->count; i++) {

--- a/client/src/cmdhfmfdes.c
+++ b/client/src/cmdhfmfdes.c
@@ -488,7 +488,7 @@ static const char *getstatus(uint16_t *sw) {
                 return "Current authentication status does not allow the requested command";
 
             case MFDES_E_BOUNDARY:
-                return "Attempted to read/write data from/to beyong the file's/record's limit";
+                return "Attempted to read/write data from/to beyond the file's/record's limit";
 
             case MFDES_E_PICC_INTEGRITY:
                 return "PICC integrity error, PICC will be disabled";

--- a/client/src/cmdhfmfdes.c
+++ b/client/src/cmdhfmfdes.c
@@ -2851,9 +2851,9 @@ static int CmdHF14ADesWriteData(const char *Cmd) {
         arg_param_begin,
         arg_strx0("nN", "fileno", "<fileno>", "File Number (1 hex byte, 0x00 - 0x1F)"),
         arg_strx0("oO", "offset", "<offset>", "File Offset (3 hex bytes, big endian), optional"),
-        arg_strx0("dD", "data", "<data>", "Data to write (hex bytes, 0xFFFF bytes max.)"),
+        arg_strx0("dD", "data", "<data>", "Data to write (hex bytes, 256 bytes max)"),
         arg_int0("type", "type", "<type>", "File Type (0=Standard/Backup, 1=Record)"),
-        arg_strx0("aA", "aid", "<aid>", "App ID to select as hex bytes (3 bytes,big endian, optional)"),
+        arg_strx0("aA", "aid", "<aid>", "App ID to select as hex bytes (3 bytes, big endian, optional)"),
         arg_param_end
     };
 


### PR DESCRIPTION
This PR changes the CLIParamHexToBuf/CLIParamStrToBuf's temporary buffer from 256 bytes to 512 bytes, allowing hex strings representing up to 256 bytes instead of 128 bytes. It also updates the help text to help the user.

As a result, this PR fixes #977.