### PR TITLE
Appveyor use build cache for ProxSace packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -141,7 +141,7 @@ clone_script:
     
     Write-Host "ProxSpace: move cache..." -NoNewLine
     
-    Move-Item -Path "C:\cache" -Destination "$env:proxspace_path\msys2\var\chache" -ErrorAction SilentlyContinue
+    Move-Item -Path "C:\cache" -Destination "$env:proxspace_path\msys2\var\cache" -ErrorAction SilentlyContinue
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
 
@@ -244,7 +244,7 @@ build_script:
     
     ExecMinGWCmd 'yes | pacman -Sc > /dev/null 2>&1'
     
-    Move-Item -Path "$env:proxspace_path\msys2\var\chache" -Destination "C:\cache"
+    Move-Item -Path "$env:proxspace_path\msys2\var\cache" -Destination "C:\cache"
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 3.0.1.{build}
 image: Visual Studio 2019
 clone_folder: C:\ProxSpace\pm3\proxmark
 cache:
-  - C:\cache
+  - C:\cache -> appveyor.yml
 environment:
   proxspace_url: https://github.com/Gator96100/ProxSpace/archive/master.zip
   proxspace_zip_file: \proxspace.zip
@@ -69,6 +69,8 @@ clone_script:
         WSLExec "WSL QT fix..." "sudo strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5"
         Add-AppveyorMessage -Message "WSL setup took $(([System.Environment]::TickCount-$WSLInstallTime) / 1000) sec" -Category Information
     }
+    
+    $env:PSInstallTime=[System.Environment]::TickCount
     
     Write-Host "ProxSpace: Removing folder..." -NoNewLine
     
@@ -171,13 +173,9 @@ install:
         Write-Host "[ OK ]" -ForegroundColor Green 
     }
     
-    $PSInstallTime=[System.Environment]::TickCount
-    
     Write-Host "ProxSpace: move cache..." -NoNewLine
     
     Move-Item -Path "$env:proxspace_cache_path" -Destination "$env:proxspace_path\msys2\var\cache" -Force
-    
-    Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
 
@@ -185,7 +183,7 @@ install:
     
     ExecUpdate "ProxSpace: installing required packages..." $false    
     
-    Add-AppveyorMessage -Message "ProxSpace download and update took $(([System.Environment]::TickCount-$PSInstallTime) / 1000) sec" -Category Information
+    Add-AppveyorMessage -Message "ProxSpace download and update took $(([System.Environment]::TickCount-$env:PSInstallTime) / 1000) sec" -Category Information
 
 build_script:
 - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -152,9 +152,11 @@ clone_script:
     
     Write-Host "ProxSpace: move cache..." -NoNewLine
     
-    Get-ChildItem C:\cache
+    Get-ChildItem "C:\cache"
     
     Copy-Item -Path "C:\cache\*" -Destination "$env:proxspace_path\msys2\var\cache\pacman\pkg" -Recurse -Force -ErrorAction SilentlyContinue
+    
+    Get-ChildItem "C:\cache"
     
     Get-ChildItem $env:proxspace_path\msys2\var\cache\pacman\pkg
     
@@ -180,6 +182,8 @@ build_script:
 - ps: >-
 
     $pmfolder = Split-Path $env:appveyor_build_folder -Leaf
+    
+    Get-ChildItem "C:\cache"
     
     Function ExecMinGWCmd($Cmd) {
         cd $env:proxspace_path
@@ -257,13 +261,17 @@ build_script:
     
     Write-Host "ProxSpace: create new cache..." -NoNewLine
     
+    Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
+    
     ExecMinGWCmd 'yes | pacman -Sc > /dev/null 2>&1'
     
     Remove-Item -Recurse -Force -Path "C:\cache\*" -ErrorAction SilentlyContinue
     
     Copy-Item -Path "$env:proxspace_path\msys2\var\cache\pacman\pkg\*" -Destination "C:\cache" -Recurse -Force
     
-    Get-ChildItem C:\cache
+    Get-ChildItem "C:\cache"
+    
+    Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,8 +78,6 @@ clone_script:
             Start-Sleep -s 5
             Receive-Job -Job $WSLjob
         }
-        
-        Receive-Job -Wait -Job $PSjob
     }
     
     $WSLjob = Start-Job -Name WSLInstall -ScriptBlock { 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -173,11 +173,11 @@ install:
     
     $PSInstallTime=[System.Environment]::TickCount
     
-    Write-Host "[ OK ]" -ForegroundColor Gree 
-    
     Write-Host "ProxSpace: move cache..." -NoNewLine
     
     Move-Item -Path "$env:proxspace_cache_path" -Destination "$env:proxspace_path\msys2\var\cache" -Force
+    
+    Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ environment:
   proxspace_zip_folder_name: ProxSpace-*
   proxspace_path: C:\ProxSpace
   proxspace_home_path: \ProxSpace\pm3
+  proxspace_cache_path: C:\cache
   wsl_git_path: C:\proxmark
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
@@ -70,6 +71,8 @@ clone_script:
     }
     
     Write-Host "ProxSpace: Removing folder..." -NoNewLine
+    
+    cd \
     
     Remove-Item -Recurse -Force -Path $env:proxspace_path -ErrorAction SilentlyContinue
     
@@ -174,11 +177,7 @@ install:
     
     Write-Host "ProxSpace: move cache..." -NoNewLine
     
-    Move-Item -Path "C:\cache" -Destination "$env:proxspace_path\msys2\var\cache" -Force
-    
-    Get-ChildItem "C:\"
-    
-    Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
+    Move-Item -Path "$env:proxspace_cache_path" -Destination "$env:proxspace_path\msys2\var\cache" -Force
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
 
@@ -271,17 +270,9 @@ build_script:
     
     ExecMinGWCmd 'yes | pacman -Sc > /dev/null 2>&1'
     
-    Get-ChildItem "C:\cache\"
+    Remove-Item -Recurse -Force -Path "$env:proxspace_cache_path" -ErrorAction SilentlyContinue
     
-    Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\" 
-    
-    Remove-Item -Recurse -Force -Path C:\cache -ErrorAction SilentlyContinue
-    
-    Move-Item -Path "$env:proxspace_path\msys2\var\cache" -Destination "C:\cache" -Force
-    
-    Get-ChildItem "C:\cache\"
-    
-    Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
+    Move-Item -Path "$env:proxspace_path\msys2\var\cache" -Destination "$env:proxspace_cache_path" -Force
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -152,7 +152,7 @@ clone_script:
     
     Write-Host "ProxSpace: move cache..." -NoNewLine
     
-    Move-Item -Path "C:\cache" -Destination "$env:proxspace_path\msys2\var\cache" -ErrorAction SilentlyContinue
+    Copy-Item -Path "C:\cache\*" -Destination "$env:proxspace_path\msys2\var\cache\pacman\pkg" -Recurse -Force -ErrorAction SilentlyContinue
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
 
@@ -255,7 +255,7 @@ build_script:
     
     ExecMinGWCmd 'yes | pacman -Sc > /dev/null 2>&1'
     
-    Move-Item -Path "$env:proxspace_path\msys2\var\cache" -Destination "C:\cache"
+    Copy-Item -Path "$env:proxspace_path\msys2\var\cache\pacman\pkg\*" -Destination "C:\cache" -Recurse -Force
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   proxspace_url: https://github.com/Gator96100/ProxSpace/archive/master.zip
   proxspace_zip_file: \proxspace.zip
   proxspace_zip_folder_name: ProxSpace-*
-  proxspace_path: \ProxSpace
+  proxspace_path: C:\ProxSpace
   proxspace_home_path: \ProxSpace\pm3
   wsl_git_path: C:\proxmark
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
@@ -155,6 +155,8 @@ clone_script:
     Get-ChildItem C:\cache
     
     Copy-Item -Path "C:\cache\*" -Destination "$env:proxspace_path\msys2\var\cache\pacman\pkg" -Recurse -Force -ErrorAction SilentlyContinue
+    
+    Get-ChildItem $env:proxspace_path\msys2\var\cache\pacman\pkg
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -151,6 +151,8 @@ clone_script:
     
     Write-Host "ProxSpace: move cache..." -NoNewLine
     
+    "dummy" > C\cache\update_cache.txt
+    
     Move-Item -Path "C:\cache" -Destination "$env:proxspace_path\msys2\var\cache" -Force
     
     Get-ChildItem "C:\"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,6 +71,11 @@ clone_script:
         }
     }
     
+    Function ExecMinGWCmd($Cmd) {
+        cd $env:proxspace_path
+        ./runme64.bat -c "$Cmd"
+    }
+    
     $WSLjob = Start-Job -Name WSLInstall -ScriptBlock { 
         Function WSLExec($Text, $Cmd) {
             Write-Host "$Text" 
@@ -145,9 +150,13 @@ clone_script:
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
 
-    ExecUpdate "ProxSpace: initial msys2 startup..." $true
+    #ExecUpdate "ProxSpace: initial msys2 startup..." $true
     
-    ExecUpdate "ProxSpace: installing required packages..." $false  
+    ExecMinGWCmd exit
+    
+    ExecMinGWCmd exit
+    
+    #ExecUpdate "ProxSpace: installing required packages..." $false  
     
     $psversion = (Select-String -Pattern 'PSVERSION=' -SimpleMatch -Path "$env:proxspace_path\msys2\ps\09-proxspace_setup.post").Line.Split("""")[1]
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 version: 3.0.1.{build}
 image: Visual Studio 2019
 clone_folder: C:\ProxSpace\pm3\proxmark
+cache:
+  - C:\cache
 environment:
   proxspace_url: https://github.com/Gator96100/ProxSpace/archive/master.zip
   proxspace_zip_file: \proxspace.zip
@@ -101,17 +103,7 @@ clone_script:
         Write-Host "[ OK ]" -ForegroundColor Green 
     }
     
-    Write-Host "ProxSpace: Removing folder..." -NoNewLine
-    
     $PSInstallTime=[System.Environment]::TickCount
-    
-    cd \
-
-    Remove-Item -Recurse -Force -Path $env:proxspace_path
-
-    Write-Host "[ OK ]" -ForegroundColor Green
-    
-    Receive-Job -Job $WSLjob
 
     Write-Host "ProxSpace: downloading..." -NoNewLine
     
@@ -138,6 +130,12 @@ clone_script:
     Get-ChildItem -Path "\$env:proxspace_zip_folder_name" | Rename-Item -NewName (Split-Path $env:proxspace_path -Leaf)
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
+    
+    Write-Host "ProxSpace: move cache..." -NoNewLine
+    
+    Move-Item -Path "C:\cache" -Destination "$env:proxspace_path\msys2\var\chache"
+    
+    Write-Host "[ OK ]" -ForegroundColor Gree 
 
     ExecUpdate "ProxSpace: initial msys2 startup..." $true
     
@@ -151,8 +149,6 @@ clone_script:
     Add-AppveyorMessage -Message "ProxSpace download and update took $(([System.Environment]::TickCount-$PSInstallTime) / 1000) sec" -Category Information
     
     GitClone "ProxSpace: Cloning repository <$env:appveyor_repo_name> to $env:appveyor_build_folder ..." $env:appveyor_build_folder
-    
-    Receive-Job -Wait -Job $WSLjob
     
     GitClone "WSL: Cloning repository <$env:appveyor_repo_name> to $env:wsl_git_path ..." $env:wsl_git_path
     
@@ -202,6 +198,9 @@ build_script:
                 throw "Tests error."
             }
         }
+        
+        #WSL: wait for installation to finish
+        Receive-Job -Wait -Name WSLInstall
     
         #Windows Subsystem for Linux (WSL)
         Write-Host "---------- WSL make ----------" -ForegroundColor Yellow   
@@ -275,6 +274,14 @@ build_script:
     ExecMinGWCmd './tools/pm3_tests.sh --clientbin client/build/proxmark3.exe client'
     
     ExecCheck "PS cmake Tests"
+    
+    Write-Host "ProxSpace: create new cache..." -NoNewLine
+    
+    ExecMinGWCmd 'yes | pacman -Sc > /dev/null 2>&1'
+    
+    Move-Item -Path "$env:proxspace_path\msys2\var\chache" -Destination "C:\cache"
+    
+    Write-Host "[ OK ]" -ForegroundColor Gree 
     
     Receive-Job -Wait -Job $WSLjob
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -153,7 +153,7 @@ clone_script:
     
     Move-Item -Path "C:\cache" -Destination "$env:proxspace_path\msys2\var\cache" -Force
     
-    Get-ChildItem "C:\cache\"
+    Get-ChildItem "C:\"
     
     Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
     
@@ -183,8 +183,6 @@ build_script:
 - ps: >-
 
     $pmfolder = Split-Path $env:appveyor_build_folder -Leaf
-    
-    Get-ChildItem "C:\cache"
     
     Function ExecMinGWCmd($Cmd) {
         cd $env:proxspace_path
@@ -267,6 +265,8 @@ build_script:
     Get-ChildItem "C:\cache\"
     
     Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\" 
+    
+    Remove-Item -Recurse -Force -Path C:\cache -ErrorAction SilentlyContinue
     
     Move-Item -Path "$env:proxspace_path\msys2\var\cache" -Destination "C:\cache" -Force
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -152,6 +152,8 @@ clone_script:
     
     Write-Host "ProxSpace: move cache..." -NoNewLine
     
+    Get-ChildItem C:\cache
+    
     Copy-Item -Path "C:\cache\*" -Destination "$env:proxspace_path\msys2\var\cache\pacman\pkg" -Recurse -Force -ErrorAction SilentlyContinue
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
@@ -255,7 +257,11 @@ build_script:
     
     ExecMinGWCmd 'yes | pacman -Sc > /dev/null 2>&1'
     
+    Remove-Item -Recurse -Force -Path "C:\cache\*" -ErrorAction SilentlyContinue
+    
     Copy-Item -Path "$env:proxspace_path\msys2\var\cache\pacman\pkg\*" -Destination "C:\cache" -Recurse -Force
+    
+    Get-ChildItem C:\cache
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 3.0.1.{build}
 image: Visual Studio 2019
 clone_folder: C:\ProxSpace\pm3\proxmark
 cache:
-  - C:\cache -> appveyor.yml
+  - C:\cache
 environment:
   proxspace_url: https://github.com/Gator96100/ProxSpace/archive/master.zip
   proxspace_zip_file: \proxspace.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,78 @@ init:
 clone_script:
 - ps: >-
     
+    Function GitClone($Text, $Folder) {
+        Write-Host "$Text" -NoNewLine
+        if(-not $env:appveyor_pull_request_number) {
+            git clone -q --branch=$env:appveyor_repo_branch https://github.com/$env:appveyor_repo_name.git $Folder
+            cd $Folder
+            git checkout -qf $env:appveyor_repo_commit
+        } else {
+            git clone -q https://github.com/$env:appveyor_repo_name.git $Folder
+            cd $Folder
+            git fetch -q origin +refs/pull/$env:appveyor_pull_request_number/merge:
+            git checkout -qf FETCH_HEAD
+        }
+        Write-Host "[ OK ]" -ForegroundColor Green 
+    }
+    
+    $WSLjob = Start-Job -Name WSLInstall -ScriptBlock { 
+        Function WSLExec($Text, $Cmd) {
+            Write-Host "$Text" 
+            wsl -- bash -c $Cmd
+            Write-Host "$Text" -NoNewLine 
+            Write-Host "[ OK ]" -ForegroundColor Green
+        }
+    
+        $WSLInstallTime=[System.Environment]::TickCount
+        WSLExec "WSL update..." "sudo apt-get update 1>/dev/null"
+        WSLExec "WSL upgrade..." "sudo apt-get upgrade -y 1>/dev/null" 
+        WSLExec "WSL cleanup..." "sudo apt-get auto-remove -y 1>/dev/null" 
+        WSLExec "WSL install..." "sudo apt-get -y install --reinstall --no-install-recommends git ca-certificates build-essential pkg-config libreadline-dev gcc-arm-none-eabi libnewlib-dev libbz2-dev qtbase5-dev cmake 1>/dev/null" 
+        WSLExec "WSL QT fix..." "sudo strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5"
+        Add-AppveyorMessage -Message "WSL setup took $(([System.Environment]::TickCount-$WSLInstallTime) / 1000) sec" -Category Information
+    }
+    
+    Write-Host "ProxSpace: Removing folder..." -NoNewLine
+    
+    Remove-Item -Recurse -Force -Path $env:proxspace_path -ErrorAction SilentlyContinue
+    
+    Write-Host "[ OK ]" -ForegroundColor Green
+
+    Write-Host "ProxSpace: downloading..." -NoNewLine
+    
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    
+    Invoke-WebRequest "$env:proxspace_url" -outfile "$env:proxspace_zip_file"
+    
+    Write-Host "[ OK ]" -ForegroundColor Green
+    
+    Write-Host "ProxSpace: extracting..." -NoNewLine
+    
+    Expand-Archive -LiteralPath "$env:proxspace_zip_file" -DestinationPath "\"
+    
+    Remove-Item "$env:proxspace_zip_file"
+    
+    Write-Host "[ OK ]" -ForegroundColor Green
+    
+    Write-Host "ProxSpace: renaming folder..." -NoNewLine
+    
+    Get-ChildItem -Path "\$env:proxspace_zip_folder_name" | Rename-Item -NewName (Split-Path $env:proxspace_path -Leaf)
+    
+    Write-Host "[ OK ]" -ForegroundColor Gree 
+    
+    $psversion = (Select-String -Pattern 'PSVERSION=' -SimpleMatch -Path "$env:proxspace_path\msys2\ps\09-proxspace_setup.post").Line.Split("""")[1]
+    
+    Write-Host "ProxSpace version: $psversion" -ForegroundColor Yellow
+    
+    GitClone "ProxSpace: Cloning repository <$env:appveyor_repo_name> to $env:appveyor_build_folder ..." $env:appveyor_build_folder
+    
+    GitClone "WSL: Cloning repository <$env:appveyor_repo_name> to $env:wsl_git_path ..." $env:wsl_git_path
+    
+
+install:
+- ps: >-
+    
     Function ExecUpdate($Text, $firstStart) {
         Write-Host "$Text"
         
@@ -77,25 +149,8 @@ clone_script:
             }
             
             Start-Sleep -s 5
-            Receive-Job -Job $WSLjob
+            Receive-Job -Name WSLInstall
         }
-    }
-    
-    $WSLjob = Start-Job -Name WSLInstall -ScriptBlock { 
-        Function WSLExec($Text, $Cmd) {
-            Write-Host "$Text" 
-            wsl -- bash -c $Cmd
-            Write-Host "$Text" -NoNewLine 
-            Write-Host "[ OK ]" -ForegroundColor Green
-        }
-    
-        $WSLInstallTime=[System.Environment]::TickCount
-        WSLExec "WSL update..." "sudo apt-get update 1>/dev/null"
-        WSLExec "WSL upgrade..." "sudo apt-get upgrade -y 1>/dev/null" 
-        WSLExec "WSL cleanup..." "sudo apt-get auto-remove -y 1>/dev/null" 
-        WSLExec "WSL install..." "sudo apt-get -y install --reinstall --no-install-recommends git ca-certificates build-essential pkg-config libreadline-dev gcc-arm-none-eabi libnewlib-dev libbz2-dev qtbase5-dev cmake 1>/dev/null" 
-        WSLExec "WSL QT fix..." "sudo strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5"
-        Add-AppveyorMessage -Message "WSL setup took $(([System.Environment]::TickCount-$WSLInstallTime) / 1000) sec" -Category Information
     }
     
     Function GitClone($Text, $Folder) {
@@ -113,45 +168,11 @@ clone_script:
         Write-Host "[ OK ]" -ForegroundColor Green 
     }
     
-    Write-Host "ProxSpace: Removing folder..." -NoNewLine
-    
     $PSInstallTime=[System.Environment]::TickCount
-    
-    cd \
-    
-    Remove-Item -Recurse -Force -Path $env:proxspace_path -ErrorAction SilentlyContinue
-    
-    Write-Host "[ OK ]" -ForegroundColor Green
-
-    Write-Host "ProxSpace: downloading..." -NoNewLine
-    
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    
-    Invoke-WebRequest "$env:proxspace_url" -outfile "$env:proxspace_zip_file"
-    
-    Write-Host "[ OK ]" -ForegroundColor Green
-    
-    Receive-Job -Job $WSLjob
-    
-    Write-Host "ProxSpace: extracting..." -NoNewLine
-    
-    Expand-Archive -LiteralPath "$env:proxspace_zip_file" -DestinationPath "\"
-    
-    Remove-Item "$env:proxspace_zip_file"
-    
-    Write-Host "[ OK ]" -ForegroundColor Green
-    
-    Receive-Job -Job $WSLjob
-    
-    Write-Host "ProxSpace: renaming folder..." -NoNewLine
-    
-    Get-ChildItem -Path "\$env:proxspace_zip_folder_name" | Rename-Item -NewName (Split-Path $env:proxspace_path -Leaf)
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
     
     Write-Host "ProxSpace: move cache..." -NoNewLine
-    
-    "dummy" > C\cache\update_cache.txt
     
     Move-Item -Path "C:\cache" -Destination "$env:proxspace_path\msys2\var\cache" -Force
     
@@ -163,24 +184,10 @@ clone_script:
 
     ExecUpdate "ProxSpace: initial msys2 startup..." $true
     
-    ExecUpdate "ProxSpace: installing required packages..." $false  
-    
-    $psversion = (Select-String -Pattern 'PSVERSION=' -SimpleMatch -Path "$env:proxspace_path\msys2\ps\09-proxspace_setup.post").Line.Split("""")[1]
-    
-    Write-Host "ProxSpace version: $psversion" -ForegroundColor Yellow
+    ExecUpdate "ProxSpace: installing required packages..." $false    
     
     Add-AppveyorMessage -Message "ProxSpace download and update took $(([System.Environment]::TickCount-$PSInstallTime) / 1000) sec" -Category Information
-    
-    GitClone "ProxSpace: Cloning repository <$env:appveyor_repo_name> to $env:appveyor_build_folder ..." $env:appveyor_build_folder
-    
-    GitClone "WSL: Cloning repository <$env:appveyor_repo_name> to $env:wsl_git_path ..." $env:wsl_git_path
-    
-    Get-ChildItem "C:\cache\"
-    
-    Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
-    
 
-install:
 build_script:
 - ps: >-
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
   proxspace_path: \ProxSpace
   proxspace_home_path: \ProxSpace\pm3
   wsl_git_path: C:\proxmark
+  APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
 init:
 - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -147,8 +147,7 @@ clone_script:
 
     ExecUpdate "ProxSpace: initial msys2 startup..." $true
     
-    ExecUpdate "ProxSpace: installing required packages..." $false
-    
+    ExecUpdate "ProxSpace: installing required packages..." $false  
     
     $psversion = (Select-String -Pattern 'PSVERSION=' -SimpleMatch -Path "$env:proxspace_path\msys2\ps\09-proxspace_setup.post").Line.Split("""")[1]
     
@@ -241,6 +240,14 @@ build_script:
     
     #ProxSpace
     
+    Write-Host "ProxSpace: create new cache..." -NoNewLine
+    
+    ExecMinGWCmd 'yes | pacman -Sc > /dev/null 2>&1'
+    
+    Move-Item -Path "$env:proxspace_path\msys2\var\chache" -Destination "C:\cache"
+    
+    Write-Host "[ OK ]" -ForegroundColor Gree 
+    
     Write-Host "---------- PS make ----------" -ForegroundColor Yellow
     
     $TestTime=[System.Environment]::TickCount  
@@ -282,14 +289,6 @@ build_script:
     ExecMinGWCmd './tools/pm3_tests.sh --clientbin client/build/proxmark3.exe client'
     
     ExecCheck "PS cmake Tests"
-    
-    Write-Host "ProxSpace: create new cache..." -NoNewLine
-    
-    ExecMinGWCmd 'yes | pacman -Sc > /dev/null 2>&1'
-    
-    Move-Item -Path "$env:proxspace_path\msys2\var\chache" -Destination "C:\cache"
-    
-    Write-Host "[ OK ]" -ForegroundColor Gree 
     
     Receive-Job -Wait -Job $WSLjob
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 3.0.1.{build}
 image: Visual Studio 2019
 clone_folder: C:\ProxSpace\pm3\proxmark
 cache:
-  - C:\cache -> appveyor.yml
+  - C:\cache
 environment:
   proxspace_url: https://github.com/Gator96100/ProxSpace/archive/master.zip
   proxspace_zip_file: \proxspace.zip
@@ -79,7 +79,6 @@ clone_script:
             Start-Sleep -s 5
             Receive-Job -Job $WSLjob
         }
-        Receive-Job -Wait -Job $PSjob
     }
     
     $WSLjob = Start-Job -Name WSLInstall -ScriptBlock { 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 3.0.1.{build}
 image: Visual Studio 2019
 clone_folder: C:\ProxSpace\pm3\proxmark
 cache:
-  - C:\cache
+  - C:\cache -> appveyor.yml
 environment:
   proxspace_url: https://github.com/Gator96100/ProxSpace/archive/master.zip
   proxspace_zip_file: \proxspace.zip
@@ -152,7 +152,7 @@ clone_script:
     
     Write-Host "ProxSpace: move cache..." -NoNewLine
     
-    Copy-Item -Path "C:\cache\*" -Destination "$env:proxspace_path\msys2\var\cache\pacman\pkg" -Recurse -Force
+    Move-Item -Path "C:\cache" -Destination "$env:proxspace_path\msys2\var\cache" -Force
     
     Get-ChildItem "C:\cache\"
     
@@ -265,15 +265,11 @@ build_script:
     
     ExecMinGWCmd 'yes | pacman -Sc > /dev/null 2>&1'
     
-    #Remove-Item -Recurse -Force -Path "C:\cache\*" -ErrorAction SilentlyContinue
-    
     Get-ChildItem "C:\cache\"
     
-    Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
+    Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\" 
     
-    New-Item -ItemType Directory -Force -Path "C:\cache"
-    
-    Copy-Item -Path "$env:proxspace_path\msys2\var\cache\pacman\pkg\*" -Destination "C:\cache" -Recurse -Force
+    Move-Item -Path "$env:proxspace_path\msys2\var\cache" -Destination "C:\cache" -Force
     
     Get-ChildItem "C:\cache\"
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,7 +103,15 @@ clone_script:
         Write-Host "[ OK ]" -ForegroundColor Green 
     }
     
+    Write-Host "ProxSpace: Removing folder..." -NoNewLine
+    
     $PSInstallTime=[System.Environment]::TickCount
+    
+    cd \
+    
+    Remove-Item -Recurse -Force -Path $env:proxspace_path -ErrorAction SilentlyContinue
+    
+    Write-Host "[ OK ]" -ForegroundColor Green
 
     Write-Host "ProxSpace: downloading..." -NoNewLine
     
@@ -133,7 +141,7 @@ clone_script:
     
     Write-Host "ProxSpace: move cache..." -NoNewLine
     
-    Move-Item -Path "C:\cache" -Destination "$env:proxspace_path\msys2\var\chache"
+    Move-Item -Path "C:\cache" -Destination "$env:proxspace_path\msys2\var\chache" -ErrorAction SilentlyContinue
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -175,7 +175,7 @@ install:
     
     Write-Host "ProxSpace: move cache..." -NoNewLine
     
-    Move-Item -Path "$env:proxspace_cache_path" -Destination "$env:proxspace_path\msys2\var\cache" -Force
+    Move-Item -Path "$env:proxspace_cache_path" -Destination "$env:proxspace_path\msys2\var\cache" -Force -ErrorAction SilentlyContinue
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 3.0.1.{build}
 image: Visual Studio 2019
 clone_folder: C:\ProxSpace\pm3\proxmark
 cache:
-  - C:\cache
+  - C:\cache -> appveyor.yml
 environment:
   proxspace_url: https://github.com/Gator96100/ProxSpace/archive/master.zip
   proxspace_zip_file: \proxspace.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,6 +79,7 @@ clone_script:
             Start-Sleep -s 5
             Receive-Job -Job $WSLjob
         }
+        Receive-Job -Wait -Job $PSjob
     }
     
     $WSLjob = Start-Job -Name WSLInstall -ScriptBlock { 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -271,6 +271,8 @@ build_script:
     
     Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
     
+    New-Item -ItemType Directory -Force -Path "C:\cache"
+    
     Copy-Item -Path "$env:proxspace_path\msys2\var\cache\pacman\pkg\*" -Destination "C:\cache" -Recurse -Force
     
     Get-ChildItem "C:\cache\"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -152,13 +152,11 @@ clone_script:
     
     Write-Host "ProxSpace: move cache..." -NoNewLine
     
-    Get-ChildItem "C:\cache"
+    Copy-Item -Path "C:\cache\*" -Destination "$env:proxspace_path\msys2\var\cache\pacman\pkg" -Recurse -Force
     
-    Copy-Item -Path "C:\cache\*" -Destination "$env:proxspace_path\msys2\var\cache\pacman\pkg" -Recurse -Force -ErrorAction SilentlyContinue
+    Get-ChildItem "C:\cache\"
     
-    Get-ChildItem "C:\cache"
-    
-    Get-ChildItem $env:proxspace_path\msys2\var\cache\pacman\pkg
+    Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
 
@@ -175,6 +173,10 @@ clone_script:
     GitClone "ProxSpace: Cloning repository <$env:appveyor_repo_name> to $env:appveyor_build_folder ..." $env:appveyor_build_folder
     
     GitClone "WSL: Cloning repository <$env:appveyor_repo_name> to $env:wsl_git_path ..." $env:wsl_git_path
+    
+    Get-ChildItem "C:\cache\"
+    
+    Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
     
 
 install:
@@ -261,15 +263,17 @@ build_script:
     
     Write-Host "ProxSpace: create new cache..." -NoNewLine
     
-    Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
-    
     ExecMinGWCmd 'yes | pacman -Sc > /dev/null 2>&1'
     
-    Remove-Item -Recurse -Force -Path "C:\cache\*" -ErrorAction SilentlyContinue
+    #Remove-Item -Recurse -Force -Path "C:\cache\*" -ErrorAction SilentlyContinue
+    
+    Get-ChildItem "C:\cache\"
+    
+    Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
     
     Copy-Item -Path "$env:proxspace_path\msys2\var\cache\pacman\pkg\*" -Destination "C:\cache" -Recurse -Force
     
-    Get-ChildItem "C:\cache"
+    Get-ChildItem "C:\cache\"
     
     Get-ChildItem "$env:proxspace_path\msys2\var\cache\pacman\pkg\"
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,29 +38,38 @@ clone_script:
     
     Function ExecUpdate($Text, $firstStart) {
         Write-Host "$Text"
-        Start-Process "cmd.exe"  "/c ""cd /D $env:proxspace_path && runme64.bat -c ""exit"""""
+        
+        $PSjob = Start-Job -Name PSInstall -ScriptBlock { 
+            cd $env:proxspace_path
+            ./runme64.bat -c "exit"
+        }
+        
         $StartTime=[System.Environment]::TickCount
         Start-Sleep -s 10
-        while($true) {
-            $cmdprocess = Get-Process "cmd" -ErrorAction SilentlyContinue
-            
-            if (!$cmdprocess -Or $cmdprocess.HasExited) {
+        while($true) {            
+            if ($PSjob.State -eq 'Completed') {
                 Write-Host "$Text" -NoNewLine 
                 Write-Host "[ OK ]" -ForegroundColor Green
                 break
             }
             
+            if ($PSjob.State -eq 'Failed') {
+                Write-Host "$Text" -NoNewLine 
+                Write-Host "[ Failed ]" -ForegroundColor Red
+                break
+            }
+            
             if ($firstStart -And (Test-Path "$env:proxspace_path\msys2\etc\pacman.conf.pacnew")) {
                 Start-Sleep -s 5
-                $tmp = $cmdprocess.CloseMainWindow()
+                Stop-Job -Job $PSjob
                 Start-Sleep -s 5
-                Stop-Process -Name "cmd" -Force -ErrorAction SilentlyContinue
                 Write-Host "$Text" -NoNewLine 
                 Write-Host "Exit by pacman.conf" -ForegroundColor Green
                 break           
             }
             
             if ([System.Environment]::TickCount-$StartTime -gt 1000000) {
+                Stop-Job -Job $PSjob
                 Write-Host "$Text" -NoNewLine 
                 Write-host "Exit by timeout" -ForegroundColor Yellow
                 break
@@ -69,11 +78,8 @@ clone_script:
             Start-Sleep -s 5
             Receive-Job -Job $WSLjob
         }
-    }
-    
-    Function ExecMinGWCmd($Cmd) {
-        cd $env:proxspace_path
-        ./runme64.bat -c "$Cmd"
+        
+        Receive-Job -Wait -Job $PSjob
     }
     
     $WSLjob = Start-Job -Name WSLInstall -ScriptBlock { 
@@ -150,13 +156,9 @@ clone_script:
     
     Write-Host "[ OK ]" -ForegroundColor Gree 
 
-    #ExecUpdate "ProxSpace: initial msys2 startup..." $true
+    ExecUpdate "ProxSpace: initial msys2 startup..." $true
     
-    ExecMinGWCmd exit
-    
-    ExecMinGWCmd exit
-    
-    #ExecUpdate "ProxSpace: installing required packages..." $false  
+    ExecUpdate "ProxSpace: installing required packages..." $false  
     
     $psversion = (Select-String -Pattern 'PSVERSION=' -SimpleMatch -Path "$env:proxspace_path\msys2\ps\09-proxspace_setup.post").Line.Split("""")[1]
     


### PR DESCRIPTION
Using the Appveyor cache to speed up the build process. Successful builds will take about the same time (WSL updating takes time), but builds that fail on ProxSpace will result in an earlier Appveyor abortion.

Fixed some small bugs as well.