### PR TITLE
fix dynamic-stack-buffer-overflow

### DIFF
--- a/client/src/nfc/ndef.c
+++ b/client/src/nfc/ndef.c
@@ -11,6 +11,7 @@
 #include "ndef.h"
 
 #include <string.h>
+#include <stdlib.h>
 
 #include "ui.h"
 #include "util.h" // sprint_hex...
@@ -637,7 +638,7 @@ static int ndefDecodePayload(NDEFHeader_t *ndef) {
                 break;
             }
 
-            char begin[ndef->TypeLen];
+            char *begin = calloc(ndef->TypeLen + 1,sizeof(char));
             memcpy(begin, ndef->Type, ndef->TypeLen);
             str_lower(begin);
 
@@ -651,6 +652,8 @@ static int ndefDecodePayload(NDEFHeader_t *ndef) {
                 ndefDecodeMime_bt(ndef);
             }
 
+            free(begin);
+            begin = NULL;
             break;
         }
         case tnfAbsoluteURIRecord:


### PR DESCRIPTION
```
[usb] pm3 --> nfc decode -d DA2010016170706C69636174696F6E2F766E642E626C7565746F6F74682E65702E6F6F62301000649201B96DFB0709466C65782032

[=] --- NDEF parsing ----------------
[=] Trying to parse NDEF records w/o NDEF header

[+] Record 1
[=] -----------------------------------------------------
[=] Header info
[+]   1 ....... Message begin
[+]    1 ...... Message end
[+]     0 ..... Chunk flag
[+]      1 .... Short record bit
[+]       1 ... ID Len present
[+] 
[+]  Header length...... 4
[+]  Type length........ 32
[+]  Payload length..... 16
[+]  ID length.......... 1
[+]  Record length...... 53
[+]  Type name format... [ 0x02 ] MIME Media Record
[=] 
[=] Payload info
[=] Type data
[=]     00: 61 70 70 6C 69 63 61 74 69 6F 6E 2F 76 6E 64 2E | application/vnd.
[=]     10: 62 6C 75 65 74 6F 6F 74 68 2E 65 70 2E 6F 6F 62 | bluetooth.ep.oob
[=] ID data
[=]     00: 30                                              | 0
[=] Payload data
[=]     00: 10 00 64 92 01 B9 6D FB 07 09 46 6C 65 78 20 32 | ..d...m...Flex 2
[=] 
[=] MIME Media Record
[!] ⚠️  Text:6f,6f,62
=================================================================
==408738==ERROR: AddressSanitizer: dynamic-stack-buffer-overflow on address 0x7ffd9dd603c0 at pc 0x7efc39c6aab7 bp 0x7ffd9dd60330 sp 0x7ffd9dd5fad8
READ of size 33 at 0x7ffd9dd603c0 thread T0
    #0 0x7efc39c6aab6 in __interceptor_strlen ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:389
    #1 0x55cf993c65c8 in str_lower src/util.c:982
    #2 0x55cf99397f8d in ndefDecodePayload src/nfc/ndef.c:643
    #3 0x55cf993985d9 in ndefRecordDecodeAndPrint src/nfc/ndef.c:700
    #4 0x55cf99398a40 in NDEFRecordsDecodeAndPrint src/nfc/ndef.c:735
    #5 0x55cf992a9d47 in CmdNfcDecode src/cmdnfc.c:88
    #6 0x55cf992abdb1 in CmdsParse src/cmdparser.c:297
    #7 0x55cf992aa0da in CmdNFC src/cmdnfc.c:356
    #8 0x55cf992abdb1 in CmdsParse src/cmdparser.c:297
    #9 0x55cf992a8d44 in CommandReceived src/cmdmain.c:348
    #10 0x55cf993aa6eb in main_loop src/proxmark3.c:462
    #11 0x55cf993ae05f in main src/proxmark3.c:1105
    #12 0x7efc37d92564 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x28564)
    #13 0x55cf99004dad in _start (/home/ray/Develop/proxmark3/client/proxmark3+0x1ffdad)

Address 0x7ffd9dd603c0 is located in stack of thread T0
SUMMARY: AddressSanitizer: dynamic-stack-buffer-overflow ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:389 in __interceptor_strlen
Shadow bytes around the buggy address:
  0x100033ba4020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100033ba4030: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100033ba4040: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100033ba4050: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100033ba4060: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x100033ba4070: ca ca ca ca 00 00 00 00[cb]cb cb cb 00 00 00 00
  0x100033ba4080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100033ba4090: 00 00 00 00 00 00 f1 f1 f1 f1 f1 f1 00 00 00 00
  0x100033ba40a0: 00 00 00 00 00 00 f3 f3 f3 f3 00 00 00 00 00 00
  0x100033ba40b0: 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1 f1 f1
  0x100033ba40c0: 00 00 00 00 00 00 00 00 00 00 f3 f3 f3 f3 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==408738==ABORTING
```