### PR TITLE
eMRTD support 1/?

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -228,6 +228,7 @@ set (TARGET_SOURCES
         ${PM3_ROOT}/client/src/cmdhf15.c
         ${PM3_ROOT}/client/src/cmdhfcryptorf.c
         ${PM3_ROOT}/client/src/cmdhfepa.c
+        ${PM3_ROOT}/client/src/cmdhfemrtd.c
         ${PM3_ROOT}/client/src/cmdhffelica.c
         ${PM3_ROOT}/client/src/cmdhffido.c
         ${PM3_ROOT}/client/src/cmdhficlass.c

--- a/client/Makefile
+++ b/client/Makefile
@@ -469,6 +469,7 @@ SRCS =  aiddesfire.c \
 		cmdhf15.c \
 		cmdhfcryptorf.c \
 		cmdhfepa.c \
+		cmdhfemrtd.c \
 		cmdhffelica.c \
 		cmdhffido.c \
 		cmdhficlass.c \

--- a/client/src/cmdhf.c
+++ b/client/src/cmdhf.c
@@ -23,6 +23,7 @@
 #include "cmdhf14b.h"       // ISO14443-B
 #include "cmdhf15.h"        // ISO15693
 #include "cmdhfepa.h"
+#include "cmdhfemrtd.h"     // eMRTD
 #include "cmdhflegic.h"     // LEGIC
 #include "cmdhficlass.h"    // ICLASS
 #include "cmdhfmf.h"        // CLASSIC
@@ -357,24 +358,25 @@ int CmdHFPlot(const char *Cmd) {
 static command_t CommandTable[] = {
 
     {"--------",    CmdHelp,          AlwaysAvailable, "----------------------- " _CYAN_("High Frequency") " -----------------------"},
-    {"14a",         CmdHF14A,         AlwaysAvailable, "{ ISO14443A RFIDs...               }"},
-    {"14b",         CmdHF14B,         AlwaysAvailable, "{ ISO14443B RFIDs...               }"},
-    {"15",          CmdHF15,          AlwaysAvailable, "{ ISO15693 RFIDs...                }"},
-//    {"cryptorf",    CmdHFCryptoRF,    AlwaysAvailable, "{ CryptoRF RFIDs...                }"},
-    {"epa",         CmdHFEPA,         AlwaysAvailable, "{ German Identification Card...    }"},
-    {"felica",      CmdHFFelica,      AlwaysAvailable, "{ ISO18092 / FeliCa RFIDs...       }"},
-    {"fido",        CmdHFFido,        AlwaysAvailable, "{ FIDO and FIDO2 authenticators... }"},
-    {"iclass",      CmdHFiClass,      AlwaysAvailable, "{ ICLASS RFIDs...                  }"},
-    {"legic",       CmdHFLegic,       AlwaysAvailable, "{ LEGIC RFIDs...                   }"},
-    {"lto",         CmdHFLTO,         AlwaysAvailable, "{ LTO Cartridge Memory RFIDs...    }"},
-    {"mf",          CmdHFMF,          AlwaysAvailable, "{ MIFARE RFIDs...                  }"},
-    {"mfp",         CmdHFMFP,         AlwaysAvailable, "{ MIFARE Plus RFIDs...             }"},
-    {"mfu",         CmdHFMFUltra,     AlwaysAvailable, "{ MIFARE Ultralight RFIDs...       }"},
-    {"mfdes",       CmdHFMFDes,       AlwaysAvailable, "{ MIFARE Desfire RFIDs...          }"},
-    {"st",          CmdHF_ST,         AlwaysAvailable, "{ ST Rothult RFIDs...              }"},
-    {"thinfilm",    CmdHFThinfilm,    AlwaysAvailable, "{ Thinfilm RFIDs...                }"},
-    {"topaz",       CmdHFTopaz,       AlwaysAvailable, "{ TOPAZ (NFC Type 1) RFIDs...      }"},
-    {"waveshare",   CmdHFWaveshare,   AlwaysAvailable, "{ Waveshare NFC ePaper...          }"},
+    {"14a",         CmdHF14A,         AlwaysAvailable, "{ ISO14443A RFIDs...                  }"},
+    {"14b",         CmdHF14B,         AlwaysAvailable, "{ ISO14443B RFIDs...                  }"},
+    {"15",          CmdHF15,          AlwaysAvailable, "{ ISO15693 RFIDs...                   }"},
+//    {"cryptorf",    CmdHFCryptoRF,    AlwaysAvailable, "{ CryptoRF RFIDs...                   }"},
+    {"epa",         CmdHFEPA,         AlwaysAvailable, "{ German Identification Card...       }"},
+    {"emrtd",       CmdHFeMRTD,       AlwaysAvailable, "{ Machine Readable Travel Document... }"},
+    {"felica",      CmdHFFelica,      AlwaysAvailable, "{ ISO18092 / FeliCa RFIDs...          }"},
+    {"fido",        CmdHFFido,        AlwaysAvailable, "{ FIDO and FIDO2 authenticators...    }"},
+    {"iclass",      CmdHFiClass,      AlwaysAvailable, "{ ICLASS RFIDs...                     }"},
+    {"legic",       CmdHFLegic,       AlwaysAvailable, "{ LEGIC RFIDs...                      }"},
+    {"lto",         CmdHFLTO,         AlwaysAvailable, "{ LTO Cartridge Memory RFIDs...       }"},
+    {"mf",          CmdHFMF,          AlwaysAvailable, "{ MIFARE RFIDs...                     }"},
+    {"mfp",         CmdHFMFP,         AlwaysAvailable, "{ MIFARE Plus RFIDs...                }"},
+    {"mfu",         CmdHFMFUltra,     AlwaysAvailable, "{ MIFARE Ultralight RFIDs...          }"},
+    {"mfdes",       CmdHFMFDes,       AlwaysAvailable, "{ MIFARE Desfire RFIDs...             }"},
+    {"st",          CmdHF_ST,         AlwaysAvailable, "{ ST Rothult RFIDs...                 }"},
+    {"thinfilm",    CmdHFThinfilm,    AlwaysAvailable, "{ Thinfilm RFIDs...                   }"},
+    {"topaz",       CmdHFTopaz,       AlwaysAvailable, "{ TOPAZ (NFC Type 1) RFIDs...         }"},
+    {"waveshare",   CmdHFWaveshare,   AlwaysAvailable, "{ Waveshare NFC ePaper...             }"},
     {"-----------", CmdHelp,          AlwaysAvailable, "--------------------- " _CYAN_("General") " ---------------------"},
     {"help",        CmdHelp,          AlwaysAvailable, "This help"},
     {"list",        CmdTraceList,     AlwaysAvailable,    "List protocol data in trace buffer"},

--- a/client/src/cmdhf14b.c
+++ b/client/src/cmdhf14b.c
@@ -1488,7 +1488,7 @@ static int handle_14b_apdu(bool chainingin, uint8_t *datain, int datainlen, bool
     return PM3_SUCCESS;
 }
 
-static int exchange_14b_apdu(uint8_t *datain, int datainlen, bool activate_field, bool leave_signal_on, uint8_t *dataout, int maxdataoutlen, int *dataoutlen) {
+int exchange_14b_apdu(uint8_t *datain, int datainlen, bool activate_field, bool leave_signal_on, uint8_t *dataout, int maxdataoutlen, int *dataoutlen) {
     *dataoutlen = 0;
     bool chaining = false;
     int res;

--- a/client/src/cmdhf14b.h
+++ b/client/src/cmdhf14b.h
@@ -15,6 +15,8 @@
 
 int CmdHF14B(const char *Cmd);
 
+int exchange_14b_apdu(uint8_t *datain, int datainlen, bool activate_field, bool leave_signal_on, uint8_t *dataout, int maxdataoutlen, int *dataoutlen);
+
 int infoHF14B(bool verbose);
 int readHF14B(bool verbose);
 #endif

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -145,23 +145,23 @@ static char calculate_check_digit(char *data) {
 
 static int asn1datalength(uint8_t *datain, int datainlen, int offset) {
     PrintAndLogEx(DEBUG, "asn1datalength, datain: %s", sprint_hex_inrow(datain, datainlen));
-    int lenfield = (int) *(datain + offset);
+    int lenfield = (int) * (datain + offset);
     PrintAndLogEx(DEBUG, "asn1datalength, lenfield: %i", lenfield);
     if (lenfield <= 0x7f) {
         return lenfield;
     } else if (lenfield == 0x81) {
-        return ((int) *(datain + offset + 1));
+        return ((int) * (datain + offset + 1));
     } else if (lenfield == 0x82) {
-        return ((int) *(datain + offset + 1) << 8) | ((int) *(datain + offset + 2));
+        return ((int) * (datain + offset + 1) << 8) | ((int) * (datain + offset + 2));
     } else if (lenfield == 0x83) {
-        return (((int) *(datain + offset + 1) << 16) | ((int) *(datain + offset + 2)) << 8) | ((int) *(datain + offset + 3));
+        return (((int) * (datain + offset + 1) << 16) | ((int) * (datain + offset + 2)) << 8) | ((int) * (datain + offset + 3));
     }
     return false;
 }
 
 static int asn1fieldlength(uint8_t *datain, int datainlen, int offset) {
     PrintAndLogEx(DEBUG, "asn1fieldlength, datain: %s", sprint_hex_inrow(datain, datainlen));
-    int lenfield = (int) *(datain + offset);
+    int lenfield = (int) * (datain + offset);
     PrintAndLogEx(DEBUG, "asn1fieldlength, thing: %i", lenfield);
     if (lenfield <= 0x7f) {
         return 1;

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -48,7 +48,7 @@ static uint16_t get_sw(uint8_t *d, uint8_t n) {
     return d[n] * 0x0100 + d[n + 1];
 }
 
-static int select_aid(const char *select_by, const char *file_id) {
+static int select_file(const char *select_by, const char *file_id) {
     bool activate_field = true;
     bool keep_field_on = true;
     uint8_t response[PM3_CMD_DATA_SIZE];
@@ -60,10 +60,10 @@ static int select_aid(const char *select_by, const char *file_id) {
     sprintf(cmd, "00%s%s0C%02lu%s", SELECT, select_by, file_id_len, file_id);
     PrintAndLogEx(INFO, "Sending: %s", cmd);
 
-    uint8_t aSELECT_AID[80];
-    int aSELECT_AID_n = 0;
-    param_gethex_to_eol(cmd, 0, aSELECT_AID, sizeof(aSELECT_AID), &aSELECT_AID_n);
-    int res = ExchangeAPDU14a(aSELECT_AID, aSELECT_AID_n, activate_field, keep_field_on, response, sizeof(response), &resplen);
+    uint8_t aSELECT_FILE[80];
+    int aSELECT_FILE_n = 0;
+    param_gethex_to_eol(cmd, 0, aSELECT_FILE, sizeof(aSELECT_FILE), &aSELECT_FILE_n);
+    int res = ExchangeAPDU14a(aSELECT_FILE, aSELECT_FILE_n, activate_field, keep_field_on, response, sizeof(response), &resplen);
     if (res) {
         DropField();
         return false;
@@ -77,7 +77,7 @@ static int select_aid(const char *select_by, const char *file_id) {
 
     uint16_t sw = get_sw(response, resplen);
     if (sw != 0x9000) {
-        PrintAndLogEx(ERR, "Selecting Card Access aid failed (%04x - %s).", sw, GetAPDUCodeDescription(sw >> 8, sw & 0xff));
+        PrintAndLogEx(ERR, "Selecting file failed (%04x - %s).", sw, GetAPDUCodeDescription(sw >> 8, sw & 0xff));
         DropField();
         return false;
     }
@@ -203,7 +203,7 @@ static int read_file(uint8_t *dataout, int maxdataoutlen, int *dataoutlen) {
 
 int infoHF_EMRTD(void) {
     // const uint8_t *data
-    if (select_aid(P1_SELECT_BY_EF, EF_CARDACCESS)) {
+    if (select_file(P1_SELECT_BY_EF, EF_CARDACCESS)) {
         uint8_t response[PM3_CMD_DATA_SIZE];
         int resplen = 0;
 

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -65,8 +65,9 @@
 // App IDs
 #define AID_MRTD "A0000002471001"
 
-uint8_t KENC_type[4] = {0x00, 0x00, 0x00, 0x01};
-uint8_t KMAC_type[4] = {0x00, 0x00, 0x00, 0x02};
+// DESKey Types
+const uint8_t KENC_type[4] = {0x00, 0x00, 0x00, 0x01};
+const uint8_t KMAC_type[4] = {0x00, 0x00, 0x00, 0x02};
 
 static int CmdHelp(const char *Cmd);
 
@@ -271,7 +272,7 @@ static void retail_mac(uint8_t *key, uint8_t *input, int inputlen, uint8_t *outp
 }
 
 
-static void deskey(uint8_t *seed, uint8_t *type, int length, uint8_t *dataout) {
+static void deskey(uint8_t *seed, const uint8_t *type, int length, uint8_t *dataout) {
     PrintAndLogEx(DEBUG, "seed: %s", sprint_hex_inrow(seed, 16));
 
     // combine seed and type

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -293,10 +293,10 @@ static void deskey(uint8_t *seed, const uint8_t *type, int length, uint8_t *data
 }
 
 static int select_file(const char *select_by, const char *file_id, bool use_14b) {
-    size_t file_id_len = strlen(file_id) / 2;
+    int file_id_len = strlen(file_id) / 2;
 
     char cmd[50];
-    sprintf(cmd, "00%s%s0C%02lu%s", SELECT, select_by, file_id_len, file_id);
+    sprintf(cmd, "00%s%s0C%02X%s", SELECT, select_by, file_id_len, file_id);
 
     return exchange_commands_noout(cmd, false, true, use_14b);
 }

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1,0 +1,247 @@
+//-----------------------------------------------------------------------------
+// Copyright (C) 2020 A. Ozkal
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// High frequency Electronic Machine Readable Travel Document commands
+//-----------------------------------------------------------------------------
+
+#include "cmdhfemrtd.h"
+#include <ctype.h>
+#include "fileutils.h"
+#include "cmdparser.h"     // command_t
+#include "comms.h"         // clearCommandBuffer
+#include "cmdtrace.h"
+#include "cliparser.h"
+#include "crc16.h"
+#include "cmdhf14a.h"
+#include "protocols.h"     // definitions of ISO14A/7816 protocol
+#include "emv/apduinfo.h"  // GetAPDUCodeDescription
+
+#define TIMEOUT 2000
+
+static int CmdHelp(const char *Cmd);
+
+static uint16_t get_sw(uint8_t *d, uint8_t n) {
+    if (n < 2)
+        return 0;
+
+    n -= 2;
+    return d[n] * 0x0100 + d[n + 1];
+}
+
+static int select_aid(const char *select_by, const char *file_id) {
+    bool activate_field = true;
+    bool keep_field_on = true;
+    uint8_t response[PM3_CMD_DATA_SIZE];
+    int resplen = 0;
+
+    size_t file_id_len = strlen(file_id) / 2;
+
+    char cmd[50];
+    sprintf(cmd, "00A4%s0C%02lu%s", select_by, file_id_len, file_id);
+    PrintAndLogEx(INFO, "Sending: %s", cmd);
+
+    uint8_t aSELECT_AID[80];
+    int aSELECT_AID_n = 0;
+    param_gethex_to_eol(cmd, 0, aSELECT_AID, sizeof(aSELECT_AID), &aSELECT_AID_n);
+    int res = ExchangeAPDU14a(aSELECT_AID, aSELECT_AID_n, activate_field, keep_field_on, response, sizeof(response), &resplen);
+    if (res) {
+        DropField();
+        return false;
+    }
+
+    if (resplen < 2) {
+        DropField();
+        return false;
+    }
+    PrintAndLogEx(INFO, "Resp: %s", sprint_hex(response, resplen));
+
+    uint16_t sw = get_sw(response, resplen);
+    if (sw != 0x9000) {
+        PrintAndLogEx(ERR, "Selecting Card Access aid failed (%04x - %s).", sw, GetAPDUCodeDescription(sw >> 8, sw & 0xff));
+        DropField();
+        return false;
+    }
+    return true;
+}
+
+static int asn1datalength(uint8_t *datain, int datainlen) {
+    char* dataintext = sprint_hex_inrow(datain, datainlen);
+
+    // lazy - https://stackoverflow.com/a/4214350/3286892
+    char subbuff[8];
+    memcpy(subbuff, &dataintext[2], 2);
+    subbuff[2] = '\0';
+
+    int thing = (int)strtol(subbuff, NULL, 16);
+    if (thing <= 0x7f) {
+        return thing;
+    } else if (thing == 0x81) {
+        memcpy(subbuff, &dataintext[2], 3);
+        subbuff[3] = '\0';
+        return (int)strtol(subbuff, NULL, 16);
+    } else if (thing == 0x82) {
+        memcpy(subbuff, &dataintext[2], 5);
+        subbuff[5] = '\0';
+        return (int)strtol(subbuff, NULL, 16);
+    } else if (thing == 0x83) {
+        memcpy(subbuff, &dataintext[2], 7);
+        subbuff[7] = '\0';
+        return (int)strtol(subbuff, NULL, 16);
+    }
+    return false;
+}
+
+static int asn1fieldlength(uint8_t *datain, int datainlen) {
+    char* dataintext = sprint_hex_inrow(datain, datainlen);
+
+    // lazy - https://stackoverflow.com/a/4214350/3286892
+    char subbuff[8];
+    memcpy(subbuff, &dataintext[2], 2);
+    subbuff[2] = '\0';
+
+    int thing = (int)strtol(subbuff, NULL, 16);
+    if (thing <= 0x7f) {
+        return 2;
+    } else if (thing == 0x81) {
+        return 4;
+    } else if (thing == 0x82) {
+        return 6;
+    } else if (thing == 0x83) {
+        return 8;
+    }
+    return false;
+}
+
+static int _read_binary(int offset, int bytes_to_read, uint8_t *dataout, int maxdataoutlen, int *dataoutlen) {
+    bool activate_field = false;
+    bool keep_field_on = true;
+    uint8_t response[PM3_CMD_DATA_SIZE];
+    int resplen = 0;
+
+    char cmd[50];
+    sprintf(cmd, "00B0%04i%02i", offset, bytes_to_read);
+    PrintAndLogEx(INFO, "Sending: %s", cmd);
+
+    uint8_t aREAD_BINARY[80];
+    int aREAD_BINARY_n = 0;
+    param_gethex_to_eol(cmd, 0, aREAD_BINARY, sizeof(aREAD_BINARY), &aREAD_BINARY_n);
+    int res = ExchangeAPDU14a(aREAD_BINARY, aREAD_BINARY_n, activate_field, keep_field_on, response, sizeof(response), &resplen);
+    if (res) {
+        DropField();
+        return false;
+    }
+    PrintAndLogEx(INFO, "Resp: %s", sprint_hex(response, resplen));
+
+    // drop sw
+    memcpy(dataout, &response, resplen - 2);
+    *dataoutlen = (resplen - 2);
+
+    uint16_t sw = get_sw(response, resplen);
+    if (sw != 0x9000) {
+        PrintAndLogEx(ERR, "Reading binary failed (%04x - %s).", sw, GetAPDUCodeDescription(sw >> 8, sw & 0xff));
+        DropField();
+        return false;
+    }
+    return true;
+}
+
+static int read_file(uint8_t *dataout, int maxdataoutlen, int *dataoutlen) {
+    uint8_t response[PM3_CMD_DATA_SIZE];
+    int resplen = 0;
+    uint8_t tempresponse[PM3_CMD_DATA_SIZE];
+    int tempresplen = 0;
+
+    if (!_read_binary(0, 4, response, sizeof(response), &resplen)) {
+        return false;
+    }
+
+    int datalen = asn1datalength(response, resplen);
+    int readlen = datalen - (3 - asn1fieldlength(response, resplen) / 2);
+    int offset = 4;
+    int toread;
+
+    while (readlen > 0) {
+        toread = readlen;
+        if (readlen > 118) {
+            toread = 118;
+        }
+
+        if (!_read_binary(offset, toread, tempresponse, sizeof(tempresponse), &tempresplen)) {
+            return false;
+        }
+
+        memcpy(&response[resplen], &tempresponse, tempresplen);
+        offset += toread;
+        readlen -= toread;
+        resplen += tempresplen;
+    }
+
+    memcpy(dataout, &response, resplen);
+    *dataoutlen = resplen;
+    return true;
+}
+
+int infoHF_EMRTD(void) {
+    // const uint8_t *data
+    if (select_aid("02", "011c")) {
+        uint8_t response[PM3_CMD_DATA_SIZE];
+        int resplen = 0;
+
+        read_file(response, sizeof(response), &resplen);
+
+        PrintAndLogEx(INFO, "EF_CardAccess: %s", sprint_hex(response, resplen));
+    } else {
+        PrintAndLogEx(INFO, "PACE unsupported. Will not read EF_CardAccess.");
+    }
+
+    DropField();
+    return PM3_SUCCESS;
+}
+
+static int cmd_hf_emrtd_info(const char *Cmd) {
+    CLIParserContext *ctx;
+    CLIParserInit(&ctx, "hf emrtd info",
+                  "Get info about an eMRTD",
+                  "hf emrtd info"
+                 );
+
+    void *argtable[] = {
+        arg_param_begin,
+        arg_param_end
+    };
+    CLIExecWithReturn(ctx, Cmd, argtable, true);
+    CLIParserFree(ctx);
+    return infoHF_EMRTD();
+}
+
+static int cmd_hf_emrtd_list(const char *Cmd) {
+    char args[128] = {0};
+    if (strlen(Cmd) == 0) {
+        snprintf(args, sizeof(args), "-t 7816");
+    } else {
+        strncpy(args, Cmd, sizeof(args) - 1);
+    }
+    return CmdTraceList(args);
+}
+
+static command_t CommandTable[] = {
+    {"help",    CmdHelp,           AlwaysAvailable, "This help"},
+    {"info",    cmd_hf_emrtd_info, IfPm3Iso14443a,  "Tag information"},
+    {"list",    cmd_hf_emrtd_list, AlwaysAvailable, "List ISO 14443A/7816 history"},
+    {NULL, NULL, NULL, NULL}
+};
+
+static int CmdHelp(const char *Cmd) {
+    (void)Cmd; // Cmd is not used so far
+    CmdsHelp(CommandTable);
+    return PM3_SUCCESS;
+}
+
+int CmdHFeMRTD(const char *Cmd) {
+    clearCommandBuffer();
+    return CmdsParse(CommandTable, Cmd);
+}

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -109,7 +109,7 @@ static char calculate_check_digit(char *data) {
 }
 
 static int asn1datalength(uint8_t *datain, int datainlen) {
-    char* dataintext = sprint_hex_inrow(datain, datainlen);
+    char *dataintext = sprint_hex_inrow(datain, datainlen);
 
     // lazy - https://stackoverflow.com/a/4214350/3286892
     char subbuff[8];
@@ -136,7 +136,7 @@ static int asn1datalength(uint8_t *datain, int datainlen) {
 }
 
 static int asn1fieldlength(uint8_t *datain, int datainlen) {
-    char* dataintext = sprint_hex_inrow(datain, datainlen);
+    char *dataintext = sprint_hex_inrow(datain, datainlen);
 
     // lazy - https://stackoverflow.com/a/4214350/3286892
     char subbuff[8];

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -804,6 +804,7 @@ int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry) {
             PrintAndLogEx(INFO, "EF_DG1: %s", sprint_hex(response, resplen));
         }
     }
+    // TODO: account for the case of no BAC
     PrintAndLogEx(DEBUG, "doc: %s", documentnumber);
     PrintAndLogEx(DEBUG, "dob: %s", dob);
     PrintAndLogEx(DEBUG, "exp: %s", expiry);
@@ -933,6 +934,8 @@ int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry) {
         PrintAndLogEx(DEBUG, "Current file: %s", file_name);
         dump_file(ks_enc, ks_mac, ssc, file_id, file_name, use_14b);
     }
+
+    dump_file(ks_enc, ks_mac, ssc, EF_SOD, "EF_SOD", use_14b);
 
     DropField();
     return PM3_SUCCESS;

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -349,13 +349,11 @@ static int secure_select_file(uint8_t *kenc, uint8_t *kmac, uint8_t *ssc, uint8_
     uint8_t response[PM3_CMD_DATA_SIZE];
     int resplen = 0;
 
-    // TODO: fix sizes
     uint8_t iv[8] = { 0x00 };
-    char command[200];
-    uint8_t cmd[200];
-    uint8_t data[100];
-    uint8_t temp[100] = {0x0c, 0xa4, 0x02, 0x0c};
-    uint8_t temp_2[100];
+    char command[54];
+    uint8_t cmd[8];
+    uint8_t data[21];
+    uint8_t temp[8] = {0x0c, 0xa4, 0x02, 0x0c};
 
     PrintAndLogEx(DEBUG, "keyenc: %s", sprint_hex_inrow(kenc, 16));
     PrintAndLogEx(DEBUG, "keymac: %s", sprint_hex_inrow(kmac, 16));
@@ -365,23 +363,23 @@ static int secure_select_file(uint8_t *kenc, uint8_t *kmac, uint8_t *ssc, uint8_
     PrintAndLogEx(DEBUG, "cmd: %s", sprint_hex_inrow(cmd, cmdlen));
     PrintAndLogEx(DEBUG, "data: %s", sprint_hex_inrow(data, datalen));
 
-    des3_encrypt_cbc(iv, kenc, data, datalen, temp_2);
-    PrintAndLogEx(DEBUG, "temp_2: %s", sprint_hex_inrow(temp_2, datalen));
-    uint8_t do87[103] = {0x87, 0x09, 0x01};
-    memcpy(do87 + 3, temp_2, datalen);
+    des3_encrypt_cbc(iv, kenc, data, datalen, temp);
+    PrintAndLogEx(DEBUG, "temp: %s", sprint_hex_inrow(temp, datalen));
+    uint8_t do87[11] = {0x87, 0x09, 0x01};
+    memcpy(do87 + 3, temp, datalen);
     PrintAndLogEx(DEBUG, "do87: %s", sprint_hex_inrow(do87, datalen + 3));
 
-    uint8_t m[153];
+    uint8_t m[19];
     memcpy(m, cmd, cmdlen);
     memcpy(m + cmdlen, do87, (datalen + 3));
     PrintAndLogEx(DEBUG, "m: %s", sprint_hex_inrow(m, datalen + cmdlen + 3));
 
-    // this is hacky
+    // TODO: this is hacky
     PrintAndLogEx(DEBUG, "ssc-b: %s", sprint_hex_inrow(ssc, 8));
     (*(ssc + 7)) += 1;
     PrintAndLogEx(DEBUG, "ssc-a: %s", sprint_hex_inrow(ssc, 8));
 
-    uint8_t n[161];
+    uint8_t n[27];
     memcpy(n, ssc, 8);
     memcpy(n + 8, m, (cmdlen + datalen + 3));
     PrintAndLogEx(DEBUG, "n: %s", sprint_hex_inrow(n, (cmdlen + datalen + 11)));

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -14,11 +14,9 @@
 #include <ctype.h>
 #include "fileutils.h"              // saveFile
 #include "cmdparser.h"              // command_t
-#include "comms.h"                  // clearCommandBuffer
-#include "cmdtrace.h"
-#include "cliparser.h"
-#include "crc16.h"
-#include "cmdhf14a.h"
+#include "cmdtrace.h"               // CmdTraceList
+#include "cliparser.h"              // CLIParserContext etc
+#include "cmdhf14a.h"               // ExchangeAPDU14a
 #include "protocols.h"              // definitions of ISO14A/7816 protocol
 #include "emv/apduinfo.h"           // GetAPDUCodeDescription
 #include "sha1.h"                   // KSeed calculation etc

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -466,7 +466,9 @@ static bool secure_select_file(uint8_t *kenc, uint8_t *kmac, uint8_t *ssc, const
     sprintf(command, "0C%s020C%02X%s00", SELECT, lc, sprint_hex_inrow(data, lc));
     PrintAndLogEx(DEBUG, "command: %s", command);
 
-    exchange_commands(command, response, &resplen, false, true, use_14b);
+    if (exchange_commands(command, response, &resplen, false, true, use_14b) == false) {
+        return false;
+    }
 
     return check_cc(ssc, kmac, response, resplen);
 }
@@ -524,7 +526,9 @@ static bool _secure_read_binary(uint8_t *kmac, uint8_t *ssc, int offset, int byt
     sprintf(command, "0C%s%02X%02X%02X%s00", READ_BINARY, p1, p2, lc, sprint_hex_inrow(data, lc));
     PrintAndLogEx(DEBUG, "command: %s", command);
 
-    exchange_commands(command, dataout, dataoutlen, false, true, use_14b);
+    if (exchange_commands(command, dataout, dataoutlen, false, true, use_14b) == false) {
+        return false;
+    }
 
     return check_cc(ssc, kmac, dataout, *dataoutlen);
 }

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -12,7 +12,7 @@
 
 #include "cmdhfemrtd.h"
 #include <ctype.h>
-#include "fileutils.h"
+#include "fileutils.h"              // saveFile
 #include "cmdparser.h"              // command_t
 #include "comms.h"                  // clearCommandBuffer
 #include "cmdtrace.h"
@@ -600,7 +600,8 @@ int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry) {
     // Select and read EF_CardAccess
     if (select_file(P1_SELECT_BY_EF, EF_CARDACCESS, true, true)) {
         read_file(response, &resplen);
-        PrintAndLogEx(INFO, "EF_CardAccess: %s", sprint_hex(response, resplen));
+        PrintAndLogEx(INFO, "Read EF_CardAccess, len: %i.", resplen);
+        PrintAndLogEx(DEBUG, "Contents (may be incomplete over 2k chars): %s", sprint_hex_inrow(response, resplen));
     } else {
         PrintAndLogEx(INFO, "PACE unsupported. Will not read EF_CardAccess.");
     }
@@ -733,8 +734,11 @@ int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry) {
         DropField();
         return PM3_ESOFT;
     }
-    PrintAndLogEx(INFO, "EF_COM: %s", sprint_hex_inrow(response, resplen));
+    PrintAndLogEx(INFO, "Read EF_COM, len: %i.", resplen);
+    PrintAndLogEx(DEBUG, "Contents (may be incomplete over 2k chars): %s", sprint_hex_inrow(response, resplen));
+    saveFile("EF_COM", ".BIN", response, resplen);
 
+    // TODO: Don't read a hardcoded list of files, reduce code repetition
     // Select EF_DG1
     if (secure_select_file(ks_enc, ks_mac, ssc, EF_DG1) == false) {
         PrintAndLogEx(ERR, "Failed to secure select EF_DG1, crypto checksum check failed.");
@@ -747,7 +751,9 @@ int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry) {
         DropField();
         return PM3_ESOFT;
     }
-    PrintAndLogEx(INFO, "EF_DG1: %s", sprint_hex_inrow(response, resplen));
+    PrintAndLogEx(INFO, "Read EF_DG1, len: %i.", resplen);
+    PrintAndLogEx(DEBUG, "Contents (may be incomplete over 2k chars): %s", sprint_hex_inrow(response, resplen));
+    saveFile("EF_DG1", ".BIN", response, resplen);
 
     // Select EF_DG2
     if (secure_select_file(ks_enc, ks_mac, ssc, EF_DG2) == false) {
@@ -761,7 +767,73 @@ int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry) {
         DropField();
         return PM3_ESOFT;
     }
-    PrintAndLogEx(INFO, "EF_DG2 (len: %i): %s", resplen, sprint_hex_inrow(response, resplen));
+    PrintAndLogEx(INFO, "Read EF_DG2, len: %i.", resplen);
+    PrintAndLogEx(DEBUG, "Contents (may be incomplete over 2k chars): %s", sprint_hex_inrow(response, resplen));
+    saveFile("EF_DG2", ".BIN", response, resplen);
+
+    // Select EF_SOD
+    if (secure_select_file(ks_enc, ks_mac, ssc, EF_SOD) == false) {
+        PrintAndLogEx(ERR, "Failed to secure select EF_SOD, crypto checksum check failed.");
+        DropField();
+        return PM3_ESOFT;
+    }
+
+    if (secure_read_file(ks_enc, ks_mac, ssc, response, &resplen) == false) {
+        PrintAndLogEx(ERR, "Failed to read EF_SOD.");
+        DropField();
+        return PM3_ESOFT;
+    }
+    PrintAndLogEx(INFO, "Read EF_SOD, len: %i.", resplen);
+    PrintAndLogEx(DEBUG, "Contents (may be incomplete over 2k chars): %s", sprint_hex_inrow(response, resplen));
+    saveFile("EF_SOD", ".BIN", response, resplen);
+
+    // Select EF_DG11
+    if (secure_select_file(ks_enc, ks_mac, ssc, EF_DG11) == false) {
+        PrintAndLogEx(ERR, "Failed to secure select EF_DG11, crypto checksum check failed.");
+        DropField();
+        return PM3_ESOFT;
+    }
+
+    if (secure_read_file(ks_enc, ks_mac, ssc, response, &resplen) == false) {
+        PrintAndLogEx(ERR, "Failed to read EF_DG11.");
+        DropField();
+        return PM3_ESOFT;
+    }
+    PrintAndLogEx(INFO, "Read EF_DG11, len: %i.", resplen);
+    PrintAndLogEx(DEBUG, "Contents (may be incomplete over 2k chars): %s", sprint_hex_inrow(response, resplen));
+    saveFile("EF_DG11", ".BIN", response, resplen);
+
+    // Select EF_DG12
+    if (secure_select_file(ks_enc, ks_mac, ssc, EF_DG12) == false) {
+        PrintAndLogEx(ERR, "Failed to secure select EF_DG12, crypto checksum check failed.");
+        DropField();
+        return PM3_ESOFT;
+    }
+
+    if (secure_read_file(ks_enc, ks_mac, ssc, response, &resplen) == false) {
+        PrintAndLogEx(ERR, "Failed to read EF_DG12.");
+        DropField();
+        return PM3_ESOFT;
+    }
+    PrintAndLogEx(INFO, "Read EF_DG12, len: %i.", resplen);
+    PrintAndLogEx(DEBUG, "Contents (may be incomplete over 2k chars): %s", sprint_hex_inrow(response, resplen));
+    saveFile("EF_DG12", ".BIN", response, resplen);
+
+    // Select EF_DG14
+    if (secure_select_file(ks_enc, ks_mac, ssc, EF_DG14) == false) {
+        PrintAndLogEx(ERR, "Failed to secure select EF_DG14, crypto checksum check failed.");
+        DropField();
+        return PM3_ESOFT;
+    }
+
+    if (secure_read_file(ks_enc, ks_mac, ssc, response, &resplen) == false) {
+        PrintAndLogEx(ERR, "Failed to read EF_DG14.");
+        DropField();
+        return PM3_ESOFT;
+    }
+    PrintAndLogEx(INFO, "Read EF_DG14, len: %i.", resplen);
+    PrintAndLogEx(DEBUG, "Contents (may be incomplete over 2k chars): %s", sprint_hex_inrow(response, resplen));
+    saveFile("EF_DG14", ".BIN", response, resplen);
 
     DropField();
     return PM3_SUCCESS;

--- a/client/src/cmdhfemrtd.h
+++ b/client/src/cmdhfemrtd.h
@@ -15,5 +15,5 @@
 
 int CmdHFeMRTD(const char *Cmd);
 
-int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry);
+int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_available);
 #endif

--- a/client/src/cmdhfemrtd.h
+++ b/client/src/cmdhfemrtd.h
@@ -1,0 +1,19 @@
+//-----------------------------------------------------------------------------
+// Copyright (C) 2020 A. Ozkal
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// High frequency Electronic Machine Readable Travel Document commands
+//-----------------------------------------------------------------------------
+
+#ifndef CMDHFEMRTD_H__
+#define CMDHFEMRTD_H__
+
+#include "common.h"
+
+int CmdHFeMRTD(const char *Cmd);
+
+int infoHF_EMRTD(void);
+#endif

--- a/client/src/cmdhfemrtd.h
+++ b/client/src/cmdhfemrtd.h
@@ -15,5 +15,5 @@
 
 int CmdHFeMRTD(const char *Cmd);
 
-int infoHF_EMRTD(void);
+int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry);
 #endif

--- a/client/src/cmdhfemrtd.h
+++ b/client/src/cmdhfemrtd.h
@@ -15,5 +15,5 @@
 
 int CmdHFeMRTD(const char *Cmd);
 
-int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry);
+int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry);
 #endif


### PR DESCRIPTION
This PR adds basic support for reading Electronic Machine Readable Travel Documents (ePassports, eIDs, Electronic Driver's Licenses etc, [anything with this logo](https://upload.wikimedia.org/wikipedia/commons/f/fb/EPassport_logo.svg)) and dumping them into files, with a command called `hf emrtd dump`.

These files can then be viewed either manually, or by using something like rfidiot's mrpkey (`python2 mrpkey.py -n /tmp/itsworkingquestionmark` etc).

The code currently supports Basic Access Control (BAC) which derives a key based on certain data in MRZ. Most if not all modern passports require BAC to read data from them. You will therefore need to supply your document number with `-n`, your date of birth in YYMMDD format with `-d` and your document's expiry date with `-e`. A feature to parse this directly from the MRZ area is planned.

---

This PR currently has the following features implemented (checklist is based on what I feel like would mean a feature complete implementation):

- [x] ISO 14a/14b support (tested)
- [x] Non-BAC passport support (untested)
- [x] BAC passport support (tested)
- [x] `hf emrtd dump` (tested)
- [ ] MRZ parsing as an alternative to `-n`, `-d`, `-e`.
- [ ] `hf emrtd info` that displays basic info (perhaps just based on EF_DG1)
- [ ] `hf emrtd info` that displays a GUI with extended info (EF_DG1, EF_DG2, EF_DG11, EF_DG12?)
- [ ] PACE passport support
- [ ] Various vulnerability checks as suggested by doegox

However, many of those changes are planned to be added in different PRs, and this specific PR is likely not going to get any further feature changes.

---

Certain parts of the code are a mess. Untangling suggestions welcome. I'll be splitting stuff into more functions in the future as I work on implementing PACE and info, and do plan on commenting more of the code during that, but I'd be okay with doing that now before this gets merged.

I've only tested with Turkish IDs and Turkish Passports (pre- and post- the NVI switch, which are 14b and 14a respectively). Testing with other eMRTDs and letting me know if they work or not would be appreciated.

---

A significant portion of the code is based on the work of Adam Laurie in RFIDIOt/mrpkey.py.