### PR TITLE
Fix mfpauth error printout

### DIFF
--- a/client/src/mifare/mifare4.c
+++ b/client/src/mifare/mifare4.c
@@ -194,7 +194,7 @@ int MifareAuth4(mf4Session_t *mf4session, uint8_t *keyn, uint8_t *key, bool acti
     }
 
     if (data[0] != 0x90) {
-        if (!silentMode) PrintAndLogEx(ERR, "Card response error: %02x", data[0]);
+        if (!silentMode) PrintAndLogEx(ERR, "Card response error: %02x %s", data[0], mfpGetErrorDescription(data[0]));
         if (dropFieldIfError) DropField();
         return 3;
     }

--- a/client/src/mifare/mifare4.c
+++ b/client/src/mifare/mifare4.c
@@ -194,7 +194,7 @@ int MifareAuth4(mf4Session_t *mf4session, uint8_t *keyn, uint8_t *key, bool acti
     }
 
     if (data[0] != 0x90) {
-        if (!silentMode) PrintAndLogEx(ERR, "Card response error: %02x", data[2]);
+        if (!silentMode) PrintAndLogEx(ERR, "Card response error: %02x", data[0]);
         if (dropFieldIfError) DropField();
         return 3;
     }


### PR DESCRIPTION
It seems that the wrong offset is used to get the error code in the `hf mfp auth` printout. I've also added a call to the `mfpGetErrorDescription` function to make it clear why the error is occuring, if known.

Before:
![image](https://user-images.githubusercontent.com/8403417/113078772-aeae9e00-91cb-11eb-88dc-2eae93113c65.png)

After:
![image](https://user-images.githubusercontent.com/8403417/113078810-c1c16e00-91cb-11eb-9a26-be8e5663c347.png)
