### PR TITLE
Fix a bug in "lf config"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed `lf config --reset` - averaging is set to 1 rather than 0 (@wh201906)
  - Added standalone mode for sniffing 14b (@jacopo-j)
  - Fixed `hf 14a apdu` - now don't skip first P2 iteration (@iceman1001)
  - Added `hf ntag424` - skeleton with SDM (@iceman1001)

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -631,7 +631,9 @@ int CmdLFConfig(const char *Cmd) {
     if (use_134)
         config.divisor = LF_DIVISOR_134;
 
-    config.averaging = (avg == 1);
+    // check if the config.averaging is not set by if(reset){...}
+    if (config.averaging == -1)
+        config.averaging = (avg == 1);
 
     if (bps > -1) {
         // bps is limited to 8


### PR DESCRIPTION
When executing "lf config --reset", the averaging will be 0 rather than 1(default).
This is because the config.averaging is set to 1 at first.(line 621)
Then this argument is overwritten unconditionally by
"config.averaging = (avg == 1);"(line 634)