### PR TITLE
Various eMRTD quirk fixes

### DIFF
--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1147,9 +1147,6 @@ static void emrtd_print_document_number(char *mrz, int offset) {
 }
 
 static void emrtd_print_name(char *mrz, int offset, int max_length, bool localized) {
-    if (max_length == 0) {
-        return;
-    }
     char final_name[100] = { 0x00 };
     int namelen = emrtd_mrz_determine_length(mrz, offset, max_length);
     int sep = emrtd_mrz_determine_separator(mrz, offset, namelen);
@@ -1352,6 +1349,10 @@ static bool emrtd_print_ef_dg11_info(uint8_t *response, int resplen) {
 
     for (int i = 0; i < taglistlen; i++) {
         emrtd_lds_get_data_by_tag(response, resplen, tagdata, &tagdatalen, taglist[i], taglist[i + 1], taglist[i] == 0x5f);
+        // Don't bother with empty tags
+        if (tagdatalen == 0) {
+            continue;
+        }
         // Special behavior for two char tags
         if (taglist[i] == 0x5f) {
             switch (taglist[i + 1]) {
@@ -1427,6 +1428,10 @@ static bool emrtd_print_ef_dg12_info(uint8_t *response, int resplen) {
 
     for (int i = 0; i < taglistlen; i++) {
         emrtd_lds_get_data_by_tag(response, resplen, tagdata, &tagdatalen, taglist[i], taglist[i + 1], taglist[i] == 0x5f);
+        // Don't bother with empty tags
+        if (tagdatalen == 0) {
+            continue;
+        }
         // Special behavior for two char tags
         if (taglist[i] == 0x5f) {
             // Several things here are longer than the rest but I can't think of a way to shorten them

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1105,6 +1105,7 @@ static int emrtd_mrz_determine_length(char *mrz, int offset, int max_length) {
 }
 
 static int emrtd_mrz_determine_separator(char *mrz, int offset, int max_length) {
+    // Note: this function does not account for len=0
     int i;
     for (i = max_length - 1; i > 0; i--) {
         if (mrz[offset + i] == '<' && mrz[offset + i + 1] == '<') {
@@ -1146,6 +1147,9 @@ static void emrtd_print_document_number(char *mrz, int offset) {
 }
 
 static void emrtd_print_name(char *mrz, int offset, int max_length, bool localized) {
+    if (max_length == 0) {
+        return;
+    }
     char final_name[100] = { 0x00 };
     int namelen = emrtd_mrz_determine_length(mrz, offset, max_length);
     int sep = emrtd_mrz_determine_separator(mrz, offset, namelen);

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1249,6 +1249,14 @@ static void emrtd_print_personalization_timestamp(uint8_t *data) {
     PrintAndLogEx(SUCCESS, "Personalization at....: " _YELLOW_("%s"), final_date);
 }
 
+static void emrtd_print_unknown_timestamp_5f85(uint8_t *data) {
+    char final_date[20] = { 0x00 };
+    sprintf(final_date, "%.4s-%.2s-%.2s %.2s:%.2s:%.2s", data, data + 4, data + 6, data + 8, data + 10, data + 12);
+
+    PrintAndLogEx(SUCCESS, "Unknown timestamp 5F85: " _YELLOW_("%s"), final_date);
+    PrintAndLogEx(HINT, "This is very likely the personalization timestamp, but it is using an undocumented tag.");
+}
+
 static bool emrtd_print_ef_dg1_info(uint8_t *response, int resplen) {
     int td_variant = 0;
 
@@ -1460,6 +1468,9 @@ static bool emrtd_print_ef_dg12_info(uint8_t *response, int resplen) {
                     break;
                 case 0x56:
                     PrintAndLogEx(SUCCESS, "Serial of Personalization System: " _YELLOW_("%.*s"), tagdatalen, tagdata);
+                    break;
+                case 0x85:
+                    emrtd_print_unknown_timestamp_5f85(tagdata);
                     break;
                 default:
                     PrintAndLogEx(SUCCESS, "Unknown Field %02X%02X....: %s", taglist[i], taglist[i + 1], sprint_hex_inrow(tagdata, tagdatalen));


### PR DESCRIPTION
- Account for undocumented 5F85 tag on belgian passports
- Ignore tags with data len of 0 when parsing, as some belgian passports do that

---

More info at #1117 