### PR TITLE
remove redundant include

### DIFF
--- a/client/src/util.c
+++ b/client/src/util.c
@@ -978,7 +978,6 @@ int num_CPUs(void) {
     GetSystemInfo(&sysinfo);
     return sysinfo.dwNumberOfProcessors;
 #else
-#include <unistd.h>
     int count = sysconf(_SC_NPROCESSORS_ONLN);
     if (count <= 0)
         count = 1;


### PR DESCRIPTION
Already included in a `#ifndef _WIN32` on L51