### PR TITLE
Sort filenames before hashing and force hashing in text mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Changed calculation of companion ARM firmware hash to be uniform accross platforms (@Doridian)
  - Changed `hf mf *` - verbose flag now also decode and prints found value blocks (@iceman1001)
  - Changed `hf mf wrbl` - added more helptext and new param --force to point out block0 writes (@iceman1001)
  - Changed `hf 15 raw` - it now uses NG frame for response (@iceman1001)

--- a/tools/mkversion.sh
+++ b/tools/mkversion.sh
@@ -63,7 +63,7 @@ sha=$(
     cd "$pm3path" || return
     # did we find the src?
     [ -f armsrc/appmain.c ] || return
-    ls armsrc/*.[ch] common_arm/*.[ch]|grep -E -v "(disabled|version_pm3|fpga_version_info)"|xargs sha256sum|sha256sum|cut -c -9
+    ls armsrc/*.[ch] common_arm/*.[ch]|grep -E -v "(disabled|version_pm3|fpga_version_info)"|sort|xargs sha256sum -t|sha256sum|cut -c -9
 )
 if [ "$sha" = "" ]; then
   sha="no sha256"


### PR DESCRIPTION
This avoids inconsistencies as can be seen between macOS and Windows platforms in how they hash the sources for the firmware mismatch checks.

Fixes done here:
- Use `sort` command to ensure filenames are sorted (not every OS sorts the files the same)
- Use `-t` argument to `sha256sum` to force hashing files in text mode, some OS (Windows) hash the .c and .h as by mistake by default

FWIW, this new hashing seems to produce the same hashes on macOS (and likely Linux), therefor I assume Windows is the odd one out here