### PR TITLE
Fix typo in CUID soft-bricked recovery command

### DIFF
--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -345,8 +345,8 @@ e.g. for 4b UID:
 
 ```
 hf 14a config --atqa force --bcc ignore --cl2 skip --rats skip
-hf mf wrbl --blk 0 -k FFFFFFFFFFFF -k 11223344440804006263646566676869 # for 1k
-hf mf wrbl --blk 0 -k FFFFFFFFFFFF -k 11223344441802006263646566676869 # for 4k
+hf mf wrbl --blk 0 -k FFFFFFFFFFFF -d 11223344440804006263646566676869 # for 1k
+hf mf wrbl --blk 0 -k FFFFFFFFFFFF -d 11223344441802006263646566676869 # for 4k
 hf 14a config --std
 hf 14a reader
 ```
@@ -355,8 +355,8 @@ e.g. for 7b UID:
 
 ```
 hf 14a config --atqa force --bcc ignore --cl2 force --cl3 skip --rats skip
-hf mf wrbl --blk 0 -k FFFFFFFFFFFF -k 04112233445566084400626364656667 # for 1k
-hf mf wrbl --blk 0 -k FFFFFFFFFFFF -k 04112233445566184200626364656667 # for 4k
+hf mf wrbl --blk 0 -k FFFFFFFFFFFF -d 04112233445566084400626364656667 # for 1k
+hf mf wrbl --blk 0 -k FFFFFFFFFFFF -d 04112233445566184200626364656667 # for 4k
 hf 14a config --std
 hf 14a reader
 ```


### PR DESCRIPTION
for command `wrbl`, data should be provided by -d instead of -k