### PR TITLE
add experimental support for macs with macports installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Added experimental support for macOS users utilizing MacPorts instead of Homebrew (@linuxgemini)
  - Added `pm3_online_check.py` - a script to verify and initialize a Proxmark3 RDV4 device (@iceman1001)
 
 ## [midsummer.4.13441][2021-06-25]

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -61,7 +61,7 @@ endif
 ifeq ($(USE_BREW),1)
   BREW_PREFIX = $(shell brew --prefix 2>/dev/null)
   ifeq ($(strip $(BREW_PREFIX)),)
-    MACPORTS_PREFIX = /opt/local
+    MACPORTS_PREFIX ?= /opt/local
   endif
 endif
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -60,7 +60,7 @@ endif
 
 ifeq ($(USE_BREW),1)
   BREW_PREFIX = $(shell brew --prefix 2>/dev/null)
-  ifeq ($(BREW_PREFIX),)
+  ifeq ($(strip $(BREW_PREFIX)),)
     MACPORTS_PREFIX = /opt/local
   endif
 endif

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -59,7 +59,10 @@ else
 endif
 
 ifeq ($(USE_BREW),1)
-  BREW_PREFIX = $(shell brew --prefix)
+  BREW_PREFIX = $(shell brew --prefix 2>/dev/null)
+  ifeq ($(BREW_PREFIX),)
+    MACPORTS_PREFIX = /opt/local
+  endif
 endif
 
 ifeq ($(DEBUG),1)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 ||[Advanced compilation parameters](/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md)|[More cheat sheets](https://github.com/RfidResearchGroup/proxmark3/wiki/More-cheat-sheets)|
 ||**[Troubleshooting](/doc/md/Installation_Instructions/Troubleshooting.md)**|[Complete client command set](/doc/commands.md)|
 ||**[JTAG](/doc/jtag_notes.md)**|[T5577 Introduction Guide](/doc/T5577_Guide.md)|
+||**[MacPorts (Mac OS X, experimental)](/doc/md/Installation_Instructions/Mac-OS-X-MacPorts-Installation-Instructions.md)** |
 
 
 ## Notes / helpful documents
@@ -135,7 +136,7 @@ This repo compiles nicely on
    - Windows/MinGW environment
    - Ubuntu, ParrotOS, Gentoo, Pentoo, Kali, NetHunter, Arch Linux, Fedora, Debian, Raspbian
    - Android / Termux
-   - Mac OS X / Homebrew / Apple Silicon M1
+   - Mac OS X / Homebrew (or MacPorts, experimental) / Apple Silicon M1
    - Docker container
       - [ RRG / Iceman repo based ubuntu 18.04 container ](https://hub.docker.com/r/secopsconsult/proxmark3)
       - [ Iceman fork based container v1.7 ](https://hub.docker.com/r/iceman1001/proxmark3/)

--- a/client/Makefile
+++ b/client/Makefile
@@ -14,10 +14,18 @@ vpath %.dic dictionaries
 OBJDIR = obj
 
 ifeq ($(USE_BREW),1)
-	INCLUDES += -I$(BREW_PREFIX)/include
-	LDLIBS += -L$(BREW_PREFIX)/lib
-	PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(BREW_PREFIX)/opt/qt/lib/pkgconfig
-	PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(BREW_PREFIX)/opt/qt5/lib/pkgconfig
+	ifdef MACPORTS_PREFIX
+		INCLUDES += -I$(MACPORTS_PREFIX)/include
+		LDLIBS += -L$(MACPORTS_PREFIX)/lib
+		PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(MACPORTS_PREFIX)/lib/pkgconfig
+		PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(MACPORTS_PREFIX)/libexec/qt/lib/pkgconfig
+		PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(MACPORTS_PREFIX)/libexec/qt5/lib/pkgconfig
+	else
+		INCLUDES += -I$(BREW_PREFIX)/include
+		LDLIBS += -L$(BREW_PREFIX)/lib
+		PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(BREW_PREFIX)/opt/qt/lib/pkgconfig
+		PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(BREW_PREFIX)/opt/qt5/lib/pkgconfig
+	endif
 endif
 
 ###################
@@ -117,8 +125,13 @@ INCLUDES += $(HARDNESTEDLIBINC)
 
 ## Lua
 ifneq ($(SKIPLUASYSTEM),1)
-    LUAINCLUDES = $(shell $(PKG_CONFIG_ENV) pkg-config --cflags lua5.2 2>/dev/null)
-    LUALDLIBS = $(shell $(PKG_CONFIG_ENV) pkg-config --libs lua5.2 2>/dev/null)
+    ifdef MACPORTS_PREFIX
+        LUAINCLUDES = $(shell $(PKG_CONFIG_ENV) pkg-config --cflags lua-5.2 2>/dev/null)
+        LUALDLIBS = $(shell $(PKG_CONFIG_ENV) pkg-config --libs lua-5.2 2>/dev/null)
+    else
+        LUAINCLUDES = $(shell $(PKG_CONFIG_ENV) pkg-config --cflags lua5.2 2>/dev/null)
+        LUALDLIBS = $(shell $(PKG_CONFIG_ENV) pkg-config --libs lua5.2 2>/dev/null)
+    endif
     ifneq ($(LUALDLIBS),)
         LUALIB =
         LUALIBLD = $(LUALDLIBS)
@@ -279,8 +292,12 @@ CXXINCLUDES += $(QTINCLUDES)
 ## Readline
 ifneq ($(SKIPREADLINE),1)
     ifeq ($(USE_BREW),1)
-        LDLIBS += -L$(BREW_PREFIX)/opt/readline/lib
-        INCLUDES += -I$(BREW_PREFIX)/opt/readline/include
+        ifdef MACPORTS_PREFIX
+            INCLUDES += -I$(MACPORTS_PREFIX)/include/readline
+        else
+            LDLIBS += -L$(BREW_PREFIX)/opt/readline/lib
+            INCLUDES += -I$(BREW_PREFIX)/opt/readline/include
+        endif
     endif
     LDLIBS += -lreadline
     READLINE_FOUND = 1

--- a/doc/md/Installation_Instructions/Mac-OS-X-MacPorts-Installation-Instructions.md
+++ b/doc/md/Installation_Instructions/Mac-OS-X-MacPorts-Installation-Instructions.md
@@ -39,7 +39,7 @@ These instructions will show how to setup the environment on OSX to the point wh
     sudo port select --set cython cython39 
     ```
 
-    This won't set a default python3.pc (and  python3-embed.pc) under the MacPorts pkgconfig includes folder.
+    This won't set a default python3.pc (and python3-embed.pc) under the MacPorts pkgconfig includes folder.
 
     To fix that, follow these steps:
 

--- a/doc/md/Installation_Instructions/Mac-OS-X-MacPorts-Installation-Instructions.md
+++ b/doc/md/Installation_Instructions/Mac-OS-X-MacPorts-Installation-Instructions.md
@@ -1,0 +1,72 @@
+# MacPorts (Mac OS X), developer installation, ***experimental***
+
+<b><h3>These insturctions are not tested on Apple Silicon!</h3></b>
+
+## Prerequisites
+
+These instructions will show how to setup the environment on OSX to the point where you'll be able to clone and compile the repo by yourself, as on Linux, Windows, etc.
+
+1. Have MacPorts installed. Visit https://www.macports.org/ for more information.
+
+    * MacPorts may require a bit more setup. Such as setting up new include environments like:
+
+    ```bash
+    export C_INCLUDE_PATH="/opt/local/include"
+    export CPLUS_INCLUDE_PATH="/opt/local/include"
+    export LIBRARY_PATH="/opt/local/lib"
+    export LDFLAGS="-L/opt/local/lib"
+    export CFLAGS="-I/opt/local/include"
+    export CPPFLAGS="-isystem/opt/local/include -I/opt/local/include"
+    ```
+
+    other than just modifying PATH variable to `/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/local/sbin:$PATH`.
+
+2. Install dependencies:
+
+    ```
+    sudo port install readline qt5 qt5-qtbase pkgconfig arm-none-eabi-gcc arm-none-eabi-binutils lua52
+    ```
+
+3. Clamp Python version for pkg-config
+
+    MacPorts doesn't handle Python version defaults when it comes to pkg-config. So even if you have done:
+
+    ```
+    sudo port install python39 cython39
+
+    sudo port select --set python python39  # this also makes calls to "python" operate on python3.9
+    sudo port select --set python3 python39
+    sudo port select --set cython cython39 
+    ```
+
+    This won't set a default python3.pc (and  python3-embed.pc) under the MacPorts pkgconfig includes folder.
+
+    To fix that, follow these steps:
+
+    ```
+    cd /opt/local/lib/pkgconfig
+    sudo ln -svf python3.pc python-3.9.pc
+    sudo ln -svf python3-embed.pc python-3.9-embed.pc
+    ```
+
+4. (optional) Install makefile dependencies:
+
+    ```
+    sudo port install recode
+    sudo port install astyle
+    ```
+
+
+## Compile and use the project
+
+To use the compiled client, the only difference is that the Proxmark3 port is `/dev/tty.usbmodemiceman1`, so commands become:
+
+```sh
+proxmark3 /dev/ttyACM0  =>  proxmark3 /dev/tty.usbmodemiceman1
+```
+
+Now you're ready to follow the [compilation instructions](/doc/md/Use_of_Proxmark/0_Compilation-Instructions.md).
+
+To flash on OS X, better to enter the bootloader mode manually, else you may experience errors.
+With your Proxmark3 unplugged from your machine, press and hold the button on your Proxmark3 as you plug it into a USB port. You can release the button, two of the four LEDs should stay on. You're in bootloader mode, ready for the next step. In case the two LEDs don't stay on when you're releasing the button, you've an old bootloader, start over and keep the button pressed during the whole flashing procedure.
+From there, you can follow the original compilation instructions.

--- a/doc/md/Installation_Instructions/Mac-OS-X-MacPorts-Installation-Instructions.md
+++ b/doc/md/Installation_Instructions/Mac-OS-X-MacPorts-Installation-Instructions.md
@@ -8,7 +8,13 @@ These instructions will show how to setup the environment on OSX to the point wh
 
 1. Have MacPorts installed. Visit https://www.macports.org/ for more information.
 
-    * MacPorts may require a bit more setup. Such as setting up new include environments like:
+    * MacPorts may require a bit more setup. You first need to set up your PATH variable:
+
+    ```bash
+    export "/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/local/sbin:$PATH"
+    ```
+
+    Although it is optional for proxmark3 repository, you can also set include variables:
 
     ```bash
     export C_INCLUDE_PATH="/opt/local/include"
@@ -18,8 +24,6 @@ These instructions will show how to setup the environment on OSX to the point wh
     export CFLAGS="-I/opt/local/include"
     export CPPFLAGS="-isystem/opt/local/include -I/opt/local/include"
     ```
-
-    other than just modifying PATH variable to `/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/local/sbin:$PATH`.
 
 2. Install dependencies:
 
@@ -59,11 +63,7 @@ These instructions will show how to setup the environment on OSX to the point wh
 
 ## Compile and use the project
 
-To use the compiled client, the only difference is that the Proxmark3 port is `/dev/tty.usbmodemiceman1`, so commands become:
-
-```sh
-proxmark3 /dev/ttyACM0  =>  proxmark3 /dev/tty.usbmodemiceman1
-```
+To use the compiled client, you can use `pm3` script, it is a wrapper of the proxmark3 client that handles automatic detection of your proxmark.
 
 Now you're ready to follow the [compilation instructions](/doc/md/Use_of_Proxmark/0_Compilation-Instructions.md).
 


### PR DESCRIPTION
currently requires symlinking python{version}(-embed).pc to python(embed).pc or python3(-embed).pc under /opt/local/lib/pkgconfig for python linking