### PR TITLE
Adding iCS tags default key from ICopy-X

### DIFF
--- a/client/dictionaries/iclass_default_keys.dic
+++ b/client/dictionaries/iclass_default_keys.dic
@@ -12,4 +12,5 @@ F0E1D2C3B4A59687 # Kd from PicoPass 2k documentation
 31ad7ebd2f282168 # From HID multiclassSE reader
 6EFD46EFCBB3C875 # From pastebin: https://pastebin.com/uHqpjiuU
 E033CA419AEE43F9 # From pastebin: https://pastebin.com/uHqpjiuU
-2020666666668888 # iCopy-X
+2020666666668888 # iCopy-X iCL tags
+6666202066668888 # iCopy-X iCS tags reversed from the SOs


### PR DESCRIPTION
Adding ICS tag initial key extracted from "hficlass.so" library.

Result:

```
[usb] pm3 --> hf iclass rdbl -b 3 -k 6666202066668888

[+]  block   3/0x03 : FF FF FF FF FF FF FF FF 
```