### PR TITLE
fix macos builds by not defining _POSIX_C_SOURCE in mfd_aes_brute.c if macos

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Install dependencies
         run: brew install readline qt5 RfidResearchGroup/proxmark3/arm-none-eabi-gcc openssl
 
+      - name: Fix linkings for qt5 and openssl
+        working-directory: /usr/local/include
+        continue-on-error: true
+        run: |
+          ln -svf ../opt/openssl@3/include/openssl .
+          ln -svf ../opt/qt@5/include/qt .
+
       - name: Install Python dependencies
         run: |
           python3 -m pip install --upgrade pip
@@ -77,6 +84,13 @@ jobs:
 
       - name: Install dependencies
         run: brew install readline qt5 RfidResearchGroup/proxmark3/arm-none-eabi-gcc openssl
+
+      - name: Fix linkings for qt5 and openssl
+        working-directory: /usr/local/include
+        continue-on-error: true
+        run: |
+          ln -svf ../opt/openssl@3/include/openssl .
+          ln -svf ../opt/qt@5/include/qt .
 
       - name: Install Python dependencies
         run: |
@@ -119,6 +133,13 @@ jobs:
 
       - name: Install dependencies
         run: brew install readline qt5 RfidResearchGroup/proxmark3/arm-none-eabi-gcc openssl
+
+      - name: Fix linkings for qt5 and openssl
+        working-directory: /usr/local/include
+        continue-on-error: true
+        run: |
+          ln -svf ../opt/openssl@3/include/openssl .
+          ln -svf ../opt/qt@5/include/qt .
 
       - name: Install Python dependencies
         run: |

--- a/tools/mfd_aes_brute/Makefile
+++ b/tools/mfd_aes_brute/Makefile
@@ -22,8 +22,12 @@ ifneq (,$(findstring MINGW,$(platform)))
 endif
 
 # OS X needs linking to openssl
-ifeq ($(platform),Darwin)
-    MYLDFLAGS += -L/usr/local/opt/openssl@3/lib
+ifeq ($(USE_BREW),1)
+    MYLDFLAGS += -L$(BREW_PREFIX)/opt/openssl@3/lib -L$(BREW_PREFIX)/opt/openssl@1.1/lib
+endif
+
+ifeq ($(USE_MACPORTS),1)
+    MYLDFLAGS += -L$(MACPORTS_PREFIX)/lib/openssl-3 -L$(MACPORTS_PREFIX)/lib/openssl-1.1
 endif
 
 brute_key : $(OBJDIR)/brute_key.o $(MYOBJS)

--- a/tools/mfd_aes_brute/mfd_aes_brute.c
+++ b/tools/mfd_aes_brute/mfd_aes_brute.c
@@ -18,7 +18,7 @@
 
 #define __STDC_FORMAT_MACROS
 
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__APPLE__)
     #define _POSIX_C_SOURCE 200112L  // need localtime_r()
 #endif
 


### PR DESCRIPTION
unistd.h in macos has this snippet:

```c
#if __DARWIN_C_LEVEL >= __DARWIN_C_FULL
#define _SC_NPROCESSORS_CONF            57
#define _SC_NPROCESSORS_ONLN            58
#endif /* __DARWIN_C_LEVEL >= __DARWIN_C_FULL */
```

`__DARWIN_C_FULL` is `900000L`.

If `__POSIX_C_SOURCE` gets defined without `__DARWIN_C_SOURCE` being defined, `__DARWIN_C_LEVEL` will be assigned to `__DARWIN_C_ANSI`, which is `010000L`.

Thus this definition will remove `_SC_NPROCESSORS_CONF`.

If we don't define `__POSIX_C_SOURCE`, `__DARWIN_C_LEVEL` will be equal to `__DARWIN_C_FULL`, and `_SC_NPROCESSORS_CONF` will be available.

This commit also includes homebrew and macports prefix definitions for mfd_aes_brute.

Signed-off-by: İlteriş Yağıztegin Eroğlu <ilteris@asenkron.com.tr>