### PR TITLE
Fix DESFire mis-annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fix DESFire mis-annotation (@VortixDev)
  - Change `lf pac demod` - now also search for inverted bitstreams (@iceman1001)
  - Change `hf 14b reader` - now supports continous mode (@iceman1001)
  - Fix `hf search` - now doesn't false identify ISO15693 (@iceman1001)

--- a/client/src/cmdhflist.c
+++ b/client/src/cmdhflist.c
@@ -776,6 +776,8 @@ void annotateMfDesfire(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize) {
                 pos++;
 
             for (uint8_t i = 0; i < 2; i++, pos++) {
+                bool found_annotation = true;
+                
                 switch (cmd[pos]) {
                     case MFDES_CREATE_APPLICATION:
                         snprintf(exp, size, "CREATE APPLICATION");
@@ -892,7 +894,12 @@ void annotateMfDesfire(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize) {
                         snprintf(exp, size, "READ SIGNATURE");
                         break;
                     default:
+                        found_annotation = false;
                         break;
+                }
+                
+                if (found_annotation) {
+                    break;
                 }
             }
         } else {


### PR DESCRIPTION
The DESFire annotation function currently iterates over the first two INF bytes to try and identify the command being used. If the first byte has a match, though, the second iteration still occurs. Thus, if both the first and second INF bytes correspond to valid DESFire command bytes, it is the second byte which final annotation will correspond to.

Example:
```
Rdr |02  5a  c0  00 00  fc  15                                               |  ok | CREATE CYCLIC RECORD FILE
```

The C0 byte is annotated rather than 5A, since they are both valid command bytes.

Post-fix:
```
Rdr |02  5a  c0  00 00  fc  15                                               |  ok | SELECT APPLICATION
```