### PR TITLE
em4x70: Add write key convenience function. 

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1186,6 +1186,10 @@ static void PacketReceived(PacketCommandNG *packet) {
             em4x70_write_pin((em4x70_data_t *)packet->data.asBytes);
             break;
         }
+        case CMD_LF_EM4X70_WRITEKEY: {
+            em4x70_write_key((em4x70_data_t *)packet->data.asBytes);
+            break;
+        }
 #endif
 
 #ifdef WITH_ISO15693

--- a/armsrc/em4x70.c
+++ b/armsrc/em4x70.c
@@ -768,3 +768,41 @@ void em4x70_write_pin(em4x70_data_t *etd) {
     lf_finalize();
     reply_ng(CMD_LF_EM4X70_WRITEPIN, status, tag.data, sizeof(tag.data));
 }
+
+void em4x70_write_key(em4x70_data_t *etd) {
+
+    uint8_t status = 0;
+
+    command_parity = etd->parity;
+
+    init_tag();
+    em4x70_setup_read();
+
+    // Find the Tag
+    if (get_signalproperties() && find_em4x70_tag()) {
+
+        // Read ID to ensure we can write to card
+        if (em4x70_read_id()) {
+            status = 1;
+            
+            // Write each crypto block
+            for(int i = 0; i < 6; i++) {
+
+                uint16_t key_word = (etd->crypt_key[(i*2)+1] << 8) + etd->crypt_key[i*2];
+                // Write each word, abort if any failure occurs
+                if (write(key_word, 9-i) != PM3_SUCCESS) {
+                    status = 0;
+                    break;
+                }
+            }
+            // TODO: Ideally here we would perform a test authentication
+            //       to ensure the new key was written correctly. This is
+            //       what the datasheet suggests. We can't do that until
+            //       we have the crypto algorithm implemented.
+        }
+    }
+
+    StopTicks();
+    lf_finalize();
+    reply_ng(CMD_LF_EM4X70_WRITEKEY, status, tag.data, sizeof(tag.data));
+}

--- a/armsrc/em4x70.h
+++ b/armsrc/em4x70.h
@@ -27,5 +27,6 @@ void em4x70_write(em4x70_data_t *etd);
 void em4x70_unlock(em4x70_data_t *etd);
 void em4x70_auth(em4x70_data_t *etd);
 void em4x70_write_pin(em4x70_data_t *etd);
+void em4x70_write_key(em4x70_data_t *etd);
 
 #endif /* EM4x70_H */

--- a/client/src/cmdlfem4x70.h
+++ b/client/src/cmdlfem4x70.h
@@ -22,6 +22,7 @@ int CmdEM4x70Write(const char *Cmd);
 int CmdEM4x70Unlock(const char *Cmd);
 int CmdEM4x70Auth(const char *Cmd);
 int CmdEM4x70WritePIN(const char *Cmd);
+int CmdEM4x70WriteKey(const char *Cmd);
 
 int em4x70_info(void);
 bool detect_4x70_block(void);

--- a/include/em4x70.h
+++ b/include/em4x70.h
@@ -31,6 +31,9 @@ typedef struct {
     uint8_t rnd[7];
     uint8_t frnd[4];
 
+    // Used to write new key
+    uint8_t crypt_key[12];
+
 } em4x70_data_t;
 
 #endif /* EM4X70_H__ */

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -521,6 +521,7 @@ typedef struct {
 #define CMD_LF_EM4X70_UNLOCK                                              0x0262
 #define CMD_LF_EM4X70_AUTH                                                0x0263
 #define CMD_LF_EM4X70_WRITEPIN                                            0x0264
+#define CMD_LF_EM4X70_WRITEKEY                                            0x0265
 // Sampling configuration for LF reader/sniffer
 #define CMD_LF_SAMPLING_SET_CONFIG                                        0x021D
 #define CMD_LF_FSK_SIMULATE                                               0x021E


### PR DESCRIPTION
Single function to write all 12 bytes of the crypt key.
Added real values in writekey/auth help text so people with blank tags can write a test key and test authentication.