### PR TITLE
Fixes a couple of new warnings [gcc 12.1.0]

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -2476,7 +2476,7 @@ void  __attribute__((noreturn)) AppMain(void) {
 
     SpinDelay(100);
     BigBuf_initialize();
-
+    #pragma GCC diagnostic ignored "-Warray-bounds"
     for (uint32_t *p = _stack_start; p < _stack_end - 0x200; ++p) {
         *p = 0xdeadbeef;
     }

--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -1510,10 +1510,9 @@ static int CmdRawDemod(const char *Cmd) {
     };
 
     //
-    size_t n = MIN(strlen(Cmd), 4);
     char tmp[7];
     memset(tmp, 0, sizeof(tmp));
-    strncpy(tmp, Cmd, n);
+    strncpy(tmp, Cmd, sizeof(tmp));
 
     CLIExecWithReturn(ctx, tmp, argtable, false);
     bool ab = arg_get_lit(ctx, 1);

--- a/client/src/cmdlft55xx.c
+++ b/client/src/cmdlft55xx.c
@@ -2577,7 +2577,7 @@ char *GetPskCfStr(uint32_t id, bool q5) {
 }
 
 char *GetBitRateStr(uint32_t id, bool xmode) {
-    static char buf[25];
+    static char buf[32];
 
     char *retStr = buf;
     if (xmode) { //xmode bitrate calc is same as em4x05 calc


### PR DESCRIPTION
Stumbled on a couple warnings about array bounds that prevented proxmark3 to be compiled on a recent arch install. 