### PR TITLE
Fix MF-DESFIRE decoding when not using wrapped cmds

### DIFF
--- a/client/src/cmdhflist.c
+++ b/client/src/cmdhflist.c
@@ -899,13 +899,31 @@ void annotateMfDesfire(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize) {
                         snprintf(exp, size, "DELETE FILE");
                         break;
                     case MFDES_AUTHENTICATE:
-                        snprintf(exp, size, "AUTH NATIVE (keyNo %d)", cmd[pos + 4]);
+                        if (cmdsize > 6) {
+                            //Assume wrapped
+                            snprintf(exp, size, "AUTH NATIVE (keyNo %d)", cmd[pos + 4]);
+                        } else {
+                            //Assume unwrapped
+                            snprintf(exp, size, "AUTH NATIVE (keyNo %d)", cmd[pos + 1]);
+                        }
                         break;  // AUTHENTICATE_NATIVE
                     case MFDES_AUTHENTICATE_ISO:
-                        snprintf(exp, size, "AUTH ISO (keyNo %d)", cmd[pos + 4]);
+                        if (cmdsize > 6) {
+                            //Assume wrapped
+                            snprintf(exp, size, "AUTH ISO (keyNo %d)", cmd[pos + 4]);
+                        } else {
+                            //Assume unwrapped
+                            snprintf(exp, size, "AUTH ISO (keyNo %d)", cmd[pos + 1]);
+                        }
                         break;  // AUTHENTICATE_STANDARD
                     case MFDES_AUTHENTICATE_AES:
-                        snprintf(exp, size, "AUTH AES (keyNo %d)", cmd[pos + 4]);
+                        if (cmdsize > 6) {
+                            //Assume wrapped
+                            snprintf(exp, size, "AUTH AES (keyNo %d)", cmd[pos + 4]);
+                        } else {
+                            //Assume unwrapped
+                            snprintf(exp, size, "AUTH AES (keyNo %d)", cmd[pos + 1]);
+                        }
                         break;
                     case MFDES_AUTHENTICATE_EV2F:
                         snprintf(exp, size, "AUTH EV2 First");


### PR DESCRIPTION
Sniffing a device talking to a DESFire EV2, it appears to not use the wrapping that is assumed there for the decoding. Doing a `hf 14a sniff` then a `hf mfdes list` gives me:

```
   36721196 |   36728204 | Rdr |0b  00  aa  02  88  e7                                                   |  ok | AUTH AES (keyNo 108)
```

The `keyNo` should actually be 2 here. The code as-is doesn't check the returned size so reads some random memory right now. With the above patch this decodes correct as:

```
   15027472 |   15034480 | Rdr |0b  00  aa  02  88  e7                                                   |  ok | AUTH AES (keyNo 2)
```

Using the built-in auth commands (which do use wrapping) shows existing commands still decode OK as well, so it seems I didn't break anything but let me know if I did or need style changed. For example here was me trying to read using keyNo 2, with above patch applied showing using the original code path/offset:

```
     924928 |     936608 | Rdr |03  90  aa  00  00  01  02  00  9e  2c                                   |  ok | AUTH AES (keyNo 2)
```