### PR TITLE
Changed `hf iclass list` to display matched keys on the CHECK command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Changed `hf iclass list` to display matched keys on the CHECK command rather than the card response, and made it check for elite keys too (@nvx)
  - Added `hf gallagher decode` command and fix Gallagher diversification for card master key (@nvx)
  - Added mmbit-002 (kibi-002, kb5004xk1) russian tag to `hf texkom read` command (@merlokk)
  - Added `hf sniff --smode` skip/group adc data to consume less memory. Now it can sniff very long signals (@merlokk)

--- a/client/src/cmdhflist.c
+++ b/client/src/cmdhflist.c
@@ -464,10 +464,17 @@ void annotateIclass(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize, bool 
                 curr_state = PICO_NONE;
                 break;
             case ICLASS_CMD_CHECK:
-                snprintf(exp, size, "CHECK");
                 curr_state = PICO_AUTH_MACS;
                 memcpy(rmac, cmd + 1, 4);
                 memcpy(tmac, cmd + 5, 4);
+
+                uint8_t key[8];
+                if (check_known_default(csn, epurse, rmac, tmac, key)) {
+                    snprintf(exp, size, "CHECK ( %s )", sprint_hex_inrow(key, 8));
+                } else {
+                    snprintf(exp, size, "CHECK");
+                }
+
                 break;
             case ICLASS_CMD_READ4:
                 snprintf(exp, size, "READ4(%d)", cmd[1]);
@@ -516,11 +523,7 @@ void annotateIclass(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize, bool 
         } else if (curr_state == PICO_AUTH_EPURSE) {
             memcpy(epurse, cmd, 8);
         } else if (curr_state == PICO_AUTH_MACS) {
-
-            uint8_t key[8];
-            if (check_known_default(csn, epurse, rmac, tmac, key)) {
-                snprintf(exp, size, "( " _GREEN_("%s") " )", sprint_hex_inrow(key, 8));
-            }
+            snprintf(exp, size, _GREEN_("CHECK SUCCESS"));
             curr_state = PICO_NONE;
         }
     }


### PR DESCRIPTION
Changed `hf iclass list` to display matched keys on the CHECK command rather than the card response
This is useful as it shows what key a reader attempted to use with a card even if the card rejected the key. To make it more apparent when the CHECK command was successful though it now shows `CHECK SUCCESS` in green when the card responds to the CHECK command, and the key is not printed in green anymore since we don't know at that point if the key actually worked or not.

Also made `hf iclass list` key check lookup using the elite algorithm too
The display currently doesn't show any different output for elite vs standard kdf since there's fairly limited room, but I'd expect people would know what sort of keys they've loaded in, and worse case could double check with `hf iclass chk`

![image](https://user-images.githubusercontent.com/551727/180103647-816b1acb-20ec-4dfc-a8eb-b7e65b61130d.png)

Split out from #1724 