### PR TITLE
Update cmdlfem410x.c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Added '--gap' option to lf em 410x sim for more control over sim data (@mwalker)
  - Changed `hf fido` - refactored load/save json objects (@iceman1001)
  - Moved / renamed  `fido2.json` ->  `client/resource/fido2_defparams.json` (@iceman1001)
  - Added openocd shikra support based on @ninjastyle82 patch to deprecated iceman fork (@iceman1001)


### PR DESCRIPTION
Draft EM4100 sim fix
For review: and feed back

The em4100 sim, by default adds 20 0x00's between tag ID repeats.
This did not allow my omnikey reader to see the sim ID.
Patch allows the end user to set the number of 0x00s (e.g. to none) with the default being the current 20.
If I set this to 0 the omnikey reader can see the Sim ID (tested on pm3 easy and rdv4).

Not sure what the "zero" argument should be called... so feedback welcome.

The EM 410x brute (for sim brute to a reader) also calls the some function.  I have added a place holder "zero" variable (set to 20) to compile and test.

Once we are happy with the initial tweak, i will repeat and add the some argument to the brute function.

Thanks