### PR TITLE
Fixed build errors on osx

### DIFF
--- a/client/src/cmdhf14a.c
+++ b/client/src/cmdhf14a.c
@@ -2219,7 +2219,7 @@ static int CmdHf14AFindapdu(const char *Cmd) {
 
     bool inc_p1 = true;
     bool skip_ins = false;
-    uint64_t all_sw[256][256] = {0};
+    uint64_t all_sw[256][256] = { { 0 } };
     uint64_t sw_occurences = 0;
     uint64_t t_start = msclock();
     uint64_t t_last_reset = msclock();

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1777,8 +1777,8 @@ int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_availab
     }
 
     // Grab the hash list
-    uint8_t dg_hashes_sod[17][64] = { 0x00 };
-    uint8_t dg_hashes_calc[17][64] = { 0x00 };
+    uint8_t dg_hashes_sod[17][64] = { { 0 } };
+    uint8_t dg_hashes_calc[17][64] = { { 0 } };
     int hash_algo = 0;
 
     if (!emrtd_select_and_read(response, &resplen, dg_table[EF_SOD].fileid, ks_enc, ks_mac, ssc, BAC, use_14b)) {
@@ -1856,8 +1856,8 @@ int infoHF_EMRTD_offline(const char *path) {
     free(data);
 
     // Grab the hash list
-    uint8_t dg_hashes_sod[17][64] = { 0x00 };
-    uint8_t dg_hashes_calc[17][64] = { 0x00 };
+    uint8_t dg_hashes_sod[17][64] = { { 0 } };
+    uint8_t dg_hashes_calc[17][64] = { { 0 } };
     int hash_algo = 0;
 
     strcpy(filepath, path);


### PR DESCRIPTION
Hi,
proxmark does not compile on osx.

This PR solves the following issues:

```
[-] CC src/cmdhf14a.c
src/cmdhf14a.c:2222:34: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    uint64_t all_sw[256][256] = {0};
                                 ^
                                 {}
1 error generated.
```

and 

```
[-] CC src/cmdhfemrtd.c
src/cmdhfemrtd.c:1780:39: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    uint8_t dg_hashes_sod[17][64] = { 0x00 };
                                      ^~~~
                                      {   }
src/cmdhfemrtd.c:1781:40: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    uint8_t dg_hashes_calc[17][64] = { 0x00 };
                                       ^~~~
                                       {   }
src/cmdhfemrtd.c:1859:39: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    uint8_t dg_hashes_sod[17][64] = { 0x00 };
                                      ^~~~
                                      {   }
src/cmdhfemrtd.c:1860:40: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    uint8_t dg_hashes_calc[17][64] = { 0x00 };
                                       ^~~~
                                       {   }
4 errors generated.
```

Thanks :)