### PR TITLE
added fix for older bootloader

### DIFF
--- a/doc/md/Installation_Instructions/Mac-OS-X-Homebrew-Installation-Instructions.md
+++ b/doc/md/Installation_Instructions/Mac-OS-X-Homebrew-Installation-Instructions.md
@@ -50,6 +50,11 @@ proxmark3 /dev/tty.usbmodemiceman1 --flash --unlock-bootloader --image /usr/loca
 
 > Depending on the firmware version your Proxmark3 can also appear as `/dev/tty.usbmodem881`.
 
+If your proxmark3 comes with an out-of-date bootloader it can be necessary to flash only the bootrom first and then re-run one of the above commands:
+
+```sh
+proxmark3 /dev/tty.usbmodemiceman1 --flash --unlock-bootloader --image /usr/local/share/proxmark3/firmware/bootrom.elf
+```
 
 ## Run the client
 


### PR DESCRIPTION
While trying to flash my Proxmark3 RDV4 I got the following output:

```
$ proxmark3 /dev/tty.usbmodemiceman1 --flash --unlock-bootloader --image /usr/local/share/proxmark3/firmware/bootrom.elf --image /usr/local/share/proxmark3/firmware/fullimage.elf

[=] Session log /.../.proxmark3/log_20201205.txt
[+] About to use the following files:
[+]    /usr/local/share/proxmark3/firmware/bootrom.elf
[+]    /usr/local/share/proxmark3/firmware/fullimage.elf
[+] Waiting for Proxmark3 to appear on /dev/tty.usbmodemiceman1
 🕑  59 found
[!!] 🚨 ====================== OBS ! ===========================================
[!!] 🚨 Note: Your bootloader does not understand the new CMD_BL_VERSION command
[!!] 🚨 It is recommended that you first update your bootloader alone,
[!!] 🚨 reboot the Proxmark3 then only update the main firmware

[=] Available memory on this board: UNKNOWN

[!!] 🚨 ====================== OBS ! ======================================
[!!] 🚨 Note: Your bootloader does not understand the new CHIP_INFO command
[!!] 🚨 It is recommended that you first update your bootloader alone,
[!!] 🚨 reboot the Proxmark3 then only update the main firmware

[=] Permitted flash range: 0x00100000-0x00140000
[+] Loading ELF file /usr/local/share/proxmark3/firmware/bootrom.elf
[+] Loading usable ELF segments:
[+]    0: V 0x00100000 P 0x00100000 (0x00000200->0x00000200) [R X] @0x94
[+]    1: V 0x00200000 P 0x00100200 (0x00000d50->0x00000d50) [R X] @0x298

[+] Loading ELF file /usr/local/share/proxmark3/firmware/fullimage.elf
[+] Loading usable ELF segments:
[+]    0: V 0x00102000 P 0x00102000 (0x00043518->0x00043518) [R X] @0x94
[!!] 🚨 Error: PHDR is not contained in Flash
[+] All done
```

I was able to fix it with only flashing the bootrom first and then re-run the flashing procedure as documented:

```
tmp proxmark3 /dev/tty.usbmodemiceman1 --flash --unlock-bootloader --image /usr/local/share/proxmark3/firmware/bootrom.elf

[=] Session log /.../.proxmark3/log_20201205.txt
[+] About to use the following file:
[+]    /usr/local/share/proxmark3/firmware/bootrom.elf
[+] Waiting for Proxmark3 to appear on /dev/tty.usbmodemiceman1
 🕑  59 found
[!!] 🚨 ====================== OBS ! ===========================================
[!!] 🚨 Note: Your bootloader does not understand the new CMD_BL_VERSION command
[!!] 🚨 It is recommended that you first update your bootloader alone,
[!!] 🚨 reboot the Proxmark3 then only update the main firmware

[=] Available memory on this board: UNKNOWN

[!!] 🚨 ====================== OBS ! ======================================
[!!] 🚨 Note: Your bootloader does not understand the new CHIP_INFO command
[!!] 🚨 It is recommended that you first update your bootloader alone,
[!!] 🚨 reboot the Proxmark3 then only update the main firmware

[=] Permitted flash range: 0x00100000-0x00140000
[+] Loading ELF file /usr/local/share/proxmark3/firmware/bootrom.elf
[+] Loading usable ELF segments:
[+]    0: V 0x00100000 P 0x00100000 (0x00000200->0x00000200) [R X] @0x94
[+]    1: V 0x00200000 P 0x00100200 (0x00000d50->0x00000d50) [R X] @0x298

[+] Flashing...
[+] Writing segments for file: /usr/local/share/proxmark3/firmware/bootrom.elf
[+]  0x00100000..0x001001ff [0x200 / 1 blocks]
. OK
[+]  0x00100200..0x00100f4f [0xd50 / 7 blocks]
....... OK

[+] All done

Have a nice day!

$ pm3-flash-all
[=] Session log /.../.proxmark3/log_20201205.txt
[+] About to use the following files:
[+]    /usr/local/Cellar/proxmark3/4.9237/bin/../share/proxmark3/firmware/bootrom.elf
[+]    /usr/local/Cellar/proxmark3/4.9237/bin/../share/proxmark3/firmware/fullimage.elf
[+] Waiting for Proxmark3 to appear on /dev/tty.usbmodemiceman1
 🕑  59 found
[=] Available memory on this board: 512K bytes

[=] Permitted flash range: 0x00100000-0x00180000
[+] Loading ELF file /usr/local/Cellar/proxmark3/4.9237/bin/../share/proxmark3/firmware/bootrom.elf
[+] Loading usable ELF segments:
[+]    0: V 0x00100000 P 0x00100000 (0x00000200->0x00000200) [R X] @0x94
[+]    1: V 0x00200000 P 0x00100200 (0x00000d50->0x00000d50) [R X] @0x298

[+] Loading ELF file /usr/local/Cellar/proxmark3/4.9237/bin/../share/proxmark3/firmware/fullimage.elf
[+] Loading usable ELF segments:
[+]    0: V 0x00102000 P 0x00102000 (0x00043518->0x00043518) [R X] @0x94
[+]    1: V 0x00200000 P 0x00145518 (0x00001374->0x00001374) [RW ] @0x435ac
[=] Note: Extending previous segment from 0x43518 to 0x4488c bytes

[+] Flashing...
[+] Writing segments for file: /usr/local/Cellar/proxmark3/4.9237/bin/../share/proxmark3/firmware/bootrom.elf
[+]  0x00100000..0x001001ff [0x200 / 1 blocks]
. OK
[+]  0x00100200..0x00100f4f [0xd50 / 7 blocks]
....... OK

[+] Writing segments for file: /usr/local/Cellar/proxmark3/4.9237/bin/../share/proxmark3/firmware/fullimage.elf
[+]  0x00102000..0x0014688b [0x4488c / 549 blocks]
...................................................................
        @@@  @@@@@@@ @@@@@@@@ @@@@@@@@@@   @@@@@@  @@@  @@@
        @@! !@@      @@!      @@! @@! @@! @@!  @@@ @@!@!@@@
        !!@ !@!      @!!!:!   @!! !!@ @!@ @!@!@!@! @!@@!!@!
        !!: :!!      !!:      !!:     !!: !!:  !!! !!:  !!!
        :    :: :: : : :: :::  :      :    :   : : ::    :
        .    .. .. . . .. ...  .      .    .   . . ..    .
...................................................................
............................................ OK

[+] All done

Have a nice day!
```

In order to help others with this issue, I added my fix to the documentation.