### PR TITLE
Fix typo

### DIFF
--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -3985,7 +3985,7 @@ static command_t CommandTable[] = {
     {"info",        CmdHFiClassInfo,            AlwaysAvailable, "Tag information"},
     {"list",        CmdHFiClassList,            AlwaysAvailable, "List iclass history"},
     {"rdbl",        CmdHFiClass_ReadBlock,      IfPm3Iclass,     "Read Picopass / iCLASS block"},
-    {"reader",      CmdHFiClassReader,          IfPm3Iclass,     "Act like an Picopass / iCLASS reader"},
+    {"reader",      CmdHFiClassReader,          IfPm3Iclass,     "Act like a Picopass / iCLASS reader"},
     {"restore",     CmdHFiClassRestore,        IfPm3Iclass,      "Restore a dump file onto a Picopass / iCLASS tag"},
     {"sniff",       CmdHFiClassSniff,           IfPm3Iclass,     "Eavesdrop Picopass / iCLASS communication"},
     {"wrbl",        CmdHFiClass_WriteBlock,     IfPm3Iclass,     "Write Picopass / iCLASS block"},

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -367,7 +367,7 @@ Check column "offline" for their availability.
 |`hf iclass info         `|Y       |`Tag information`
 |`hf iclass list         `|Y       |`List iclass history`
 |`hf iclass rdbl         `|N       |`Read Picopass / iCLASS block`
-|`hf iclass reader       `|N       |`Act like an Picopass / iCLASS reader`
+|`hf iclass reader       `|N       |`Act like a Picopass / iCLASS reader`
 |`hf iclass restore      `|N       |`Restore a dump file onto a Picopass / iCLASS tag`
 |`hf iclass sniff        `|N       |`Eavesdrop Picopass / iCLASS communication`
 |`hf iclass wrbl         `|N       |`Write Picopass / iCLASS block`


### PR DESCRIPTION
Changing "an Picopass" to "a Picopass"