### PR TITLE
Update bt_manual_v10.md

### DIFF
--- a/doc/bt_manual_v10.md
+++ b/doc/bt_manual_v10.md
@@ -204,7 +204,24 @@ Discovery started
 [agent] Enter PIN code: 1234
 [bluetooth]# quit
 ```
-
+If bluetoothctl fails to pair without prompting you for a PIN code, use the remove command to remove it, turn off pairable, turn off scanning, and try the bluetoothctl commands above:
+```[bluetooth]# pair aa:bb:cc:dd:ee:ff
+Attempting to pair with aa:bb:cc:dd:ee:ff
+Failed to pair: org.bluez.Error.ConnectionAttemptFailed
+[bluetooth]# pair aa:bb:cc:dd:ee:ff
+Attempting to pair with aa:bb:cc:dd:ee:ff
+Failed to pair: org.bluez.Error.ConnectionAttemptFailed
+[bluetooth]# remove aa:bb:cc:dd:ee:ff
+[DEL] Device aa:bb:cc:dd:ee:ff aa-bb-cc-dd-ee-ff
+Device has been removed
+[bluetooth]# pairable off
+Changing pairable off succeeded
+[CHG] Controller 00:00:00:00:00:00 Pairable: no
+[bluetooth]# scan off
+[CHG] Controller 00:00:00:00:00:00 Discovering: no
+Discovery stopped
+```
+ 
 #### 5.2.2 Fast connection using dedicated USB Bluetooth adapter under Linux
 ^[Top](#top)
 


### PR DESCRIPTION
Added troubleshooting steps needed when bluetoothctl wasn't pairing and also didn't prompt for a PIN.