### PR TITLE
Visual Studio Code client debugging on Windows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,13 +18,21 @@
                     "text": "-enable-pretty-printing",
                     "ignoreFailures": true
                 }
-            ]
+            ],
+            "windows": {
+                "processId": "${input:ProcessIDWindows}",
+                "miDebuggerPath": "${workspaceFolder}/../../msys2/mingw64/bin/gdb.exe",
+                "externalConsole": true,//for ProxSpace externalConsole=true is required, because the internal cosole stops updating after a while
+                "environment": [{
+                    "name": "PATH","value": "${workspaceFolder}/../../msys2/mingw64/bin;${workspaceFolder}/../../msys2/usr/local/bin;${workspaceFolder}/../../msys2/usr/bin;${workspaceFolder}/../../msys2/bin"
+                }]
+            }
         },{
             "name": "(gdb) Build & Launch",
             "type": "cppdbg",
             "request": "launch",
             "program": "${cwd}/client/proxmark3",
-            "args": ["/dev/ttyACM0"],
+            "args": ["/dev/ttyACM0"], 
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],
@@ -38,7 +46,15 @@
                 }
             ],
             "preLaunchTask": "client: Debug: clean & make",
-            "miDebuggerPath": "/usr/bin/gdb"
+            "miDebuggerPath": "/usr/bin/gdb",
+            "windows": {
+                "args": ["COM5"],
+                "miDebuggerPath": "${workspaceFolder}/../../msys2/mingw64/bin/gdb.exe",
+                "externalConsole": true,//for ProxSpace externalConsole=true is required, because the internal cosole stops updating after a while
+                "environment": [{
+                    "name": "PATH","value": "${workspaceFolder}/../../msys2/mingw64/bin;${workspaceFolder}/../../msys2/usr/local/bin;${workspaceFolder}/../../msys2/usr/bin;${workspaceFolder}/../../msys2/bin"
+                }]
+            }
         }
     ],
     "inputs": [
@@ -50,6 +66,15 @@
             "args": {
                 "command": "pgrep -n proxmark3",
             }
+            
+        },{
+            "id": "ProcessIDWindows",
+            "type": "command",
+            "command": "shellCommand.execute",
+            "args": {
+                "command": "${workspaceFolder}/../../runme64.bat -c \"cat /proc/$(pgrep -n proxmark3)/winpid\"",
+            }
+            
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,6 +7,18 @@
             "label": "all: Make & run",
             "type": "shell",
             "command": "make -j && ./pm3",
+            "windows": {
+                "options": {
+                    "cwd": "${workspaceFolder}/../..",
+                    "shell": {
+                        "executable": "${workspaceFolder}/../../runme64.bat",
+                        "args": [
+                            "-c \"cd ${workspaceFolderBasename} &&"
+                        ],
+                        
+                    }
+                }
+              },
             "problemMatcher": [
                 "$gcc"
             ],
@@ -19,6 +31,18 @@
             "label": "choose: Make",
             "type": "shell",
             "command": "make ${input:componentType} -j",
+            "windows": {
+                "options": {
+                    "cwd": "${workspaceFolder}/../..",
+                    "shell": {
+                        "executable": "${workspaceFolder}/../../runme64.bat",
+                        "args": [
+                            "-c \"cd ${workspaceFolderBasename} &&"
+                        ],
+                        
+                    }
+                }
+              },
             "problemMatcher": [
                 "$gcc"
             ],
@@ -28,6 +52,18 @@
             "label": "client: Debug: make",
             "type": "shell",
             "command": "make client -j DEBUG=1",
+            "windows": {
+                "options": {
+                    "cwd": "${workspaceFolder}/../..",
+                    "shell": {
+                        "executable": "${workspaceFolder}/../../runme64.bat",
+                        "args": [
+                            "-c \"cd ${workspaceFolderBasename} &&"
+                        ],
+                        
+                    }
+                }
+              },
             "problemMatcher": [
                 "$gcc"
             ],
@@ -37,6 +73,18 @@
             "label": "client: Debug: clean & make",
             "type": "shell",
             "command": "make client/clean && make client -j DEBUG=1",
+            "windows": {
+                "options": {
+                    "cwd": "${workspaceFolder}/../..",
+                    "shell": {
+                        "executable": "${workspaceFolder}/../../runme64.bat",
+                        "args": [
+                            "-c \"cd ${workspaceFolderBasename} &&"
+                        ],
+                        
+                    }   
+                }
+              },
             "problemMatcher": [
                 "$gcc"
             ],
@@ -46,18 +94,54 @@
             "label": "fullimage: Make & Flash",
             "type": "shell",
             "command": "make fullimage && ./pm3-flash-fullimage",
+            "windows": {
+                "options": {
+                    "cwd": "${workspaceFolder}/../..",
+                    "shell": {
+                        "executable": "${workspaceFolder}/../../runme64.bat",
+                        "args": [
+                            "-c \"cd ${workspaceFolderBasename} &&"
+                        ],
+                        
+                    }
+                }
+              },
             "problemMatcher": []
         },
         {
             "label": "BOOTROM: Make & Flash",
             "type": "shell",
             "command": "make bootrom && ./pm3-flash-bootrom",
+            "windows": {
+                "options": {
+                    "cwd": "${workspaceFolder}/../..",
+                    "shell": {
+                        "executable": "${workspaceFolder}/../../runme64.bat",
+                        "args": [
+                            "-c \"cd ${workspaceFolderBasename} &&"
+                        ],
+                        
+                    }
+                }
+              },
             "problemMatcher": []
         },
         {
             "label": "Run client",
             "type": "shell",
             "command": "./pm3",
+            "windows": {
+                "options": {
+                    "cwd": "${workspaceFolder}/../..",
+                    "shell": {
+                        "executable": "${workspaceFolder}/../../runme64.bat",
+                        "args": [
+                            "-c \"cd ${workspaceFolderBasename} &&"
+                        ],
+                        
+                    }
+                }
+              },
             "problemMatcher": []
         }
     ],


### PR DESCRIPTION
**To get Client debugging working on ProxSpace**
1.	Have w working ProxSpace environment for Proxmark compilation
2.	Install Visual Studio Code
3.	Within ProxSpace run `git clone https://github.com/RfidResearchGroup/proxmark3.git`
	**Your proxmark3 folder has to be in proxspace/pm3/ and cannot be in another directory, however the name of the proxmark3 does not matter.**
4.	Open your proxmark3 folder in Visual Studio Code
5.	Open .vscode/launch.json and change `"args": ["COM5"]` to your com port
6.	Select the “(gdb) Build & Launch” configuration Launch

**To get Client debugging working on WSL**
1.	Have a working WSL environment for Proxmark compilation
2.	Install Visual Studio Code
3.	Install the Visual Studio Code [Remote – WSL](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) extension 
4.	Within WSL navigate to your proxmark3 folder and type `code .`
5.	Open .vscode/launch.json and change `"args": ["/dev/ttyACM0"]` to `"args": ["/dev/ttySx"]`
6.	Select the “(gdb) Build & Launch” configuration Launch

I have to admit the WSL solution seems to work smoother, but I’m not writing a remote extension for ProxSpace.
