### PR TITLE
New 'lf hitag pwmdemod' cmd decoding the reader messages from graph b…

### DIFF
--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -30,6 +30,7 @@
 #include "crypto/asn1utils.h"    // ASN1 decode / print
 
 uint8_t g_DemodBuffer[MAX_DEMOD_BUF_LEN];
+uint8_t g_DemodBitRangeBuffer[MAX_DEMOD_BUF_LEN];
 size_t g_DemodBufferLen = 0;
 int32_t g_DemodStartIdx = 0;
 int g_DemodClock = 0;
@@ -41,6 +42,10 @@ static int CmdHelp(const char *Cmd);
 void setDemodBuff(uint8_t *buff, size_t size, size_t start_idx) {
     if (buff == NULL) return;
 
+    // By default, disable bit range buffer by setting a 
+    // zero value (tested in proxguiqt.cpp)
+    g_DemodBitRangeBuffer[0] = 0;
+
     if (size > MAX_DEMOD_BUF_LEN - start_idx)
         size = MAX_DEMOD_BUF_LEN - start_idx;
 
@@ -49,6 +54,16 @@ void setDemodBuff(uint8_t *buff, size_t size, size_t start_idx) {
 
     g_DemodBufferLen = size;
 }
+
+//set the g_DemodBuffer with given array ofq binary (one bit per byte)
+//by marshmellow
+void setDemodBuff2(uint8_t *buff, size_t size, size_t start_idx, uint8_t *bitRange) {
+    uint8_t b = bitRange[0];
+    setDemodBuff(buff, size, start_idx);
+    if (bitRange)
+        g_DemodBitRangeBuffer[0] = b;
+}
+
 
 bool getDemodBuff(uint8_t *buff, size_t *size) {
     if (buff == NULL) return false;

--- a/client/src/cmddata.h
+++ b/client/src/cmddata.h
@@ -71,6 +71,7 @@ int NRZrawDemod(int clk, int invert, int maxErr, bool verbose);                 
 int printDemodBuff(uint8_t offset, bool strip_leading, bool invert, bool print_hex);
 
 void setDemodBuff(uint8_t *buff, size_t size, size_t start_idx);
+void setDemodBuff2(uint8_t *buff, size_t size, size_t start_idx, uint8_t *bitRange);
 bool getDemodBuff(uint8_t *buff, size_t *size);
 void save_restoreDB(uint8_t saveOpt);// option '1' to save g_DemodBuffer any other to restore
 int AutoCorrelate(const int *in, int *out, size_t len, size_t window, bool SaveGrph, bool verbose);
@@ -84,6 +85,7 @@ int AskEdgeDetect(const int *in, int *out, int len, int threshold);
 
 #define MAX_DEMOD_BUF_LEN (1024*128)
 extern uint8_t g_DemodBuffer[MAX_DEMOD_BUF_LEN];
+extern uint8_t g_DemodBitRangeBuffer[MAX_DEMOD_BUF_LEN];
 extern size_t g_DemodBufferLen;
 
 extern int g_DemodClock;

--- a/client/src/proxguiqt.h
+++ b/client/src/proxguiqt.h
@@ -36,7 +36,8 @@ class Plot: public QWidget {
     uint32_t CursorAPos;
     uint32_t CursorBPos;
     void PlotGraph(int *buffer, size_t len, QRect plotRect, QRect annotationRect, QPainter *painter, int graphNum);
-    void PlotDemod(uint8_t *buffer, size_t len, QRect plotRect, QRect annotationRect, QPainter *painter, int graphNum, uint32_t plotOffset);
+    void PlotDemod(uint8_t *buffer, size_t len, QRect plotRect, QRect annotationRect, QPainter *painter, 
+                   int graphNum, uint32_t plotOffset, uint8_t* bitRange);
     void plotGridLines(QPainter *painter, QRect r);
     int xCoordOf(int i, QRect r);
     int yCoordOf(int v, QRect r, int maxVal);

--- a/common/lfdemod.h
+++ b/common/lfdemod.h
@@ -73,6 +73,7 @@ int      pskRawDemod_ext(uint8_t *dest, size_t *size, int *clock, int *invert, i
 void     psk2TOpsk1(uint8_t *bits, size_t size);
 void     psk1TOpsk2(uint8_t *bits, size_t size);
 size_t   removeParity(uint8_t *bits, size_t startIdx, uint8_t pLen, uint8_t pType, size_t bLen);
+size_t   HitagPWMDemod(uint8_t *dest, size_t size, uint8_t *fchigh, uint8_t *fclow, uint32_t *startIdx, uint8_t *bitRange);
 
 //tag specific
 int detectAWID(uint8_t *dest, size_t *size, int *waveStartIdx);


### PR DESCRIPTION
This new command is based on the 'data rawdemode' commands.
It is intended to be used on graph buffer data captured with a previous 'lf search'
Since the decode is done in variable bit range I've had to modify proxguiqt.cpp to take into account. Not sure
if this was the best way to deal with this problem.
There is a know bug when zooming and scrolling, the displayed demodulation bits are shifted and do not follow the signal.