### PR TITLE
Fix PAC/Stanley checksum calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fix PAC/Stanley checksum calculation (@rknoll)
  - Added option --mem to `hf mf nested`, from icopyx source (@doegox)
  - Port fpga-xc3s100e and icopyx source code specificities to this repo (@doegox)
  - `hf mfdes` - Transactions. commit, abort, commit reader id. (@merlokk)

--- a/client/src/cmdlfpac.c
+++ b/client/src/cmdlfpac.c
@@ -54,7 +54,7 @@ static int pac_buf_to_cardid(uint8_t *src, const size_t src_size, uint8_t *dst, 
             PrintAndLogEx(DEBUG, "DEBUG: Error - PAC: Parity check failed");
             return PM3_ESOFT;
         }
-        if (idx < dataLength - 1) checksum ^= byte;
+        if (idx < dataLength - 1) checksum ^= dst[idx];
     }
     if (dst[dataLength - 1] != checksum) {
         PrintAndLogEx(DEBUG, "DEBUG: Error - PAC: Bad checksum - expected: %02X, actual: %02X", dst[dataLength - 1], checksum);


### PR DESCRIPTION
The parity bit needs to be discarded when calculating the final
checksum byte value of PAC/Stanley card IDs. Verified by scanning
a tag which is now correctly identified.