### PR TITLE
bsd/gnu-safe file byte calc

### DIFF
--- a/recovery/Makefile
+++ b/recovery/Makefile
@@ -11,7 +11,7 @@ FWMAXSIZE = $(shell echo $$(($(PLATFORM_SIZE)*1024)))
 BINS = bootrom.bin fullimage.bin $(INSTALLFW)
 
 all: $(BINS)
-	@FWSIZE=$$(stat -c "%s" $(INSTALLFW));\
+	@FWSIZE=$$(wc -c < $(INSTALLFW));\
 	if [ $$FWSIZE -gt $(FWMAXSIZE) ]; then \
 		echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"; \
 	    echo "ERROR: Firmware image too large for your platform! $$FWSIZE > $(FWMAXSIZE)"; \


### PR DESCRIPTION
either needs to use the correct bsd/gnu flag for bytes via stat:
**gnu** `stat -c "%s"`
**bsd** `stat -f "%z"`

or can use slightly slower `wc -c` which should be safe across both.