### PR TITLE
Fix mistaken MIFARE increment and decrement constants

### DIFF
--- a/include/protocols.h
+++ b/include/protocols.h
@@ -160,8 +160,8 @@ ISO 7816-4 Basic interindustry commands. For command APDU's.
 #define MIFARE_MAGICWUPC1           0x40
 #define MIFARE_MAGICWUPC2           0x43
 #define MIFARE_MAGICWIPEC           0x41
-#define MIFARE_CMD_INC              0xC0
-#define MIFARE_CMD_DEC              0xC1
+#define MIFARE_CMD_DEC              0xC0
+#define MIFARE_CMD_INC              0xC1
 #define MIFARE_CMD_RESTORE          0xC2
 #define MIFARE_CMD_TRANSFER         0xB0
 

--- a/tools/mf_nonce_brute/protocol.h
+++ b/tools/mf_nonce_brute/protocol.h
@@ -6,8 +6,8 @@
 
 #define MIFARE_AUTH_KEYA        0x60
 #define MIFARE_AUTH_KEYB        0x61
-#define MIFARE_CMD_INC          0xC0
-#define MIFARE_CMD_DEC          0xC1
+#define MIFARE_CMD_DEC          0xC0
+#define MIFARE_CMD_INC          0xC1
 #define MIFARE_CMD_RESTORE      0xC2
 #define MIFARE_CMD_TRANSFER     0xB0
 


### PR DESCRIPTION
The increment and decrement commands have their values mixed up - decrement is 0xC0 and increment is 0xC1. This is stated correctly in the comment of `include/protocols.h`, but there seems to have been a mistake when setting the constants. Although these constants are used in a few places, the only place it appears that this mix-up has an effect is in command annotations:

![Trace](https://i.imgur.com/OByN6zK.png)