### PR TITLE
Fix compilation on M1 Macs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed compilation of mfd_aes_brute on Apple M1 based Macs (@Doridian)
  - Changed calculation of companion ARM firmware hash to be uniform accross platforms (@Doridian)
  - Changed `hf mf *` - verbose flag now also decode and prints found value blocks (@iceman1001)
  - Changed `hf mf wrbl` - added more helptext and new param --force to point out block0 writes (@iceman1001)

--- a/tools/mfd_aes_brute/Makefile
+++ b/tools/mfd_aes_brute/Makefile
@@ -1,9 +1,17 @@
 MYSRCPATHS = ../../common ../../common/mbedtls
 MYSRCS = util_posix.c randoms.c
 MYINCLUDES =  -I../../include -I../../common -I../../common/mbedtls
-MYCFLAGS = -march=native -Ofast
+MYCFLAGS = -Ofast
 MYDEFS =
 MYLDLIBS = -lcrypto
+
+# A better way would be to just try compiling with march and seeing if we succeed
+cpu_arch = $(shell uname -m)
+ifneq ($(findstring arm64, $(cpu_arch)), )
+    MYCFLAGS += -mcpu=native
+else
+    MYCFLAGS += -march=native
+endif
 
 ifneq ($(SKIPPTHREAD),1)
     MYLDLIBS += -lpthread


### PR DESCRIPTION
`mfd_aes_brute` was throwing a compilation error first because of using `-march=native` which does not exist on M1 Macs (yet), so I swapped that over to `-mcpu=native` conditionally.
Secondly, it did not have a method for checking AES-NI state on those machines either (the fallback being Linux only).
For now hardcoded to false, as M1 CPUs do not support AES-NI (and the check function was only used for display purposes in the first place)