### PR TITLE
ui: Load readline after stdio.h

### DIFF
--- a/client/src/ui.c
+++ b/client/src/ui.c
@@ -14,15 +14,16 @@
 #if !defined(_WIN32)
 #define _POSIX_C_SOURCE 200112L
 #endif
-#ifdef HAVE_READLINE
-#include <readline/readline.h>
-#endif
 #include "ui.h"
 #include "commonutil.h"  // ARRAYLEN
 
 #include <stdio.h> // for Mingw readline
 #include <stdarg.h>
 #include <stdlib.h>
+
+#ifdef HAVE_READLINE
+#include <readline/readline.h>
+#endif
 
 #include <complex.h>
 #include "util.h"


### PR DESCRIPTION
(As seen on https://man7.org/linux/man-pages/man3/readline.3.html, stdio.h is supposed to be imported before readline.h.)

[Fixes CI](https://ci.appveyor.com/project/RfidResearchGroup/proxmark3/builds/36979009) and build issues that are faced after commit https://github.com/RfidResearchGroup/proxmark3/commit/7bc3067fa4ea05d176353314ee0d8f11b68fda33:

![](https://elixi.re/i/lzd63y2x.png)