### PR TITLE
Update flash.c

### DIFF
--- a/client/src/flash.c
+++ b/client/src/flash.c
@@ -123,7 +123,8 @@ static int build_segs_from_phdrs(flash_file_t *ctx, FILE *fd, Elf32_Phdr *phdrs,
         if (paddr < FLASH_START || (paddr + filesz) > flash_end) {
             PrintAndLogEx(ERR, "Error: PHDR is not contained in Flash");
             if ((paddr + filesz) > flash_end) {
-                PrintAndLogEx(ERR, "Firmware probably too big for your device");
+                PrintAndLogEx(ERR, "Firmware is probably too big for your device");
+                PrintAndLogEx(ERR, "See README.md for information on compiling for platforms with 256KB of flash memory");
             }
             return PM3_EFILE;
         }


### PR DESCRIPTION
Adding a suggested step to point the user in the right direction since the README.md has some dedicated notes on this topic.  It's likely that users seeing this message are compiling the firmware for the first time and may require the extra guidance.  Also, they have an unusable device until they re-compile and flash again.  I'm sure the extra note will be appreciated.

[+] Loading usable ELF segments:
[+]    0: V 0x00102000 P 0x00102000 (0x00040888->0x00040888) [R X] @0x94
[!!] 🚨 Error: PHDR is not contained in Flash
[!!] 🚨 Firmware probably too big for your device
[=] The flashing procedure failed, follow the suggested steps!
[+] All done