### PR TITLE
added default parameters for `hf cipurse`

### DIFF
--- a/client/src/cmdhfcipurse.c
+++ b/client/src/cmdhfcipurse.c
@@ -734,7 +734,7 @@ static int CmdHFCipurseDefault(const char *Cmd) {
         uint8_t ckey[CIPURSE_AES_KEY_LENGTH] = CIPURSE_DEFAULT_KEY;
         memcpy(defaultKey, ckey, CIPURSE_AES_KEY_LENGTH);
     }
-    
+
     defaultKeyId = arg_get_int_def(ctx, 2, defaultKeyId);
 
     uint8_t hdata[250] = {0};
@@ -765,7 +765,7 @@ static int CmdHFCipurseDefault(const char *Cmd) {
 
 
     PrintAndLogEx(INFO, "-----------" _CYAN_("Default parameters") "---------------------------------");
-    
+
     PrintAndLogEx(INFO, "Key ID : %d", defaultKeyId);
     PrintAndLogEx(INFO, "Key    : %s", sprint_hex(defaultKey, sizeof(defaultKey)));
     PrintAndLogEx(INFO, "File ID: 0x%04x", defaultFileId);

--- a/client/src/cmdhfcipurse.c
+++ b/client/src/cmdhfcipurse.c
@@ -719,6 +719,7 @@ static int CmdHFCipurseDefault(const char *Cmd) {
 
     void *argtable[] = {
         arg_param_begin,
+        arg_lit0(NULL, "clear",   "resets to defaults"),
         arg_int0("n",  NULL,      "<dec>", "Key ID"),
         arg_str0("k",  "key",     "<hex>", "Authentication key"),
         arg_str0(NULL, "fid",     "<hex>", "File ID"),
@@ -726,11 +727,19 @@ static int CmdHFCipurseDefault(const char *Cmd) {
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
 
-    defaultKeyId = arg_get_int_def(ctx, 1, defaultKeyId);
+    bool clearing = arg_get_lit(ctx, 1);
+    if (clearing) {
+        defaultKeyId = 1;
+        defaultFileId = 0x2ff7;
+        uint8_t ckey[CIPURSE_AES_KEY_LENGTH] = CIPURSE_DEFAULT_KEY;
+        memcpy(defaultKey, ckey, CIPURSE_AES_KEY_LENGTH);
+    }
+    
+    defaultKeyId = arg_get_int_def(ctx, 2, defaultKeyId);
 
     uint8_t hdata[250] = {0};
     int hdatalen = sizeof(hdata);
-    CLIGetHexWithReturn(ctx, 2, hdata, &hdatalen);
+    CLIGetHexWithReturn(ctx, 3, hdata, &hdatalen);
     if (hdatalen && hdatalen != 16) {
         PrintAndLogEx(ERR, _RED_("ERROR:") " key length for AES128 must be 16 bytes only");
         CLIParserFree(ctx);
@@ -742,7 +751,7 @@ static int CmdHFCipurseDefault(const char *Cmd) {
 
     memset(hdata, 0, sizeof(hdata));
     hdatalen = sizeof(hdata);
-    CLIGetHexWithReturn(ctx, 3, hdata, &hdatalen);
+    CLIGetHexWithReturn(ctx, 4, hdata, &hdatalen);
     if (hdatalen && hdatalen != 2) {
         PrintAndLogEx(ERR, _RED_("ERROR:") " file id length must be 2 bytes only");
         CLIParserFree(ctx);

--- a/client/src/cmdhfcipurse.c
+++ b/client/src/cmdhfcipurse.c
@@ -32,6 +32,10 @@
 #include "util.h"
 #include "fileutils.h"   // laodFileJSONroot
 
+static uint8_t defaultKeyId = 1;
+static uint8_t defaultKey[CIPURSE_AES_KEY_LENGTH] = CIPURSE_DEFAULT_KEY;
+static uint16_t defaultFileId = 0x2ff7;
+
 static int CmdHelp(const char *Cmd);
 
 static int CmdHFCipurseInfo(const char *Cmd) {
@@ -117,7 +121,7 @@ static int CmdHFCipurseAuth(const char *Cmd) {
 
     bool APDULogging = arg_get_lit(ctx, 1);
     bool verbose = arg_get_lit(ctx, 2);
-    uint8_t keyId = arg_get_int_def(ctx, 3, 1);
+    uint8_t keyId = arg_get_int_def(ctx, 3, defaultKeyId);
 
     uint8_t hdata[250] = {0};
     int hdatalen = sizeof(hdata);
@@ -128,9 +132,11 @@ static int CmdHFCipurseAuth(const char *Cmd) {
         return PM3_EINVARG;
     }
 
-    uint8_t key[] = {0x73, 0x73, 0x73, 0x73, 0x73, 0x73, 0x73, 0x73, 0x73, 0x73, 0x73, 0x73, 0x73, 0x73, 0x73, 0x73};
+    uint8_t key[CIPURSE_AES_KEY_LENGTH] = {0};
     if (hdatalen)
         memcpy(key, hdata, CIPURSE_AES_KEY_LENGTH);
+    else
+        memcpy(key, defaultKey, sizeof(defaultKey));
 
     SetAPDULogging(APDULogging);
 
@@ -150,7 +156,7 @@ static int CmdHFCipurseAuth(const char *Cmd) {
     uint8_t kvv[CIPURSE_KVV_LENGTH] = {0};
     CipurseCGetKVV(key, kvv);
     if (verbose) {
-        PrintAndLogEx(INFO, "Key id" _YELLOW_("%d") " key " _YELLOW_("%s") " KVV " _YELLOW_("%s")
+        PrintAndLogEx(INFO, "Key id " _YELLOW_("%d") " key " _YELLOW_("%s") " KVV " _YELLOW_("%s")
                       , keyId
                       , sprint_hex(key, CIPURSE_AES_KEY_LENGTH)
                       , sprint_hex_inrow(kvv, CIPURSE_KVV_LENGTH)
@@ -182,6 +188,8 @@ static int CLIParseKeyAndSecurityLevels(CLIParserContext *ctx, size_t keyid, siz
     }
     if (hdatalen)
         memcpy(key, hdata, CIPURSE_AES_KEY_LENGTH);
+    else
+        memcpy(key, defaultKey, sizeof(defaultKey));
 
     *sreq = CPSMACed;
     *sresp = CPSMACed;
@@ -254,11 +262,11 @@ static int CmdHFCipurseReadFile(const char *Cmd) {
 
     bool APDULogging = arg_get_lit(ctx, 1);
     bool verbose = arg_get_lit(ctx, 2);
-    uint8_t keyId = arg_get_int_def(ctx, 3, 1);
+    uint8_t keyId = arg_get_int_def(ctx, 3, defaultKeyId);
 
     CipurseChannelSecurityLevel sreq = CPSMACed;
     CipurseChannelSecurityLevel sresp = CPSMACed;
-    uint8_t key[] = CIPURSE_DEFAULT_KEY;
+    uint8_t key[CIPURSE_AES_KEY_LENGTH] = {0};
     int res = CLIParseKeyAndSecurityLevels(ctx, 4, 8, 9, key, &sreq, &sresp);
     if (res) {
         CLIParserFree(ctx);
@@ -274,7 +282,7 @@ static int CmdHFCipurseReadFile(const char *Cmd) {
         return PM3_EINVARG;
     }
 
-    uint16_t fileId = 0x2ff7;
+    uint16_t fileId = defaultFileId;
     if (hdatalen)
         fileId = (hdata[0] << 8) + hdata[1];
 
@@ -366,19 +374,19 @@ static int CmdHFCipurseWriteFile(const char *Cmd) {
 
     bool APDULogging = arg_get_lit(ctx, 1);
     bool verbose = arg_get_lit(ctx, 2);
-    uint8_t keyId = arg_get_int_def(ctx, 3, 1);
+    uint8_t keyId = arg_get_int_def(ctx, 3, defaultKeyId);
 
     CipurseChannelSecurityLevel sreq = CPSMACed;
     CipurseChannelSecurityLevel sresp = CPSMACed;
 
-    uint8_t key[] = CIPURSE_DEFAULT_KEY;
+    uint8_t key[CIPURSE_AES_KEY_LENGTH] = {0};
     int res = CLIParseKeyAndSecurityLevels(ctx, 4, 8, 9, key, &sreq, &sresp);
     if (res) {
         CLIParserFree(ctx);
         return PM3_EINVARG;
     }
 
-    uint16_t fileId = 0x2ff7;
+    uint16_t fileId = defaultFileId;
 
     uint8_t hdata[250] = {0};
     int hdatalen = sizeof(hdata);
@@ -491,11 +499,11 @@ static int CmdHFCipurseReadFileAttr(const char *Cmd) {
 
     bool APDULogging = arg_get_lit(ctx, 1);
     bool verbose = arg_get_lit(ctx, 2);
-    uint8_t keyId = arg_get_int_def(ctx, 3, 1);
+    uint8_t keyId = arg_get_int_def(ctx, 3, defaultKeyId);
 
     CipurseChannelSecurityLevel sreq = CPSMACed;
     CipurseChannelSecurityLevel sresp = CPSMACed;
-    uint8_t key[] = CIPURSE_DEFAULT_KEY;
+    uint8_t key[CIPURSE_AES_KEY_LENGTH] = {0};
     int res = CLIParseKeyAndSecurityLevels(ctx, 4, 7, 8, key, &sreq, &sresp);
     if (res) {
         CLIParserFree(ctx);
@@ -511,7 +519,7 @@ static int CmdHFCipurseReadFileAttr(const char *Cmd) {
         return PM3_EINVARG;
     }
 
-    uint16_t fileId = 0x2ff7;
+    uint16_t fileId = defaultFileId;
     if (hdatalen)
         fileId = (hdata[0] << 8) + hdata[1];
 
@@ -617,11 +625,11 @@ static int CmdHFCipurseDeleteFile(const char *Cmd) {
 
     bool APDULogging = arg_get_lit(ctx, 1);
     bool verbose = arg_get_lit(ctx, 2);
-    uint8_t keyId = arg_get_int_def(ctx, 3, 1);
+    uint8_t keyId = arg_get_int_def(ctx, 3, defaultKeyId);
 
     CipurseChannelSecurityLevel sreq = CPSMACed;
     CipurseChannelSecurityLevel sresp = CPSMACed;
-    uint8_t key[] = CIPURSE_DEFAULT_KEY;
+    uint8_t key[CIPURSE_AES_KEY_LENGTH] = {0};
     int res = CLIParseKeyAndSecurityLevels(ctx, 4, 6, 7, key, &sreq, &sresp);
     if (res) {
         CLIParserFree(ctx);
@@ -637,7 +645,7 @@ static int CmdHFCipurseDeleteFile(const char *Cmd) {
         return PM3_EINVARG;
     }
 
-    uint16_t fileId = 0x2ff7;
+    uint16_t fileId = defaultFileId;
     if (hdatalen)
         fileId = (hdata[0] << 8) + hdata[1];
 
@@ -703,6 +711,59 @@ static int CmdHFCipurseTest(const char *Cmd) {
     return PM3_SUCCESS;
 }
 
+static int CmdHFCipurseDefault(const char *Cmd) {
+    CLIParserContext *ctx;
+    CLIParserInit(&ctx, "hf cipurse default",
+                  "Set default parameters for access to cipurse card",
+                  "hf cipurse default -n 1 -k 65656565656565656565656565656565 --fid 2ff7 -> Set key, key id and file id\n");
+
+    void *argtable[] = {
+        arg_param_begin,
+        arg_int0("n",  NULL,      "<dec>", "Key ID"),
+        arg_str0("k",  "key",     "<hex>", "Authentication key"),
+        arg_str0(NULL, "fid",     "<hex>", "File ID"),
+        arg_param_end
+    };
+    CLIExecWithReturn(ctx, Cmd, argtable, true);
+
+    defaultKeyId = arg_get_int_def(ctx, 1, defaultKeyId);
+
+    uint8_t hdata[250] = {0};
+    int hdatalen = sizeof(hdata);
+    CLIGetHexWithReturn(ctx, 2, hdata, &hdatalen);
+    if (hdatalen && hdatalen != 16) {
+        PrintAndLogEx(ERR, _RED_("ERROR:") " key length for AES128 must be 16 bytes only");
+        CLIParserFree(ctx);
+        return PM3_EINVARG;
+    }
+
+    if (hdatalen)
+        memcpy(defaultKey, hdata, CIPURSE_AES_KEY_LENGTH);
+
+    memset(hdata, 0, sizeof(hdata));
+    hdatalen = sizeof(hdata);
+    CLIGetHexWithReturn(ctx, 3, hdata, &hdatalen);
+    if (hdatalen && hdatalen != 2) {
+        PrintAndLogEx(ERR, _RED_("ERROR:") " file id length must be 2 bytes only");
+        CLIParserFree(ctx);
+        return PM3_EINVARG;
+    }
+
+    if (hdatalen)
+        defaultFileId = (hdata[0] << 8) + hdata[1];
+
+    CLIParserFree(ctx);
+
+
+    PrintAndLogEx(INFO, "-----------" _CYAN_("Default parameters") "---------------------------------");
+    
+    PrintAndLogEx(INFO, "Key ID : %d", defaultKeyId);
+    PrintAndLogEx(INFO, "Key    : %s", sprint_hex(defaultKey, sizeof(defaultKey)));
+    PrintAndLogEx(INFO, "File ID: 0x%04x", defaultFileId);
+
+    return PM3_SUCCESS;
+}
+
 static command_t CommandTable[] = {
     {"help",      CmdHelp,                   AlwaysAvailable, "This help."},
     {"info",      CmdHFCipurseInfo,          IfPm3Iso14443a,  "Get info about CIPURSE tag"},
@@ -711,6 +772,7 @@ static command_t CommandTable[] = {
     {"write",     CmdHFCipurseWriteFile,     IfPm3Iso14443a,  "Write binary file"},
     {"aread",     CmdHFCipurseReadFileAttr,  IfPm3Iso14443a,  "Read file attributes"},
     {"delete",    CmdHFCipurseDeleteFile,    IfPm3Iso14443a,  "Delete file"},
+    {"default",   CmdHFCipurseDefault,       IfPm3Iso14443a,  "Set default key and file id for all the other commands"},
     {"test",      CmdHFCipurseTest,          AlwaysAvailable, "Tests"},
     {NULL, NULL, 0, NULL}
 };

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -973,7 +973,7 @@
         },
         "help": {
             "command": "help",
-            "description": "help use `<command> help` for details of a command prefs { edit client/device preferences... } -------- ----------------------- technology ----------------------- analyse { analyse utils... } data { plot window / data buffer manipulation... } emv { emv iso-14443 / iso-7816... } hf { high frequency commands... } hw { hardware commands... } lf { low frequency commands... } nfc { nfc commands... } reveng { crc calculations from reveng software... } smart { smart card iso-7816 commands... } script { scripting commands... } trace { trace manipulation... } wiegand { wiegand format manipulation... } -------- ----------------------- general ----------------------- clear clear screen hints turn hints on / off msleep add a pause in milliseconds rem add a text line in log file quit exit exit program [=] session log /home/osboxes/.proxmark3/logs/log_20210625.txt --------------------------------------------------------------------------------------- auto available offline: no run lf search / hf search / data plot / data save",
+            "description": "help use `<command> help` for details of a command prefs { edit client/device preferences... } -------- ----------------------- technology ----------------------- analyse { analyse utils... } data { plot window / data buffer manipulation... } emv { emv iso-14443 / iso-7816... } hf { high frequency commands... } hw { hardware commands... } lf { low frequency commands... } nfc { nfc commands... } reveng { crc calculations from reveng software... } smart { smart card iso-7816 commands... } script { scripting commands... } trace { trace manipulation... } wiegand { wiegand format manipulation... } -------- ----------------------- general ----------------------- clear clear screen hints turn hints on / off msleep add a pause in milliseconds rem add a text line in log file quit exit exit program [=] session log e:\\proxspace\\pm3/.proxmark3/logs/log_20210630.txt --------------------------------------------------------------------------------------- auto available offline: no run lf search / hf search / data plot / data save",
             "notes": [
                 "auto"
             ],
@@ -1721,6 +1721,22 @@
                 "-k, --key <hex> auth key"
             ],
             "usage": "hf cipurse auth [-hav] [-n <dec>] [-k <hex>]"
+        },
+        "hf cipurse default": {
+            "command": "hf cipurse default",
+            "description": "set default parameters for access to cipurse card",
+            "notes": [
+                "hf cipurse default -n 1 -k 65656565656565656565656565656565 --fid 2ff7 -> set key, key id and file id"
+            ],
+            "offline": false,
+            "options": [
+                "-h, --help this help",
+                "--clear resets to defaults",
+                "-n <dec> key id",
+                "-k, --key <hex> authentication key",
+                "--fid <hex> file id"
+            ],
+            "usage": "hf cipurse default [-h] [--clear] [-n <dec>] [-k <hex>] [--fid <hex>]"
         },
         "hf cipurse delete": {
             "command": "hf cipurse delete",
@@ -5078,8 +5094,8 @@
             "command": "hw connect",
             "description": "connects to a proxmark3 device via specified serial port. baudrate here is only for physical uart or uart-bt, not for usb-cdc or blue shark add-on",
             "notes": [
-                "hw connect -p /dev/ttyacm0",
-                "hw connect -p /dev/ttyacm0 -b 115200"
+                "hw connect -p com3",
+                "hw connect -p com3 -b 115200"
             ],
             "offline": true,
             "options": [
@@ -9201,8 +9217,8 @@
         }
     },
     "metadata": {
-        "commands_extracted": 571,
+        "commands_extracted": 572,
         "extracted_by": "PM3Help2JSON v1.00",
-        "extracted_on": "2021-06-25T21:34:48"
+        "extracted_on": "2021-06-30T09:30:39"
     }
 }

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -247,6 +247,7 @@ Check column "offline" for their availability.
 |`hf cipurse write       `|N       |`Write binary file`
 |`hf cipurse aread       `|N       |`Read file attributes`
 |`hf cipurse delete      `|N       |`Delete file`
+|`hf cipurse default     `|N       |`Set default key and file id for all the other commands`
 |`hf cipurse test        `|Y       |`Tests`
 
 


### PR DESCRIPTION
now not needs to enter them each time