### PR TITLE
Prevent Windows users from soft bricking their devices

### DIFF
--- a/pm3
+++ b/pm3
@@ -150,6 +150,12 @@ function get_pm3_list_Windows {
     # Normal SERIAL PORTS (COM)
     for DEV in $(wmic /locale:ms_409 path Win32_SerialPort Where "PNPDeviceID LIKE '%VID_9AC4&PID_4B8F%' Or PNPDeviceID LIKE '%VID_2D2D&PID_504D%'" Get DeviceID 2>/dev/null | awk -b '/^COM/{print $1}'); do
         DEV=${DEV/ */}
+		if [ ! $(wmic /locale:ms_409 path Win32_SerialPort Where "DeviceID='$DEV'" Get PNPDeviceID 2>/dev/null | awk -b '/^USB/{print $1}') = "USB\VID_9AC4&PID_4B8F\ICEMAN" ]; then
+			if [ $(basename -- "$0") = "pm3-flash-all" ]; then
+				echo -e "\033[0;31m[!] Using pm3-flash-all on an oudated bootloader, use pm3-flash-bootrom first!"
+				exit 1
+			fi
+		fi
         PM3LIST+=("$DEV")
         if [ ${#PM3LIST[*]} -ge "$N" ]; then
             return

--- a/pm3
+++ b/pm3
@@ -150,8 +150,9 @@ function get_pm3_list_Windows {
     # Normal SERIAL PORTS (COM)
     for DEV in $(wmic /locale:ms_409 path Win32_SerialPort Where "PNPDeviceID LIKE '%VID_9AC4&PID_4B8F%' Or PNPDeviceID LIKE '%VID_2D2D&PID_504D%'" Get DeviceID 2>/dev/null | awk -b '/^COM/{print $1}'); do
         DEV=${DEV/ */}
-		if [ ! $(wmic /locale:ms_409 path Win32_SerialPort Where "DeviceID='$DEV'" Get PNPDeviceID 2>/dev/null | awk -b '/^USB/{print $1}') = "USB\VID_9AC4&PID_4B8F\ICEMAN" ]; then
-			if [ $(basename -- "$0") = "pm3-flash-all" ]; then
+		#prevent soft bricking when using pm3-flash-all on an outdated bootloader
+		if [ $(basename -- "$0") = "pm3-flash-all" ]; then
+			if [ ! $(wmic /locale:ms_409 path Win32_SerialPort Where "DeviceID='$DEV'" Get PNPDeviceID 2>/dev/null | awk -b '/^USB/{print $1}') = "USB\VID_9AC4&PID_4B8F\ICEMAN" ]; then
 				echo -e "\033[0;31m[!] Using pm3-flash-all on an oudated bootloader, use pm3-flash-bootrom first!"
 				exit 1
 			fi
@@ -198,9 +199,18 @@ function get_pm3_list_WSL {
     fi
 
     # Normal SERIAL PORTS (COM)
-    for DEV in $($PSHEXE -command "Get-CimInstance -ClassName Win32_serialport | Where-Object {\$_.PNPDeviceID -like '*VID_9AC4&PID_4B8F*' -or \$_.PNPDeviceID -like '*VID_2D2D&PID_504D*'} | Select DeviceID" 2>/dev/null | sed -nr 's#^COM([0-9]+)\b#/dev/ttyS\1#p'); do
+    for DEV in $($PSHEXE -command "Get-CimInstance -ClassName Win32_serialport | Where-Object {\$_.PNPDeviceID -like '*VID_9AC4&PID_4B8F*' -or \$_.PNPDeviceID -like '*VID_2D2D&PID_504D*'} | Select -expandproperty DeviceID" 2>/dev/null | tr -dc '[:print:]'); do
+		_comport=$DEV
+		DEV=$(echo $DEV | sed -nr 's#^COM([0-9]+)\b#/dev/ttyS\1#p')
         # ttyS counterpart takes some more time to appear
         if [ -e "$DEV" ]; then
+			#prevent soft bricking when using pm3-flash-all on an outdated bootloader
+			if [ $(basename -- "$0") = "pm3-flash-all" ]; then
+				if [ ! $($PSHEXE -command "Get-CimInstance -ClassName Win32_serialport | Where-Object {\$_.DeviceID -eq '$DEV'} | Select -expandproperty PNPDeviceID" 2>/dev/null) = "USB\VID_9AC4&PID_4B8F\ICEMAN" ]; then
+					echo -e "\033[0;31m[!] Using pm3-flash-all on an oudated bootloader, use pm3-flash-bootrom first!"
+					exit 1
+				fi
+			fi
             PM3LIST+=("$DEV")
             if [ ! -w "$DEV" ]; then
                 echo "[!] Let's give users read/write access to $DEV"

--- a/pm3
+++ b/pm3
@@ -206,7 +206,7 @@ function get_pm3_list_WSL {
         if [ -e "$DEV" ]; then
 			#prevent soft bricking when using pm3-flash-all on an outdated bootloader
 			if [ $(basename -- "$0") = "pm3-flash-all" ]; then
-				if [ ! $($PSHEXE -command "Get-CimInstance -ClassName Win32_serialport | Where-Object {\$_.DeviceID -eq '$DEV'} | Select -expandproperty PNPDeviceID" 2>/dev/null) = "USB\VID_9AC4&PID_4B8F\ICEMAN" ]; then
+				if [ ! $($PSHEXE -command "Get-CimInstance -ClassName Win32_serialport | Where-Object {\$_.DeviceID -eq '$_comport'} | Select -expandproperty PNPDeviceID" 2>/dev/null) = "USB\VID_9AC4&PID_4B8F\ICEMAN" ]; then
 					echo -e "\033[0;31m[!] Using pm3-flash-all on an oudated bootloader, use pm3-flash-bootrom first!"
 					exit 1
 				fi


### PR DESCRIPTION
Many users use pm3-flash-all when coming from builds that are based on the official firmware, but that does result in the device not showing up. 

This addition checks if the PNPDeviceID has the Iceman suffix. It might not be the best check, but it should help inexperienced users. 
