### PR TITLE
eMRTD info: Split EF_SOD into a new section, add further case handling

### DIFF
--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1832,9 +1832,9 @@ int infoHF_EMRTD_offline(const char *path) {
             if (calc_all_zero == true && sod_all_zero == true) {
                 continue;
             } else if (calc_all_zero == true) {
-                PrintAndLogEx(SUCCESS, "EF_DG%i: " _YELLOW_("File read access denied, but is in EF_SOD"), i);
+                PrintAndLogEx(SUCCESS, "EF_DG%i: " _YELLOW_("File couldn't be read, but is in EF_SOD."), i);
             } else if (sod_all_zero == true) {
-                PrintAndLogEx(SUCCESS, "EF_DG%i: " _YELLOW_("File not in EF_SOD"), i);
+                PrintAndLogEx(SUCCESS, "EF_DG%i: " _YELLOW_("File is not in EF_SOD."), i);
             } else if (hash_matches == false) {
                 PrintAndLogEx(SUCCESS, "EF_DG%i: " _RED_("Invalid"), i);
             } else {


### PR DESCRIPTION
This PR splits EF_SOD into a new section and accounts for further cases such as file not being in EF_SOD, file being in EF_SOD but not actually being read.

This should conclude hash verifications for EF_SOD, hopefully... just need to do cert verifs one day.

![](https://elixi.re/i/we2e4v0g.png)

![](https://elixi.re/i/xdh1ubk4.png)

![](https://elixi.re/i/mofte2kh.png)

![](https://elixi.re/i/409xn29a.png)