### PR TITLE
hf iclass dump, restore, rdbl, wrbl cliparserization and argument normalization

### DIFF
--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -1999,10 +1999,10 @@ void iClass_Restore(iclass_restore_req_t *msg) {
 
         // data + mac
         if (iclass_writeblock_ext(item.blockno, item.data, mac, use_mac)) {
-            Dbprintf("Write block [%02d] " _GREEN_("successful"), item.blockno);
+            Dbprintf("Write block [%3d/0x%02X] " _GREEN_("successful"), item.blockno, item.blockno);
             written++;
         } else {
-            Dbprintf("Write block [%02d] " _RED_("failed"), item.blockno);
+            Dbprintf("Write block [%3d/0x%02X] " _RED_("failed"), item.blockno, item.blockno);
         }
     }
 

--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -1999,10 +1999,10 @@ void iClass_Restore(iclass_restore_req_t *msg) {
 
         // data + mac
         if (iclass_writeblock_ext(item.blockno, item.data, mac, use_mac)) {
-            Dbprintf("Write block [%02x] " _GREEN_("successful"), item.blockno);
+            Dbprintf("Write block [%02d] " _GREEN_("successful"), item.blockno);
             written++;
         } else {
-            Dbprintf("Write block [%02x] " _RED_("failed"), item.blockno);
+            Dbprintf("Write block [%02d] " _RED_("failed"), item.blockno);
         }
     }
 

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -947,8 +947,8 @@ static int CmdHFiClassDecrypt(const char *Cmd) {
     void *argtable[] = {
         arg_param_begin,
         arg_str0("f", "file", "<filename>", "filename of dumpfile"),
-        arg_str0("d", "data", "<encrypted blk>", "3DES encrypted data"),
-        arg_str0("k", "key", "<transport key>", "3DES transport key"),
+        arg_str0("d", "data", "<hex>", "3DES encrypted data"),
+        arg_str0("k", "key", "<hex>", "3DES transport key"),
         arg_lit0("v", "verbose", "verbose output"),
         arg_param_end
     };
@@ -1183,8 +1183,8 @@ static int CmdHFiClassEncryptBlk(const char *Cmd) {
 
     void *argtable[] = {
         arg_param_begin,
-        arg_str1("d", "data", "<block data>", "data to encrypt"),
-        arg_str0("k", "key", "<transport key>", "3DES transport key"),
+        arg_str1("d", "data", "<hex>", "data to encrypt"),
+        arg_str0("k", "key", "<hex>", "3DES transport key"),
         arg_lit0("v", "verbose", "verbose output"),
         arg_param_end
     };
@@ -1292,10 +1292,10 @@ static int CmdHFiClassDump(const char *Cmd) {
     void *argtable[] = {
         arg_param_begin,
         arg_str0("f", "file", "<filename>", "filename to save dump to"),
-        arg_str0("k", "key", "<key>", "debit key as 16 hex symbols OR NR/MAC for replay"),
-        arg_int0(NULL, "ki", "<key idx>", "debit key index to select key from memory 'hf iclass managekeys'"),
-        arg_str0(NULL, "credit", "<credit key>", "credit key as 16 hex symbols"),
-        arg_int0(NULL, "ci", "<credit idx>", "credit key index to select key from memory 'hf iclass managekeys'"),
+        arg_str0("k", "key", "<hex>", "debit key as 16 hex symbols OR NR/MAC for replay"),
+        arg_int0(NULL, "ki", "<dec>", "debit key index to select key from memory 'hf iclass managekeys'"),
+        arg_str0(NULL, "credit", "<hex>", "credit key as 16 hex symbols"),
+        arg_int0(NULL, "ci", "<dec>", "credit key index to select key from memory 'hf iclass managekeys'"),
         arg_lit0(NULL, "elite", "elite computations applied to key"),
         arg_lit0(NULL, "raw", "raw, the key is interpreted as raw block 3/4"),
         arg_lit0(NULL, "nr", "replay of NR/MAC"),
@@ -1664,10 +1664,10 @@ static int CmdHFiClass_WriteBlock(const char *Cmd) {
 
     void *argtable[] = {
         arg_param_begin,
-        arg_str0("k", "key", "<key>", "Access key as 16 hex symbols"),
-        arg_int0(NULL, "ki", "<key idx>", "Key index to select key from memory 'hf iclass managekeys'"),
-        arg_int1("b", "block", "<block>", "The block number to read as an integer"),
-        arg_str1("d", "data", "<data>", "data to write as 16 hex symbols"),
+        arg_str0("k", "key", "<hex>", "Access key as 16 hex symbols"),
+        arg_int0(NULL, "ki", "<dec>", "Key index to select key from memory 'hf iclass managekeys'"),
+        arg_int1("b", "block", "<dec>", "The block number to read as an integer"),
+        arg_str1("d", "data", "<hex>", "data to write as 16 hex symbols"),
         arg_lit0(NULL, "credit", "key is assumed to be the credit key"),
         arg_lit0(NULL, "elite", "elite computations applied to key"),
         arg_lit0(NULL, "raw", "no computations applied to key (raw)"),
@@ -1763,10 +1763,10 @@ static int CmdHFiClassRestore(const char *Cmd) {
     void *argtable[] = {
         arg_param_begin,
         arg_str1("f", "file", "<filename>", "specify a filename to restore"),
-        arg_str0("k", "key", "<key>", "Access key as 16 hex symbols"),
-        arg_int0(NULL, "ki", "<key idx>", "Key index to select key from memory 'hf iclass managekeys'"),
-        arg_int1(NULL, "first", "<first block>", "The first block number to restore as an integer"),
-        arg_int1(NULL, "last", "<last block>", "The last block number to restore as an integer"),
+        arg_str0("k", "key", "<hex>", "Access key as 16 hex symbols"),
+        arg_int0(NULL, "ki", "<dec>", "Key index to select key from memory 'hf iclass managekeys'"),
+        arg_int1(NULL, "first", "<dec>", "The first block number to restore as an integer"),
+        arg_int1(NULL, "last", "<dec>", "The last block number to restore as an integer"),
         arg_lit0(NULL, "credit", "key is assumed to be the credit key"),
         arg_lit0(NULL, "elite", "elite computations applied to key"),
         arg_lit0(NULL, "raw", "no computations applied to key (raw)"),
@@ -1977,9 +1977,9 @@ static int CmdHFiClass_ReadBlock(const char *Cmd) {
 
     void *argtable[] = {
         arg_param_begin,
-        arg_str0("k", "key", "<key>", "Access key as 16 hex symbols"),
-        arg_int0(NULL, "ki", "<key idx>", "Key index to select key from memory 'hf iclass managekeys'"),
-        arg_int1("b", "block", "<block>", "The block number to read as an integer"),
+        arg_str0("k", "key", "<hex>", "Access key as 16 hex symbols"),
+        arg_int0(NULL, "ki", "<dec>", "Key index to select key from memory 'hf iclass managekeys'"),
+        arg_int1("b", "block", "<dec>", "The block number to read as an integer"),
         arg_lit0(NULL, "credit", "key is assumed to be the credit key"),
         arg_lit0(NULL, "elite", "elite computations applied to key"),
         arg_lit0(NULL, "raw", "no computations applied to key (raw)"),
@@ -2298,8 +2298,8 @@ static int CmdHFiClassView(const char *Cmd) {
     void *argtable[] = {
         arg_param_begin,
         arg_str1("f", "file", "<filename>",  "filename of dump"),
-        arg_int0(NULL, "first", "<first block>", "Begin printing from this block (default block6)"),
-        arg_int0(NULL, "last", "<last block>", "End printing at this block (default 0, ALL)"),
+        arg_int0(NULL, "first", "<dec>", "Begin printing from this block (default block6)"),
+        arg_int0(NULL, "last", "<dec>", "End printing at this block (default 0, ALL)"),
         arg_lit0("v", "verbose", "verbose output"),
         arg_param_end
     };
@@ -3224,7 +3224,7 @@ static int CmdHFiClassPermuteKey(const char *Cmd) {
     void *argtable[] = {
         arg_param_begin,
         arg_lit0("r",  "reverse",        "reverse permuted key"),
-        arg_str1(NULL, "key", "<bytes>", "input key"),
+        arg_str1(NULL, "key", "<hex>", "input key"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, false);

--- a/doc/cheatsheet.md
+++ b/doc/cheatsheet.md
@@ -93,11 +93,16 @@ Write to iCLASS Block
 ```
 Options
 ---
-b <block>  : The block number as 2 hex symbols
-d <data>   : Set the Data to write as 16 hex symbols
-k <key>    : Access Key as 16 hex symbols or 1 hex to select key from memory
+-k, --key <key>                Access key as 16 hex symbols
+-b, --block <block>            The block number to read as an integer
+-d, --data <data>              data to write as 16 hex symbols
+    --ki <key idx>                 Key index to select key from memory 'hf iclass managekeys'
+    --credit                       key is assumed to be the credit key
+    --elite                        elite computations applied to key
+    --raw                          no computations applied to key (raw)
+    --nr                           replay of NR/MAC
 
-pm3 --> hf iclass wrbl b 07 d 6ce099fe7e614fd0 k 0
+pm3 --> hf iclass wrbl -b 7 -d 6ce099fe7e614fd0 --ki 0
 ```
 
 Print keystore
@@ -155,7 +160,7 @@ pm3 --> hf iclass eload -f hf-iclass-db883702f8ff12e0.bin
 Clone iCLASS Legacy Sequence
 ```
 pm3 --> hf iclass rdbl -b 7 --ki 0
-pm3 --> hf iclass wrbl b 7 d 6ce099fe7e614fd0 k 0
+pm3 --> hf iclass wrbl -b 7 -d 6ce099fe7e614fd0 --ki 0
 ```
 
 Simulate iCLASS

--- a/doc/cheatsheet.md
+++ b/doc/cheatsheet.md
@@ -78,10 +78,15 @@ Read iCLASS Block
 ```
 Options
 ---
-b <block>  : The block number as 2 hex symbols
-k <key>    : Access Key as 16 hex symbols or 1 hex to select key from memory
+-k, --key <key>                Access key as 16 hex symbols
+-b, --block <block>            The block number to read as an integer
+    --ki <key idx>             Key index to select key from memory 'hf iclass managekeys'
+    --credit                   key is assumed to be the credit key
+    --elite                    elite computations applied to key
+    --raw                      no computations applied to key (raw)
+    --nr                       replay of NR/MAC
 
-pm3 --> hf iclass rdbl b 7 k 0
+pm3 --> hf iclass rdbl -b 7 --ki 0
 ```
 
 Write to iCLASS Block
@@ -149,7 +154,7 @@ pm3 --> hf iclass eload -f hf-iclass-db883702f8ff12e0.bin
 
 Clone iCLASS Legacy Sequence
 ```
-pm3 --> hf iclass rdbl b 7 k 0
+pm3 --> hf iclass rdbl -b 7 --ki 0
 pm3 --> hf iclass wrbl b 7 d 6ce099fe7e614fd0 k 0
 ```
 

--- a/doc/cheatsheet.md
+++ b/doc/cheatsheet.md
@@ -62,9 +62,16 @@ Dump iCLASS card contents
 ```
 Options
 ---
-k <key>      : *Access Key as 16 hex symbols or 1 hex to select key from memory
+-f, --file <filename>          filename to save dump to
+-k, --key <key>                debit key as 16 hex symbols OR NR/MAC for replay
+    --ki <key idx>             debit key index to select key from memory 'hf iclass managekeys'
+    --credit <credit key>      credit key as 16 hex symbols
+    --ci <credit idx>          credit key index to select key from memory 'hf iclass managekeys'
+    --elite                    elite computations applied to key
+    --raw                      raw, the key is interpreted as raw block 3/4
+    --nr                       replay of NR/MAC
 
-m3 --> hf iclass dump k 0
+pm3 --> hf iclass dump --ki 0
 ```
 
 Read iCLASS Block
@@ -161,7 +168,7 @@ pm3 --> hf iclass sim 3
 
 Simulate iCLASS Sequence
 ```
-pm3 --> hf iclass dump k 0
+pm3 --> hf iclass dump --ki 0
 pm3 --> hf iclass eload -f hf-iclass-db883702f8ff12e0.bin
 pm3 --> hf iclass sim 3
 ```
@@ -177,7 +184,7 @@ e              : If 'e' is specified, elite computations applied to key
 pm3 --> hf iclass sim 2
 pm3 --> hf iclass loclass -f iclass_mac_attack.bin
 pm3 --> hf iclass managekeys n 7 k <Kcus>
-pm3 --> hf iclass dump k 7 e
+pm3 --> hf iclass dump --ki 7 --elite
 ```
 
 Verify custom iCLASS key

--- a/doc/cheatsheet.md
+++ b/doc/cheatsheet.md
@@ -63,10 +63,10 @@ Dump iCLASS card contents
 Options
 ---
 -f, --file <filename>          filename to save dump to
--k, --key <key>                debit key as 16 hex symbols OR NR/MAC for replay
-    --ki <key idx>             debit key index to select key from memory 'hf iclass managekeys'
-    --credit <credit key>      credit key as 16 hex symbols
-    --ci <credit idx>          credit key index to select key from memory 'hf iclass managekeys'
+-k, --key <hex>                debit key as 16 hex symbols OR NR/MAC for replay
+    --ki <dec>                 debit key index to select key from memory 'hf iclass managekeys'
+    --credit <hex>             credit key as 16 hex symbols
+    --ci <dec>                 credit key index to select key from memory 'hf iclass managekeys'
     --elite                    elite computations applied to key
     --raw                      raw, the key is interpreted as raw block 3/4
     --nr                       replay of NR/MAC
@@ -78,9 +78,9 @@ Read iCLASS Block
 ```
 Options
 ---
--k, --key <key>                Access key as 16 hex symbols
--b, --block <block>            The block number to read as an integer
-    --ki <key idx>             Key index to select key from memory 'hf iclass managekeys'
+-k, --key <hex>                Access key as 16 hex symbols
+-b, --block <dec>              The block number to read as an integer
+    --ki <dec>                 Key index to select key from memory 'hf iclass managekeys'
     --credit                   key is assumed to be the credit key
     --elite                    elite computations applied to key
     --raw                      no computations applied to key (raw)
@@ -93,14 +93,14 @@ Write to iCLASS Block
 ```
 Options
 ---
--k, --key <key>                Access key as 16 hex symbols
--b, --block <block>            The block number to read as an integer
--d, --data <data>              data to write as 16 hex symbols
-    --ki <key idx>                 Key index to select key from memory 'hf iclass managekeys'
-    --credit                       key is assumed to be the credit key
-    --elite                        elite computations applied to key
-    --raw                          no computations applied to key (raw)
-    --nr                           replay of NR/MAC
+-k, --key <hex>                Access key as 16 hex symbols
+-b, --block <dec>              The block number to read as an integer
+-d, --data <hex>               data to write as 16 hex symbols
+    --ki <dec>                 Key index to select key from memory 'hf iclass managekeys'
+    --credit                   key is assumed to be the credit key
+    --elite                    elite computations applied to key
+    --raw                      no computations applied to key (raw)
+    --nr                       replay of NR/MAC
 
 pm3 --> hf iclass wrbl -b 7 -d 6ce099fe7e614fd0 --ki 0
 ```
@@ -128,8 +128,8 @@ Encrypt iCLASS Block
 ```
 Options
 ---
--d, --data <block data>        data to encrypt
--k, --key <transport key>      3DES transport key
+-d, --data <hex>               data to encrypt
+-k, --key <hex>                3DES transport key
 -v, --verbose                  verbose output
 
 pm3 --> hf iclass encrypt -d 0000000f2aa3dba8
@@ -140,8 +140,8 @@ Decrypt iCLASS Block / file
 Options
 ---
 -f, --file <filename>          filename of dumpfile
--d, --data <encrypted blk>     3DES encrypted data
--k, --key <transport key>      3DES transport key
+-d, --data <hex>               3DES encrypted data
+-k, --key <hex>                3DES transport key
 -v, --verbose                  verbose output
 
 pm3 --> hf iclass decrypt -d 2AD4C8211F996871


### PR DESCRIPTION
hf iclass dump, restore, wrbl, & rdbl have been cliparserized.  Start block and end block commands now use `--first` and `--last` arguments and expect integers instead of 1 byte hex.  Blocks are now printed with decimal representation to match.

A new key index argument has been added when referencing keys in memory.