### PR TITLE
Add Gallagher key checking/KDF on MIFARE Desfire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 ## [unreleased][unreleased]
  - Change many commands to cliparser (@iceman1001, @tcprst, @mwalker33,...)
  - ...
+ - Add Gallagher key checking/KDF on MIFARE Desfire (@NZSmartie)
  - Add dictionaries with common words of proper size (@will-caruana)
  - Add `hf mf supercard` (@iceman1001)
  - Add initial suport for MIFARE Key Diversification, cf AN10922 (@NZSmartie)

--- a/client/resources/aid_desfire.json
+++ b/client/resources/aid_desfire.json
@@ -336,5 +336,21 @@ FFFFFF General Issuer Information (FIDs 00: MAD Version; 01: Card Holder; 02: Ca
         "Name": "MemberCard",
         "Description": "CAR2GO - Member Card",
         "Type": "carsharing"
+    },
+    {
+        "AID": "2F81F4",
+        "Vendor": "Gallagher",
+        "Country": "NZ",
+        "Name": "Access control",
+        "Description": "Card Application Directory (CAD)",
+        "Type": ""
+    },
+    {
+        "AID": "2081F4",
+        "Vendor": "Gallagher",
+        "Country": "NZ",
+        "Name": "Access control",
+        "Description": "Cardax Card Data Application",
+        "Type": ""
     }
 ]

--- a/common/generator.h
+++ b/common/generator.h
@@ -43,5 +43,7 @@ int mfc_algo_sky_all(uint8_t *uid, uint8_t *keys);
 
 uint32_t lf_t55xx_white_pwdgen(uint32_t id);
 
+int mfdes_kdf_input_gallagher(uint8_t *uid, uint8_t uidLen, uint8_t keyNo, uint32_t aid, uint8_t *kdfInputOut, uint8_t *kdfInputLen);
+
 int generator_selftest(void);
 #endif

--- a/include/mifare.h
+++ b/include/mifare.h
@@ -97,6 +97,7 @@ typedef enum {
 typedef enum {
     MFDES_KDF_ALGO_NONE = 0,
     MFDES_KDF_ALGO_AN10922 = 1,
+    MFDES_KDF_ALGO_GALLAGHER = 2,
 } mifare_des_kdf_algo_t;
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Both `hf mfdes auth` and `hf mfdes chk` now support Key Diversification for AN10922 and as special treat, Gallagher issued cards.

For `hf mfdes auth`:
```
    -d, --kdf <kdf>                Key Derivation Function (KDF) (0=None, 1=AN10922, 2=Gallagher)
    -i, --kdfi <kdfi>              KDF input (HEX 1-31 bytes)
```

And for `hf mfdes chk`:
```
    -f, --kdf <kdf>                Key Derivation Function (KDF) (0=None, 1=AN10922, Gallagher)
    -i, --kdfi <kdfi>              KDF input (HEX 1-31 bytes)
```

> Please note the `-f` option for `chk` since `-d` is used to specify the dictionary input

Examples:
- `hf mfdes auth -a 2081f4 -m 3 -t 4 -d 2 -n 2 -k 00112233445566778899aabbccddeeff`
  Will diversify the key for key `2` on AID `2081F4` for Gallagher issued cards

- `hf mfdes chk -f 1 -i 00112233 -d mfdes_default_keys`
  Will read in all the default keys from the dictionary, and diversify them
  using AN10922 with the input data `00112233`

- `hf mfdes chk -f 2 -d mfdes_default_keys`
  Will read in all the default keys from the dictionary, and diversify them
  using AN10922 but with input data generated from the card's UID, AID and
  key number.