### PR TITLE
em4x50: fixed bug in eload and restore

### DIFF
--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -166,8 +166,8 @@ static int em4x50_load_file(const char *filename, uint8_t *data, size_t data_len
     uint32_t serial = 0, device_id = 0;
 
     // valid em4x50 data?
-    serial = bytes_to_num(data + 4 * EM4X50_DEVICE_SERIAL, 4);
-    device_id = bytes_to_num(data + 4 * EM4X50_DEVICE_ID, 4);
+    serial = bytes_to_num(dump + 4 * EM4X50_DEVICE_SERIAL, 4);
+    device_id = bytes_to_num(dump + 4 * EM4X50_DEVICE_ID, 4);
     if (serial == device_id) {
         PrintAndLogEx(WARNING, "No valid EM4x50 data in file %s", filename);
         free(dump);


### PR DESCRIPTION
fixed useless 0 == 0 comparison when checking for valid em4x50 data in dump file;
eload and restore functions should work again