### PR TITLE
eMRTD support 2/?

### DIFF
--- a/client/src/cmdhf14b.c
+++ b/client/src/cmdhf14b.c
@@ -26,6 +26,7 @@
 #include "mifare/ndef.h"   // NDEFRecordsDecodeAndPrint
 
 #define TIMEOUT 2000
+#define APDU_TIMEOUT 4000
 
 // iso14b apdu input frame length
 static uint16_t apdu_frame_length = 0;
@@ -1438,7 +1439,7 @@ static int handle_14b_apdu(bool chainingin, uint8_t *datain, int datainlen, bool
         SendCommandMIX(CMD_HF_ISO14443B_COMMAND, ISO14B_APDU | flags, 0, 0, NULL, 0);
 
     PacketResponseNG resp;
-    if (WaitForResponseTimeout(CMD_HF_ISO14443B_COMMAND, &resp, TIMEOUT)) {
+    if (WaitForResponseTimeout(CMD_HF_ISO14443B_COMMAND, &resp, APDU_TIMEOUT)) {
         uint8_t *recv = resp.data.asBytes;
         int rlen = resp.oldarg[0];
         uint8_t res = resp.oldarg[1];

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -221,12 +221,6 @@ static void des3_decrypt_cbc(uint8_t *iv, uint8_t *key, uint8_t *input, int inpu
     mbedtls_des3_free(&ctx);
 }
 
-static void emrtd_pad_docnum(char *input) {
-    for (int i = strlen(input); i < 9; i++) {
-        input[i] = '<';
-    }
-}
-
 static int pad_block(uint8_t *input, int inputlen, uint8_t *output) {
     uint8_t padding[8] = {0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
@@ -834,8 +828,6 @@ static bool emrtd_do_auth(char *documentnumber, char *dob, char *expiry, bool BA
     uint8_t response[EMRTD_MAX_FILE_SIZE] = { 0x00 };
     int resplen = 0;
 
-    emrtd_pad_docnum(documentnumber);
-
     // Try to 14a
     SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
     PacketResponseNG resp;
@@ -1237,7 +1229,8 @@ static int cmd_hf_emrtd_dump(const char *Cmd) {
     if (CLIParamStrToBuf(arg_get_str(ctx, 1), docnum, 9, &slen) != 0 || slen == 0) {
         BAC = false;
     } else {
-        if ( slen != 9) {
+        if (slen != 9) {
+            // Pad to 9 with <
             memset(docnum + slen, 0x3c, 9 - slen);
         }
     }

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1174,9 +1174,9 @@ int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
 
     if (td_variant == 3) {
         // Passport form factor
+        PrintAndLogEx(SUCCESS, "Nationality...........: " _YELLOW_("%.3s"), mrz + 44 + 10);
         emrtd_print_name(mrz, 5, 38);
         emrtd_print_document_number(mrz, 44);
-        PrintAndLogEx(SUCCESS, "Nationality...........: " _YELLOW_("%.3s"), mrz + 44 + 10);
         emrtd_print_dob(mrz, 44 + 13);
         emrtd_print_legal_sex(&mrz[44 + 20]);
         emrtd_print_expiry(mrz, 44 + 21);
@@ -1184,29 +1184,28 @@ int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
 
         // Calculate and verify composite check digit
         char composite_check_data[50] = { 0x00 };
-        memcpy(composite_check_data, mrz, 9);
-        memcpy(composite_check_data + 9, mrz + 13, 7);
-        memcpy(composite_check_data + 7, mrz + 21, 22);
+        memcpy(composite_check_data, mrz + 44, 10);
+        memcpy(composite_check_data + 10, mrz + 44 + 13, 7);
+        memcpy(composite_check_data + 17, mrz + 44 + 21, 23);
 
-        if (!emrtd_compare_check_digit(composite_check_data, 36, mrz[87])) {
+        if (!emrtd_compare_check_digit(composite_check_data, 39, mrz[87])) {
             PrintAndLogEx(SUCCESS, _RED_("Composite check digit is invalid."));
         }
     } else if (td_variant == 1) {
         // ID form factor
+        PrintAndLogEx(SUCCESS, "Nationality...........: " _YELLOW_("%.3s"), mrz + 30 + 15);
+        emrtd_print_name(mrz, 60, 30);
         emrtd_print_document_number(mrz, 5);
-        emrtd_print_optional_elements(mrz, 15, 15, false);
         emrtd_print_dob(mrz, 30);
         emrtd_print_legal_sex(&mrz[30 + 7]);
         emrtd_print_expiry(mrz, 30 + 8);
-        PrintAndLogEx(SUCCESS, "Nationality...........: " _YELLOW_("%.3s"), mrz + 30 + 15);
+        emrtd_print_optional_elements(mrz, 15, 15, false);
         emrtd_print_optional_elements(mrz, 30 + 18, 11, false);
 
         // Calculate and verify composite check digit
         if (!emrtd_compare_check_digit(mrz, 59, mrz[59])) {
             PrintAndLogEx(SUCCESS, _RED_("Composite check digit is invalid."));
         }
-
-        emrtd_print_name(mrz, 60, 30);
     }
 
     DropField();

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -280,24 +280,24 @@ static void retail_mac(uint8_t *key, uint8_t *input, int inputlen, uint8_t *outp
 }
 
 static void emrtd_deskey(uint8_t *seed, const uint8_t *type, int length, uint8_t *dataout) {
-    PrintAndLogEx(DEBUG, "seed: %s", sprint_hex_inrow(seed, 16));
+    PrintAndLogEx(DEBUG, "seed.............. %s", sprint_hex_inrow(seed, 16));
 
     // combine seed and type
     uint8_t data[50];
     memcpy(data, seed, length);
     memcpy(data + length, type, 4);
-    PrintAndLogEx(DEBUG, "data: %s", sprint_hex_inrow(data, length + 4));
+    PrintAndLogEx(DEBUG, "data.............. %s", sprint_hex_inrow(data, length + 4));
 
     // SHA1 the key
     unsigned char key[64];
     mbedtls_sha1(data, length + 4, key);
-    PrintAndLogEx(DEBUG, "key: %s", sprint_hex_inrow(key, length + 4));
+    PrintAndLogEx(DEBUG, "key............... %s", sprint_hex_inrow(key, length + 4));
 
     // Set parity bits
     for (int i = 0; i < ((length + 4) / 8); i++) {
         mbedtls_des_key_set_parity(key + (i * 8));
     }
-    PrintAndLogEx(DEBUG, "post-parity key: %s", sprint_hex_inrow(key, 20));
+    PrintAndLogEx(DEBUG, "post-parity key... %s", sprint_hex_inrow(key, 20));
 
     memcpy(dataout, &key, length);
 }
@@ -320,9 +320,7 @@ static int emrtd_get_challenge(int length, uint8_t *dataout, int *dataoutlen, bo
 
 static int emrtd_external_authenticate(uint8_t *data, int length, uint8_t *dataout, int *dataoutlen, bool use_14b) {
     char cmd[100];
-
     sprintf(cmd, "00%s0000%02X%s%02X", EMRTD_EXTERNAL_AUTHENTICATE, length, sprint_hex_inrow(data, length), length);
-
     return emrtd_exchange_commands(cmd, dataout, dataoutlen, false, true, use_14b);
 }
 
@@ -724,9 +722,10 @@ static bool emrtd_dump_file(uint8_t *ks_enc, uint8_t *ks_mac, uint8_t *ssc, cons
 
 static void rng(int length, uint8_t *dataout) {
     // Do very very secure prng operations
-    for (int i = 0; i < (length / 4); i++) {
-        num_to_bytes(prng_successor(msclock() + i, 32), 4, &dataout[i * 4]);
-    }
+    //for (int i = 0; i < (length / 4); i++) {
+    //    num_to_bytes(prng_successor(msclock() + i, 32), 4, &dataout[i * 4]);
+    //}
+    memset(dataout, 0x00, length);   
 }
 
 static bool emrtd_do_bac(char *documentnumber, char *dob, char *expiry, uint8_t *ssc, uint8_t *ks_enc, uint8_t *ks_mac, bool use_14b) {
@@ -743,9 +742,9 @@ static bool emrtd_do_bac(char *documentnumber, char *dob, char *expiry, uint8_t 
     rng(8, rnd_ifd);
     rng(16, k_ifd);
 
-    PrintAndLogEx(DEBUG, "doc: %s", documentnumber);
-    PrintAndLogEx(DEBUG, "dob: %s", dob);
-    PrintAndLogEx(DEBUG, "exp: %s", expiry);
+    PrintAndLogEx(DEBUG, "doc............... " _GREEN_("%s"), documentnumber);
+    PrintAndLogEx(DEBUG, "dob............... " _GREEN_("%s"), dob);
+    PrintAndLogEx(DEBUG, "exp............... " _GREEN_("%s"), expiry);
 
     char documentnumbercd = emrtd_calculate_check_digit(documentnumber);
     char dobcd = emrtd_calculate_check_digit(dob);
@@ -753,40 +752,40 @@ static bool emrtd_do_bac(char *documentnumber, char *dob, char *expiry, uint8_t 
 
     char kmrz[25];
     sprintf(kmrz, "%s%i%s%i%s%i", documentnumber, documentnumbercd, dob, dobcd, expiry, expirycd);
-    PrintAndLogEx(DEBUG, "kmrz: %s", kmrz);
+    PrintAndLogEx(DEBUG, "kmrz.............. " _GREEN_("%s"), kmrz);
 
     uint8_t kseed[16] = { 0x00 };
     mbedtls_sha1((unsigned char *)kmrz, strlen(kmrz), kseed);
-    PrintAndLogEx(DEBUG, "kseed: %s", sprint_hex_inrow(kseed, 16));
+    PrintAndLogEx(DEBUG, "kseed (sha1)...... %s ", sprint_hex_inrow(kseed, 16));
 
     emrtd_deskey(kseed, KENC_type, 16, kenc);
     emrtd_deskey(kseed, KMAC_type, 16, kmac);
-    PrintAndLogEx(DEBUG, "kenc: %s", sprint_hex_inrow(kenc, 16));
-    PrintAndLogEx(DEBUG, "kmac: %s", sprint_hex_inrow(kmac, 16));
+    PrintAndLogEx(DEBUG, "kenc.............. %s", sprint_hex_inrow(kenc, 16));
+    PrintAndLogEx(DEBUG, "kmac.............. %s", sprint_hex_inrow(kmac, 16));
 
     // Get Challenge
     if (emrtd_get_challenge(8, rnd_ic, &resplen, use_14b) == false) {
         PrintAndLogEx(ERR, "Couldn't get challenge.");
         return false;
     }
-    PrintAndLogEx(DEBUG, "rnd_ic: %s", sprint_hex_inrow(rnd_ic, 8));
+    PrintAndLogEx(DEBUG, "rnd_ic............ %s", sprint_hex_inrow(rnd_ic, 8));
 
     memcpy(S, rnd_ifd, 8);
     memcpy(S + 8, rnd_ic, 8);
     memcpy(S + 16, k_ifd, 16);
 
-    PrintAndLogEx(DEBUG, "S: %s", sprint_hex_inrow(S, 32));
+    PrintAndLogEx(DEBUG, "S................. %s", sprint_hex_inrow(S, 32));
 
     uint8_t iv[8] = { 0x00 };
     uint8_t e_ifd[32] = { 0x00 };
 
     des3_encrypt_cbc(iv, kenc, S, sizeof(S), e_ifd);
-    PrintAndLogEx(DEBUG, "e_ifd: %s", sprint_hex_inrow(e_ifd, 32));
+    PrintAndLogEx(DEBUG, "e_ifd............. %s", sprint_hex_inrow(e_ifd, 32));
 
     uint8_t m_ifd[8] = { 0x00 };
 
     retail_mac(kmac, e_ifd, 32, m_ifd);
-    PrintAndLogEx(DEBUG, "m_ifd: %s", sprint_hex_inrow(m_ifd, 8));
+    PrintAndLogEx(DEBUG, "m_ifd............. %s", sprint_hex_inrow(m_ifd, 8));
 
     uint8_t cmd_data[40];
     memcpy(cmd_data, e_ifd, 32);
@@ -801,7 +800,7 @@ static bool emrtd_do_bac(char *documentnumber, char *dob, char *expiry, uint8_t 
 
     uint8_t dec_output[32] = { 0x00 };
     des3_decrypt_cbc(iv, kenc, response, 32, dec_output);
-    PrintAndLogEx(DEBUG, "dec_output: %s", sprint_hex_inrow(dec_output, 32));
+    PrintAndLogEx(DEBUG, "dec_output........ %s", sprint_hex_inrow(dec_output, 32));
 
     if (memcmp(rnd_ifd, dec_output + 8, 8) != 0) {
         PrintAndLogEx(ERR, "Challenge failed, rnd_ifd does not match.");
@@ -815,18 +814,18 @@ static bool emrtd_do_bac(char *documentnumber, char *dob, char *expiry, uint8_t 
         kseed[x] = k_ifd[x] ^ k_icc[x];
     }
 
-    PrintAndLogEx(DEBUG, "kseed: %s", sprint_hex_inrow(kseed, 16));
+    PrintAndLogEx(DEBUG, "kseed............ %s", sprint_hex_inrow(kseed, 16));
 
     emrtd_deskey(kseed, KENC_type, 16, ks_enc);
     emrtd_deskey(kseed, KMAC_type, 16, ks_mac);
 
-    PrintAndLogEx(DEBUG, "ks_enc: %s", sprint_hex_inrow(ks_enc, 16));
-    PrintAndLogEx(DEBUG, "ks_mac: %s", sprint_hex_inrow(ks_mac, 16));
+    PrintAndLogEx(DEBUG, "ks_enc........ %s", sprint_hex_inrow(ks_enc, 16));
+    PrintAndLogEx(DEBUG, "ks_mac........ %s", sprint_hex_inrow(ks_mac, 16));
 
     memcpy(ssc, rnd_ic + 4, 4);
     memcpy(ssc + 4, rnd_ifd + 4, 4);
 
-    PrintAndLogEx(DEBUG, "ssc: %s", sprint_hex_inrow(ssc, 8));
+    PrintAndLogEx(DEBUG, "ssc........... %s", sprint_hex_inrow(ssc, 8));
 
     return true;
 }
@@ -1023,9 +1022,17 @@ static int cmd_hf_emrtd_dump(const char *Cmd) {
     // Go through all args, if even one isn't supplied, mark BAC as unavailable
     if (CLIParamStrToBuf(arg_get_str(ctx, 1), docnum, 9, &slen) != 0 || slen == 0) {
         BAC = false;
-    } else if (CLIParamStrToBuf(arg_get_str(ctx, 2), dob, 6, &slen) != 0 || slen == 0) {
+    } else {
+        if ( slen != 9) {
+            memset(docnum + slen, 0x3c, 9 - slen);
+        }
+    }
+    
+    if (CLIParamStrToBuf(arg_get_str(ctx, 2), dob, 6, &slen) != 0 || slen == 0) {
         BAC = false;
-    } else if (CLIParamStrToBuf(arg_get_str(ctx, 3), expiry, 6, &slen) != 0 || slen == 0) {
+    } 
+    
+    if (CLIParamStrToBuf(arg_get_str(ctx, 3), expiry, 6, &slen) != 0 || slen == 0) {
         BAC = false;
     }
 

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1182,7 +1182,15 @@ int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
         emrtd_print_expiry(mrz, 44 + 21);
         emrtd_print_optional_elements(mrz, 44 + 28, 14, true);
 
-        // TODO: verify composite check digit here
+        // Calculate and verify composite check digit
+        char composite_check_data[50] = { 0x00 };
+        memcpy(composite_check_data, mrz, 9);
+        memcpy(composite_check_data + 9, mrz + 13, 7);
+        memcpy(composite_check_data + 7, mrz + 21, 22);
+
+        if (!emrtd_compare_check_digit(composite_check_data, 36, mrz[87])) {
+            PrintAndLogEx(SUCCESS, _RED_("Composite check digit is invalid."));
+        }
     } else if (td_variant == 1) {
         // ID form factor
         emrtd_print_document_number(mrz, 5);
@@ -1192,7 +1200,12 @@ int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
         emrtd_print_expiry(mrz, 30 + 8);
         PrintAndLogEx(SUCCESS, "Nationality...........: " _YELLOW_("%.3s"), mrz + 30 + 15);
         emrtd_print_optional_elements(mrz, 30 + 18, 11, false);
-        // TODO: verify composite check digit here
+
+        // Calculate and verify composite check digit
+        if (!emrtd_compare_check_digit(mrz, 59, mrz[59])) {
+            PrintAndLogEx(SUCCESS, _RED_("Composite check digit is invalid."));
+        }
+
         emrtd_print_name(mrz, 60, 30);
     }
 

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -221,6 +221,12 @@ static void des3_decrypt_cbc(uint8_t *iv, uint8_t *key, uint8_t *input, int inpu
     mbedtls_des3_free(&ctx);
 }
 
+static void emrtd_pad_docnum(char *input) {
+    for (int i = strlen(input); i < 9; i++) {
+        input[i] = '<';
+    }
+}
+
 static int pad_block(uint8_t *input, int inputlen, uint8_t *output) {
     uint8_t padding[8] = {0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
@@ -834,6 +840,8 @@ int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
     bool BAC = false;
     bool use_14b = false;
 
+    emrtd_pad_docnum(documentnumber);
+
     // Try to 14a
     SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
     PacketResponseNG resp;
@@ -960,7 +968,7 @@ static int cmd_hf_emrtd_dump(const char *Cmd) {
 
     void *argtable[] = {
         arg_param_begin,
-        arg_str0("n", "documentnumber", "<alphanum>", "9 character document number"),
+        arg_str0("n", "documentnumber", "<alphanum>", "document number, up to 9 chars"),
         arg_str0("d", "dateofbirth", "<YYMMDD>", "date of birth in YYMMDD format"),
         arg_str0("e", "expiry", "<YYMMDD>", "expiry in YYMMDD format"),
         arg_param_end

--- a/client/src/cmdhfemrtd.h
+++ b/client/src/cmdhfemrtd.h
@@ -16,4 +16,5 @@
 int CmdHFeMRTD(const char *Cmd);
 
 int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_available);
+int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_available);
 #endif


### PR DESCRIPTION
This PR adds a basic `hf emrtd info` command that spits out some of the data from EF_DG1. I do plan on reading and printing data from other files in the future too, and maybe even eventually adding a GUI.

![](https://elixi.re/i/qa9xh6gf.png)

It also includes a fix to automatically pad document numbers by iceman, alongside some other small fixes.

---

This PR currently has the following features implemented (checklist is based on what I feel like would mean a feature complete implementation):

- [x] ISO 14a/14b support (tested)
- [x] Non-BAC passport support (untested)
- [x] BAC passport support (tested)
- [x] `hf emrtd dump` (tested)
- [x] `hf emrtd info` that displays basic info (perhaps just based on EF_DG1, tested)
- [ ] `hf emrtd info` that displays extended info (EF_DG1, EF_DG2, EF_DG11, EF_DG12?)
- [ ] `hf emrtd dump` dumping more detailed data from the files by parsing them, such as extracting the JPG and the cert file
- [ ] `hf emrtd info` that displays a GUI with extended info (EF_DG1, EF_DG2, EF_DG11, EF_DG12?)
- [ ] PACE passport support
- [ ] Various vulnerability checks as suggested by doegox
- [ ] Cert verification as suggested by iceman

However, many of those changes are planned to be added in different PRs, and this specific PR is likely not going to get any further feature changes.