### PR TITLE
Minimal change to utilize ARM NEON capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Use 128 bit slices whenever ARM NEON is available to speed up hardnested (@Doridian)
  - Fixed compilation of mfd_aes_brute on Apple M1 based Macs (@Doridian)
  - Changed calculation of companion ARM firmware hash to be uniform accross platforms (@Doridian)
  - Changed `hf mf *` - verbose flag now also decode and prints found value blocks (@iceman1001)

--- a/client/deps/hardnested/hardnested_bf_core.c
+++ b/client/deps/hardnested/hardnested_bf_core.c
@@ -74,6 +74,8 @@ THE SOFTWARE.
 #define MAX_BITSLICES 128
 #elif defined(__SSE2__)
 #define MAX_BITSLICES 128
+#elif defined(__ARM_NEON)
+#define MAX_BITSLICES 128
 #else // MMX or SSE or NOSIMD
 #define MAX_BITSLICES 64
 #endif


### PR DESCRIPTION
ARMv8 always ships with NEON capabilities supporting 128-bit operations.
This gives ~ +50% speedup on hardnested on Apple M1