### PR TITLE
Fix old UID display on hf mf csetuid

### DIFF
--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -2082,9 +2082,10 @@ void MifareCSetBlock(uint32_t arg0, uint32_t arg1, uint8_t *datain) {
             if (!iso14443a_select_card(uid, NULL, &cuid, true, 0, true)) {
                 if (DBGLEVEL >= DBG_ERROR) Dbprintf("Can't select card");
                 errormsg = MAGIC_UID;
+                mifare_classic_halt_ex(NULL);
+                break;
             }
             mifare_classic_halt_ex(NULL);
-            break;
         }
 
         // wipe tag, fill it with zeros

--- a/client/src/mifare/mifarehost.c
+++ b/client/src/mifare/mifarehost.c
@@ -859,7 +859,7 @@ int mfCSetUID(uint8_t *uid, uint8_t *atqa, uint8_t *sak, uint8_t *oldUID, uint8_
     PrintAndLogEx(SUCCESS, "new block 0:  %s", sprint_hex(block0, 16));
 
     if (wipecard)      params |= MAGIC_WIPE;
-    if (oldUID == NULL) params |= MAGIC_UID;
+    if (oldUID != NULL) params |= MAGIC_UID;
 
     return mfCSetBlock(0, block0, oldUID, params);
 }


### PR DESCRIPTION
This PR fixes the issue where hf mf csetuid always displays an old UID of 00 00 00 00.

Before:

![](https://elixi.re/i/4gn11plk.png)

(Ignore the print debugging)

After:

![](https://elixi.re/i/u69h6pdx.png)