### PR TITLE
hf 14a list: fix support for other options and provide specific help.

### DIFF
--- a/client/src/cmdhf14a.c
+++ b/client/src/cmdhf14a.c
@@ -171,11 +171,19 @@ static uint16_t frameLength = 0;
 uint16_t atsFSC[] = {16, 24, 32, 40, 48, 64, 96, 128, 256};
 
 static int CmdHF14AList(const char *Cmd) {
+    // leading space for when concatenated to other args
+    const char type[20] = " -t 14a";
+    if ((strcmp(Cmd, "-h") == 0) || (strcmp(Cmd, "--help") == 0)) {
+        PrintAndLogEx(NORMAL, _CYAN_("Alias for ") _RED_("trace list%s\n")
+            _CYAN_("See `trace list -h` for more options"), type);
+        return PM3_SUCCESS;
+    }
     char args[128] = {0};
     if (strlen(Cmd) == 0) {
-        snprintf(args, sizeof(args), "-t 14a");
+        snprintf(args, sizeof(args), type);
     } else {
         strncpy(args, Cmd, sizeof(args) - 1);
+        strncat(args, type, sizeof(args) - strlen(args));
     }
     return CmdTraceList(args);
 }


### PR DESCRIPTION
@iceman as told in PM

* fix force the trace type also when other args are given. Otherwise e.g. `hf 14a list` will show 14a annotations but not `hf 14a list -c`
* short help text for the alias rather than dumping the whole trace list help when invoking one of the 16 aliases

If this looks ok to you we can do the same for the 15 other aliases of `trace list`