### PR TITLE
hf_iceclass: Ensure dump filename is NULL-terminated

### DIFF
--- a/armsrc/Standalone/hf_iceclass.c
+++ b/armsrc/Standalone/hf_iceclass.c
@@ -170,9 +170,10 @@ static void save_to_flash(uint8_t *data, uint16_t datalen, char *filename) {
                 data[4], data[5], data[6], data[7]
                );
     } else {
-        int fnlen = MIN(strlen(filename), SPIFFS_OBJ_NAME_LEN);
+        int fnlen = MIN(strlen(filename) + 1, SPIFFS_OBJ_NAME_LEN);
         // if the given name len longer than buffer allows, cut it down to size
         memcpy(fn, filename, fnlen);
+        fn[fnlen-1] = '\0';
     }
 
     int res;


### PR DESCRIPTION
This fixes the filename used in the save_to_flash function in hf_iceclass.

strlen will not count the null-terminator, thus this function previously 
trimmed off the null, resulting in garbage data in filenames.