### PR TITLE
fix homebrew dependency detection

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -78,9 +78,13 @@ else
 endif
 
 ifeq ($(USE_BREW),1)
-  BREW_PREFIX = $(shell brew --prefix 2>/dev/null)
-  ifeq ($(strip $(BREW_PREFIX)),)
-    USE_BREW = 0
+  ifneq ($(strip $(HOMEBREW_PREFIX)),)
+    BREW_PREFIX = $(HOMEBREW_PREFIX)
+  else
+    BREW_PREFIX = $(shell brew --prefix 2>/dev/null)
+    ifeq ($(strip $(BREW_PREFIX)),)
+      USE_BREW = 0
+    endif
   endif
 endif
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -37,8 +37,7 @@ OBJDIR = obj
 ifeq ($(USE_BREW),1)
 	INCLUDES += -I$(BREW_PREFIX)/include
 	LDLIBS += -L$(BREW_PREFIX)/lib
-	PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(BREW_PREFIX)/opt/qt/lib/pkgconfig
-	PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(BREW_PREFIX)/opt/qt5/lib/pkgconfig
+	PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(BREW_PREFIX)/lib/pkgconfig:$(BREW_PREFIX)/opt/qt/lib/pkgconfig:$(BREW_PREFIX)/opt/qt5/lib/pkgconfig
 endif
 
 ifdef ($(USE_MACPORTS),1)
@@ -479,7 +478,7 @@ ifeq ($(SKIPPYTHON),1)
         $(info Python3 library:   skipped)
 else
     ifeq ($(PYTHON_FOUND),1)
-        $(info Python3 library:   Python3 v$(shell pkg-config --modversion python3) found, enabled)
+        $(info Python3 library:   Python3 v$(shell $(PKG_CONFIG_ENV) pkg-config --modversion python3) found, enabled)
     else
         $(info Python3 library:   Python3 not found, disabled)
     endif


### PR DESCRIPTION
I noticed that Qt5 and Python pkg-config detection was not working when running `brew install proxmark3 --HEAD --with-generic` on my MacOS Ventura system.

If I built without homebrew then my system's Qt5 and Python3.9 were detected fine.

Here are a couple of fixes to get the brew recipe working.

1. It looks like HOMEBREW_PREFIX is set by the `brew` recipe, so we can set proxmark3's internal BREW_PREFIX from that instead. 
2. Change PKG_CONFIG_PATH a concatenated list of paths to include Qt, and the main homebrew pkgconfig path in `$(HOMEBREW_PREFIX)/lib/pkgconfig`
3. Use `PKG_CONFIG_ENV` when outputting the Python version

Depends on https://github.com/RfidResearchGroup/homebrew-proxmark3/pull/35

Before:
```
===================================================================
Version info:      Iceman/master/v4.14831-843-gfd7216fa8-dirty
Client platform:   Darwin
GUI support:       QT5 found, enabled (Qt version 5.15.5 in /usr/local/Cellar/qt@5/5.15.5_1/lib)
native BT support: Bluez not found, disabled
Jansson library:   system library not found, using local library
Lua library:       system library not found, using local library
Python3 library:   Python3 not found, disabled
Readline library:  enabled
Whereami library:  system library not found, using local library
Lua SWIG:          wrapper found
compiler version:  Apple clang version 14.0.0 (clang-1400.0.28.1)
===================================================================
```

After:
```
===================================================================
Version info:      Iceman/master/v4.14831-843-gfd7216fa8-dirty
Client platform:   Darwin
GUI support:       QT5 found, enabled (Qt version 5.15.5 in /usr/local/Cellar/qt@5/5.15.5_1/lib)
native BT support: Bluez not found, disabled
Jansson library:   system library found
Lua library:       system library not found, using local library
Python3 library:   Python3 v3.9 found, enabled
Readline library:  enabled
Whereami library:  system library not found, using local library
Lua SWIG:          wrapper found
Python SWIG:       wrapper found
compiler version:  Apple clang version 14.0.0 (clang-1400.0.28.1)
===================================================================
```