### PR TITLE
bugfix: hf mfu dump not working

### DIFF
--- a/client/src/cmdhfmfu.c
+++ b/client/src/cmdhfmfu.c
@@ -2148,7 +2148,7 @@ static int CmdHF14AMfUDump(const char *Cmd) {
     ul_print_type(tagtype, 0);
     PrintAndLogEx(SUCCESS, "Reading tag memory...");
     uint8_t keytype = 0;
-    if (has_auth_key) {
+    if (has_auth_key || has_pwd) {
         if (tagtype & UL_C)
             keytype = 1; //UL_C auth
         else


### PR DESCRIPTION
#1426 
it works now!
```
[usb] pm3 --> hf mfu dump -k bc77b6ed
[+] TYPE: NTAG 213 144bytes (NT2H1311G0DU)  
[+] Reading tag memory...
[=] Start to read from page 0. Total: 45 KeyType: 2
[#] UsePwd
[=] MFU dump file information
[=] -------------------------------------------------------------
[=]       Version | 00 53 04 02 01 00 0F 03 
[=]         TBD 0 | 00 00 
[=]         TBD 1 | 00 
[=]     Signature | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[=]     Counter 0 | 00 00 00 
[=]     Tearing 0 | 00 
[=]     Counter 1 | 00 00 00 
[=]     Tearing 1 | 00 
[=]     Counter 2 | 00 00 00 
[=]     Tearing 2 | 00 
[=] Max data page | 43 (176 bytes)
[=]   Header size | 56
[=] -------------------------------------------------------------
[=] block#   | data        |lck| ascii
[=] ---------+-------------+---+------
[=]   0/0x00 | 53 5C 4D CA |   | S\M.
[=]   1/0x01 | EE 02 1F 00 |   | ....
[=]   2/0x02 | F3 48 00 00 |   | .H..
[=]   3/0x03 | E1 10 12 00 | 0 | ....
[=]   4/0x04 | 00 00 48 4B | 0 | ..HK
[=]   5/0x05 | 00 00 31 33 | 0 | ..13
[=]   6/0x06 | 00 21 03 05 | 0 | .!..
[=]   7/0x07 | 00 06 14 77 | 0 | ...w
[=]   8/0x08 | E3 24 02 00 | 0 | .$..
[=]   9/0x09 | 00 00 00 00 | 0 | ....
[=]  10/0x0A | 00 00 00 00 | 0 | ....
[=]  11/0x0B | 00 00 00 00 | 0 | ....
[=]  12/0x0C | 00 00 00 00 | 0 | ....
[=]  13/0x0D | 00 00 00 00 | 0 | ....
[=]  14/0x0E | 00 00 00 00 | 0 | ....
[=]  15/0x0F | 00 00 00 00 | 0 | ....
[=]  16/0x10 | 00 00 00 00 | 0 | ....
[=]  17/0x11 | 00 00 00 00 | 0 | ....
[=]  18/0x12 | 00 00 00 00 | 0 | ....
[=]  19/0x13 | 00 00 00 00 | 0 | ....
[=]  20/0x14 | 00 00 00 00 | 0 | ....
[=]  21/0x15 | 00 00 00 00 | 0 | ....
[=]  22/0x16 | 00 00 00 00 | 0 | ....
[=]  23/0x17 | 00 00 00 00 | 0 | ....
[=]  24/0x18 | 00 00 00 00 | 0 | ....
[=]  25/0x19 | 00 00 00 00 | 0 | ....
[=]  26/0x1A | 00 00 00 00 | 0 | ....
[=]  27/0x1B | 00 00 00 00 | 0 | ....
[=]  28/0x1C | 00 00 00 00 | 0 | ....
[=]  29/0x1D | 00 00 00 00 | 0 | ....
[=]  30/0x1E | 00 00 00 00 | 0 | ....
[=]  31/0x1F | 00 00 00 00 | 0 | ....
[=]  32/0x20 | 00 00 00 00 | 0 | ....
[=]  33/0x21 | 00 00 00 00 | 0 | ....
[=]  34/0x22 | 00 00 00 00 | 0 | ....
[=]  35/0x23 | 00 00 00 00 | 0 | ....
[=]  36/0x24 | 00 00 00 00 | 0 | ....
[=]  37/0x25 | 00 00 00 00 | 0 | ....
[=]  38/0x26 | 00 00 00 00 | 0 | ....
[=]  39/0x27 | 00 00 00 00 | 0 | ....
[=]  40/0x28 | 00 00 00 BD | 0 | ....
[=]  41/0x29 | 04 00 00 04 | 0 | ....
[=]  42/0x2A | C0 05 00 00 | 0 | ....
[=]  43/0x2B | 00 00 00 00 | 0 | ....
[=]  44/0x2C | 00 00 00 00 | 0 | ....
[=] ---------------------------------
[=] Using UID as filename
[+] saved 236 bytes to binary file hf-mfu-535C4DEE021F00-dump-17.bin
[+] saved to json file hf-mfu-535C4DEE021F00-dump-17.json
```