### PR TITLE
Update changelog & rename hf_i2c_recovery.lua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Added `hf_14a_i2crevive` Script, revives soft bricked i2c (@equipter)
  - Changed `hf mf view` - now prints all keys and all value blocks under the ´verbose´ param (@iceman1001)
  - Added a new OSX install guide (@maxieds)
  - Added new public key (@anon)

--- a/client/luascripts/hf_14a_i2crevive.lua
+++ b/client/luascripts/hf_14a_i2crevive.lua
@@ -8,10 +8,10 @@ desc = [[
 This script tries to recover soft bricked ntag i2c tags through the use of raw commands
 ]]
 example = [[
-    1. script run hf_i2c_recovery
+    1. script run hf_14a_i2crevive
 ]]
 usage = [[
-script run hf_i2c_recovery
+script run hf_14a_i2crevive
 ]]
 arguments = [[
     -h      this help


### PR DESCRIPTION
added to changelog and changed the name of hf_i2c_recovery to hf_14a_i2crevive to denote its a 14a script :)