### PR TITLE
Fix double free error #1467

### DIFF
--- a/client/src/cmdtrace.c
+++ b/client/src/cmdtrace.c
@@ -521,6 +521,7 @@ static int download_trace(void) {
     if (!GetFromDevice(BIG_BUF, g_trace, PM3_CMD_DATA_SIZE, 0, NULL, 0, &response, 4000, true)) {
         PrintAndLogEx(WARNING, "timeout while waiting for reply.");
         free(g_trace);
+        g_trace = NULL;
         return PM3_ETIMEOUT;
     }
 


### PR DESCRIPTION
Fixes  #1467 
Setting g_trace to NULL after free
to fix double free error

Before:
```
[fpc] pm3 --> hf 14a sniff

[#] Starting to sniff. Press PM3 Button to stop.
[fpc] pm3 --> trace list -t 14a
[=] downloading tracelog data from device
[=] Waiting for a response from the Proxmark3...
[=] You can cancel this operation by pressing the pm3 button
[-] ⛔ Timed out while trying to download data from device
[!] ⚠️  timeout while waiting for reply.
[+] Recorded activity (trace len = 0 bytes)
[fpc] pm3 --> 
[fpc] pm3 --> 
[fpc] pm3 --> trace list -t 14a
=================================================================
==30448==ERROR: AddressSanitizer: attempting double-free on 0x615000031400 in thread T4 (WorkerThread):
    #0 0x7f0380ae68f7 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:127
    #1 0x5603b839ff09 in download_trace src/cmdtrace.c:507
    #2 0x5603b83a2b6a in CmdTraceList src/cmdtrace.c:754
    #3 0x5603b838fc30 in CmdsParse src/cmdparser.c:297
    #4 0x5603b83a3552 in CmdTrace src/cmdtrace.c:909
    #5 0x5603b838fc30 in CmdsParse src/cmdparser.c:297
    #6 0x5603b838cbc3 in CommandReceived src/cmdmain.c:348
    #7 0x5603b848c5f8 in main_loop src/proxmark3.c:462
    #8 0x7f037f792340  (/lib/x86_64-linux-gnu/libQt5Core.so.5+0xcd340)
    #9 0x7f03809cf44f in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x944f)
    #10 0x7f037f218d52 in clone (/lib/x86_64-linux-gnu/libc.so.6+0x117d52)

0x615000031400 is located 0 bytes inside of 512-byte region [0x615000031400,0x615000031600)
freed by thread T4 (WorkerThread) here:
    #0 0x7f0380ae68f7 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:127
    #1 0x5603b839ffd9 in download_trace src/cmdtrace.c:523
    #2 0x5603b83a2b6a in CmdTraceList src/cmdtrace.c:754
    #3 0x5603b838fc30 in CmdsParse src/cmdparser.c:297
    #4 0x5603b83a3552 in CmdTrace src/cmdtrace.c:909
    #5 0x5603b838fc30 in CmdsParse src/cmdparser.c:297
    #6 0x5603b838cbc3 in CommandReceived src/cmdmain.c:348
    #7 0x5603b848c5f8 in main_loop src/proxmark3.c:462
    #8 0x7f037f792340  (/lib/x86_64-linux-gnu/libQt5Core.so.5+0xcd340)

previously allocated by thread T4 (WorkerThread) here:
    #0 0x7f0380ae6e17 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x5603b839ff23 in download_trace src/cmdtrace.c:511
    #2 0x5603b83a2b6a in CmdTraceList src/cmdtrace.c:754
    #3 0x5603b838fc30 in CmdsParse src/cmdparser.c:297
    #4 0x5603b83a3552 in CmdTrace src/cmdtrace.c:909
    #5 0x5603b838fc30 in CmdsParse src/cmdparser.c:297
    #6 0x5603b838cbc3 in CommandReceived src/cmdmain.c:348
    #7 0x5603b848c5f8 in main_loop src/proxmark3.c:462
    #8 0x7f037f792340  (/lib/x86_64-linux-gnu/libQt5Core.so.5+0xcd340)

Thread T4 (WorkerThread) created by T0 here:
    #0 0x7f0380a8a6d5 in __interceptor_pthread_create ../../../../src/libsanitizer/asan/asan_interceptors.cpp:216
    #1 0x7f037f791df2 in QThread::start(QThread::Priority) (/lib/x86_64-linux-gnu/libQt5Core.so.5+0xccdf2)

SUMMARY: AddressSanitizer: double-free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:127 in __interceptor_free
==30448==ABORTING
```

