### PR TITLE
eMRTD support 3/?

### DIFF
--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -705,15 +705,27 @@ static bool emrtd_select_and_read(uint8_t *dataout, int *dataoutlen, const char 
 }
 
 static bool emrtd_dump_ef_dg5(uint8_t *file_contents, int file_length) {
-    uint8_t response[EMRTD_MAX_FILE_SIZE];
-    int resplen = 0;
+    uint8_t data[EMRTD_MAX_FILE_SIZE];
+    int datalen = 0;
 
     // If we can't find image in EF_DG5, return false.
-    if (!emrtd_lds_get_data_by_tag(file_contents, &file_length, response, &resplen, 0x5f, 0x40, true)) {
+    if (!emrtd_lds_get_data_by_tag(file_contents, &file_length, data, &datalen, 0x5f, 0x40, true)) {
         return false;
     }
 
-    saveFile("EF_DG5", ".jpg", response, resplen);
+    saveFile("EF_DG5", ".jpg", data, datalen);
+    return true;
+}
+
+static bool emrtd_dump_ef_sod(uint8_t *file_contents, int file_length) {
+    uint8_t data[EMRTD_MAX_FILE_SIZE];
+
+    int datalenlen = emrtd_get_asn1_field_length(file_contents, file_length, 1);
+    int datalen = emrtd_get_asn1_data_length(file_contents, file_length, 1);
+
+    memcpy(data, file_contents + datalenlen + 1, datalen);
+
+    saveFile("EF_SOD", ".p7b", data, datalen);
     return true;
 }
 
@@ -731,6 +743,8 @@ static bool emrtd_dump_file(uint8_t *ks_enc, uint8_t *ks_mac, uint8_t *ssc, cons
 
     if (strcmp(file, EMRTD_EF_DG5) == 0) {
         emrtd_dump_ef_dg5(response, resplen);
+    } else if (strcmp(file, EMRTD_EF_SOD) == 0) {
+        emrtd_dump_ef_sod(response, resplen);
     }
 
     return true;

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -704,6 +704,19 @@ static bool emrtd_select_and_read(uint8_t *dataout, int *dataoutlen, const char 
     return true;
 }
 
+static bool emrtd_dump_ef_dg5(uint8_t *file_contents, int file_length) {
+    uint8_t response[EMRTD_MAX_FILE_SIZE];
+    int resplen = 0;
+
+    // If we can't find image in EF_DG5, return false.
+    if (!emrtd_lds_get_data_by_tag(file_contents, &file_length, response, &resplen, 0x5f, 0x40, true)) {
+        return false;
+    }
+
+    saveFile("EF_DG5", ".jpg", response, resplen);
+    return true;
+}
+
 static bool emrtd_dump_file(uint8_t *ks_enc, uint8_t *ks_mac, uint8_t *ssc, const char *file, const char *name, bool use_secure, bool use_14b) {
     uint8_t response[EMRTD_MAX_FILE_SIZE];
     int resplen = 0;
@@ -715,6 +728,10 @@ static bool emrtd_dump_file(uint8_t *ks_enc, uint8_t *ks_mac, uint8_t *ssc, cons
     PrintAndLogEx(INFO, "Read %s, len: %i.", name, resplen);
     PrintAndLogEx(DEBUG, "Contents (may be incomplete over 2k chars): %s", sprint_hex_inrow(response, resplen));
     saveFile(name, ".BIN", response, resplen);
+
+    if (strcmp(file, EMRTD_EF_DG5) == 0) {
+        emrtd_dump_ef_dg5(response, resplen);
+    }
 
     return true;
 }


### PR DESCRIPTION
This PR adds support for dumping additional files from the card when doing `hf emrtd dump`, specifically:

- EF_DG2: Passport Image
- EF_DG5: Passport Image
- EF_SOD: PKCS#7 certificate

---

This PR currently has the following features implemented (checklist is based on what I feel like would mean a feature complete implementation):

- [x] ISO 14a/14b support (tested)
- [x] Non-BAC passport support (untested)
- [x] BAC passport support (tested)
- [x] `hf emrtd dump` (tested)
- [x] `hf emrtd info` that displays basic info (perhaps just based on EF_DG1, tested)
- [x] `hf emrtd dump` dumping more detailed data from the files by parsing them, such as extracting the JPG and the cert file
- [ ] `hf emrtd info` that displays extended info (EF_DG1, EF_DG2, EF_DG11, EF_DG12?)
- [ ] `hf emrtd info` that displays a GUI with extended info (EF_DG1, EF_DG2, EF_DG11, EF_DG12?)
- [ ] PACE passport support
- [ ] Various vulnerability checks as suggested by doegox
- [ ] Cert verification as suggested by iceman

However, many of those changes are planned to be added in different PRs, and this specific PR is likely not going to get any further feature changes.