### PR TITLE
Re-enabled the -k option in hf 15 raw (to keep the field on after sen…

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1236,7 +1236,11 @@ static void PacketReceived(PacketCommandNG *packet) {
             break;
         }
         case CMD_HF_ISO15693_COMMAND: {
-            DirectTag15693Command(packet->oldarg[0], packet->oldarg[1], packet->oldarg[2], packet->data.asBytes);
+            DirectTag15693Command(true, packet->oldarg[0], packet->oldarg[1], packet->oldarg[2], packet->data.asBytes);
+            break;
+        }
+        case CMD_HF_ISO15693_COMMAND_NEXT: {
+            DirectTag15693Command(false, packet->oldarg[0], packet->oldarg[1], packet->oldarg[2], packet->data.asBytes);
             break;
         }
         case CMD_HF_ISO15693_FINDAFI: {

--- a/armsrc/iso15693.c
+++ b/armsrc/iso15693.c
@@ -1928,7 +1928,7 @@ void BruteforceIso15693Afi(uint32_t speed) {
 
 // Allows to directly send commands to the tag via the client
 // OBS:  doesn't turn off rf field afterwards.
-void DirectTag15693Command(uint32_t datalen, uint32_t speed, uint32_t recv, uint8_t *data) {
+void DirectTag15693Command(bool reset_tag, uint32_t datalen, uint32_t speed, uint32_t recv, uint8_t *data) {
 
     LED_A_ON();
 
@@ -1953,7 +1953,7 @@ void DirectTag15693Command(uint32_t datalen, uint32_t speed, uint32_t recv, uint
     }
 
     uint32_t start_time = 0;
-    int recvlen = SendDataTag(data, datalen, true, speed, (recv ? recvbuf : NULL), sizeof(recvbuf), start_time, timeout, &eof_time);
+    int recvlen = SendDataTag(data, datalen, reset_tag, speed, (recv ? recvbuf : NULL), sizeof(recvbuf), start_time, timeout, &eof_time);
 
     if (recvlen == PM3_ETEAROFF) { // tearoff occurred
         reply_mix(CMD_ACK, recvlen, 0, 0, NULL, 0);
@@ -1972,10 +1972,6 @@ void DirectTag15693Command(uint32_t datalen, uint32_t speed, uint32_t recv, uint
             reply_mix(CMD_ACK, 1, 0, 0, NULL, 0);
         }
     }
-    // note: this prevents using hf 15 cmd with s option - which isn't implemented yet anyway
-    // also prevents hf 15 raw -k  keep_field on ...
-    FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
-    LED_D_OFF();
 }
 
 /*

--- a/armsrc/iso15693.h
+++ b/armsrc/iso15693.h
@@ -48,7 +48,7 @@ void AcquireRawAdcSamplesIso15693(void);
 void ReaderIso15693(uint32_t parameter, iso15_card_select_t *p_card); // Simulate an ISO15693 reader - greg
 void SimTagIso15693(uint8_t *uid); // simulate an ISO15693 tag - greg
 void BruteforceIso15693Afi(uint32_t speed); // find an AFI of a tag - atrox
-void DirectTag15693Command(uint32_t datalen, uint32_t speed, uint32_t recv, uint8_t *data); // send arbitrary commands from CLI - atrox
+void DirectTag15693Command(bool reset_tag, uint32_t datalen, uint32_t speed, uint32_t recv, uint8_t *data); // send arbitrary commands from CLI - atrox
 
 void SniffIso15693(uint8_t jam_search_len, uint8_t *jam_search_string);
 

--- a/client/src/cmdhf15.c
+++ b/client/src/cmdhf15.c
@@ -1454,6 +1454,7 @@ static int CmdHF15Raw(const char *Cmd) {
         arg_lit0("2", NULL, "use slower '1 out of 256' mode"),
         arg_lit0("c",  "crc", "calculate and append CRC"),
         arg_lit0("k",  NULL, "keep signal field ON after receive"),
+        arg_lit0("n",  NULL, "next command - assume field ON before sending"),
         arg_lit0("r",  NULL, "do not read response"),
         arg_str1("d", "data", "<hex>", "raw bytes to send"),
         arg_param_end
@@ -1462,10 +1463,11 @@ static int CmdHF15Raw(const char *Cmd) {
     int fast = (arg_get_lit(ctx, 1) == false);
     bool crc = arg_get_lit(ctx, 2);
     bool keep_field_on = arg_get_lit(ctx, 3);
-    bool read_respone = (arg_get_lit(ctx, 4) == false);
+    bool next_cmd = arg_get_lit(ctx, 4);
+    bool read_respone = (arg_get_lit(ctx, 5) == false);
     int datalen = 0;
     uint8_t data[300];
-    CLIGetHexWithReturn(ctx, 5, data, &datalen);
+    CLIGetHexWithReturn(ctx, 6, data, &datalen);
     CLIParserFree(ctx);
 
     if (crc) {
@@ -1479,7 +1481,7 @@ static int CmdHF15Raw(const char *Cmd) {
     // arg2 (recv == 1 == expect a response)
     PacketResponseNG resp;
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO15693_COMMAND, datalen, fast, read_respone, data, datalen);
+    SendCommandMIX(next_cmd?CMD_HF_ISO15693_COMMAND_NEXT:CMD_HF_ISO15693_COMMAND, datalen, fast, read_respone, data, datalen);
 
     if (read_respone) {
         if (WaitForResponseTimeout(CMD_ACK, &resp, 2000)) {

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -516,6 +516,7 @@ typedef struct {
 #define CMD_HF_ISO15693_SIMULATE                                          0x0311
 #define CMD_HF_ISO15693_SNIFF                                             0x0312
 #define CMD_HF_ISO15693_COMMAND                                           0x0313
+#define CMD_HF_ISO15693_COMMAND_NEXT                                      0x0314
 #define CMD_HF_ISO15693_FINDAFI                                           0x0315
 #define CMD_HF_ISO15693_CSETUID                                           0x0316
 #define CMD_HF_ISO15693_SLIX_L_DISABLE_PRIVACY                            0x0317


### PR DESCRIPTION
…ding an ISO15693 command) and added a -n option to send the next command without resetting the field first.

So for example, to select a chip with UID 0E0401235708FE78, then read address 00h, then read address 01h in 3 commands, dropping the field at the 3rd command:

[usb] pm3 --> hf 15 raw -k -c -d 222578fe08572301040e
[+] received 3 octets
[+] 00 78 F0

[usb] pm3 --> hf 15 raw -k -n -c -d 122000
[+] received 7 octets
[+] 00 E1 40 80 09 3D 70

[usb] pm3 --> hf 15 raw -n -c -d 122001
[+] received 7 octets
[+] 00 03 10 D1 01 45 38