### PR TITLE
MFU emulation now supports automatic exit after <num> blocks read.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Added `mf mfu sim t 7 n <numreads>` - MFU emulation now supports automatic exit after <num> blocks read. (@cyberpunk-re)
  - Added T55xx Guide to assist in learning how to use the T55xx chip (@mwalker33)
  - Fix 'hf iclass wrbl' - dealing with tags in unsecured vs secured pagemode now is correct (@iceman1001)
  - Change many commands to cliparser (@iceman1001, @tcprst, @mwalker33,...)

--- a/armsrc/Standalone/hf_aveful.c
+++ b/armsrc/Standalone/hf_aveful.c
@@ -243,7 +243,7 @@ void RunMod(void) {
                 uint8_t flags = FLAG_7B_UID_IN_DATA;
 
                 Dbprintf("Starting simulation, press pm3-button to stop and go back to search state.");
-                SimulateIso14443aTag(7, flags, card.uid);
+                SimulateIso14443aTag(7, flags, card.uid, 0);
 
                 // Go back to search state if user presses pm3-button
                 state = STATE_SEARCH;

--- a/armsrc/Standalone/hf_young.c
+++ b/armsrc/Standalone/hf_young.c
@@ -244,22 +244,22 @@ void RunMod(void) {
 
                     if (uids[selected].sak == 0x08 && uids[selected].atqa[0] == 0x04 && uids[selected].atqa[1] == 0) {
                         DbpString("Mifare Classic 1k");
-                        SimulateIso14443aTag(1, flags, data);
+                        SimulateIso14443aTag(1, flags, data, 0);
                     } else if (uids[selected].sak == 0x18 && uids[selected].atqa[0] == 0x02 && uids[selected].atqa[1] == 0) {
                         DbpString("Mifare Classic 4k (4b uid)");
-                        SimulateIso14443aTag(8, flags, data);
+                        SimulateIso14443aTag(8, flags, data, 0);
                     } else if (uids[selected].sak == 0x08 && uids[selected].atqa[0] == 0x44 && uids[selected].atqa[1] == 0) {
                         DbpString("Mifare Classic 4k (7b uid)");
-                        SimulateIso14443aTag(8, flags, data);
+                        SimulateIso14443aTag(8, flags, data, 0);
                     } else if (uids[selected].sak == 0x00 && uids[selected].atqa[0] == 0x44 && uids[selected].atqa[1] == 0) {
                         DbpString("Mifare Ultralight");
-                        SimulateIso14443aTag(2, flags, data);
+                        SimulateIso14443aTag(2, flags, data, 0);
                     } else if (uids[selected].sak == 0x20 && uids[selected].atqa[0] == 0x04 && uids[selected].atqa[1] == 0x03) {
                         DbpString("Mifare DESFire");
-                        SimulateIso14443aTag(3, flags, data);
+                        SimulateIso14443aTag(3, flags, data, 0);
                     } else {
                         Dbprintf("Unrecognized tag type -- defaulting to Mifare Classic emulation");
-                        SimulateIso14443aTag(1, flags, data);
+                        SimulateIso14443aTag(1, flags, data, 0);
                     }
 
                 } else if (button_pressed == BUTTON_SINGLE_CLICK) {

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1274,9 +1274,10 @@ static void PacketReceived(PacketCommandNG *packet) {
                 uint8_t tagtype;
                 uint8_t flags;
                 uint8_t uid[10];
+                uint8_t exitAfter;
             } PACKED;
             struct p *payload = (struct p *) packet->data.asBytes;
-            SimulateIso14443aTag(payload->tagtype, payload->flags, payload->uid);  // ## Simulate iso14443a tag - pass tag type & UID
+            SimulateIso14443aTag(payload->tagtype, payload->flags, payload->uid, payload->exitAfter);  // ## Simulate iso14443a tag - pass tag type & UID
             break;
         }
         case CMD_HF_ISO14443A_ANTIFUZZ: {

--- a/armsrc/iso14443a.h
+++ b/armsrc/iso14443a.h
@@ -129,7 +129,7 @@ RAMFUNC bool MillerDecoding(uint8_t bit, uint32_t non_real_time);
 RAMFUNC int ManchesterDecoding(uint8_t bit, uint16_t offset, uint32_t non_real_time);
 
 void RAMFUNC SniffIso14443a(uint8_t param);
-void SimulateIso14443aTag(uint8_t tagType, uint8_t flags, uint8_t *data);
+void SimulateIso14443aTag(uint8_t tagType, uint8_t flags, uint8_t *data, uint8_t numReads);
 bool SimulateIso14443aInit(int tagType, int flags, uint8_t *data, tag_response_info_t **responses, uint32_t *cuid, uint32_t counters[3], uint8_t tearings[3], uint8_t *pages);
 bool GetIso14443aCommandFromReader(uint8_t *received, uint8_t *par, int *len);
 void iso14443a_antifuzz(uint32_t flags);

--- a/client/src/cmdhf14a.c
+++ b/client/src/cmdhf14a.c
@@ -211,7 +211,7 @@ static int usage_hf_14a_config(void) {
 
 static int usage_hf_14a_sim(void) {
     PrintAndLogEx(NORMAL, "\n Emulating ISO/IEC 14443 type A tag with 4,7 or 10 byte UID\n");
-    PrintAndLogEx(NORMAL, "Usage: hf 14a sim [h] t <type> u <uid> [x] [e] [v]");
+    PrintAndLogEx(NORMAL, "Usage: hf 14a sim [h] t <type> u <uid> [n <numreads>] [x] [e] [v]");
     PrintAndLogEx(NORMAL, "Options:");
     PrintAndLogEx(NORMAL, "    h     : This help");
     PrintAndLogEx(NORMAL, "    t     : 1 = MIFARE Classic 1k");
@@ -225,6 +225,7 @@ static int usage_hf_14a_sim(void) {
     PrintAndLogEx(NORMAL, "            9 = FM11RF005SH Shanghai Metro");
     PrintAndLogEx(NORMAL, "           10 = JCOP 31/41 Rothult");
     PrintAndLogEx(NORMAL, "    u     : 4, 7 or 10 byte UID");
+    PrintAndLogEx(NORMAL, "    n     : (Optional) Exit simulation after <numreads> blocks have been read by reader. 0 = infinite");
     PrintAndLogEx(NORMAL, "    x     : (Optional) Performs the 'reader attack', nr/ar attack against a reader");
     PrintAndLogEx(NORMAL, "    e     : (Optional) Fill simulator keys from found keys");
     PrintAndLogEx(NORMAL, "    v     : (Optional) Verbose");
@@ -657,6 +658,7 @@ int CmdHF14ASim(const char *Cmd) {
     bool errors = false;
     sector_t *k_sector = NULL;
     uint8_t k_sectorsCount = 40;
+    uint8_t exitAfterNReads = 0;
 
     while (param_getchar(Cmd, cmdp) != 0x00 && !errors) {
         switch (tolower(param_getchar(Cmd, cmdp))) {
@@ -693,6 +695,10 @@ int CmdHF14ASim(const char *Cmd) {
                 }
                 cmdp += 2;
                 break;
+            case 'n':
+                exitAfterNReads = param_get8(Cmd, cmdp + 1);
+                cmdp += 2;
+                break;
             case 'v':
                 verbose = true;
                 cmdp++;
@@ -722,10 +728,12 @@ int CmdHF14ASim(const char *Cmd) {
         uint8_t tagtype;
         uint8_t flags;
         uint8_t uid[10];
+        uint8_t exitAfter;
     } PACKED payload;
 
     payload.tagtype = tagtype;
     payload.flags = flags;
+    payload.exitAfter = exitAfterNReads;
     memcpy(payload.uid, uid, uidlen);
 
     clearCommandBuffer();

--- a/client/src/cmdhfmfu.c
+++ b/client/src/cmdhfmfu.c
@@ -155,15 +155,17 @@ static int usage_hf_mfu_eload(void) {
 static int usage_hf_mfu_sim(void) {
     PrintAndLogEx(NORMAL, "\nEmulating Ultralight tag from emulator memory\n");
     PrintAndLogEx(NORMAL, "\nBe sure to load the emulator memory first!\n");
-    PrintAndLogEx(NORMAL, "Usage: hf mfu sim t 7 u <uid>");
+    PrintAndLogEx(NORMAL, "Usage: hf mfu sim t 7 u <uid> [n <num>]");
     PrintAndLogEx(NORMAL, "Options:");
     PrintAndLogEx(NORMAL, "    h       : this help");
     PrintAndLogEx(NORMAL, "    t 7     : 7 = NTAG or Ultralight sim (required)");
+    PrintAndLogEx(NORMAL, "    n <num> : exit simulation after <num> blocks have been read by reader. 0 = infinite (optional)");
     PrintAndLogEx(NORMAL, "    u <uid> : 4 or 7 byte UID (optional)");
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(NORMAL, "Examples:");
     PrintAndLogEx(NORMAL, _YELLOW_("        hf mfu sim t 7"));
     PrintAndLogEx(NORMAL, _YELLOW_("        hf mfu sim t 7 u 1122344556677"));
+    PrintAndLogEx(NORMAL, _YELLOW_("        hf mfu sim t 7 u 1122344556677 n 5"));
     PrintAndLogEx(NORMAL, "");
     return PM3_SUCCESS;
 }


### PR DESCRIPTION
Added `hf mfu sim t 7 n <numreads>` to allow the ultralight emulation to exit after `<numreads>` blocks. The approach was similar to the one that had been implemented for mifare classic tags.