### PR TITLE
Enhance hf mf uidbruteforces (UID length, HF MF 4K, help)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Changed - AID limitations when using Gallagher key diversification (@DarkMatterMatt)
  - Fixed build issues that may happen from building `mfd_aes_brute` (@linuxgemini)
  - Added silicon data parsing logic for NXP chips in `hf mfu info` (@linuxgemini)
+ - Added Mifare Classic 4K, enhance UID length management and fix help in `hf_mf_uidbruteforce` (@cactuschibre)
 
 ## [Frostbit.4.14831] [2022-01-11]
  - Changed Wiegand format lookup - now case-insensitive (@iceman1001)

--- a/client/luascripts/hf_mf_uidbruteforce.lua
+++ b/client/luascripts/hf_mf_uidbruteforce.lua
@@ -92,7 +92,7 @@ local function main(args)
         if o == 'e' then end_id = a end
         if o == 't' then timeout = a end
         if o == 'x' then mftype = a end
-        if o == 'h' then return print(usage) end
+        if o == 'h' then return help() end
     end
 
     -- template

--- a/client/luascripts/hf_mf_uidbruteforce.lua
+++ b/client/luascripts/hf_mf_uidbruteforce.lua
@@ -28,8 +28,9 @@ arguments = [[
     -e       0-0xFFFFFFFF         end id
     -t       0-99999, pause       timeout (ms) between cards
                                   (use the word 'pause' to wait for user input)
-    -x       mfc, mfu             mifare type:
+    -x       mfc, mfc4, mfu       mifare type:
                                     mfc for Mifare Classic (default)
+                                    mfc4 for Mifare Classic 4K
                                     mfu for Mifare Ultralight EV1
 ]]
 
@@ -107,6 +108,9 @@ local function main(args)
     if mftype == 'mfc' then
         command = 'hf 14a sim -t 1 -u ' .. uid_format
         msg('Bruteforcing Mifare Classic card numbers')
+    elseif mftype == 'mfc4' then
+	    command = 'hf 14a sim -t 8 -u ' .. uid_format
+	    msg('Bruteforcing Mifare Classic 4K card numbers')
     elseif mftype == 'mfu' then
         command = 'hf 14a sim -t 2 -u ' .. uid_format
         msg('Bruteforcing Mifare Ultralight card numbers')

--- a/client/luascripts/hf_mf_uidbruteforce.lua
+++ b/client/luascripts/hf_mf_uidbruteforce.lua
@@ -11,11 +11,11 @@ desc =[[
 This script bruteforces 4 or 7 byte UID Mifare classic card numbers.
 ]]
 example =[[
-Bruteforce a 4 byte UID Mifare classic card number, starting at 11223344, ending at 11223346.
+Bruteforce a 4 bytes UID Mifare classic card number, starting at 11223344, ending at 11223346.
 
     script run hf_mf_uidbruteforce -s 0x11223344 -e 0x11223346 -t 1000 -x mfc
 
-Bruteforce a 7 byte UID Mifare Ultralight card number, starting at 11223344556677, ending at 11223344556679.
+Bruteforce a 7 bytes UID Mifare Ultralight card number, starting at 11223344556677, ending at 11223344556679.
 
     script run hf_mf_uidbruteforce -s 0x11223344556677 -e 0x11223344556679 -t 1000 -x mfu
 ]]

--- a/client/luascripts/hf_mf_uidbruteforce.lua
+++ b/client/luascripts/hf_mf_uidbruteforce.lua
@@ -86,6 +86,7 @@ local function main(args)
     local start_id = 0
     local end_id = 0xFFFFFFFFFFFFFF
     local mftype = 'mfc'
+    local uid_format = '%14x'
 
     for o, a in getopt.getopt(args, 'e:s:t:x:h') do
         if o == 's' then start_id = a end
@@ -98,11 +99,16 @@ local function main(args)
     -- template
     local command = ''
 
+    -- if the end_id is equals or inferior to 0xFFFFFFFF then use the 4 bytes UID format by default
+    if string.len(end_id) <= 10 then
+        uid_format = '%08x'
+    end
+
     if mftype == 'mfc' then
-        command = 'hf 14a sim -t 1 -u %014x'
+        command = 'hf 14a sim -t 1 -u ' .. uid_format
         msg('Bruteforcing Mifare Classic card numbers')
     elseif mftype == 'mfu' then
-        command = 'hf 14a sim -t 2 -u %014x'
+        command = 'hf 14a sim -t 2 -u ' .. uid_format
         msg('Bruteforcing Mifare Ultralight card numbers')
     else
         return print(usage)


### PR DESCRIPTION
- Better interpretation of 4 or 7 bytes UID in UID bruteforcer
- Add Mifare Classic 4K in UID bruteforcer
- Fix help menu in UID bruteforcer