### PR TITLE
Update to 'hf 14a reader --ecp'

### DIFF
--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -2445,6 +2445,7 @@ static int GetATQA(uint8_t *resp, uint8_t *resp_par, bool use_ecp, bool use_mags
 #define ECP_RETRY_TIMEOUT 100    
 #define WUPA_RETRY_TIMEOUT 10    // 10ms
 
+
     // 0x26 - REQA
     // 0x52 - WAKE-UP
     // 0x7A - MAGESAFE WAKE UP
@@ -2456,9 +2457,11 @@ static int GetATQA(uint8_t *resp, uint8_t *resp_par, bool use_ecp, bool use_mags
     }
 
     if (use_ecp) {
-        // We drop the field to bring the phone back into an 'IDLE' state
-        switch_off();
-        set_tracing(true);
+        // In case a device was already selected, we send a S-BLOCK deselect to bring it into an idle state so it can be selected again
+        uint8_t deselect_cmd[] = {0xc2, 0xe0, 0xb4};
+        ReaderTransmit(deselect_cmd, sizeof(deselect_cmd), NULL);
+        // Read response if present
+        ReaderReceive(resp, resp_par);
     }
 
     uint32_t save_iso14a_timeout = iso14a_get_timeout();

--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -2455,6 +2455,12 @@ static int GetATQA(uint8_t *resp, uint8_t *resp_par, bool use_ecp, bool use_mags
         wupa[0] = MAGSAFE_CMD_WUPA_4;
     }
 
+    if (use_ecp) {
+        // We drop the field to bring the phone back into an 'IDLE' state
+        switch_off();
+        set_tracing(true);
+    }
+
     uint32_t save_iso14a_timeout = iso14a_get_timeout();
     iso14a_set_timeout(1236 / 128 + 1);  // response to WUPA is expected at exactly 1236/fc. No need to wait longer.
 


### PR DESCRIPTION
Replaced RF reset with an s-block deselect as suggested [in previous pr](https://github.com/RfidResearchGroup/proxmark3/pull/1696).