### PR TITLE
Fixed comment in MIFARE Classic dictionary.

### DIFF
--- a/client/dictionaries/mfc_default_keys.dic
+++ b/client/dictionaries/mfc_default_keys.dic
@@ -653,7 +653,7 @@ C01FC822C6E5
 # More keys:
 8a19d40cf2b5
 ae8587108640
-135b88a94b8b, SafLock standalone door locks.
+135b88a94b8b # SafLock standalone door locks.
 #
 # Russian Troika card
 08B386463229


### PR DESCRIPTION
One line was commented with a wrong marker (`,` instead of `#`).