### PR TITLE
Update cmdlft55xx.c

### DIFF
--- a/client/src/cmdlft55xx.c
+++ b/client/src/cmdlft55xx.c
@@ -3301,7 +3301,7 @@ static int CmdT55xxBruteForce(const char *Cmd) {
     uint32_t curr = 0;
     uint8_t found = 0; // > 0 if found xx1 xx downlink needed, 1 found
 
-    if (start_password >= end_password) {
+    if (start_password > end_password) {
         PrintAndLogEx(FAILED, "Error, start larger then end password");
         return PM3_EINVARG;
     }
@@ -3331,7 +3331,10 @@ static int CmdT55xxBruteForce(const char *Cmd) {
     PrintAndLogEx(NORMAL, "");
 
     if (found) {
-        PrintAndLogEx(SUCCESS, "Found valid password: [ " _GREEN_("%08X") " ]", curr - 1);
+        if (curr != end_password) {
+            PrintAndLogEx(SUCCESS, "Found valid password: [ " _GREEN_("%08X") " ]", curr - 1);
+        } else
+            PrintAndLogEx(SUCCESS, "Found valid password: [ " _GREEN_("%08X") " ]", curr);
         T55xx_Print_DownlinkMode((found >> 1) & 3);
     } else
         PrintAndLogEx(WARNING, "Bruteforce failed, last tried: [ " _YELLOW_("%08X") " ]", curr);


### PR DESCRIPTION
Fixed two bugs:  >= preventing users from testing one password (start_password=end_password) and reporting that the start password is greater than the end password.  The second issue is when the end password _is_ the correct password, the found password reported was curr -1.

[usb] pm3 --> lf t55xx bruteforce -s 00000042 -e 00000042
[=] press <Enter> to exit
[=] Search password range [00000042 -> 00000042]
.[=] Trying password 00000042
[=]  Chip type......... T55x7
[=]  Modulation........ FSK2a
[=]  Bit rate.......... 4 - RF/50
[=]  Inverted.......... Yes
[=]  Offset............ 34
[=]  Seq. terminator... No
[=]  Block0............ 00107070 (auto detect)
[=]  Downlink mode..... default/fixed bit length
[=]  Password set...... Yes
[=]  Password.......... 00000042


[+] Found valid password: [ 00000042 ]
Downlink Mode used : default/fixed bit length

[+] time in bruteforce 0 seconds
