### PR TITLE
fix bcc incorrect

### DIFF
--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -2537,7 +2537,7 @@ int iso14443a_select_card(uint8_t *uid_ptr, iso14a_card_select_t *p_card, uint32
                 }
 
                 // finally, add the last bits and BCC of the UID
-                for (uint16_t i = collision_answer_offset; i < (Demod.len - 1) * 8; i++, uid_resp_bits++) {
+                for (uint16_t i = collision_answer_offset; i < Demod.len * 8; i++, uid_resp_bits++) {
                     uint16_t UIDbit = (resp[i / 8] >> (i % 8)) & 0x01;
                     uid_resp[uid_resp_bits / 8] |= UIDbit << (uid_resp_bits % 8);
                 }


### PR DESCRIPTION
two 14a card
execute `hf 14a info`
```
[usb] pm3 --> hf 14a info
[#] Multiple tags detected. Collision after Bit 1
[#] BCC0 incorrect, got 0x00, expected 0xdf
[#] Aborting
```
in fact, the bcc is correct
```
[usb] pm3 --> trace list -t 14a
[=] downloading tracelog data from device
[+] Recorded activity (trace len = 72 bytes)
[=] start = start of start frame end = end of frame. src = source of transfer
[=] ISO14443A - all times are in carrier periods (1/13.56MHz)

      Start |        End | Src | Data (! denotes parity error)                                           | CRC | Annotation
------------+------------+-----+-------------------------------------------------------------------------+-----+--------------------
          0 |        992 | Rdr |52(7)                                                                    |     | WUPA
       2116 |       4484 | Tag |44  03                                                                   |     |
       7040 |       9504 | Rdr |93  20                                                                   |     | ANTICOLL
      10564 |      16388 | Tag |ea! 6d  fe! 37! ff                                                       |     |
      22656 |      25312 | Rdr |93  22  02                                                               | !crc| SELECT_XXX
      26436 |      32324 | Tag |68  6d  ee  36  df
```
after fixed
```
[usb] pm3 --> hf 14a info -v
[#] Multiple tags detected. Collision after Bit 1

[=] --- ISO14443-a Information---------------------
[+]  UID: 6A 6D EE 36
[+] ATQA: 03 44
[+]  SAK: 08 [2]
[+] Possible types:
[+]    MIFARE Classic 1K CL2
[=] proprietary non iso14443-4 card found, RATS not supported
[#] Multiple tags detected. Collision after Bit 1
[#] Multiple tags detected. Collision after Bit 1
[#] Multiple tags detected. Collision after Bit 1
[#] Multiple tags detected. Collision after Bit 1
[+] Prng detection: weak
[#] Multiple tags detected. Collision after Bit 1
[#] Auth error
[?] Hint: try `hf mf` commands
```