### PR TITLE
Fix RESTORE annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fix RESTORE mis-annotation (@VortixDev)
  - Changed `smart raw` - now uses NG (@iceman1001)
  - Added `hf iclass configcard` - now can download / generate config card dumps with a cardhelper [WIP] (@iceman1001)
  - Fix swapped DESELECT and WTX annotations (@VortixDev)

--- a/client/src/cmdhflist.c
+++ b/client/src/cmdhflist.c
@@ -228,7 +228,10 @@ int applyIso14443a(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize) {
             snprintf(exp, size, "DEC(%d)", cmd[1]);
             break;
         case MIFARE_CMD_RESTORE:
-            snprintf(exp, size, "RESTORE(%d)", cmd[1]);
+            if (cmdsize == 4)
+                snprintf(exp, size, "RESTORE(%d)", cmd[1]);
+            else
+                return 0;
             break;
         case MIFARE_CMD_TRANSFER:
             snprintf(exp, size, "TRANSFER(%d)", cmd[1]);


### PR DESCRIPTION
The ISO 14443a annotation marks any data starting with `C2` as the RESTORE command, though this first byte is shared with the DESELECT S-block. The MFDES annotation function calls the ISO 14443a annotation function before applying its own annotations, and as it does not check the size of the command before labelling it as RESTORE, any DESELECT command is labelled as RESTORE(224) (treating the first CRC byte as the block parameter). I have modified the ISO 14443a annotation function to perform size checking.

Before:
![image](https://user-images.githubusercontent.com/8403417/114060408-41ff6780-988d-11eb-9752-4d275daf1e19.png)

After:
![image](https://user-images.githubusercontent.com/8403417/114060327-2d22d400-988d-11eb-86b6-bd887f0606ad.png)

