### PR TITLE
Fix `hf 14a reader --ecp` to work consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed `hf 14a reader --ecp` to work consistently (@kormax)
  - Change `trace list -t 14a` to annotate ECP frames of all valid V1 and V2 formats (@kormax)
  - Changed `hf mf staticnested` - significant speedups by using two encrypted nonces (@xianglin1998)
  - Change use of `sprintf` in code to `snprintf` to fix compilation on macOS (@Doridian)


### PR DESCRIPTION
When testing the ECP functionality of `hf 14a reader --ecp` with IOS15/16-based devices I found it not to work consistently, requiring me to try the command a couple of times before it succeeds:

```
# This example worked pretty much the same with or without '-k' parameter

[usb] pm3 --> hf 14a reader --ecp -k  
[!] ⚠️  iso14443a card select failed  
[=] field is on  
[usb] pm3 --> hf 14a reader --ecp -k  
[!] ⚠️  iso14443a card select failed  
[=] field is on. 
[usb] pm3 --> hf 14a reader --ecp -k  
[+]  UID: 08 06 8C A9   
[+] ATQA: 00 04. 
[+]  SAK: 20 [1]. 
[+]  ATS: 05 78 80 70 02   
[+] Card is selected. You can now start sending commands. 
[=] field is on. 
[usb] pm3 --> hf 14a reader --ecp -k  
[!] ⚠️  iso14443a card select failed. 
[=] field is on  
[usb] pm3 --> hf 14a reader --ecp -k
[!] ⚠️  iso14443a card select failed  
[=] field is on  
[usb] pm3 --> hf 14a reader --ecp -k  
[+]  UID: 08 CA 54 DE  
[+] ATQA: 00 04  
[+]  SAK: 20 [1]  
[+]  ATS: 05 78 80 70 02   
[+] Card is selected. You can now start sending commands  
[=] field is on
```

Digging deeper into the problem, I've noticed that it takes an iPhone to "hear" at least two ECP cycles while in a field in order to react to the next WUPA. Current code did not allow this to happen due to a pretty short retry timeout of 10ms accompanied by a ECP delay of 15ms. 

In order to fix the issue:
1.  The retry timeout was changed to increase to 100ms if '--ecp' param is set.  (The more cards there are on a phone, the longer it takes for it to process, but it did not exceed 60ms for me when testing);
2. The ECP delay was reduced to 10ms;
3. Retry loop was changed so that the ECP frame is sent only after the first iteration (as it is more in line with how real ECP-compliant readers work).

Results speak for themselves:
```
[usb] pm3 --> hf 14a reader --ecp
[+]  UID: 08 E3 7C 4D 
[+] ATQA: 00 04
[+]  SAK: 20 [1]
[+]  ATS: 05 78 80 70 02 
[usb] pm3 --> hf 14a reader --ecp
[+]  UID: 08 BD 2F 41 
[+] ATQA: 00 04
[+]  SAK: 20 [1]
[+]  ATS: 05 78 80 70 02 
[usb] pm3 --> hf 14a reader --ecp -k
[+]  UID: 08 E4 43 3B 
[+] ATQA: 00 04
[+]  SAK: 20 [1]
[+]  ATS: 05 78 80 70 02 
[+] Card is selected. You can now start sending commands
[=] field is on
```

Judging from the commits related to this feature made in the past, it seems that it had worked before, so it might have become broken after some IOS software version.