### PR TITLE
Add support for Apple Silicon (M1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed Makefile to account for changes when running on Apple Silicon (@tcprst)
  - Added support for debugging ARM with JTAG & VSCode (@Gator96100)
  - Added MFUL "Gen1b" suport to `hf_mfu_setuid.lua` (@iceman1001)
  - Added possibility to get bargraph in `lf tune` and `hf tune` (@iceman1001, @doegox)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -57,6 +57,11 @@ else
   RANLIB= ranlib
 endif
 
+# For detection of Apple Silicon
+ifeq ($(platform),Darwin)
+  BREW_PREFIX = $(shell brew --prefix)
+endif
+
 ifeq ($(DEBUG),1)
   DEFCXXFLAGS = -g -O0 -pipe
   DEFCFLAGS = -g -O0 -fstrict-aliasing -pipe

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(PkgConfig)
 if (NOT SKIPQT EQUAL 1)
     if(APPLE AND EXISTS /usr/local/opt/qt5)
         # Homebrew installs Qt5 (up to at least 5.11.0) in
-        # /usr/local/qt5. Ensure that it can be found by CMake
+        # /usr/local/opt/qt5. Ensure that it can be found by CMake
         # since it is not in the default /usr/local prefix.
         # Add it to PATHS so that it doesn't override the
         # CMAKE_PREFIX_PATH environment variable.
@@ -40,6 +40,16 @@ if (NOT SKIPQT EQUAL 1)
         # e.g. find_package(Qt5Core ${QT_FIND_PACKAGE_OPTIONS})
         list(APPEND QT_FIND_PACKAGE_OPTIONS PATHS /usr/local/opt/qt5)
     endif(APPLE AND EXISTS /usr/local/opt/qt5)
+    if(APPLE AND EXISTS /opt/homebrew/opt/qt5)
+        # Homebrew on Apple Silicon installs Qt5 in
+        # /opt/homebrew/opt/qt5. Ensure that it can be found by CMake
+        # since it is not in the default /usr/local prefix.
+        # Add it to PATHS so that it doesn't override the
+        # CMAKE_PREFIX_PATH environment variable.
+        # QT_FIND_PACKAGE_OPTIONS should be passed to find_package,
+        # e.g. find_package(Qt5Core ${QT_FIND_PACKAGE_OPTIONS})
+        list(APPEND QT_FIND_PACKAGE_OPTIONS PATHS /opt/homebrew/opt/qt5)
+    endif(APPLE AND EXISTS /opt/homebrew/opt/qt5)
     set(QT_PACKAGELIST
         Qt5Core
         Qt5Widgets
@@ -77,8 +87,8 @@ endif (EMBED_READLINE OR EMBED_BZIP2)
 
 if (NOT SKIPREADLINE EQUAL 1)
     if (APPLE)
-      find_path(READLINE_INCLUDE_DIRS readline/readline.h /usr/local/opt/readline/include /opt/local/include /opt/include /usr/local/include /usr/include NO_DEFAULT_PATH)
-      find_library(READLINE_LIBRARIES readline /usr/local/opt/readline/lib /opt/local/lib /opt/lib /usr/local/lib /usr/lib NO_DEFAULT_PATH)
+      find_path(READLINE_INCLUDE_DIRS readline/readline.h /usr/local/opt/readline/include /opt/local/include /opt/include /usr/local/include /usr/include /opt/homebrew/opt/readline/include NO_DEFAULT_PATH)
+      find_library(READLINE_LIBRARIES readline /usr/local/opt/readline/lib /opt/local/lib /opt/lib /usr/local/lib /usr/lib /opt/homebrew/opt/readline/lib NO_DEFAULT_PATH)
     endif (APPLE)
     if (EMBED_READLINE)
         ExternalProject_Add(ncurses

--- a/client/Makefile
+++ b/client/Makefile
@@ -17,8 +17,7 @@ vpath %.dic dictionaries
 OBJDIR = obj
 
 ifeq ($(platform),Darwin)
-    # cf brew info qt: qt not symlinked anymore
-    PKG_CONFIG_ENV := PKG_CONFIG_PATH=/usr/local/opt/qt/lib/pkgconfig
+	PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(BREW_PREFIX)/opt/qt/lib/pkgconfig
 endif
 
 ###################
@@ -279,8 +278,8 @@ CXXINCLUDES += $(QTINCLUDES)
 ## Readline
 ifneq ($(SKIPREADLINE),1)
     ifeq ($(platform),Darwin)
-        LDLIBS += -L/usr/local/opt/readline/lib
-        INCLUDES += -I/usr/local/opt/readline/include
+		LDLIBS += -L$(BREW_PREFIX)/opt/readline/lib
+		INCLUDES += -I$(BREW_PREFIX)/opt/readline/include
     endif
     LDLIBS += -lreadline
     READLINE_FOUND = 1

--- a/doc/md/Installation_Instructions/Mac-OS-X-Homebrew-Installation-Instructions.md
+++ b/doc/md/Installation_Instructions/Mac-OS-X-Homebrew-Installation-Instructions.md
@@ -1,5 +1,21 @@
 # Homebrew (Mac OS X), automatic installation
 
+## Apple Silicon (M1) Notes
+
+Ensure Rosetta 2 is installed as it's currently needed to run `arm-none-eabi-gcc` as it's delivered as a precombiled x86_64 binary.
+
+If you see an error like:
+
+```sh
+bad CPU type in executable
+```
+
+Then you are missing Rosetta 2 and need to install it: `/usr/sbin/softwareupdate --install-rosetta`
+
+Homebrew has changed their prefix to differentiate between native Apple Silicon and Intel compiled binaries.  The Makefile attempts to account for this but please note that whichever terminal or application you're using must be running under Architecture "Apple" as seen by Activity Monitor as all child processes inherit the Rosetta 2 environment of their parent.  You can check which architecture you're currently running under with a `uname -m` in your terminal.
+
+Visual Studio Code still runs under Rosetta 2 and if you're developing for proxmark3 on an Apple Silicon Mac you might want to consider running the Insiders build which has support for running natively on Apple Silicon.
+
 ## Install Proxmark3 tools
 
 These instructions comes from @Chrisfu, where we got the proxmark3.rb scriptfile from.


### PR DESCRIPTION
This PR adds support for compiling proxmark3 on Apple Silicon.  Homebrew has changed prefixes for certain dependencies and I've updated the doc to include information about Rosetta 2 which is needed for `arm-none-eabi-gcc` 