### PR TITLE
Improve 'hf 14a reader --ecp -k' performance

### DIFF
--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -2455,6 +2455,12 @@ static int GetATQA(uint8_t *resp, uint8_t *resp_par, bool use_ecp, bool use_mags
         wupa[0] = MAGSAFE_CMD_WUPA_4;
     }
 
+    if (use_ecp) {
+        // We drop the field to bring the phone back into an 'IDLE' state
+        switch_off();
+        set_tracing(true);
+    }
+
     uint32_t save_iso14a_timeout = iso14a_get_timeout();
     iso14a_set_timeout(1236 / 128 + 1);  // response to WUPA is expected at exactly 1236/fc. No need to wait longer.
 


### PR DESCRIPTION
This commit improves upon changes done in the previous one by adding an RF field reset before a polling sequence when using 'hf 14a reader --ecp' command. It seems to help bringing the phone into an idle state consistently so that it can be selected once again.


```
# Trace done after this change

[usb] pm3 --> hf 14a reader --ecp -k
[+]  UID: 08 0A 9D BF 
[+] ATQA: 00 04
[+]  SAK: 20 [1]
[+]  ATS: 05 78 80 70 02 
[+] Card is selected. You can now start sending commands
[=] field is on
[usb] pm3 --> hf 14a reader --ecp -k
[+]  UID: 08 6A 24 B3 
[+] ATQA: 00 04
[+]  SAK: 20 [1]
[+]  ATS: 05 78 80 70 02 
[+] Card is selected. You can now start sending commands
[=] field is on
[usb] pm3 --> hf 14a reader --ecp -k
[+]  UID: 08 40 B8 0D 
[+] ATQA: 00 04
[+]  SAK: 20 [1]
[+]  ATS: 05 78 80 70 02 
[+] Card is selected. You can now start sending commands
[=] field is on
```
Seems to work both with the locked phone and an unlocked one with a card authorised.