### PR TITLE
Re-enabled the -k option in hf 15 raw

### DIFF
--- a/armsrc/iso15693.c
+++ b/armsrc/iso15693.c
@@ -2357,9 +2357,12 @@ void BruteforceIso15693Afi(uint32_t speed) {
 
 // Allows to directly send commands to the tag via the client
 // OBS:  doesn't turn off rf field afterwards.
-void DirectTag15693Command(uint32_t datalen, uint32_t speed, uint32_t recv, uint8_t *data) {
+void DirectTag15693Command(uint32_t datalen, uint32_t speed, uint32_t flags, uint8_t *data) {
 
     LED_A_ON();
+
+    bool recv = flags & 1 ? true : false;
+    bool field_already_on = flags & 2 ? true : false;
 
     uint8_t recvbuf[ISO15693_MAX_RESPONSE_LENGTH];
     uint16_t timeout;
@@ -2382,7 +2385,8 @@ void DirectTag15693Command(uint32_t datalen, uint32_t speed, uint32_t recv, uint
     }
 
     uint32_t start_time = 0;
-    int recvlen = SendDataTag(data, datalen, true, speed, (recv ? recvbuf : NULL), sizeof(recvbuf), start_time, timeout, &eof_time);
+    int recvlen = SendDataTag(data, datalen, !field_already_on, speed, (recv ? recvbuf : NULL), sizeof(recvbuf), start_time, timeout, &eof_time);
+
 
     if (recvlen == PM3_ETEAROFF) { // tearoff occurred
         reply_mix(CMD_ACK, recvlen, 0, 0, NULL, 0);
@@ -2406,8 +2410,8 @@ void DirectTag15693Command(uint32_t datalen, uint32_t speed, uint32_t recv, uint
     }
     // note: this prevents using hf 15 cmd with s option - which isn't implemented yet anyway
     // also prevents hf 15 raw -k  keep_field on ...
-    FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
-    LED_D_OFF();
+    //FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
+    //LED_D_OFF();
 }
 
 /*

--- a/client/src/cmdhf15.c
+++ b/client/src/cmdhf15.c
@@ -1480,10 +1480,12 @@ static int CmdHF15Raw(const char *Cmd) {
     // arg: len, speed, recv?
     // arg0 (datalen,  cmd len?  .arg0 == crc?)
     // arg1 (speed == 0 == 1 of 256,  == 1 == 1 of 4 )
-    // arg2 (recv == 1 == expect a response)
+    // arg2 (recv == 1 == expect a response) |
+    //      (2 == field is already on, 0 == field is off)
     PacketResponseNG resp;
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO15693_COMMAND, datalen, fast, read_respone, data, datalen);
+    SendCommandMIX(CMD_HF_ISO15693_COMMAND, datalen, fast, (read_respone? 1 : 0) | (g_field_on ? 2 : 0), data, datalen);
+    g_field_on = true;
 
     if (read_respone) {
         if (WaitForResponseTimeout(CMD_ACK, &resp, 2000)) {

--- a/client/src/comms.h
+++ b/client/src/comms.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 #ifndef DropField
-#define DropField() { clearCommandBuffer(); SetISODEPState(ISODEP_INACTIVE); SendCommandNG(CMD_HF_DROPFIELD, NULL, 0); }
+#define DropField() { clearCommandBuffer(); SetISODEPState(ISODEP_INACTIVE); SendCommandNG(CMD_HF_DROPFIELD, NULL, 0); g_field_on = false; }
 #endif
 
 #ifndef DropFieldEx

--- a/client/src/util.c
+++ b/client/src/util.c
@@ -40,6 +40,8 @@ uint8_t g_debugMode = 0;
 uint8_t g_printAndLog = PRINTANDLOG_PRINT | PRINTANDLOG_LOG;
 // global client tell if a pending prompt is present
 bool g_pendingPrompt = false;
+// global client: set to false by DropField()
+bool g_field_on = false;
 
 #ifdef _WIN32
 #include <windows.h>

--- a/client/src/util.h
+++ b/client/src/util.h
@@ -32,6 +32,7 @@
 extern uint8_t g_debugMode;
 extern uint8_t g_printAndLog;
 extern bool g_pendingPrompt;
+extern bool g_field_on;
 
 #define PRINTANDLOG_PRINT 1
 #define PRINTANDLOG_LOG   2


### PR DESCRIPTION
(to keep the field on after sending an ISO15693 command), and made DirectTag15693Command not start by resetting the field if the previous commmand left the field on (i.e. only hf 15 raw -k).

This is the same idea as PR #1596 (https://github.com/RfidResearchGroup/proxmark3/pull/1596) but without adding the -n flag and extra command, which admittedly was a nasty solution.

As an added bonus, this implementation doesn't break backward compatibility - i.e. it will work exactly as before with an older client that can't pass the extra "field already on" flag to DirectTag15693Command()