### PR TITLE
Be more CONSTant with the parameters we will not modify

### DIFF
--- a/client/include/pm3.h
+++ b/client/include/pm3.h
@@ -18,8 +18,8 @@
 
 typedef struct pm3_device pm3;
 
-pm3 *pm3_open(char *port);
-int pm3_console(pm3 *dev, char *cmd);
+pm3 *pm3_open(const char *port);
+int pm3_console(pm3 *dev, const char *cmd);
 const char *pm3_name_get(pm3 *dev);
 void pm3_close(pm3 *dev);
 pm3 *pm3_get_current_dev(void);

--- a/client/src/cmdmain.c
+++ b/client/src/cmdmain.c
@@ -351,7 +351,7 @@ static int CmdHelp(const char *Cmd) {
 // Entry point into our code: called whenever the user types a command and
 // then presses Enter, which the full command line that they typed.
 //-----------------------------------------------------------------------------
-int CommandReceived(char *Cmd) {
+int CommandReceived(const char *Cmd) {
     return CmdsParse(CommandTable, Cmd);
 }
 

--- a/client/src/cmdmain.h
+++ b/client/src/cmdmain.h
@@ -22,7 +22,7 @@
 #include "common.h"
 #include "cmdparser.h"    // command_t
 
-int CommandReceived(char *Cmd);
+int CommandReceived(const char *Cmd);
 int CmdRem(const char *Cmd);
 command_t *getTopLevelCommandTable(void);
 

--- a/client/src/comms.c
+++ b/client/src/comms.c
@@ -549,7 +549,7 @@ bool IsCommunicationThreadDead(void) {
     return ret;
 }
 
-bool OpenProxmark(pm3_device_t **dev, char *port, bool wait_for_port, int timeout, bool flash_mode, uint32_t speed) {
+bool OpenProxmark(pm3_device_t **dev, const char *port, bool wait_for_port, int timeout, bool flash_mode, uint32_t speed) {
 
     if (!wait_for_port) {
         PrintAndLogEx(INFO, "Using UART port " _YELLOW_("%s"), port);

--- a/client/src/comms.h
+++ b/client/src/comms.h
@@ -84,7 +84,7 @@ void clearCommandBuffer(void);
 
 #define FLASHMODE_SPEED 460800
 bool IsCommunicationThreadDead(void);
-bool OpenProxmark(pm3_device_t **dev, char *port, bool wait_for_port, int timeout, bool flash_mode, uint32_t speed);
+bool OpenProxmark(pm3_device_t **dev, const char *port, bool wait_for_port, int timeout, bool flash_mode, uint32_t speed);
 int TestProxmark(pm3_device_t *dev);
 void CloseProxmark(pm3_device_t *dev);
 

--- a/client/src/pm3.c
+++ b/client/src/pm3.c
@@ -27,7 +27,7 @@
 #include "util_posix.h"
 #include "comms.h"
 
-pm3_device_t *pm3_open(char *port) {
+pm3_device_t *pm3_open(const char *port) {
     pm3_init();
     OpenProxmark(&g_session.current_device, port, false, 20, false, USART_BAUD_RATE);
     if (g_session.pm3_present && (TestProxmark(g_session.current_device) != PM3_SUCCESS)) {
@@ -54,7 +54,7 @@ void pm3_close(pm3_device_t *dev) {
     }
 }
 
-int pm3_console(pm3_device_t *dev, char *cmd) {
+int pm3_console(pm3_device_t *dev, const char *cmd) {
     // For now, there is no real device context:
     (void) dev;
     return CommandReceived(cmd);


### PR DESCRIPTION
If these are `const char` it makes it every so slightly easier when playing around with Swift integration.  I'm sure Swift integration shouldn't be one the strong motivations in the project, but if it doesn't hurt anything, I figure why not?