### PR TITLE
4x50 serial

### DIFF
--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -508,7 +508,7 @@ bool detect_4x50_block(void) {
     em4x50_data_t etd = {
         .pwd_given = false,
         .addr_given = true,
-        .addresses = (EM4X50_DEVICE_ID << 8) | EM4X50_DEVICE_ID,
+        .addresses = (EM4X50_DEVICE_SERIAL << 8) | EM4X50_DEVICE_SERIAL,
     };
     em4x50_word_t words[EM4X50_NO_WORDS];
     return (em4x50_read(&etd, words) == PM3_SUCCESS);


### PR DESCRIPTION
- changed reading of "uid" to "serial" in function detect_4x50_block since output is always „serial"
- lf em 4x50 info: complete data is displayed only via additional verbose option (-v)