### PR TITLE
fix build error #1384

### DIFF
--- a/armsrc/Standalone/lf_tharexde.c
+++ b/armsrc/Standalone/lf_tharexde.c
@@ -70,7 +70,6 @@
 #define LF_EM4X50_LOGFILE_COLLECT       "lf_em4x50_collect.log"
 #define MAX_NO_PWDS_TO_SAVE             50
 
-uint32_t gPassword;
 
 static void LoadDataInstructions(const char *inputfile) {
     Dbprintf("");


### PR DESCRIPTION
removed the definition of gPassword in lf_tharexde.c.
it was already defined in em4x50.c