### PR TITLE
Fix swapped DESELECT and WTX annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fix swapped DESELECT and WTX annotations (@VortixDev)
  - Fixed `hf 15 findafi` - cliparser bug, and loop is user interruptable (@iceman1001)
  - Added `hf mf wipe` - takes a keyfile and wipes a MFC to default values (@iceman1001)
  - Changed `pm3 shell` - now prioritise USB connections in WSL1 (@gator96100)

--- a/client/src/cmdhflist.c
+++ b/client/src/cmdhflist.c
@@ -743,10 +743,10 @@ void annotateMfDesfire(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize) {
         // S-block 11xxx010
         if ((cmd[0] & 0xC0) && (cmdsize == 3)) {
             switch ((cmd[0] & 0x30)) {
-                case 0x30:
+                case 0x00:
                     snprintf(exp, size, "S-block DESELECT");
                     break;
-                case 0x00:
+                case 0x30:
                     snprintf(exp, size, "S-block WTX");
                     break;
                 default:


### PR DESCRIPTION
The MFDES annotation function currently checks for DESELECT and WTX the wrong way around.