### PR TITLE
Fix some bugs in the iClass SIO detection and printing

### DIFF
--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -2443,8 +2443,9 @@ static int CmdHFiClass_loclass(const char *Cmd) {
 }
 
 static void detect_credential(uint8_t *data, bool *legacy, bool *se, bool *sr) {
-    char* r1 = strstr((char*)data + (5 * 8), "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF");
-    char* r2 = strstr((char*)data + (11 * 8), "\x05\x00\x05\x00");
+    bool r1 = !memcmp(data + (5 * 8), "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 8);
+    uint8_t pattern[] = {0x05, 0x00, 0x05, 0x00};
+    bool r2 = byte_strstr(data + (11 * 8), 6 * 8, pattern, sizeof(pattern)) != -1;
 
     *legacy = (r1) && (data[6 * 8] != 0x30);
     *se = (r2) && (data[6 * 8] == 0x30);
@@ -2458,40 +2459,31 @@ static void printIclassSIO(uint8_t *iclass_dump) {
     bool isLegacy, isSE, isSR;
     detect_credential(iclass_dump, &isLegacy, &isSE, &isSR);
 
-    uint8_t pattern[] = {0x05, 0x00, 0x05, 0x00};
+    uint8_t *sio_start;
     if (isSE) {
-
-        int dlen = byte_strstr(iclass_dump + (6 * 8), 8*8, pattern, sizeof(pattern));
-        if (dlen) {
-
-            dlen += sizeof(pattern);
-
-            PrintAndLogEx(NORMAL, "");
-            PrintAndLogEx(INFO, "---------------------------- " _CYAN_("SIO - RAW") " ----------------------------");
-            print_hex_noascii_break(iclass_dump + (6*8), dlen, 32);
-            PrintAndLogEx(NORMAL, "");
-            PrintAndLogEx(INFO, "------------------------- " _CYAN_("SIO - ASN1 TLV") " --------------------------");
-            asn1_print(iclass_dump + (6 * 8), dlen, "  ");
-            PrintAndLogEx(NORMAL, "");
-        }
+        sio_start = iclass_dump + (6 * 8);
+    } else if (isSR) {
+        sio_start = iclass_dump + (10 * 8);
+    } else {
+        return;
     }
 
-    if (isSR) {
-
-        int dlen = byte_strstr(iclass_dump + (10 * 8), 8*8, pattern, sizeof(pattern));
-
-        if (dlen) {
-            dlen += sizeof(pattern);
-
-            PrintAndLogEx(NORMAL, "");
-            PrintAndLogEx(INFO, "---------------------------- " _CYAN_("SIO - RAW") " ----------------------------");
-            print_hex_noascii_break(iclass_dump + (10*8), dlen, 32);
-            PrintAndLogEx(NORMAL, "");
-            PrintAndLogEx(INFO, "------------------------- " _CYAN_("SIO - ASN1 TLV") " --------------------------");
-            asn1_print(iclass_dump + (10 * 8), dlen, "  ");
-            PrintAndLogEx(NORMAL, "");
-        }
+    uint8_t pattern[] = {0x05, 0x00, 0x05, 0x00};
+    int dlen = byte_strstr(sio_start, 8 * 8, pattern, sizeof(pattern));
+    if (dlen == -1) {
+        return;
     }
+
+    dlen += sizeof(pattern);
+
+    PrintAndLogEx(NORMAL, "");
+    PrintAndLogEx(INFO, "---------------------------- " _CYAN_("SIO - RAW") " ----------------------------");
+    print_hex_noascii_break(sio_start, dlen, 32);
+    PrintAndLogEx(NORMAL, "");
+    PrintAndLogEx(INFO, "------------------------- " _CYAN_("SIO - ASN1 TLV") " --------------------------");
+    asn1_print(sio_start, dlen, "  ");
+    PrintAndLogEx(NORMAL, "");
+
 }
 
 void printIclassDumpContents(uint8_t *iclass_dump, uint8_t startblock, uint8_t endblock, size_t filesize) {
@@ -2536,8 +2528,10 @@ void printIclassDumpContents(uint8_t *iclass_dump, uint8_t startblock, uint8_t e
     */
     uint8_t pagemap = get_pagemap(hdr);
 
-    bool isLegacy, isSE, isSR;
-    detect_credential(iclass_dump, &isLegacy, &isSE, &isSR);
+    bool isLegacy = false, isSE = false, isSR = false;
+    if (filemaxblock >= 17) {
+        detect_credential(iclass_dump, &isLegacy, &isSE, &isSR);
+    }
 
     int i = startblock;
     PrintAndLogEx(NORMAL, "");
@@ -4127,4 +4121,3 @@ int info_iclass(void) {
 
     return PM3_SUCCESS;
 }
-


### PR DESCRIPTION
Fixes some bugs in the SIO detection and printing. Initially noticed when astyle reformatted some of the code I noticed the use of substr() on binary data containing 0x00's which substr will stop on, as well as incorrectly assuming the return of byte_substr will be 0 instead of -1 on a failed match, added some bounds checking, and simplified some of the code to reduce duplication.

The practical differences between the new and old code is the old code is more prone to false positives (matching on a single 0x05 character instead of the full 0x05, 0x00, 0x05, 0x00 sequence to identify SIO), as well as some potential undefined behaviour if sufficiently short dump files were loaded (I notice json files seem to allocate a fixed size buffer so these wouldn't have been too bad, but other formats seem to only allocate a buffer the size of the dump so it would have possibly overrun that buffer in some cases).

Split from PR #1724