### PR TITLE
Show hints by default

### DIFF
--- a/client/src/preferences.c
+++ b/client/src/preferences.c
@@ -53,7 +53,7 @@ int preferences_load(void) {
     session.overlay.h = 200;
     session.overlay.w = session.plot.w;
     session.overlay_sliders = true;
-    session.show_hints = false;
+    session.show_hints = true;
 
 //    setDefaultPath (spDefault, "");
 //    setDefaultPath (spDump, "");


### PR DESCRIPTION
As PR title says, the intended behavior, as discussed on discord, is for them to be on by default, but this wasn't the case on the code, so I fixed it.