### PR TITLE
hf lto dump, restore, info, rdbl, wrbl - now use cliparser

### DIFF
--- a/doc/cliparser_todo.md
+++ b/doc/cliparser_todo.md
@@ -101,7 +101,6 @@ hf legic crc
 hf legic eload
 hf legic esave
 hf legic wipe
-hf lto wrbl
 hf lto list
 hf mf list
 hf mf darkside

--- a/doc/cliparser_todo.md
+++ b/doc/cliparser_todo.md
@@ -101,7 +101,6 @@ hf legic crc
 hf legic eload
 hf legic esave
 hf legic wipe
-hf lto restore
 hf lto rdbl
 hf lto wrbl
 hf lto list

--- a/doc/cliparser_todo.md
+++ b/doc/cliparser_todo.md
@@ -101,7 +101,6 @@ hf legic crc
 hf legic eload
 hf legic esave
 hf legic wipe
-hf lto rdbl
 hf lto wrbl
 hf lto list
 hf mf list

--- a/doc/cliparser_todo.md
+++ b/doc/cliparser_todo.md
@@ -101,9 +101,7 @@ hf legic crc
 hf legic eload
 hf legic esave
 hf legic wipe
-hf lto dump
 hf lto restore
-hf lto info
 hf lto rdbl
 hf lto wrbl
 hf lto list


### PR DESCRIPTION
The `hf lto` commands are now cliparserized and tested