### PR TITLE
Minor changes to hf jooki command

### DIFF
--- a/client/src/cmdhfjooki.c
+++ b/client/src/cmdhfjooki.c
@@ -348,8 +348,6 @@ static int CmdHF14AJookiEncode(const char *Cmd) {
 
 	 if( ftid && ffid ) {
 		 figure_abbr = true;
-		 tid = 0x01;
-		 fid = 0x00;
 	 }
 
 	 if ( ftid > 0x04 || ffid > 0x20 ) {
@@ -363,7 +361,7 @@ static int CmdHF14AJookiEncode(const char *Cmd) {
         PrintAndLogEx(ERR, "Select one tag type or use figurine type id and figurine id");
         return PM3_EINVARG;
     } else {
-    	tid = ftid;
+    	tid = 0x01;
     	fid = ffid;
 	 }
 

--- a/client/src/cmdhfjooki.c
+++ b/client/src/cmdhfjooki.c
@@ -67,7 +67,7 @@ jooki_figure_t jooks_figures[] = {
     {0x01, 0x0C, "White Knight", "Figurine"},
     {0x01, 0x0D, "White Whale", "Figurine"},
 
-    {0x02, 0x01, "Generic Flat", "Stone"},
+    {0x02, 0x00, "Generic Flat", "Stone"},
 
     {0x03, 0x00, "record", "Sys"},
     {0x03, 0x01, "factory_mode_on", "Sys"},
@@ -77,9 +77,10 @@ jooki_figure_t jooks_figures[] = {
     {0x03, 0x05, "toy_safe_on", "Sys"},
     {0x03, 0x06, "toy_safe_off", "Sys"},
     {0x03, 0x07, "wifi_on", "Sys"},
-    {0x03, 0x08, "bt_on", "Sys"},
-    {0x03, 0x0a, "bt_off", "Sys"},
-    {0x03, 0x0b, "production_finished", "Sys"},
+    {0x03, 0x08, "wifi_off", "Sys"},
+    {0x03, 0x09, "bt_on", "Sys"},
+    {0x03, 0x0A, "bt_off", "Sys"},
+    {0x03, 0x0B, "production_finished", "Sys"},
 
     {0x04, 0x00, "test.0", "Test"},
     {0x04, 0x01, "test.1", "Test"},

--- a/client/src/cmdhfjooki.c
+++ b/client/src/cmdhfjooki.c
@@ -336,7 +336,7 @@ static int CmdHF14AJookiEncode(const char *Cmd) {
 	 bool figure_abbr = true;
 
 	 uint8_t ftid = arg_get_u32_def(ctx, 18, 0);
-	 uint8_t ffid = arg_get_u32_def(ctx, 19, 0); //default 0 ist schlecht
+	 uint8_t ffid = arg_get_u32_def(ctx, 19, 0); 
 
     CLIParserFree(ctx);
     


### PR DESCRIPTION
- Extended the parameter list of `hf jooki encode` command with `-y` for figurine type id and `-f` for figurine id.
- Made changes to command codes