### PR TITLE
fix hf_craftbyte.c emulation card types

### DIFF
--- a/armsrc/Standalone/hf_craftbyte.c
+++ b/armsrc/Standalone/hf_craftbyte.c
@@ -86,7 +86,22 @@ void RunMod(void) {
                 }
 
                 Dbprintf("Starting simulation, press pm3-button to stop and go back to search state.");
-                SimulateIso14443aTag(3, flags, card.uid, 0);
+                   if (card.sak == 0x08 && card.atqa[0] == 0x04 && card.atqa[1] == 0) {
+					    DbpString("Mifare Classic 1k");
+						SimulateIso14443aTag(1, flags, card.uid, 0); 
+                    } else if (card.sak == 0x08 && card.atqa[0] == 0x44 && card.atqa[1] == 0) {
+                        DbpString("Mifare Classic 4k ");
+                        SimulateIso14443aTag(8, flags, card.uid, 0);
+                    } else if (card.sak == 0x00 && card.atqa[0] == 0x44 && card.atqa[1] == 0) {
+                        DbpString("Mifare Ultralight");
+                        SimulateIso14443aTag(2, flags, card.uid, 0);
+                    } else if (card.sak == 0x20 && card.atqa[0] == 0x04 && card.atqa[1] == 0x03) {
+                        DbpString("Mifare DESFire");
+                        SimulateIso14443aTag(3, flags, card.uid, 0);
+                    } else {
+                        Dbprintf("Unrecognized tag type -- defaulting to Mifare Classic emulation");
+                        SimulateIso14443aTag(1, flags, card.uid, 0);
+                    }    
 
                 // Go back to search state if user presses pm3-button
                 state = STATE_READ;


### PR DESCRIPTION
Hello,

As commented:
https://github.com/RfidResearchGroup/proxmark3/issues/1543
I fixed emulation card type in hf_craftbyte.c . The original code  isn't checking the tag type when the UID is emulated.

Regards.
