### PR TITLE
add 'hf mfu eload -a' to treat dump file as Amiibo

### DIFF
--- a/client/src/cmdhfmfu.c
+++ b/client/src/cmdhfmfu.c
@@ -2695,12 +2695,14 @@ static int CmdHF14AMfUeLoad(const char *Cmd) {
                   "Load emulator memory with data from (bin/eml/json) dump file\n",
                   "hf mfu eload -f hf-mfu-04010203040506.bin\n"
                   "hf mfu eload -f hf-mfu-04010203040506.bin -q 57   -> load 57 blocks from myfile"
+                  "hf mfu eload -f hf-mfu-04010203040506.bin -a -> load myfile and treat as Amiibo"
                  );
 
     void *argtable[] = {
         arg_param_begin,
         arg_str1("f", "file", "<fn>", "Filename of dump"),
         arg_int0("q", "qty", "<dec>", "Number of blocks to load from eml file"),
+        arg_lit0("a", "amiibo", "Treat dump as Amiibo"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, false);


### PR DESCRIPTION
This adds a parameter to make simulating decrypted Amiibo files a bit easier.

Prior to this, I was using `pm3_amii_bin2eml.pl` but it's a bit cumbersome, since the script only adds a fake 56 byte header to the dump file.  It looks like the client code already handles the lack of a header, so most of the script is unnecessary anyway.

`hf mfu -f myfile -a` will pull out the UID from the decrypted Amiibo binary and helpfully print out a hint to show which command to use.

```
[usb] pm3 --> hf mfu eload -a -f mm.bin
[=] 255 blocks ( 1020 bytes ) to upload
[+] loaded 540 bytes from binary file mm.bin
[=] detected plain mfu dump format
[+] plain mfu dump format was converted to 135 blocks

[=] MFU dump file information
[=] -------------------------------------------------------------
[=] Version..... 00 00 00 00 00 00 00 00 
[=] TBD 0....... 00 00 
[=] TBD 1....... 00 
[=] Signature... 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[=]              00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[=] Counter 0... 00 00 00 
[=] Tearing 0... 00 
[=] Counter 1... 00 00 00 
[=] Tearing 1... 00 
[=] Counter 2... 00 00 00 
[=] Tearing 2... 00 
[=] Max data page... 133 ( 536 bytes )
[=] Header size..... 56 bytes

[snip]

[=] MIFARE Ultralight override, will use 149 blocks ( 596 bytes )
[=] Uploading to emulator memory
[=] ......................................................................................................................................................
[?] You are ready to simulate an Amiibo.  Try `hf mfu sim -t 7 -u 04FE42302E5980`
```