### PR TITLE
Fix USB communications when receiving empty frames

### DIFF
--- a/client/src/comms.c
+++ b/client/src/comms.c
@@ -414,6 +414,15 @@ __attribute__((force_align_arg_pointer))
                         }
                     }
                 }
+                else if ((!error) && (length == 0)) { // we received an empty frame
+                    if (rx.ng)
+                        rx.length = 0; // set received length to 0
+                    else {  // old frames can't be empty
+                        PrintAndLogEx(WARNING, "Received empty MIX packet frame (length: 0x00)");
+
+                        error = true;
+                    }
+                }
                 if (!error) {                        // Get the postamble
                     res = uart_receive(sp, (uint8_t *)&rx_raw.foopost, sizeof(PacketResponseNGPostamble), &rxlen);
                     if ((res != PM3_SUCCESS) || (rxlen != sizeof(PacketResponseNGPostamble))) {


### PR DESCRIPTION
E.g. before this fix, iso15 (and others using the same way from ARM to client) raw commands expecting results but with no answer from the tag where showing the previously received commands instead of : "[!] /!\ command failed".

BEFORE:
[usb] pm3 --> hf 15 raw -c -d 260100
[+] received 12 octets
[+] 00 02 05 43 20 0B 66 24 16 E0 6C 56 
[usb] pm3 --> hf 15 raw -c -d 010203 # invalid command (tag is not answering)
[+] received 12 octets
[+] 00 02 05 43 20 0B 66 24 16 E0 6C 56

AFTER:
[usb] pm3 --> hf 15 raw -c -d 260100
[+] received 12 octets
[+] 00 02 05 43 20 0B 66 24 16 E0 6C 56 
[usb] pm3 --> hf 15 raw -c -d 010203 # invalid command (tag is not answering)
[!] ⚠️  command failed
