### PR TITLE
EM4x70 Unlock support

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1174,6 +1174,10 @@ static void PacketReceived(PacketCommandNG *packet) {
             em4x70_write((em4x70_data_t *)packet->data.asBytes);
             break;
         }
+        case CMD_LF_EM4X70_UNLOCK: {
+            em4x70_unlock((em4x70_data_t *)packet->data.asBytes);
+            break;
+        }
 #endif
 
 #ifdef WITH_ISO15693

--- a/armsrc/em4x70.h
+++ b/armsrc/em4x70.h
@@ -19,5 +19,6 @@ typedef struct {
 
 void em4x70_info(em4x70_data_t *etd);
 void em4x70_write(em4x70_data_t *etd);
+void em4x70_unlock(em4x70_data_t *etd);
 
 #endif /* EM4x70_H */

--- a/client/src/cmdlfem4x70.c
+++ b/client/src/cmdlfem4x70.c
@@ -80,18 +80,18 @@ int CmdEM4x70Info(const char *Cmd) {
 
     CLIParserContext *ctx;
 
-    CLIParserInit(&ctx, "lf em 4x10 info",
+    CLIParserInit(&ctx, "lf em 4x70 info",
                   "Tag Information EM4x70\n"
                   "  Tag variants include ID48 automotive transponder.\n"
                   "  ID48 does not use command parity (default).\n"
                   "  V4070 and EM4170 do require parity bit.",
                   "lf em 4x70 info\n"
-                  "lf em 4x70 info -x -> adds parity bit to command\n"
+                  "lf em 4x70 info --par -> adds parity bit to command\n"
                 );
 
     void *argtable[] = {
         arg_param_begin,
-        arg_lit0("x", "parity", "Add parity bit when sending commands"),
+        arg_lit0(NULL, "par", "Add parity bit when sending commands"),
         arg_param_end
     };
 
@@ -124,17 +124,17 @@ int CmdEM4x70Write(const char *Cmd) {
 
     CLIParserContext *ctx;
 
-    CLIParserInit(&ctx, "lf em 4x10 write",
+    CLIParserInit(&ctx, "lf em 4x70 write",
                   "Write EM4x70\n",
-                  "lf em 4x70 write -b 15 d c0de -> write 'c0de' to block 15\n"
-                  "lf em 4x70 write -x -b 15 -d c0de -> adds parity bit to commands\n"
+                  "lf em 4x70 write -b 15 -d c0de -> write 'c0de' to block 15\n"
+                  "lf em 4x70 write -b 15 -d c0de --par -> adds parity bit to commands\n"
                 );
 
     void *argtable[] = {
         arg_param_begin,
-        arg_lit0("x", "parity", "Add parity bit when sending commands"),
-        arg_int1("b", "block",  "<dec>", "block/word address, dec"),
-        arg_str1("d", "data",   "<hex>", "data, 2 bytes"),
+        arg_lit0(NULL, "par",    "Add parity bit when sending commands"),
+        arg_int1("b",  "block",  "<dec>", "block/word address, dec"),
+        arg_str1("d",  "data",   "<hex>", "data, 2 bytes"),
         arg_param_end
     };
 
@@ -188,19 +188,19 @@ int CmdEM4x70Unlock(const char *Cmd) {
 
     CLIParserContext *ctx;
 
-    CLIParserInit(&ctx, "lf em 4x10 unlock",
+    CLIParserInit(&ctx, "lf em 4x70 unlock",
                   "Unlock EM4x70 by sending PIN\n"
                   "Default pin may be:\n"
                   " AAAAAAAA\n"
                   " 00000000\n",
                   "lf em 4x70 unlock -p 11223344 -> Unlock with PIN\n"
-                  "lf em 4x70 unlock -x -p 11223344 -> Unlock with PIN using parity commands\n"
+                  "lf em 4x70 unlock -p 11223344 --par -> Unlock with PIN using parity commands\n"
                 );
 
     void *argtable[] = {
         arg_param_begin,
-        arg_lit0("x", "parity", "Add parity bit when sending commands"),
-        arg_str1("p", "pin", "<hex>", "pin, 4 bytes"),
+        arg_lit0(NULL, "par", "Add parity bit when sending commands"),
+        arg_str1("p",  "pin", "<hex>", "pin, 4 bytes"),
         arg_param_end
     };
 

--- a/client/src/cmdlfem4x70.h
+++ b/client/src/cmdlfem4x70.h
@@ -19,6 +19,7 @@
 int CmdLFEM4X70(const char *Cmd);
 int CmdEM4x70Info(const char *Cmd);
 int CmdEM4x70Write(const char *Cmd);
+int CmdEM4x70Unlock(const char *Cmd);
 
 int em4x70_info(void);
 bool detect_4x70_block(void);

--- a/include/em4x70.h
+++ b/include/em4x70.h
@@ -19,6 +19,10 @@ typedef struct {
     // Used for writing address
     uint8_t address;
     uint16_t word;
+
+    // PIN to unlock
+    uint32_t pin;
+
 } em4x70_data_t;
 
 #endif /* EM4X70_H__ */

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -518,6 +518,7 @@ typedef struct {
 #define CMD_LF_EM4X50_CHK                                                 0x0253
 #define CMD_LF_EM4X70_INFO                                                0x0260
 #define CMD_LF_EM4X70_WRITE                                               0x0261
+#define CMD_LF_EM4X70_UNLOCK                                              0x0262
 // Sampling configuration for LF reader/sniffer
 #define CMD_LF_SAMPLING_SET_CONFIG                                        0x021D
 #define CMD_LF_FSK_SIMULATE                                               0x021E


### PR DESCRIPTION
Support for unlocking a tag by providing the pin.
I had to rename the parity command-line switches, as I think 'p' makes more sense for the password/pin to unlock the tag.
