### PR TITLE
fix naming convertion messes up

### DIFF
--- a/armsrc/Standalone/hf_14asniff.c
+++ b/armsrc/Standalone/hf_14asniff.c
@@ -19,7 +19,7 @@
  * at power-off).
  *
  * Short-pressing the button again will stop sniffing, and at _this_ point
- * append trace data from RAM to a file in flash (hf_14asniff.trc) and unmount.
+ * append trace data from RAM to a file in flash (hf_14asniff.trace) and unmount.
  *
  * Once the data is saved, standalone mode will exit.
  *
@@ -31,10 +31,10 @@
  *
  * To retrieve trace data from flash:
  *
- * 1. mem spiffs dump -s hf_14asniff.trc -d trace.trc
+ * 1. mem spiffs dump -s hf_14asniff.trace -d hf_14asniff.trace
  *    Copies trace data file from flash to your PC.
  *
- * 2. trace load trace.trc
+ * 2. trace load hf_14asniff.trace
  *    Loads trace data from a file into PC-side buffers.
  *
  * 3. For ISO14a: trace list -t 14a -1
@@ -66,13 +66,13 @@
 #include "ticks.h"
 #include "BigBuf.h"
 
-#define HF_14ASNIFF_LOGFILE "hf_14asniff.trc"
+#define HF_14ASNIFF_LOGFILE "hf_14asniff.trace"
 
 static void DownloadTraceInstructions(void) {
     Dbprintf("");
     Dbprintf("To get the trace from flash and display it:");
-    Dbprintf("1. mem spiffs dump -s "HF_14ASNIFF_LOGFILE" -d trace.trc");
-    Dbprintf("2. trace load -f trace.trc");
+    Dbprintf("1. mem spiffs dump -s "HF_14ASNIFF_LOGFILE" -d hf_14asniff.trace");
+    Dbprintf("2. trace load -f hf_14asniff.trace");
     Dbprintf("3. trace list -t 14a -1");
 }
 

--- a/client/src/cmdflashmemspiffs.c
+++ b/client/src/cmdflashmemspiffs.c
@@ -386,9 +386,6 @@ static int CmdFlashMemSpiFFSDump(const char *Cmd) {
     // set file extension
     char *suffix = strchr(fn, '.');
     if (suffix) {
-        size_t new_fn_len = strlen(fn) - strlen(suffix);
-        char *new_fn = (char *) calloc(new_fn_len, sizeof(char));
-        new_fn = (char *) memccpy(new_fn, fn, new_fn_len, sizeof(char));
         saveFile(fn, suffix, dump, len);
     } else
         saveFile(fn, ".bin", dump, len); // default

--- a/client/src/cmdflashmemspiffs.c
+++ b/client/src/cmdflashmemspiffs.c
@@ -385,9 +385,9 @@ static int CmdFlashMemSpiFFSDump(const char *Cmd) {
 
     // set file extension
     char *suffix = strchr(fn, '.');
-    if (suffix) {
+    if (suffix)
         saveFile(fn, suffix, dump, len);
-    } else
+    else
         saveFile(fn, ".bin", dump, len); // default
 
     if (eml) {

--- a/client/src/cmdflashmemspiffs.c
+++ b/client/src/cmdflashmemspiffs.c
@@ -386,9 +386,9 @@ static int CmdFlashMemSpiFFSDump(const char *Cmd) {
     // set file extension
     char *suffix = strchr(fn, '.');
     if (suffix) {
-        int new_fn_len = strlen(fn) - strlen(suffix);
+        size_t new_fn_len = strlen(fn) - strlen(suffix);
         char *new_fn = (char *) calloc(new_fn_len, sizeof(char));
-        new_fn = strncpy(new_fn, fn, new_fn_len);
+        new_fn = (char *) memccpy(new_fn, fn, new_fn_len, sizeof(char));
         saveFile(fn, suffix, dump, len);
     } else
         saveFile(fn, ".bin", dump, len); // default

--- a/client/src/cmdflashmemspiffs.c
+++ b/client/src/cmdflashmemspiffs.c
@@ -383,7 +383,16 @@ static int CmdFlashMemSpiFFSDump(const char *Cmd) {
         strncpy(fn, dest, dlen);
     }
 
-    saveFile(fn, ".bin", dump, len);
+    // set file extension
+    char *suffix = strchr(fn, '.');
+    if (suffix) {
+        int new_fn_len = strlen(fn) - strlen(suffix);
+        char *new_fn = (char *) calloc(new_fn_len, sizeof(char));
+        new_fn = strncpy(new_fn, fn, new_fn_len);
+        saveFile(fn, suffix, dump, len);
+    } else
+        saveFile(fn, ".bin", dump, len); // default
+
     if (eml) {
         uint8_t eml_len = 16;
         if (strstr(fn, "class") != NULL)


### PR DESCRIPTION
```
[usb] pm3 --> mem spiff dump -s hf_14asniff.trace -d hf_14asniff.bin
[=] downloading 1390 bytes from `hf_14asniff.trace` (spiffs)
[+] saved 1390 bytes to binary file hf_14asniff-5.bin
[usb] pm3 --> mem spiff dump -s hf_14asniff.trace -d hf_14asniffwefawe
[=] downloading 1390 bytes from `hf_14asniff.trace` (spiffs)
[+] saved 1390 bytes to binary file hf_14asniffwefawe.bin
[usb] pm3 --> mem spiff dump -s hf_14asniff.trace -d hf_14asniffwefawe
[=] downloading 1390 bytes from `hf_14asniff.trace` (spiffs)
[+] saved 1390 bytes to binary file hf_14asniffwefawe-1.bin
[usb] pm3 --> mem spiff dump -s hf_14asniff.trace -d hf_14asniff.bin1
[=] downloading 1390 bytes from `hf_14asniff.trace` (spiffs)
[+] saved 1390 bytes to binary file hf_14asniff.bin1
[usb] pm3 --> mem spiff dump -s hf_14asniff.trace -d hf_14asniff.trace
[=] downloading 1390 bytes from `hf_14asniff.trace` (spiffs)
[+] saved 1390 bytes to binary file hf_14asniff.trace
[usb] pm3 --> mem spiff dump -s hf_14asniff.trace -d hf_14asniff.trace
[=] downloading 1390 bytes from `hf_14asniff.trace` (spiffs)
[+] saved 1390 bytes to binary file hf_14asniff-1.trace
[usb] pm3 --> mem spiff dump -s hf_14asniff.trace -d ....hf_14asniff.trace
[=] downloading 1390 bytes from `hf_14asniff.trace` (spiffs)
[+] saved 1390 bytes to binary file ....hf_14asniff.trace
[usb] pm3 --> mem spiff dump -s hf_14asniff.trace -d ....hf_14asniff.trace
[=] downloading 1390 bytes from `hf_14asniff.trace` (spiffs)
[+] saved 1390 bytes to binary file -1....hf_14asniff.trace
```
seems better😀