### PR TITLE
hf emrtd info: EF_DG11 parsing + Rework to make it easier to write support to read external files

### DIFF
--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1192,7 +1192,8 @@ static bool emrtd_print_ef_dg11_info(bool *BAC, uint8_t *ssc, uint8_t *ks_enc, u
     uint8_t tagdata[1000] = { 0x00 };
     int tagdatalen = 0;
 
-    PrintAndLogEx(INFO, "=====EF_DG11=====");
+    PrintAndLogEx(NORMAL, "");
+    PrintAndLogEx(INFO, "-------------------- " _CYAN_("EF_DG11") " -------------------");
 
     if (!emrtd_select_and_read(response, &resplen, EMRTD_EF_DG11, ks_enc, ks_mac, ssc, *BAC, *use_14b)) {
         PrintAndLogEx(ERR, "Failed to read EF_DG11.");
@@ -1281,6 +1282,9 @@ int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
 
     // Select and authenticate with the eMRTD
     bool auth_result = emrtd_do_auth(documentnumber, dob, expiry, BAC_available, &BAC, ssc, ks_enc, ks_mac, &use_14b);
+
+    PrintAndLogEx(NORMAL, "");
+    PrintAndLogEx(INFO, "------------------ " _CYAN_("Basic Info") " ------------------");
     PrintAndLogEx(SUCCESS, "Communication standard: %s", use_14b ? _YELLOW_("ISO/IEC 14443(B)") : _YELLOW_("ISO/IEC 14443(A)"));
     PrintAndLogEx(SUCCESS, "BAC...................: %s", BAC ? _GREEN_("Enforced") : _RED_("Not enforced"));
     PrintAndLogEx(SUCCESS, "Authentication result.: %s", auth_result ? _GREEN_("Successful") : _RED_("Failed"));
@@ -1297,7 +1301,8 @@ int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
         return PM3_ESOFT;
     }
 
-    PrintAndLogEx(INFO, "=====EF_DG1=====");
+    PrintAndLogEx(NORMAL, "");
+    PrintAndLogEx(INFO, "-------------------- " _CYAN_("EF_DG1") " --------------------");
 
     // MRZ on TD1 is 90 characters, 30 on each row.
     // MRZ on TD3 is 88 characters, 44 on each row.

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1216,7 +1216,34 @@ static bool emrtd_print_ef_dg11_info(bool *BAC, uint8_t *ssc, uint8_t *ks_enc, u
                     PrintAndLogEx(SUCCESS, "Personal Number.......: " _YELLOW_("%.*s"), tagdatalen, tagdata);
                     break;
                 case 0x11:
+                    // TODO: acc for < separation
                     PrintAndLogEx(SUCCESS, "Place of Birth........: " _YELLOW_("%.*s"), tagdatalen, tagdata);
+                    break;
+                case 0x42:
+                    // TODO: acc for < separation
+                    PrintAndLogEx(SUCCESS, "Permanent Address.....: " _YELLOW_("%.*s"), tagdatalen, tagdata);
+                    break;
+                case 0x12:
+                    PrintAndLogEx(SUCCESS, "Telephone.............: " _YELLOW_("%.*s"), tagdatalen, tagdata);
+                    break;
+                case 0x13:
+                    PrintAndLogEx(SUCCESS, "Profession............: " _YELLOW_("%.*s"), tagdatalen, tagdata);
+                    break;
+                case 0x14:
+                    PrintAndLogEx(SUCCESS, "Title.................: " _YELLOW_("%.*s"), tagdatalen, tagdata);
+                    break;
+                case 0x15:
+                    PrintAndLogEx(SUCCESS, "Personal Summary......: " _YELLOW_("%.*s"), tagdatalen, tagdata);
+                    break;
+                case 0x16:
+                    saveFile("ProofOfCitizenship", ".jpg", tagdata, tagdatalen);
+                    break;
+                case 0x17:
+                    // TODO: acc for < separation
+                    PrintAndLogEx(SUCCESS, "Other valid TDs nums..: " _YELLOW_("%.*s"), tagdatalen, tagdata);
+                    break;
+                case 0x18:
+                    PrintAndLogEx(SUCCESS, "Custody Information...: " _YELLOW_("%.*s"), tagdatalen, tagdata);
                     break;
                 case 0x2b:
                     emrtd_print_dob((char *) tagdata, 0, true);
@@ -1228,7 +1255,8 @@ static bool emrtd_print_ef_dg11_info(bool *BAC, uint8_t *ssc, uint8_t *ks_enc, u
 
             i += 1;
         } else {
-            PrintAndLogEx(INFO, "Reading %02X: %s", taglist[i], sprint_hex_inrow(tagdata, tagdatalen));
+            // TODO: Account for A0
+            PrintAndLogEx(SUCCESS, "Unknown Field %02X......: %s", taglist[i], sprint_hex_inrow(tagdata, tagdatalen));
         }
     }
     return true;


### PR DESCRIPTION
This PR adds EF_DG11 parsing to `hf emrtd info`, and fancy headers for files (with color, as the iceman tax):

![](https://cdn.discordapp.com/attachments/773082731079925801/789578035212582972/efdg11.png)

The compat chart looks like this for EF_DG11:

![](https://cdn.discordapp.com/attachments/773082731079925801/789578053742493736/dg11support.png)

I've also quickly gone over the code to make it possibly easier to read dumps from files. Wanted to push this out ASAP as doegox expressed interest in looking into that (and as I wanted to avoid merge conflicts), so this PR comes without any coverity fixes.

---

For more info on this PR series, see #1117