### PR TITLE
emrtd: Fix file reading and parsing

### DIFF
--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -1207,13 +1207,13 @@ static void emrtd_print_legal_sex(char *legal_sex) {
 
 static int emrtd_mrz_determine_length(char *mrz, int offset, int max_length) {
     int i;
-    for (i = max_length - 1; i >= 0; i--) {
-        if (mrz[offset + i] != '<') {
-            break;
+    for (i = max_length; i >= 1; i--) {
+        if (mrz[offset + i - 1] != '<') {
+            return i;
         }
     }
-    // if not found,  it will return -1
-    return i;
+
+    return 0;
 }
 
 static int emrtd_mrz_determine_separator(char *mrz, int offset, int max_length) {
@@ -1237,14 +1237,11 @@ static void emrtd_mrz_replace_pad(char *data, int datalen, char newchar) {
 
 static void emrtd_print_optional_elements(char *mrz, int offset, int length, bool verify_check_digit) {
     int i = emrtd_mrz_determine_length(mrz, offset, length);
-    if (i == -1) {
+    if (i == 0) {
         return;
     }
 
-    // Only print optional elements if they're available
-    if (i != 0) {
-        PrintAndLogEx(SUCCESS, "Optional elements.....: " _YELLOW_("%.*s"), i, mrz + offset);
-    }
+    PrintAndLogEx(SUCCESS, "Optional elements.....: " _YELLOW_("%.*s"), i, mrz + offset);
 
     if (verify_check_digit && !emrtd_mrz_verify_check_digit(mrz, offset, length)) {
         PrintAndLogEx(SUCCESS, _RED_("Optional element check digit is invalid."));
@@ -1253,7 +1250,7 @@ static void emrtd_print_optional_elements(char *mrz, int offset, int length, boo
 
 static void emrtd_print_document_number(char *mrz, int offset) {
     int i = emrtd_mrz_determine_length(mrz, offset, 9);
-    if (i == -1) {
+    if (i == 0) {
         return;
     }
 
@@ -1267,7 +1264,7 @@ static void emrtd_print_document_number(char *mrz, int offset) {
 static void emrtd_print_name(char *mrz, int offset, int max_length, bool localized) {
     char final_name[100] = { 0x00 };
     int namelen = emrtd_mrz_determine_length(mrz, offset, max_length);
-    if (namelen == -1) {
+    if (namelen == 0) {
         return;
     }
     int sep = emrtd_mrz_determine_separator(mrz, offset, namelen);

--- a/client/src/cmdhfemrtd.c
+++ b/client/src/cmdhfemrtd.c
@@ -262,7 +262,7 @@ static int emrtd_get_asn1_data_length(uint8_t *datain, int datainlen, int offset
         // https://wf.lavatech.top/ave-but-random/emrtd-data-quirks#EF_SOD
         return datainlen;
     } else if (lenfield == 0x81) {
-        int tmp = (*(datain + offset + 1) << 8);
+        int tmp = (*(datain + offset + 1));
         return tmp;
         //return ((int) * (datain + offset + 1));
     } else if (lenfield == 0x82) {


### PR DESCRIPTION
This PR fixes two issues with the emrtd logic.

20ca241 fixes a small bug introduced in 2a9d064fd6fb53b1f628fc7d319b3fa9edda6382 on the `emrtd_get_asn1_data_length` function where file lengths on longer files were incorrectly determined and as such failed to read properly:

![](https://nda.lol/i/isrxfveb.png)

![](https://nda.lol/i/kze3qnf9.png)

---

a20f3af fixes a small bug introduced in 501b31cf453596023cb0a79ebf133810f48eb473 on the `emrtd_mrz_determine_length` function where certain fields (such as Legal Name, Document Number, Optional elements) had the last character cropped off.

![](https://nda.lol/i/7b37i4ml.png)

("old, working" is before 501b31cf453596023cb0a79ebf133810f48eb473, "old, broken" is after 501b31cf453596023cb0a79ebf133810f48eb473, "new" is this current fix)

I also ack that there was a bug in the logic in `emrtd_mrz_determine_length` before 501b31cf453596023cb0a79ebf133810f48eb473 where it could return -1 which made coverity unhappy. I have since fixed this issue.

---

thanks craftbyte for bringing these to my attention, btw