### PR TITLE
Add initial suport for MIFARE Key Diversification (AN10922)

### DIFF
--- a/client/src/mifare/desfire_crypto.h
+++ b/client/src/mifare/desfire_crypto.h
@@ -126,8 +126,10 @@ size_t key_block_size(const desfirekey_t  key);
 size_t padded_data_length(const size_t nbytes, const size_t block_size);
 size_t maced_data_length(const desfirekey_t  key, const size_t nbytes);
 size_t enciphered_data_length(const desfiretag_t tag, const size_t nbytes, int communication_settings);
-void cmac_generate_subkeys(desfirekey_t key);
+void cmac_generate_subkeys(desfirekey_t key, MifareCryptoDirection direction);
 void cmac(const desfirekey_t  key, uint8_t *ivect, const uint8_t *data, size_t len, uint8_t *cmac);
+
+void mifare_kdf_an10922(const desfirekey_t key, const uint8_t *data, size_t dataLen);
 
 void desfire_crc32(const uint8_t *data, const size_t len, uint8_t *crc);
 void desfire_crc32_append(uint8_t *data, const size_t len);

--- a/include/mifare.h
+++ b/include/mifare.h
@@ -94,6 +94,11 @@ typedef enum {
     MFDES_ALGO_AES = 4
 } mifare_des_authalgo_t;
 
+typedef enum {
+    MFDES_KDF_ALGO_NONE = 0,
+    MFDES_KDF_ALGO_AN10922 = 1,
+} mifare_des_kdf_algo_t;
+
 //-----------------------------------------------------------------------------
 // "hf 14a sim x", "hf mf sim x" attacks
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This adds two new options to `hf mfdes auth`

```
    -d, --kdf <kdf>                Key Derivation Function (KDF) (0=None, 1=AN10922)
    -i, --kdfi <kdfi>              KDF input (HEX 1-31 bytes)
```

By specifying `-d 1` and some kdf data `-i 00112233`, the key will be
diversified using AN10922.