### PR TITLE
Iso15 sim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fix `hf 15 sim` - Added basic response to GET_SYSTEM_INFO and READBLOCK requests in order to fix iso15693 tag sim
  - Added `mf mfu sim t 7 n <numreads>` - MFU emulation now supports automatic exit after <num> blocks read. (@cyberpunk-re)
  - Added T55xx Guide to assist in learning how to use the T55xx chip (@mwalker33)
  - Fix 'hf iclass wrbl' - dealing with tags in unsecured vs secured pagemode now is correct (@iceman1001)

--- a/armsrc/iso15693.c
+++ b/armsrc/iso15693.c
@@ -104,10 +104,12 @@
 #define ISO15693_MAX_COMMAND_LENGTH      45 // allows write single block with the maximum block size of 256bits. Write multiple blocks not supported yet
 
 // 32 + 2 crc + 1
-#define ISO15_MAX_FRAME 35
-#define CMD_ID_RESP     5
-#define CMD_READ_RESP   13
-#define CMD_INV_RESP    12
+#define ISO15_MAX_FRAME     35
+#define CMD_ID_RESP         5
+#define CMD_READ_RESP       13
+#define CMD_INV_RESP        12
+#define CMD_SYSINFO_RESP    17
+#define CMD_READBLOCK_RESP  7
 
 //#define Crc(data, len)        Crc(CRC_15693, (data), (len))
 #define CheckCrc15(data, len)   check_crc(CRC_15693, (data), (len))
@@ -1679,27 +1681,7 @@ void SimTagIso15693(uint8_t *uid) {
 
     LED_C_ON();
 
-    // Build INVENTORY command
-    uint8_t resp_inv[CMD_INV_RESP] = {0};
 
-    resp_inv[0] = 0; // No error, no protocol format extension
-    resp_inv[1] = 0; // DSFID (data storage format identifier).  0x00 = not supported
-
-    // 64-bit UID
-    resp_inv[2] = uid[7];
-    resp_inv[3] = uid[6];
-    resp_inv[4] = uid[5];
-    resp_inv[5] = uid[4];
-    resp_inv[6] = uid[3];
-    resp_inv[7] = uid[2];
-    resp_inv[8] = uid[1];
-    resp_inv[9] = uid[0];
-
-    // CRC
-    AddCrc15(resp_inv, 10);
-    CodeIso15693AsTag(resp_inv, CMD_INV_RESP);
-
-    tosend_t *ts = get_tosend();
 
     enum { NO_FIELD, IDLE, ACTIVATED, SELECTED, HALTED } chip_state = NO_FIELD;
 
@@ -1745,10 +1727,95 @@ void SimTagIso15693(uint8_t *uid) {
         if ((cmd_len >= 5) && (cmd[0] & ISO15_REQ_INVENTORY) && (cmd[1] == ISO15_CMD_INVENTORY)) {
             bool slow = !(cmd[0] & ISO15_REQ_DATARATE_HIGH);
             uint32_t response_time = reader_eof_time + DELAY_ISO15693_VCD_TO_VICC_SIM;
+                // Build INVENTORY command
+    uint8_t resp_inv[CMD_INV_RESP] = {0};
+
+    resp_inv[0] = 0; // No error, no protocol format extension
+    resp_inv[1] = 0; // DSFID (data storage format identifier).  0x00 = not supported
+
+    // 64-bit UID
+    resp_inv[2] = uid[7];
+    resp_inv[3] = uid[6];
+    resp_inv[4] = uid[5];
+    resp_inv[5] = uid[4];
+    resp_inv[6] = uid[3];
+    resp_inv[7] = uid[2];
+    resp_inv[8] = uid[1];
+    resp_inv[9] = uid[0];
+
+    // CRC
+    AddCrc15(resp_inv, 10);
+    CodeIso15693AsTag(resp_inv, CMD_INV_RESP);
+    
+    tosend_t *ts = get_tosend();
+    
             TransmitTo15693Reader(ts->buf, ts->max, &response_time, 0, slow);
             LogTrace_ISO15693(resp_inv, CMD_INV_RESP, response_time * 32, (response_time * 32) + (ts->max * 32 * 64), NULL, false);
 
             chip_state = SELECTED;
+        }
+        
+        // GET_SYSTEM_INFO
+        if ((cmd[1] == ISO15_CMD_SYSINFO)) {
+            bool slow = !(cmd[0] & ISO15_REQ_DATARATE_HIGH);
+            uint32_t response_time = reader_eof_time + DELAY_ISO15693_VCD_TO_VICC_SIM;
+            
+                // Build GET_SYSTEM_INFO command
+    uint8_t resp_sysinfo[CMD_SYSINFO_RESP] = {0};
+    
+    resp_sysinfo[0] = 0;    // Response flags.
+    resp_sysinfo[1] = 0x0F; // Information flags.
+    
+    // 64-bit UID
+    resp_sysinfo[2] = uid[7];
+    resp_sysinfo[3] = uid[6];
+    resp_sysinfo[4] = uid[5];
+    resp_sysinfo[5] = uid[4];
+    resp_sysinfo[6] = uid[3];
+    resp_sysinfo[7] = uid[2];
+    resp_sysinfo[8] = uid[1];
+    resp_sysinfo[9] = uid[0];
+    
+    resp_sysinfo[10] = 0;    // DSFID
+    resp_sysinfo[11] = 0;    // AFI
+
+    resp_sysinfo[12] = 0x1B; // Memory size [0].
+    resp_sysinfo[13] = 0x03; // Memory size [1].
+    resp_sysinfo[14] = 0x01; // Memory size [2].
+    
+    // CRC
+    AddCrc15(resp_sysinfo, 15);
+    CodeIso15693AsTag(resp_sysinfo, CMD_SYSINFO_RESP);
+    
+    tosend_t *ts = get_tosend();
+            
+            TransmitTo15693Reader(ts->buf, ts->max, &response_time, 0, slow);
+            LogTrace_ISO15693(resp_sysinfo, CMD_SYSINFO_RESP, response_time * 32, (response_time * 32) + (ts->max * 32 * 64), NULL, false);
+        }
+        
+        // READ_BLOCK
+        if ((cmd[1] == ISO15_CMD_READ)) {
+            bool slow = !(cmd[0] & ISO15_REQ_DATARATE_HIGH);
+            uint32_t response_time = reader_eof_time + DELAY_ISO15693_VCD_TO_VICC_SIM;
+            
+    // Build GET_SYSTEM_INFO command
+    uint8_t resp_readblock[CMD_READBLOCK_RESP] = {0};
+    
+    resp_readblock[0] = 0;    // Response flags.
+    resp_readblock[1] = 0;    // Block data.
+    resp_readblock[2] = 0;    // Block data.
+    resp_readblock[3] = 0;    // Block data.
+    resp_readblock[4] = 0;    // Block data.
+    
+    // CRC
+    AddCrc15(resp_readblock, 5);
+    CodeIso15693AsTag(resp_readblock, CMD_READBLOCK_RESP);
+    
+    tosend_t *ts = get_tosend();
+    
+    
+            TransmitTo15693Reader(ts->buf, ts->max, &response_time, 0, slow);
+            LogTrace_ISO15693(resp_readblock, CMD_READBLOCK_RESP, response_time * 32, (response_time * 32) + (ts->max * 32 * 64), NULL, false);
         }
     }
 

--- a/armsrc/iso15693.c
+++ b/armsrc/iso15693.c
@@ -1727,27 +1727,28 @@ void SimTagIso15693(uint8_t *uid) {
         if ((cmd_len >= 5) && (cmd[0] & ISO15_REQ_INVENTORY) && (cmd[1] == ISO15_CMD_INVENTORY)) {
             bool slow = !(cmd[0] & ISO15_REQ_DATARATE_HIGH);
             uint32_t response_time = reader_eof_time + DELAY_ISO15693_VCD_TO_VICC_SIM;
-                // Build INVENTORY command
-    uint8_t resp_inv[CMD_INV_RESP] = {0};
+            
+            // Build INVENTORY command
+            uint8_t resp_inv[CMD_INV_RESP] = {0};
 
-    resp_inv[0] = 0; // No error, no protocol format extension
-    resp_inv[1] = 0; // DSFID (data storage format identifier).  0x00 = not supported
+            resp_inv[0] = 0; // No error, no protocol format extension
+            resp_inv[1] = 0; // DSFID (data storage format identifier).  0x00 = not supported
 
-    // 64-bit UID
-    resp_inv[2] = uid[7];
-    resp_inv[3] = uid[6];
-    resp_inv[4] = uid[5];
-    resp_inv[5] = uid[4];
-    resp_inv[6] = uid[3];
-    resp_inv[7] = uid[2];
-    resp_inv[8] = uid[1];
-    resp_inv[9] = uid[0];
-
-    // CRC
-    AddCrc15(resp_inv, 10);
-    CodeIso15693AsTag(resp_inv, CMD_INV_RESP);
+            // 64-bit UID
+            resp_inv[2] = uid[7];
+            resp_inv[3] = uid[6];
+            resp_inv[4] = uid[5];
+            resp_inv[5] = uid[4];
+            resp_inv[6] = uid[3];
+            resp_inv[7] = uid[2];
+            resp_inv[8] = uid[1];
+            resp_inv[9] = uid[0];
+            
+            // CRC
+            AddCrc15(resp_inv, 10);
+            CodeIso15693AsTag(resp_inv, CMD_INV_RESP);
     
-    tosend_t *ts = get_tosend();
+            tosend_t *ts = get_tosend();
     
             TransmitTo15693Reader(ts->buf, ts->max, &response_time, 0, slow);
             LogTrace_ISO15693(resp_inv, CMD_INV_RESP, response_time * 32, (response_time * 32) + (ts->max * 32 * 64), NULL, false);
@@ -1760,34 +1761,34 @@ void SimTagIso15693(uint8_t *uid) {
             bool slow = !(cmd[0] & ISO15_REQ_DATARATE_HIGH);
             uint32_t response_time = reader_eof_time + DELAY_ISO15693_VCD_TO_VICC_SIM;
             
-                // Build GET_SYSTEM_INFO command
-    uint8_t resp_sysinfo[CMD_SYSINFO_RESP] = {0};
+            // Build GET_SYSTEM_INFO command
+            uint8_t resp_sysinfo[CMD_SYSINFO_RESP] = {0};
     
-    resp_sysinfo[0] = 0;    // Response flags.
-    resp_sysinfo[1] = 0x0F; // Information flags.
+            resp_sysinfo[0] = 0;    // Response flags.
+            resp_sysinfo[1] = 0x0F; // Information flags.
     
-    // 64-bit UID
-    resp_sysinfo[2] = uid[7];
-    resp_sysinfo[3] = uid[6];
-    resp_sysinfo[4] = uid[5];
-    resp_sysinfo[5] = uid[4];
-    resp_sysinfo[6] = uid[3];
-    resp_sysinfo[7] = uid[2];
-    resp_sysinfo[8] = uid[1];
-    resp_sysinfo[9] = uid[0];
+            // 64-bit UID
+            resp_sysinfo[2] = uid[7];
+            resp_sysinfo[3] = uid[6];
+            resp_sysinfo[4] = uid[5];
+            resp_sysinfo[5] = uid[4];
+            resp_sysinfo[6] = uid[3];
+            resp_sysinfo[7] = uid[2];
+            resp_sysinfo[8] = uid[1];
+            resp_sysinfo[9] = uid[0];
     
-    resp_sysinfo[10] = 0;    // DSFID
-    resp_sysinfo[11] = 0;    // AFI
+            resp_sysinfo[10] = 0;    // DSFID
+            resp_sysinfo[11] = 0;    // AFI
 
-    resp_sysinfo[12] = 0x1B; // Memory size [0].
-    resp_sysinfo[13] = 0x03; // Memory size [1].
-    resp_sysinfo[14] = 0x01; // Memory size [2].
+            resp_sysinfo[12] = 0x1B; // Memory size [0].
+            resp_sysinfo[13] = 0x03; // Memory size [1].
+            resp_sysinfo[14] = 0x01; // Memory size [2].
     
-    // CRC
-    AddCrc15(resp_sysinfo, 15);
-    CodeIso15693AsTag(resp_sysinfo, CMD_SYSINFO_RESP);
+            // CRC
+            AddCrc15(resp_sysinfo, 15);
+            CodeIso15693AsTag(resp_sysinfo, CMD_SYSINFO_RESP);
     
-    tosend_t *ts = get_tosend();
+            tosend_t *ts = get_tosend();
             
             TransmitTo15693Reader(ts->buf, ts->max, &response_time, 0, slow);
             LogTrace_ISO15693(resp_sysinfo, CMD_SYSINFO_RESP, response_time * 32, (response_time * 32) + (ts->max * 32 * 64), NULL, false);
@@ -1798,22 +1799,21 @@ void SimTagIso15693(uint8_t *uid) {
             bool slow = !(cmd[0] & ISO15_REQ_DATARATE_HIGH);
             uint32_t response_time = reader_eof_time + DELAY_ISO15693_VCD_TO_VICC_SIM;
             
-    // Build GET_SYSTEM_INFO command
-    uint8_t resp_readblock[CMD_READBLOCK_RESP] = {0};
+            // Build GET_SYSTEM_INFO command
+            uint8_t resp_readblock[CMD_READBLOCK_RESP] = {0};
     
-    resp_readblock[0] = 0;    // Response flags.
-    resp_readblock[1] = 0;    // Block data.
-    resp_readblock[2] = 0;    // Block data.
-    resp_readblock[3] = 0;    // Block data.
-    resp_readblock[4] = 0;    // Block data.
+            resp_readblock[0] = 0;    // Response flags.
+            resp_readblock[1] = 0;    // Block data.
+            resp_readblock[2] = 0;    // Block data.
+            resp_readblock[3] = 0;    // Block data.
+            resp_readblock[4] = 0;    // Block data.
     
-    // CRC
-    AddCrc15(resp_readblock, 5);
-    CodeIso15693AsTag(resp_readblock, CMD_READBLOCK_RESP);
+            // CRC
+            AddCrc15(resp_readblock, 5);
+            CodeIso15693AsTag(resp_readblock, CMD_READBLOCK_RESP);
     
-    tosend_t *ts = get_tosend();
-    
-    
+            tosend_t *ts = get_tosend();
+
             TransmitTo15693Reader(ts->buf, ts->max, &response_time, 0, slow);
             LogTrace_ISO15693(resp_readblock, CMD_READBLOCK_RESP, response_time * 32, (response_time * 32) + (ts->max * 32 * 64), NULL, false);
         }

--- a/armsrc/iso15693.c
+++ b/armsrc/iso15693.c
@@ -1765,7 +1765,7 @@ void SimTagIso15693(uint8_t *uid) {
             uint8_t resp_sysinfo[CMD_SYSINFO_RESP] = {0};
     
             resp_sysinfo[0] = 0;    // Response flags.
-            resp_sysinfo[1] = 0x0F; // Information flags.
+            resp_sysinfo[1] = 0x0F; // Information flags (0x0F - DSFID, AFI, Mem size, IC)
     
             // 64-bit UID
             resp_sysinfo[2] = uid[7];
@@ -1780,9 +1780,9 @@ void SimTagIso15693(uint8_t *uid) {
             resp_sysinfo[10] = 0;    // DSFID
             resp_sysinfo[11] = 0;    // AFI
 
-            resp_sysinfo[12] = 0x1B; // Memory size [0].
-            resp_sysinfo[13] = 0x03; // Memory size [1].
-            resp_sysinfo[14] = 0x01; // Memory size [2].
+            resp_sysinfo[12] = 0x1B; // Memory size.
+            resp_sysinfo[13] = 0x03; // Memory size.
+            resp_sysinfo[14] = 0x01; // IC reference.
     
             // CRC
             AddCrc15(resp_sysinfo, 15);

--- a/test.cmd
+++ b/test.cmd
@@ -1,0 +1,2 @@
+hw version
+hw version

--- a/test.cmd
+++ b/test.cmd
@@ -1,2 +1,0 @@
-hw version
-hw version


### PR DESCRIPTION
Fix `hf 15 sim` - Added basic responses to GET_SYSTEM_INFO and READBLOCK (returns empty block) requests to fix the currently broken iso15693 tag simulation.
A proper tag dump emulation should be implemented, but you can now successfully simulate the UID an ISO 15693 tag.