### PR TITLE
Encode ISO15693 response as tag byte by byte, instead of 2 bytes by 2…

### DIFF
--- a/armsrc/iso15693.c
+++ b/armsrc/iso15693.c
@@ -252,11 +252,9 @@ void CodeIso15693AsTag(const uint8_t *cmd, size_t len) {
     ts->buf[++ts->max] = 0x1D;  // 00011101
 
     // data
-    for (size_t i = 0; i < len; i += 2) {
+    for (size_t i = 0; i < len; i ++) {
         ts->buf[++ts->max] = encode_4bits[cmd[i] & 0xF];
         ts->buf[++ts->max] = encode_4bits[cmd[i] >> 4];
-        ts->buf[++ts->max] = encode_4bits[cmd[i + 1] & 0xF];
-        ts->buf[++ts->max] = encode_4bits[cmd[i + 1] >> 4];
     }
 
     // EOF


### PR DESCRIPTION
… bytes, so that responses with an odd number of bytes don't end up encoded and transmitted with an extraneous uninitialized byte after the CRC.

For an example of the symptom without this patch, have one PM3 running "hf 15 sim -u xxxxxxxxxxxxxxxx", and run "hf 15 info" on a second PM3 sitting on top of the first one: after the command returns, you'll find an extra byte after the 2 CRC bytes in the tag's response in the trace ("trace list") on the second PM3. The extraneous byte can be anything, as it's read beyond the command response buffer. The reason for this is that the response to the System Information command is 17 bytes long (odd number of bytes) but 18 bytes get encoded.

The PM3 tolerates the extraneous byte in the simulated tag's response, but most "real" ISO15693 readers and cellphones dismiss the response as malformed.