### PR TITLE
Fix the bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,40 +7,40 @@ assignees: ''
 
 ---
 
-***Things to try before submitting bug report***
-read the [troubleshooting guide](/doc/md/Installation_Instructions/Troubleshooting.md)
+***Things to try before submitting bug report***  
+read the [troubleshooting guide](https://github.com/RfidResearchGroup/proxmark3/blob/master/doc/md/Installation_Instructions/Troubleshooting.md)
 
-***Compilation problems***
+***Compilation problems***  
 Try compiling with verbose.  `make VERBOSE=1` with main makefile or `make V=1` with cmake.
 
-***flashing problems***
+***flashing problems***  
 Have you followed the instructions properly?  ie,  flashed bootrom seperately first if you are going from Offical repo to Iceman repo.
 
 
 -
 
-**Describe the bug**
+**Describe the bug**  
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+**To Reproduce**  
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+**Expected behavior**  
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+**Screenshots**  
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+**Desktop (please complete the following information):**  
  - OS: [e.g. iOS]
  - inside proxmark3 client run the following commands and paste the output here.
  - hw version
  - hw status
  - data tune
 
-**Additional context**
+**Additional context**  
 Add any other context about the problem here.


### PR DESCRIPTION
Fix the link of troubleshooting guide, which should be a URL rather than a path.
Add 2 spaces after every title to get the same appearance on both Github and the editor.