### PR TITLE
Fixed ledcontrol in SimulateTagLowFrequencyEx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Fixed `hf mfdes` - fix buffer overflow (@AxisRay)
  - Changed `hf mfdes` - detect LRP mode and info updates (@merlokk)
  - Fixed `hf mfdes` - increase response buffer length (@merlokk)
+ - Fixed `SimulateTagLowFrequencyEx` ignoring the `ledcontrol` argument (@zabszk)
 
 ## [crimson.4.14434][2021-09-18]
  - Fixed `hf mf staticnested` - flashmem / non loop now works (@horrordash)

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -901,7 +901,7 @@ void SimulateTagLowFrequencyEx(int period, int gap, bool ledcontrol, int numcycl
 OUT:
     StopTicks();
     FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
-    LED_D_OFF();
+    if (ledcontrol) LED_D_OFF();
 }
 
 void SimulateTagLowFrequency(int period, int gap, bool ledcontrol) {


### PR DESCRIPTION
Fixed the issue where SimulateTagLowFrequencyEx in some cases was controlling the LEDs even if ledcontrol argument was set to false.