### PR TITLE
hw tune

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -163,7 +163,9 @@ static void MeasureAntennaTuning(void) {
         uint8_t results[256];
     } PACKED payload;
 
-    memset(payload.results, 0, sizeof(payload.results));
+    // Need to clear all values to ensure non-random responses.
+    memset(&payload, 0, sizeof(payload));
+    // memset(payload.results, 0, sizeof(payload.results));
 
     sample_config *sc = getSamplingConfig();
     payload.divisor = sc->divisor;


### PR DESCRIPTION
Patch to correct invalid hw tune voltage values when no antenna is connected.
