### PR TITLE
Fixed incorrect card config bit being checked for iClass key access flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed `hf iclass info` and `hf iclass view` key access info looking at the wrong card config bit (@nvx)
  - Added `hf gallagher decode` command and fix Gallagher diversification for card master key (@nvx)
  - Added mmbit-002 (kibi-002, kb5004xk1) russian tag to `hf texkom read` command (@merlokk)
  - Added `hf sniff --smode` skip/group adc data to consume less memory. Now it can sniff very long signals (@merlokk)

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -588,8 +588,8 @@ static void mem_app_config(const picopass_hdr_t *hdr) {
 
     PrintAndLogEx(INFO, "------------------------- " _CYAN_("KeyAccess") " ------------------------");
     PrintAndLogEx(INFO, " * Kd, Debit key, AA1    Kc, Credit key, AA2 *");
-    uint8_t book = isset(mem, 0x20);
-    if (book) {
+    uint8_t keyAccess = isset(mem, 0x01);
+    if (keyAccess) {
         PrintAndLogEx(INFO, "    Read A....... debit");
         PrintAndLogEx(INFO, "    Read B....... credit");
         PrintAndLogEx(INFO, "    Write A...... debit");


### PR DESCRIPTION
Fixed incorrect card config bit being checked for iClass key access flag. Fixes `hf iclass view` and `hf iclass info` command output. The bit now matches what the PicoPass datasheet describes, as well as matching practical experience testing iClass cards in the wild.

Split from #1724