### PR TITLE
Fix Makefile for QT5 on macOS

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -15,6 +15,7 @@ OBJDIR = obj
 
 ifeq ($(platform),Darwin)
 	PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(BREW_PREFIX)/opt/qt/lib/pkgconfig
+	PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(BREW_PREFIX)/opt/qt5/lib/pkgconfig
 endif
 
 ###################


### PR DESCRIPTION
brew updates QT to QT6 and versions QT5 which we need to link for pkgconfig

Leaving the old qt directory for backwards/forwards compatibility