### PR TITLE
decode password in case of the read/write comand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Added new standalone mode `lf_em4100rsww` (@zabszk)
  - Fixed `hf 15 slixdisable` wrong pass id (@r1ddl3rz)
  - Added 122 new keys from Flipper Zero community to `mfc_default_keys.dic` (@UberGuidoZ)
+ - Added showing password for the read command in the `lf t55xx sniff` command (@merlokk)
 
 ## [Frostbit.4.14831][2022-01-11]
  - Changed Wiegand format lookup - now case-insensitive (@iceman1001)


### PR DESCRIPTION
the most confusing command. 
OR read with a password
OR write without
it has the same length 38 bits

if the token is with a password - all is OK, 
if not - read command with a password will lead to writing the shifted password to the memory and:
 **IF the most bit of the data (the password from the read command) is `1` ----> IT LEADS TO LOCK this block of the memory**