### PR TITLE
Rawdemod parsing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fix `data rawdemod` parsing for psk2 and user defined clock (@cyberpunk-re)
  - Fix issue #844 - `lf t55xx config` => recompute block0 (@cyberpunk-re)
  - EM4x50: changed cli parameter from w (word) to d (data) (@tharexde)
  - EM4x50: new function 4x50 login: authenticate against tag (@tharexde)

--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -1367,7 +1367,6 @@ int CmdPSK1rawDemod(const char *Cmd) {
     if (strlen(Cmd) > 16 || cmdp == 'h') return usage_data_rawdemod_p1();
     int clk = 0, invert = 0, max_err = 100;
     sscanf(Cmd, "%i %i %i", &clk, &invert, &max_err);
-
     if (clk == 1) {
         invert = 1;
         clk = 0;

--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -1367,6 +1367,7 @@ int CmdPSK1rawDemod(const char *Cmd) {
     if (strlen(Cmd) > 16 || cmdp == 'h') return usage_data_rawdemod_p1();
     int clk = 0, invert = 0, max_err = 100;
     sscanf(Cmd, "%i %i %i", &clk, &invert, &max_err);
+
     if (clk == 1) {
         invert = 1;
         clk = 0;
@@ -1428,7 +1429,7 @@ static int CmdRawDemod(const char *Cmd) {
     else if (str_startswith(Cmd, "am")) ans = Cmdaskmandemod(Cmd + 2);
     else if (str_startswith(Cmd, "ar")) ans = Cmdaskrawdemod(Cmd + 2);
     else if (str_startswith(Cmd, "nr") || Cmd[0] == 'n') ans = CmdNRZrawDemod(Cmd + 2);
-    else if (str_startswith(Cmd, "p1") || Cmd[0] == 'p') ans = CmdPSK1rawDemod(Cmd + 2);
+    else if (str_startswith(Cmd, "p1")) ans = CmdPSK1rawDemod(Cmd + 2);
     else if (str_startswith(Cmd, "p2")) ans = CmdPSK2rawDemod(Cmd + 2);
     else PrintAndLogEx(WARNING, "Unknown modulation entered - see help ('h') for parameter structure");
 

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -1081,6 +1081,11 @@ int DetectPSKClock(uint8_t *dest, size_t size, int clock, size_t *firstPhaseShif
     *firstPhaseShift = firstFullWave;
     if (g_debugMode == 2) prnt("DEBUG PSK: firstFullWave: %zu, waveLen: %d", firstFullWave, fullWaveLen);
 
+    // Avoid autodetect if user selected a clock
+    for(uint8_t validClk = 1; validClk < 8; validClk++) {
+        if(clock == clk[validClk]) return(clock);
+    }
+
     //test each valid clock from greatest to smallest to see which lines up
     for (clkCnt = 7; clkCnt >= 1 ; clkCnt--) {
         uint8_t tol = *fc / 2;


### PR DESCRIPTION
fix: `data rawdemod` parsing bug that prevented selection of psk2 modulation
Also rawdemod for psk was ignoring user-defined clock values (autodetection always took precedence).