### PR TITLE
missing newline in 4x50 sim help text

### DIFF
--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -1149,7 +1149,7 @@ int CmdEM4x50Sim(const char *Cmd) {
     CLIParserInit(&ctx, "lf em 4x50 sim",
                   "Simulates a EM4x50 tag\n"
                   "First upload to device using `lf em 4x50 eload`",
-                  "lf em 4x50 sim"
+                  "lf em 4x50 sim\n"
                   "lf em 4x50 sim -p 27182818   -> uses password for eload data"
                  );
 


### PR DESCRIPTION
added newline (cliparser 4x50 sim)