### PR TITLE
iclass output improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Changed `hf iclass view` to suppress consecutive blocks with repeated contents (@nvx)
+ - Fixed `hf iclass info` and `hf iclass view` key access info looking at the wrong card config bit (@nvx)
+ - Changed `hf iclass list` to display matched keys on the CHECK command rather than the card response, and made it check for elite keys too (@nvx)
  - Added `hf gallagher decode` command and fix Gallagher diversification for card master key (@nvx)
  - Added mmbit-002 (kibi-002, kb5004xk1) russian tag to `hf texkom read` command (@merlokk)
  - Added `hf sniff --smode` skip/group adc data to consume less memory. Now it can sniff very long signals (@merlokk)

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -588,8 +588,8 @@ static void mem_app_config(const picopass_hdr_t *hdr) {
 
     PrintAndLogEx(INFO, "------------------------- " _CYAN_("KeyAccess") " ------------------------");
     PrintAndLogEx(INFO, " * Kd, Debit key, AA1    Kc, Credit key, AA2 *");
-    uint8_t book = isset(mem, 0x20);
-    if (book) {
+    uint8_t keyAccess = isset(mem, 0x01);
+    if (keyAccess) {
         PrintAndLogEx(INFO, "    Read A....... debit");
         PrintAndLogEx(INFO, "    Read B....... credit");
         PrintAndLogEx(INFO, "    Write A...... debit");

--- a/client/src/cmdhflist.c
+++ b/client/src/cmdhflist.c
@@ -464,10 +464,17 @@ void annotateIclass(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize, bool 
                 curr_state = PICO_NONE;
                 break;
             case ICLASS_CMD_CHECK:
-                snprintf(exp, size, "CHECK");
                 curr_state = PICO_AUTH_MACS;
                 memcpy(rmac, cmd + 1, 4);
                 memcpy(tmac, cmd + 5, 4);
+
+                uint8_t key[8];
+                if (check_known_default(csn, epurse, rmac, tmac, key)) {
+                    snprintf(exp, size, "CHECK ( %s )", sprint_hex_inrow(key, 8));
+                } else {
+                    snprintf(exp, size, "CHECK");
+                }
+
                 break;
             case ICLASS_CMD_READ4:
                 snprintf(exp, size, "READ4(%d)", cmd[1]);
@@ -516,11 +523,7 @@ void annotateIclass(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize, bool 
         } else if (curr_state == PICO_AUTH_EPURSE) {
             memcpy(epurse, cmd, 8);
         } else if (curr_state == PICO_AUTH_MACS) {
-
-            uint8_t key[8];
-            if (check_known_default(csn, epurse, rmac, tmac, key)) {
-                snprintf(exp, size, "( " _GREEN_("%s") " )", sprint_hex_inrow(key, 8));
-            }
+            snprintf(exp, size, _GREEN_("CHECK SUCCESS"));
             curr_state = PICO_NONE;
         }
     }


### PR DESCRIPTION
Fixed `hf iclass info` and `hf iclass view` key access info looking at the wrong card config bit

Changed `hf iclass list` to display matched keys on the CHECK command rather than the card response
This is useful as it shows what key a reader attempted to use with a card even if the card rejected the key. To make it more apparent when the CHECK command was successful though it now shows `CHECK SUCCESS` in green when the card responds to the CHECK command, and the key is not printed in green anymore since we don't know at that point if the key actually worked or not.

Also made `hf iclass list` key check lookup using the elite algorithm too
The display currently doesn't show any different output for elite vs standard kdf since there's fairly limited room, but I'd expect people would know what sort of keys they've loaded in, and worse case could double check with `hf iclass chk`

![image](https://user-images.githubusercontent.com/551727/180103647-816b1acb-20ec-4dfc-a8eb-b7e65b61130d.png)

iClass dump views (ie, `hf iclass view`) now suppress repeated blocks, similar to how hexdump works. It will only suppress blocks in the application area, and will never suppress detected iclass credential blocks. For example a dump that has blocks 17-236 all containing just FF's:

```
<blocks 16 and prior output unchanged>
[=]  17/0x11 | FF FF FF FF FF FF FF FF | ........ |   | User
[=] *
[=] 236/0xEC | FF FF FF FF FF FF FF FF | ........ |   | User
```

Needless to say this is quite handy when dealing with complete card dumps when the AA2 area is blank.

I also fixed a small client memory leak in `check_known_default`, `prekey` wasn't being free'd, and fixed up the SIO detection logic (was using strstr on binary data so would have only been matching on `0x05` instead of the full `0x05, 0x00, 0x05, 0x00` pattern leading to false positives in some cases) and simplified a bit of the SIO printing code too (the duplicate logic was triggering me a little)