### PR TITLE
Make HF_15SNIFF standalone mode compatible with old PM3 (without flashmem)

### DIFF
--- a/armsrc/Standalone/Makefile.hal
+++ b/armsrc/Standalone/Makefile.hal
@@ -65,8 +65,8 @@ define KNOWN_STANDALONE_DEFINITIONS
 | HF_14ASNIFF     | 14a sniff to flashmem                  |
 | (RDV4 only)     |                                        |
 +----------------------------------------------------------+
-| HF_15SNIFF      | 15693 sniff to flashmem                |
-| (RDV4 only)     |                                        |
+| HF_15SNIFF      | 15693 sniff to flashmem (rdv4) or ram  |
+|                 |                                        |
 +----------------------------------------------------------+
 | HF_AVEFUL       | Mifare ultralight read/simulation      |
 |                 | - Ave Ozkal                            |
@@ -119,7 +119,7 @@ STANDALONE_MODES := LF_SKELETON LF_EM4100EMUL LF_EM4100RSWB LF_EM4100RSWW LF_EM4
 STANDALONE_MODES += HF_14ASNIFF HF_15SNIFF HF_AVEFUL HF_BOG HF_COLIN HF_CRAFTBYTE HF_ICECLASS HF_LEGIC HF_LEGICSIM HF_MATTYRUN HF_MFCSIM HF_MSDSAL HF_TCPRST HF_TMUDFORD HF_YOUNG HF_REBLAY DANKARMULTI
 STANDALONE_MODES_REQ_BT := HF_REBLAY
 STANDALONE_MODES_REQ_SMARTCARD :=
-STANDALONE_MODES_REQ_FLASH := LF_HIDFCBRUTE LF_ICEHID LF_NEXID LF_THAREXDE HF_14ASNIFF HF_15SNIFF HF_BOG HF_COLIN HF_ICECLASS HF_MFCSIM HF_LEGICSIM
+STANDALONE_MODES_REQ_FLASH := LF_HIDFCBRUTE LF_ICEHID LF_NEXID LF_THAREXDE HF_14ASNIFF HF_BOG HF_COLIN HF_ICECLASS HF_MFCSIM HF_LEGICSIM
 ifneq ($(filter $(STANDALONE),$(STANDALONE_MODES)),)
     STANDALONE_PLATFORM_DEFS += -DWITH_STANDALONE_$(STANDALONE)
     ifneq ($(filter $(STANDALONE),$(STANDALONE_MODES_REQ_SMARTCARD)),)

--- a/armsrc/Standalone/hf_15sniff.c
+++ b/armsrc/Standalone/hf_15sniff.c
@@ -98,15 +98,22 @@ void RunMod(void) {
     StandAloneMode();
 
     Dbprintf(_YELLOW_("HF 15693 SNIFF started"));
+#ifdef WITH_FLASH
     rdv40_spiffs_lazy_mount();
+#endif
 
     SniffIso15693(0, NULL);
 
     Dbprintf("Stopped sniffing");
     SpinDelay(200);
 
-    // Write stuff to spiffs logfile
     uint32_t trace_len = BigBuf_get_traceLen();
+#ifndef WITH_FLASH
+    // Keep stuff in BigBuf for USB/BT dumping
+    if (trace_len > 0)
+        Dbprintf("[!] Trace length (bytes) = %u", trace_len);
+#else
+    // Write stuff to spiffs logfile
     if (trace_len > 0) {
         Dbprintf("[!] Trace length (bytes) = %u", trace_len);
 
@@ -130,6 +137,7 @@ void RunMod(void) {
 
     SpinErr(LED_A, 200, 5);
     SpinDelay(100);
+#endif
 
     Dbprintf("-=[ exit ]=-");
     LEDsoff();


### PR DESCRIPTION
Make HF_15SNIFF standalone mode compatible with old PM3 (without flashmem)