### PR TITLE
eMRTD support 3/?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ tools/andrew/*
 tools/jtag_openocd/openocd_configuration
 ppls patches/*
 *- Copy.*
+/EF_*
 
 client/lualibs/mfc_default_keys.lua
 client/lualibs/pm3_cmd.lua

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1485,7 +1485,6 @@ static int emrtd_print_ef_dg12_info(uint8_t *data, size_t datalen) {
 }
 
 static int emrtd_ef_sod_extract_signatures(uint8_t *data, size_t datalen, uint8_t *dataout, size_t *dataoutlen) {
-    // very very very very cursed code.
     uint8_t top[EMRTD_MAX_FILE_SIZE] = { 0x00 };
     uint8_t signeddata[EMRTD_MAX_FILE_SIZE] = { 0x00 };
     uint8_t emrtdsigcontainer[EMRTD_MAX_FILE_SIZE] = { 0x00 };

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1532,16 +1532,15 @@ static int emrtd_ef_sod_extract_signatures(uint8_t *data, size_t datalen, uint8_
     return PM3_SUCCESS;
 }
 
-static int emrtd_parse_ef_sod_hashes(uint8_t *data, size_t datalen, uint8_t *hashes) {
+static int emrtd_parse_ef_sod_hashes(uint8_t *data, size_t datalen, uint8_t *hashes, int *hashalgo) {
     uint8_t emrtdsig[EMRTD_MAX_FILE_SIZE] = { 0x00 };
     uint8_t hashlist[EMRTD_MAX_FILE_SIZE] = { 0x00 };
-    uint8_t hash[65] = { 0x00 };
+    uint8_t hash[64] = { 0x00 };
     size_t hashlen = 0;
 
     uint8_t hashidstr[4] = { 0x00 };
     size_t hashidstrlen = 0;
 
-    // size_t emrtdsiglen, e_datalen, e_fieldlen = 0;
     size_t emrtdsiglen = 0;
     size_t hashlistlen = 0;
     size_t e_datalen = 0;
@@ -1572,8 +1571,10 @@ static int emrtd_parse_ef_sod_hashes(uint8_t *data, size_t datalen, uint8_t *has
             case 0x30:
                 emrtd_lds_get_data_by_tag(hashlist + offset + e_fieldlen + 1, e_datalen, hashidstr, &hashidstrlen, 0x02, 0x00, false, false, 0);
                 emrtd_lds_get_data_by_tag(hashlist + offset + e_fieldlen + 1, e_datalen, hash, &hashlen, 0x04, 0x00, false, false, 0);
-                if (hashlen <= 64) {  // TODO: This is for coverity, account for it.
+                if (hashlen <= 64) {
                     memcpy(hashes + (hashidstr[0] * 64), hash, hashlen);
+                } else {
+                    PrintAndLogEx(ERR, "error (emrtd_parse_ef_sod_hashes) hashlen out-of-bounds");
                 }
                 break;
         }

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -629,7 +629,7 @@ static int emrtd_lds_determine_tag_length(uint8_t tag) {
     return 1;
 }
 
-static bool emrtd_lds_get_data_by_tag(uint8_t *datain, int datainlen, uint8_t *dataout, int *dataoutlen, int tag1, int tag2, bool twobytetag, bool entertoptag, int skiptagcount) {
+static bool emrtd_lds_get_data_by_tag(uint8_t *datain, size_t datainlen, uint8_t *dataout, size_t *dataoutlen, int tag1, int tag2, bool twobytetag, bool entertoptag, size_t skiptagcount) {
     int offset = 0;
     int skipcounter = 0;
 
@@ -720,7 +720,7 @@ static int emrtd_dump_ef_dg2(uint8_t *file_contents, size_t file_length) {
 
 static int emrtd_dump_ef_dg5(uint8_t *file_contents, size_t file_length) {
     uint8_t data[EMRTD_MAX_FILE_SIZE];
-    int datalen = 0;
+    size_t datalen = 0;
 
     // If we can't find image in EF_DG5, return false.
     if (emrtd_lds_get_data_by_tag(file_contents, file_length, data, &datalen, 0x5F, 0x40, true, true, 0) == false) {
@@ -738,7 +738,7 @@ static int emrtd_dump_ef_dg5(uint8_t *file_contents, size_t file_length) {
 
 static int emrtd_dump_ef_dg7(uint8_t *file_contents, size_t file_length) {
     uint8_t data[EMRTD_MAX_FILE_SIZE];
-    int datalen = 0;
+    size_t datalen = 0;
 
     // If we can't find image in EF_DG7, return false.
     if (emrtd_lds_get_data_by_tag(file_contents, file_length, data, &datalen, 0x5F, 0x42, true, true, 0) == false) {
@@ -1005,7 +1005,7 @@ int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
     saveFile(dg_table[EF_COM].filename, ".BIN", response, resplen);
 
     uint8_t filelist[50];
-    int filelistlen = 0;
+    size_t filelistlen = 0;
 
     if (!emrtd_lds_get_data_by_tag(response, resplen, filelist, &filelistlen, 0x5c, 0x00, false, true, 0)) {
         PrintAndLogEx(ERR, "Failed to read file list from EF_COM.");
@@ -1017,7 +1017,7 @@ int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
     // Add EF_SOD to the list
     filelist[filelistlen++] = 0x77;
     // Dump all files in the file list
-    for (int i = 0; i < filelistlen; i++) {
+    for (size_t i = 0; i < filelistlen; i++) {
         emrtd_dg_t *dg = emrtd_tag_to_dg(filelist[i]);
         if (dg == NULL) {
             PrintAndLogEx(INFO, "File tag not found, skipping: %02X", filelist[i]);
@@ -1232,7 +1232,7 @@ static void emrtd_print_unknown_timestamp_5f85(uint8_t *data) {
 
 static int emrtd_print_ef_com_info(uint8_t *data, size_t datalen) {
     uint8_t filelist[50];
-    int filelistlen = 0;
+    size_t filelistlen = 0;
     int res = emrtd_lds_get_data_by_tag(data, datalen, filelist, &filelistlen, 0x5c, 0x00, false, true, 0);
     if (!res) {
         PrintAndLogEx(ERR, "Failed to read file list from EF_COM.");
@@ -1262,7 +1262,7 @@ static int emrtd_print_ef_dg1_info(uint8_t *data, size_t datalen) {
     // MRZ on TD1 is 90 characters, 30 on each row.
     // MRZ on TD3 is 88 characters, 44 on each row.
     char mrz[90] = { 0x00 };
-    int mrzlen = 0;
+    size_t mrzlen = 0;
 
     if (!emrtd_lds_get_data_by_tag(data, datalen, (uint8_t *) mrz, &mrzlen, 0x5f, 0x1f, true, true, 0)) {
         PrintAndLogEx(ERR, "Failed to read MRZ from EF_DG1.");
@@ -1339,9 +1339,9 @@ static int emrtd_print_ef_dg1_info(uint8_t *data, size_t datalen) {
 
 static int emrtd_print_ef_dg11_info(uint8_t *data, size_t datalen) {
     uint8_t taglist[100] = { 0x00 };
-    int taglistlen = 0;
+    size_t taglistlen = 0;
     uint8_t tagdata[1000] = { 0x00 };
-    int tagdatalen = 0;
+    size_t tagdatalen = 0;
 
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "-------------------- " _CYAN_("EF_DG11") " -------------------");
@@ -1418,9 +1418,9 @@ static int emrtd_print_ef_dg11_info(uint8_t *data, size_t datalen) {
 
 static int emrtd_print_ef_dg12_info(uint8_t *data, size_t datalen) {
     uint8_t taglist[100] = { 0x00 };
-    int taglistlen = 0;
+    size_t taglistlen = 0;
     uint8_t tagdata[1000] = { 0x00 };
-    int tagdatalen = 0;
+    size_t tagdatalen = 0;
 
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "-------------------- " _CYAN_("EF_DG12") " -------------------");
@@ -1491,14 +1491,14 @@ static int emrtd_ef_sod_extract_signatures(uint8_t *data, size_t datalen, uint8_
     uint8_t emrtdsigtext[EMRTD_MAX_FILE_SIZE] = { 0x00 };
     size_t toplen, signeddatalen, emrtdsigcontainerlen, emrtdsiglen, emrtdsigtextlen = 0;
 
-    if (!emrtd_lds_get_data_by_tag(data, (int) datalen, top, (int *) &toplen, 0x30, 0x00, false, true, 0)) {
+    if (!emrtd_lds_get_data_by_tag(data, datalen, top, &toplen, 0x30, 0x00, false, true, 0)) {
         PrintAndLogEx(ERR, "Failed to read top from EF_SOD.");
         return false;
     }
 
     PrintAndLogEx(DEBUG, "top: %s.", sprint_hex_inrow(top, toplen));
 
-    if (!emrtd_lds_get_data_by_tag(top, (int) toplen, signeddata, (int *) &signeddatalen, 0xA0, 0x00, false, false, 0)) {
+    if (!emrtd_lds_get_data_by_tag(top, toplen, signeddata, &signeddatalen, 0xA0, 0x00, false, false, 0)) {
         PrintAndLogEx(ERR, "Failed to read signedData from EF_SOD.");
         return false;
     }
@@ -1506,14 +1506,14 @@ static int emrtd_ef_sod_extract_signatures(uint8_t *data, size_t datalen, uint8_
     PrintAndLogEx(DEBUG, "signeddata: %s.", sprint_hex_inrow(signeddata, signeddatalen));
 
     // Do true on reading into the tag as it's a "sequence"
-    if (!emrtd_lds_get_data_by_tag(signeddata, (int) signeddatalen, emrtdsigcontainer, (int *) &emrtdsigcontainerlen, 0x30, 0x00, false, true, 0)) {
+    if (!emrtd_lds_get_data_by_tag(signeddata, signeddatalen, emrtdsigcontainer, &emrtdsigcontainerlen, 0x30, 0x00, false, true, 0)) {
         PrintAndLogEx(ERR, "Failed to read eMRTDSignature container from EF_SOD.");
         return false;
     }
 
     PrintAndLogEx(DEBUG, "emrtdsigcontainer: %s.", sprint_hex_inrow(emrtdsigcontainer, emrtdsigcontainerlen));
 
-    if (!emrtd_lds_get_data_by_tag(emrtdsigcontainer, (int) emrtdsigcontainerlen, emrtdsig, (int *) &emrtdsiglen, 0xA0, 0x00, false, false, 0)) {
+    if (!emrtd_lds_get_data_by_tag(emrtdsigcontainer, emrtdsigcontainerlen, emrtdsig, &emrtdsiglen, 0xA0, 0x00, false, false, 0)) {
         PrintAndLogEx(ERR, "Failed to read eMRTDSignature from EF_SOD.");
         return false;
     }
@@ -1521,7 +1521,7 @@ static int emrtd_ef_sod_extract_signatures(uint8_t *data, size_t datalen, uint8_
     PrintAndLogEx(DEBUG, "emrtdsig: %s.", sprint_hex_inrow(emrtdsig, emrtdsiglen));
 
     // TODO: Not doing memcpy here, it didn't work, fix it somehow
-    if (!emrtd_lds_get_data_by_tag(emrtdsig, (int) emrtdsiglen, emrtdsigtext, (int *) &emrtdsigtextlen, 0x04, 0x00, false, false, 0)) {
+    if (!emrtd_lds_get_data_by_tag(emrtdsig, emrtdsiglen, emrtdsigtext, &emrtdsigtextlen, 0x04, 0x00, false, false, 0)) {
         PrintAndLogEx(ERR, "Failed to read eMRTDSignature (text) from EF_SOD.");
         return false;
     }
@@ -1555,7 +1555,7 @@ static int emrtd_print_ef_sod_info(uint8_t *data, size_t datalen) {
 
     PrintAndLogEx(DEBUG, "hash data: %s", sprint_hex_inrow(emrtdsig, emrtdsiglen));
 
-    if (!emrtd_lds_get_data_by_tag(emrtdsig, (int) emrtdsiglen, hashlist, (int *) &hashlistlen, 0x30, 0x00, false, true, 1)) {
+    if (!emrtd_lds_get_data_by_tag(emrtdsig, emrtdsiglen, hashlist, &hashlistlen, 0x30, 0x00, false, true, 1)) {
         PrintAndLogEx(ERR, "Failed to read hash list from EF_SOD.");
         return false;
     }
@@ -1571,8 +1571,8 @@ static int emrtd_print_ef_sod_info(uint8_t *data, size_t datalen) {
 
         switch (hashlist[offset]) {
             case 0x30:
-                emrtd_lds_get_data_by_tag(hashlist + offset + e_fieldlen + 1, (int) e_datalen, hashidstr, (int *) &hashidstrlen, 0x02, 0x00, false, false, 0);
-                emrtd_lds_get_data_by_tag(hashlist + offset + e_fieldlen + 1, (int) e_datalen, hash, (int *) &hashlen, 0x04, 0x00, false, false, 0);
+                emrtd_lds_get_data_by_tag(hashlist + offset + e_fieldlen + 1, e_datalen, hashidstr, &hashidstrlen, 0x02, 0x00, false, false, 0);
+                emrtd_lds_get_data_by_tag(hashlist + offset + e_fieldlen + 1, e_datalen, hash, &hashlen, 0x04, 0x00, false, false, 0);
                 PrintAndLogEx(SUCCESS, "Hash for EF_DG%i: %s", hashidstr[0], sprint_hex_inrow(hash, hashlen));
                 break;
         }
@@ -1625,7 +1625,7 @@ int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
     }
 
     uint8_t filelist[50];
-    int filelistlen = 0;
+    size_t filelistlen = 0;
 
     if (!emrtd_lds_get_data_by_tag(response, resplen, filelist, &filelistlen, 0x5c, 0x00, false, true, 0)) {
         PrintAndLogEx(ERR, "Failed to read file list from EF_COM.");
@@ -1676,7 +1676,7 @@ int infoHF_EMRTD_offline(const char *path) {
     }
 
     uint8_t filelist[50];
-    int filelistlen = 0;
+    size_t filelistlen = 0;
     res = emrtd_lds_get_data_by_tag(data, datalen, filelist, &filelistlen, 0x5c, 0x00, false, true, 0);
     if (!res) {
         PrintAndLogEx(ERR, "Failed to read file list from EF_COM.");

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -84,28 +84,28 @@ typedef enum  { // list must match dg_table
 } emrtd_dg_enum;
 
 static emrtd_dg_t dg_table[] = {
-//  tag     fileid  filename           desc                                                 pace   req    fast   parser                    dumper
-    {0x60, "011E", "EF_COM",          "Header and Data Group Presence Information",         false, true,  true,  emrtd_print_ef_com_info,  NULL},
-    {0x61, "0101", "EF_DG1",          "Details recorded in MRZ",                            false, true,  true,  emrtd_print_ef_dg1_info,  NULL},
-    {0x75, "0102", "EF_DG2",          "Encoded Face",                                       false, true,  false, NULL,                     emrtd_dump_ef_dg2},
-    {0x63, "0103", "EF_DG3",          "Encoded Finger(s)",                                  true,  false, false, NULL,                     NULL},
-    {0x76, "0104", "EF_DG4",          "Encoded Eye(s)",                                     true,  false, false, NULL,                     NULL},
-    {0x65, "0105", "EF_DG5",          "Displayed Portrait",                                 false, false, false, NULL,                     emrtd_dump_ef_dg5},
-    {0x66, "0106", "EF_DG6",          "Reserved for Future Use",                            false, false, false, NULL,                     NULL},
-    {0x67, "0107", "EF_DG7",          "Displayed Signature or Usual Mark",                  false, false, false, NULL,                     emrtd_dump_ef_dg7},
-    {0x68, "0108", "EF_DG8",          "Data Feature(s)",                                    false, false, true,  NULL,                     NULL},
-    {0x69, "0109", "EF_DG9",          "Structure Feature(s)",                               false, false, true,  NULL,                     NULL},
-    {0x6a, "010A", "EF_DG10",         "Substance Feature(s)",                               false, false, true,  NULL,                     NULL},
-    {0x6b, "010B", "EF_DG11",         "Additional Personal Detail(s)",                      false, false, true,  emrtd_print_ef_dg11_info, NULL},
-    {0x6c, "010C", "EF_DG12",         "Additional Document Detail(s)",                      false, false, true,  emrtd_print_ef_dg12_info, NULL},
-    {0x6d, "010D", "EF_DG13",         "Optional Detail(s)",                                 false, false, true,  NULL,                     NULL},
-    {0x6e, "010E", "EF_DG14",         "Security Options",                                   false, false, true,  NULL,                     NULL},
-    {0x6f, "010F", "EF_DG15",         "Active Authentication Public Key Info",              false, false, true,  NULL,                     NULL},
-    {0x70, "0110", "EF_DG16",         "Person(s) to Notify",                                false, false, true,  NULL,                     NULL},
-    {0x77, "011D", "EF_SOD",          "Document Security Object",                           false, false, true,  emrtd_print_ef_sod_info,  emrtd_dump_ef_sod},
-    {0xff, "011C", "EF_CardAccess",   "PACE SecurityInfos",                                 true,  true,  true,  NULL,                     NULL},
-    {0xff, "011D", "EF_CardSecurity", "PACE SecurityInfos for Chip Authentication Mapping", true,  false, true,  NULL,                     NULL},
-    {0x00, NULL, NULL, NULL, false, false, false, NULL, NULL}
+//  tag     fileid  filename           desc                                                 pace   eac    req    fast   parser                    dumper
+    {0x60, "011E", "EF_COM",          "Header and Data Group Presence Information",         false, false, true,  true,  emrtd_print_ef_com_info,  NULL},
+    {0x61, "0101", "EF_DG1",          "Details recorded in MRZ",                            false, false, true,  true,  emrtd_print_ef_dg1_info,  NULL},
+    {0x75, "0102", "EF_DG2",          "Encoded Face",                                       false, false, true,  false, NULL,                     emrtd_dump_ef_dg2},
+    {0x63, "0103", "EF_DG3",          "Encoded Finger(s)",                                  false, true,  false, false, NULL,                     NULL},
+    {0x76, "0104", "EF_DG4",          "Encoded Eye(s)",                                     false, true,  false, false, NULL,                     NULL},
+    {0x65, "0105", "EF_DG5",          "Displayed Portrait",                                 false, false, false, false, NULL,                     emrtd_dump_ef_dg5},
+    {0x66, "0106", "EF_DG6",          "Reserved for Future Use",                            false, false, false, false, NULL,                     NULL},
+    {0x67, "0107", "EF_DG7",          "Displayed Signature or Usual Mark",                  false, false, false, false, NULL,                     emrtd_dump_ef_dg7},
+    {0x68, "0108", "EF_DG8",          "Data Feature(s)",                                    false, false, false, true,  NULL,                     NULL},
+    {0x69, "0109", "EF_DG9",          "Structure Feature(s)",                               false, false, false, true,  NULL,                     NULL},
+    {0x6a, "010A", "EF_DG10",         "Substance Feature(s)",                               false, false, false, true,  NULL,                     NULL},
+    {0x6b, "010B", "EF_DG11",         "Additional Personal Detail(s)",                      false, false, false, true,  emrtd_print_ef_dg11_info, NULL},
+    {0x6c, "010C", "EF_DG12",         "Additional Document Detail(s)",                      false, false, false, true,  emrtd_print_ef_dg12_info, NULL},
+    {0x6d, "010D", "EF_DG13",         "Optional Detail(s)",                                 false, false, false, true,  NULL,                     NULL},
+    {0x6e, "010E", "EF_DG14",         "Security Options",                                   false, false, false, true,  NULL,                     NULL},
+    {0x6f, "010F", "EF_DG15",         "Active Authentication Public Key Info",              false, false, false, true,  NULL,                     NULL},
+    {0x70, "0110", "EF_DG16",         "Person(s) to Notify",                                false, false, false, true,  NULL,                     NULL},
+    {0x77, "011D", "EF_SOD",          "Document Security Object",                           false, false, false, true,  emrtd_print_ef_sod_info,  emrtd_dump_ef_sod},
+    {0xff, "011C", "EF_CardAccess",   "PACE SecurityInfos",                                 true,  false, true,  true,  NULL,                     NULL},
+    {0xff, "011D", "EF_CardSecurity", "PACE SecurityInfos for Chip Authentication Mapping", true,  false, false, true,  NULL,                     NULL},
+    {0x00, NULL, NULL, NULL, false, false, false, false, NULL, NULL}
 };
 
 static emrtd_dg_t *emrtd_tag_to_dg(uint8_t tag) {
@@ -1026,7 +1026,7 @@ int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
             continue;
         }
         PrintAndLogEx(DEBUG, "Current file: %s", dg->filename);
-        if (!dg->pace) {
+        if (!dg->pace && !dg->eac) {
             emrtd_dump_file(ks_enc, ks_mac, ssc, dg->fileid, dg->filename, BAC, use_14b);
         }
     }
@@ -1643,7 +1643,7 @@ int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
             PrintAndLogEx(INFO, "File tag not found, skipping: %02X", filelist[i]);
             continue;
         }
-        if (dg->fastdump && !dg->pace) {
+        if (dg->fastdump && !dg->pace && !dg->eac) {
             if (emrtd_select_and_read(response, &resplen, dg->fileid, ks_enc, ks_mac, ssc, BAC, use_14b)) {
                 if (dg->parser != NULL)
                     dg->parser(response, resplen);

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1831,7 +1831,7 @@ static int cmd_hf_emrtd_info(const char *Cmd) {
         arg_str0("n", "documentnumber", "<alphanum>", "document number, up to 9 chars"),
         arg_str0("d", "dateofbirth", "<YYMMDD>", "date of birth in YYMMDD format"),
         arg_str0("e", "expiry", "<YYMMDD>", "expiry in YYMMDD format"),
-        arg_str0("m", "mrz", "<[0-9A-Z<]>", "2nd line of MRZ, 44 chars"),
+        arg_str0("m", "mrz", "<[0-9A-Z<]>", "2nd line of MRZ, 44 chars (passports only)"),
         arg_str0(NULL, "path", "<dirpath>", "display info from offline dump stored in dirpath"),
         arg_param_end
     };

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -622,8 +622,15 @@ static int emrtd_read_file(uint8_t *dataout, int *dataoutlen, uint8_t *kenc, uin
     return true;
 }
 
+static int emrtd_lds_determine_tag_length(uint8_t tag) {
+    if ((tag == 0x5F) || (tag == 0x7F)) {
+        return 2;
+    }
+    return 1;
+}
+
 static bool emrtd_lds_get_data_by_tag(uint8_t *datain, int datainlen, uint8_t *dataout, int *dataoutlen, int tag1, int tag2, bool twobytetag) {
-    int offset = 1;
+    int offset = emrtd_lds_determine_tag_length(*datain);
     offset += emrtd_get_asn1_field_length(datain, datainlen, offset);
 
     int e_idlen = 0;
@@ -632,11 +639,7 @@ static bool emrtd_lds_get_data_by_tag(uint8_t *datain, int datainlen, uint8_t *d
     while (offset < datainlen) {
         PrintAndLogEx(DEBUG, "emrtd_lds_get_data_by_tag, offset: %i, data: %X", offset, *(datain + offset));
         // Determine element ID length to set as offset on asn1datalength
-        if ((*(datain + offset) == 0x5F) || (*(datain + offset) == 0x7F)) {
-            e_idlen = 2;
-        } else {
-            e_idlen = 1;
-        }
+        e_idlen = emrtd_lds_determine_tag_length(*(datain + offset));
 
         // Get the length of the element
         e_datalen = emrtd_get_asn1_data_length(datain + offset, datainlen - offset, e_idlen);

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -20,7 +20,7 @@
 #include "protocols.h"              // definitions of ISO14A/7816 protocol
 #include "emv/apduinfo.h"           // GetAPDUCodeDescription
 #include "sha1.h"                   // KSeed calculation etc
-#include "crypto/libpcrypto.h"      // Hash calculation (sha256), TODO: AES too
+#include "crypto/libpcrypto.h"      // Hash calculation (sha256, sha512)
 #include "mifare/desfire_crypto.h"  // des_encrypt/des_decrypt
 #include "des.h"                    // mbedtls_des_key_set_parity
 #include "cmdhf14b.h"               // exchange_14b_apdu

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -61,7 +61,7 @@ static int emrtd_print_ef_dg12_info(uint8_t *data, size_t datalen);
 static int emrtd_print_ef_sod_info(uint8_t *data, size_t datalen);
 
 typedef enum  { // list must match dg_table
-    EF_COM=0,
+    EF_COM = 0,
     EF_DG1,
     EF_DG2,
     EF_DG3,
@@ -109,7 +109,7 @@ static emrtd_dg_t dg_table[] = {
 };
 
 static emrtd_dg_t *emrtd_tag_to_dg(uint8_t tag) {
-    for (int dgi=0; dg_table[dgi].filename != NULL; dgi++) {
+    for (int dgi = 0; dg_table[dgi].filename != NULL; dgi++) {
         if (dg_table[dgi].tag == tag) {
             return &dg_table[dgi];
         }
@@ -117,7 +117,7 @@ static emrtd_dg_t *emrtd_tag_to_dg(uint8_t tag) {
     return NULL;
 }
 static emrtd_dg_t *emrtd_fileid_to_dg(const char *file_id) {
-    for (int dgi=0; dg_table[dgi].filename != NULL; dgi++) {
+    for (int dgi = 0; dg_table[dgi].filename != NULL; dgi++) {
         if (strcmp(dg_table[dgi].fileid, file_id) == 0) {
             return &dg_table[dgi];
         }
@@ -698,7 +698,7 @@ static int emrtd_dump_ef_dg2(uint8_t *file_contents, size_t file_length) {
     // Note: Doing file_length - 6 to account for the longest data we're checking.
     for (offset = 0; offset < file_length - 6; offset++) {
         if ((file_contents[offset] == 0xFF && file_contents[offset + 1] == 0xD8 && file_contents[offset + 2] == 0xFF && file_contents[offset + 3] == 0xE0) ||
-            (file_contents[offset] == 0x00 && file_contents[offset + 1] == 0x00 && file_contents[offset + 2] == 0x00 && file_contents[offset + 3] == 0x0C && file_contents[offset + 4] == 0x6A && file_contents[offset + 5] == 0x50)) {
+                (file_contents[offset] == 0x00 && file_contents[offset + 1] == 0x00 && file_contents[offset + 2] == 0x00 && file_contents[offset + 3] == 0x0C && file_contents[offset + 4] == 0x6A && file_contents[offset + 5] == 0x50)) {
             datalen = file_length - offset;
             break;
         }
@@ -752,7 +752,7 @@ static int emrtd_dump_ef_dg7(uint8_t *file_contents, size_t file_length) {
 static int emrtd_dump_ef_sod(uint8_t *file_contents, size_t file_length) {
     int fieldlen = emrtd_get_asn1_field_length(file_contents, file_length, 1);
     int datalen = emrtd_get_asn1_data_length(file_contents, file_length, 1);
-    
+
     if (fieldlen + 1 > EMRTD_MAX_FILE_SIZE) {
         PrintAndLogEx(ERR, "error (emrtd_dump_ef_sod) fieldlen out-of-bounds");
         return PM3_SUCCESS;
@@ -773,7 +773,7 @@ static bool emrtd_dump_file(uint8_t *ks_enc, uint8_t *ks_mac, uint8_t *ssc, cons
     PrintAndLogEx(INFO, "Read %s, len: %i.", name, resplen);
     PrintAndLogEx(DEBUG, "Contents (may be incomplete over 2k chars): %s", sprint_hex_inrow(response, resplen));
     saveFile(name, ".BIN", response, resplen);
-    emrtd_dg_t * dg = emrtd_fileid_to_dg(file);
+    emrtd_dg_t *dg = emrtd_fileid_to_dg(file);
     if ((dg != NULL) && (dg->dumper != NULL)) {
         dg->dumper(response, resplen);
     }
@@ -785,7 +785,7 @@ static void rng(int length, uint8_t *dataout) {
     //for (int i = 0; i < (length / 4); i++) {
     //    num_to_bytes(prng_successor(msclock() + i, 32), 4, &dataout[i * 4]);
     //}
-    memset(dataout, 0x00, length);   
+    memset(dataout, 0x00, length);
 }
 
 static bool emrtd_do_bac(char *documentnumber, char *dob, char *expiry, uint8_t *ssc, uint8_t *ks_enc, uint8_t *ks_mac, bool use_14b) {
@@ -1013,7 +1013,7 @@ int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
     filelist[filelistlen++] = 0x77;
     // Dump all files in the file list
     for (int i = 0; i < filelistlen; i++) {
-        emrtd_dg_t * dg = emrtd_tag_to_dg(filelist[i]);
+        emrtd_dg_t *dg = emrtd_tag_to_dg(filelist[i]);
         if (dg == NULL) {
             PrintAndLogEx(INFO, "File tag not found, skipping: %02X", filelist[i]);
             continue;
@@ -1034,9 +1034,9 @@ static bool emrtd_compare_check_digit(char *datain, int datalen, char expected_c
     uint8_t check_digit = emrtd_calculate_check_digit(tempdata) + 0x30;
     bool res = check_digit == expected_check_digit;
     PrintAndLogEx(DEBUG, "emrtd_compare_check_digit, expected %c == %c calculated ( %s )"
-        , expected_check_digit
-        , check_digit
-        , (res) ? _GREEN_("ok") : _RED_("fail"));
+                  , expected_check_digit
+                  , check_digit
+                  , (res) ? _GREEN_("ok") : _RED_("fail"));
     return res;
 }
 
@@ -1238,7 +1238,7 @@ static int emrtd_print_ef_com_info(uint8_t *data, size_t datalen) {
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "-------------------- " _CYAN_("EF_COM") " --------------------");
     for (int i = 0; i < filelistlen; i++) {
-        emrtd_dg_t * dg = emrtd_tag_to_dg(filelist[i]);
+        emrtd_dg_t *dg = emrtd_tag_to_dg(filelist[i]);
         if (dg == NULL) {
             PrintAndLogEx(INFO, "File tag not found, skipping: %02X", filelist[i]);
             continue;
@@ -1520,7 +1520,7 @@ int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
     }
 
     int res = emrtd_print_ef_com_info(response, resplen);
-    if ( res != PM3_SUCCESS) {
+    if (res != PM3_SUCCESS) {
         DropField();
         return res;
     }
@@ -1537,7 +1537,7 @@ int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
     filelist[filelistlen++] = 0x77;
     // Dump all files in the file list
     for (int i = 0; i < filelistlen; i++) {
-        emrtd_dg_t * dg = emrtd_tag_to_dg(filelist[i]);
+        emrtd_dg_t *dg = emrtd_tag_to_dg(filelist[i]);
         if (dg == NULL) {
             PrintAndLogEx(INFO, "File tag not found, skipping: %02X", filelist[i]);
             continue;
@@ -1570,7 +1570,7 @@ int infoHF_EMRTD_offline(const char *path) {
     }
 
     int res = emrtd_print_ef_com_info(data, datalen);
-    if ( res != PM3_SUCCESS) {
+    if (res != PM3_SUCCESS) {
         free(data);
         free(filepath);
         return res;
@@ -1590,7 +1590,7 @@ int infoHF_EMRTD_offline(const char *path) {
     filelist[filelistlen++] = 0x77;
     // Read files in the file list
     for (int i = 0; i < filelistlen; i++) {
-        emrtd_dg_t * dg = emrtd_tag_to_dg(filelist[i]);
+        emrtd_dg_t *dg = emrtd_tag_to_dg(filelist[i]);
         if (dg == NULL) {
             PrintAndLogEx(INFO, "File tag not found, skipping: %02X", filelist[i]);
             continue;
@@ -1599,8 +1599,7 @@ int infoHF_EMRTD_offline(const char *path) {
             strcpy(filepath, path);
             strncat(filepath, PATHSEP, 2);
             strcat(filepath, dg->filename);
-            if (loadFile_safeEx(filepath, ".BIN", (void **)&data, (size_t *)&datalen, false) == PM3_SUCCESS)
-            {
+            if (loadFile_safeEx(filepath, ".BIN", (void **)&data, (size_t *)&datalen, false) == PM3_SUCCESS) {
                 // we won't halt on parsing errors
                 if (dg->parser != NULL)
                     dg->parser(data, datalen);
@@ -1669,7 +1668,7 @@ static int cmd_hf_emrtd_dump(const char *Cmd) {
             memset(docnum + slen, '<', 9 - slen);
         }
     }
-    
+
     if (CLIParamStrToBuf(arg_get_str(ctx, 2), dob, 6, &slen) != 0 || slen == 0) {
         BAC = false;
     } else {
@@ -1679,7 +1678,7 @@ static int cmd_hf_emrtd_dump(const char *Cmd) {
             error = true;
         }
     }
-    
+
     if (CLIParamStrToBuf(arg_get_str(ctx, 3), expiry, 6, &slen) != 0 || slen == 0) {
         BAC = false;
     } else {
@@ -1755,7 +1754,7 @@ static int cmd_hf_emrtd_info(const char *Cmd) {
             memset(docnum + slen, '<', 9 - slen);
         }
     }
-    
+
     if (CLIParamStrToBuf(arg_get_str(ctx, 2), dob, 6, &slen) != 0 || slen == 0) {
         BAC = false;
     } else {
@@ -1765,7 +1764,7 @@ static int cmd_hf_emrtd_info(const char *Cmd) {
             error = true;
         }
     }
-    
+
     if (CLIParamStrToBuf(arg_get_str(ctx, 3), expiry, 6, &slen) != 0 || slen == 0) {
         BAC = false;
     } else {

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1550,6 +1550,9 @@ static int emrtd_parse_ef_sod_hash_algo(uint8_t *data, size_t datalen, int *hash
         *hashalgo = 1;
     } else if (memcmp(emrtd_hashalgo_sha512, hashalgoset, 11) == 0) {
         *hashalgo = 3;
+    } else {
+        *hashalgo = 0;
+        return PM3_ESOFT;
     }
 
     return PM3_SUCCESS;
@@ -1576,7 +1579,9 @@ static int emrtd_parse_ef_sod_hashes(uint8_t *data, size_t datalen, uint8_t *has
 
     PrintAndLogEx(DEBUG, "hash data: %s", sprint_hex_inrow(emrtdsig, emrtdsiglen));
 
-    emrtd_parse_ef_sod_hash_algo(emrtdsig, emrtdsiglen, hashalgo);
+    if (emrtd_parse_ef_sod_hash_algo(emrtdsig, emrtdsiglen, hashalgo) != PM3_SUCCESS) {
+        PrintAndLogEx(ERR, "Failed to parse hash list. Unknown algo?");
+    }
 
     if (!emrtd_lds_get_data_by_tag(emrtdsig, emrtdsiglen, hashlist, &hashlistlen, 0x30, 0x00, false, true, 1)) {
         PrintAndLogEx(ERR, "Failed to read hash list from EF_SOD.");

--- a/client/src/cmdhfemrtd.h
+++ b/client/src/cmdhfemrtd.h
@@ -19,6 +19,7 @@ typedef struct emrtd_dg_s {
     const char *filename;
     const char *desc;
     bool pace;
+    bool eac; // EAC only (we can't dump these)
     bool required; // some are required only if PACE
     bool fastdump; // fast to dump
     int (*parser)(uint8_t *data, size_t datalen);

--- a/client/src/cmdhfemrtd.h
+++ b/client/src/cmdhfemrtd.h
@@ -27,6 +27,14 @@ typedef struct emrtd_dg_s {
     int (*dumper)(uint8_t *data, size_t datalen);
 } emrtd_dg_t;
 
+typedef struct emrtd_hashalg_s {
+    const char *name;
+    int (*hasher)(uint8_t *datain, int datainlen, uint8_t *dataout);
+    size_t hashlen;
+    size_t descriptorlen;
+    const uint8_t descriptor[15];
+} emrtd_hashalg_t;
+
 int CmdHFeMRTD(const char *Cmd);
 
 int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_available);

--- a/client/src/cmdhfemrtd.h
+++ b/client/src/cmdhfemrtd.h
@@ -15,6 +15,7 @@
 
 typedef struct emrtd_dg_s {
     uint8_t tag;
+    uint8_t dgnum;
     const char *fileid;
     const char *filename;
     const char *desc;

--- a/client/src/crypto/libpcrypto.c
+++ b/client/src/crypto/libpcrypto.c
@@ -19,6 +19,7 @@
 #include <mbedtls/cmac.h>
 #include <mbedtls/pk.h>
 #include <mbedtls/ecdsa.h>
+#include <mbedtls/sha1.h>
 #include <mbedtls/sha256.h>
 #include <mbedtls/sha512.h>
 #include <mbedtls/ctr_drbg.h>
@@ -89,6 +90,15 @@ static int fixed_rand(void *rng_state, unsigned char *output, size_t len) {
     } else {
         memset(output, 0x00, len);
     }
+
+    return 0;
+}
+
+int sha1hash(uint8_t *input, int length, uint8_t *hash) {
+    if (!hash || !input)
+        return 1;
+
+    mbedtls_sha1(input, length, hash);
 
     return 0;
 }

--- a/client/src/crypto/libpcrypto.h
+++ b/client/src/crypto/libpcrypto.h
@@ -21,6 +21,7 @@ int aes_decode(uint8_t *iv, uint8_t *key, uint8_t *input, uint8_t *output, int l
 int aes_cmac(uint8_t *iv, uint8_t *key, uint8_t *input, uint8_t *mac, int length);
 int aes_cmac8(uint8_t *iv, uint8_t *key, uint8_t *input, uint8_t *mac, int length);
 
+int sha1hash(uint8_t *input, int length, uint8_t *hash);
 int sha256hash(uint8_t *input, int length, uint8_t *hash);
 int sha512hash(uint8_t *input, int length, uint8_t *hash);
 


### PR DESCRIPTION
Big PR with lots of changes, sorry!

Changelog:

- New Feature: Partial EF_SOD parsing (rather unclean code-wise sadly)
- New Feature: `hf emrtd info` now parses and verifies hashes of files. The hash part is **NOT** verified against the signature in EF_SOD. The certificate in EF_SOD is **NOT** verified against authorities' signing certs from ICAO. Both of these are future goals.
- Improvement: emrtd_lds_get_data_by_tag improvements
- Improvement: Note that -m option is for passports (TD3) only
- Improvement: Introduce a new flag for files: EAC. While eMRTDs aren't required to enforce EAC for sensitive biometrics (fingerprints, iris scans etc), they are enforced on every eMRTD that I saw. The previous flag of PACE was incorrect for these in general. We may want to introduce a new flag to try to dump these files too. See ICAO 9303 p11 section 7 and TR-03110-1 for more info.
- Refactor: Change of a lot of ints ot size_ts. Unsure if I should also change the for loops that involve the returned size values, advice welcome.
- Refactor: Use memcmp for determining if the file is a JPEG or a JPEG2K. I did a bit of a hack to keep overhead low.

---

Opinions requested before merge:

- I'm not super happy with how I store the read hashes (`dg_hashes`).
- ~~or how I manage the sha256/sha512 thing. Perhaps smth similar to how `dg_table` is implemented might be a better idea? Input welcome.~~ I've implemented this change.
- ~~I can't find much info on if anything other than sha256 or sha512 are used. Info or sample EF_SODs welcome.~~ They may be used (no limits are specified), but it should be fairly easy to implement anything new due to the change right above this. ICAO 9309 p10 says it's AlgorithmIdentifier from RFC 3280, which in turn refers to RFC 3279 (which is incomplete as it lacks SHA256 and SHA512, so I based it on [RFC3447](https://tools.ietf.org/html/rfc3447#page-43)).
- I'm not happy with how I had to sneak in `dgnum` to `dg_table`. Opinions on better impls welcome.