### PR TITLE
Change 'hf 14a list' to annotate more ECP frame formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Change `trace list -t 14a` to annotate ECP frames of all valid V1 and V2 formats (@kormax)
  - Changed `hf mf staticnested` - significant speedups by using two encrypted nonces (@xianglin1998)
  - Change use of `sprintf` in code to `snprintf` to fix compilation on macOS (@Doridian)
  - Change `hf mf mad` - it now takes a dump file for offline MAD decoding (@iceman1001)

--- a/client/src/cmdhflist.c
+++ b/client/src/cmdhflist.c
@@ -181,9 +181,17 @@ int applyIso14443a(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize, bool i
             return PM3_SUCCESS;
         }
 
-        if (cmdsize > 10 && (memcmp(cmd, "\x6a\x02\xC8\x01\x00\x03\x00\x02\x79", 9) == 0)) {
-            snprintf(exp, size, "ECP");
-            return PM3_SUCCESS;
+        if (cmdsize >= 7 && cmd[0] == ECP_HEADER) {
+            // Second byte of ECP frame indicates its version
+            // Version 0x01 payload is 7 bytes long (including crc)
+            // Version 0x02 payload is 15 bytes long (including crc)
+            if (cmd[1] == 0x01 && cmdsize == 7) {
+                snprintf(exp, size, "ECP1");
+                return PM3_SUCCESS;
+            } else if (cmd[1] == 0x02 && cmdsize == 15) {
+                snprintf(exp, size, "ECP2");
+                return PM3_SUCCESS;
+            }
         }
 
         gs_ntag_i2c_state = 0;

--- a/include/protocols.h
+++ b/include/protocols.h
@@ -158,6 +158,8 @@ ISO 7816-4 Basic interindustry commands. For command APDU's.
 #define ICLASS_DEBIT(x)             (((x) & 0x80) == 0x80)
 
 
+#define ECP_HEADER                  0x6A
+
 // 7bit Apple Magsafe wake up command
 #define MAGSAFE_CMD_WUPA_1          0x7A
 #define MAGSAFE_CMD_WUPA_2          0x7B


### PR DESCRIPTION
Updated the logic behind 14a annotation to support more ECP (Apple Enhanced Contactless Protocol/Polling) frame variations with different parameters and versions, changed labels to indicate if it's version 1 or 2 (ECP1/ECP2).

As a result of this change, following frames (and possibly more still unknown ones) will be annotated:
- VASUP-A (Used by readers to wake up the phone to inform it about what passes to present for authentication after an unlock):
  `6a  01  00  00  00` 
- IPHONE (Used by iPhones so that other phones won't react to an NFC field and request an unlock, might be used for other purposes):  
 `6a  01  cf  00  00`
- More V2 frame variations for transit bypass.

