### PR TITLE
determine qmake path similar to uic/moc

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -289,6 +289,7 @@ ifneq ($(SKIPQT),1)
     QTLDLIBS = $(shell $(PKG_CONFIG_ENV) pkg-config --libs Qt5Core Qt5Widgets 2>/dev/null)
     MOC = $(shell $(PKG_CONFIG_ENV) pkg-config --variable=host_bins Qt5Core)/moc
     UIC = $(shell $(PKG_CONFIG_ENV) pkg-config --variable=host_bins Qt5Core)/uic
+    QMAKE = $(shell $(PKG_CONFIG_ENV) pkg-config --variable=host_bins Qt5Core)/qmake
     ifneq ($(QTLDLIBS),)
         QT5_FOUND = 1
     else
@@ -297,6 +298,7 @@ ifneq ($(SKIPQT),1)
         QTLDLIBS = $(shell $(PKG_CONFIG_ENV) pkg-config --libs QtCore QtGui 2>/dev/null)
         MOC = $(shell $(PKG_CONFIG_ENV) pkg-config --variable=moc_location QtCore)
         UIC = $(shell $(PKG_CONFIG_ENV) pkg-config --variable=uic_location QtCore)
+        QMAKE = $(shell $(PKG_CONFIG_ENV) pkg-config --variable=exec_prefix QtCore)/bin/qmake
     endif
     ifeq ($(QTLDLIBS),)
         # if both pkg-config commands failed, search in common places
@@ -313,6 +315,7 @@ ifneq ($(SKIPQT),1)
             endif
             MOC = $(QTDIR)/bin/moc
             UIC = $(QTDIR)/bin/uic
+            QMAKE = $(QTDIR)/bin/qmake
         endif
     endif
     ifneq ($(QTLDLIBS),)
@@ -437,9 +440,9 @@ ifeq ($(SKIPQT),1)
 else
     ifeq ($(QT_FOUND),1)
         ifeq ($(QT5_FOUND),1)
-            $(info GUI support:       QT5 found, enabled ($(shell QT_SELECT=5 qmake -v 2>/dev/null|grep -o 'Qt version.*')))
+            $(info GUI support:       QT5 found, enabled ($(shell QT_SELECT=5 $(QMAKE) -v 2>/dev/null|grep -o 'Qt version.*')))
         else
-            $(info GUI support:       QT4 found, enabled ($(shell QT_SELECT=4 qmake -v 2>/dev/null|grep -o 'Qt version.*')))
+            $(info GUI support:       QT4 found, enabled ($(shell QT_SELECT=4 $(QMAKE) -v 2>/dev/null|grep -o 'Qt version.*')))
         endif
     else
         $(info GUI support:       QT not found, disabled)


### PR DESCRIPTION
On MacOS Ventura, if I build proxmark3 locally then the client Makefile has a hard time finding the Qt version.  It assumes `qmake` is in the path, which seems to be only the case when running from the brew recipe.

Since there's already code to determine the paths of `uic` and `moc`, then let's just throw `qmake` into there as well!

Before:
```
===================================================================
Version info:      Iceman/master/v4.14831-842-g6fb4723cd
Client platform:   Darwin
GUI support:       QT5 found, enabled ()
native BT support: skipped
Jansson library:   system library found
Lua library:       system library not found, using local library
Python3 library:   Python3 v3.9 found, enabled
Readline library:  enabled
Whereami library:  system library not found, using local library
Lua SWIG:          wrapper found
Python SWIG:       wrapper found
compiler version:  Apple clang version 14.0.0 (clang-1400.0.28.1)
===================================================================
```
After:
```
===================================================================
Version info:      Iceman/master/v4.14831-842-g6fb4723cd-dirty
Client platform:   Darwin
GUI support:       QT5 found, enabled (Qt version 5.15.5 in /usr/local/Cellar/qt@5/5.15.5_1/lib)
native BT support: skipped
Jansson library:   system library found
Lua library:       system library not found, using local library
Python3 library:   Python3 v3.9 found, enabled
Readline library:  enabled
Whereami library:  system library not found, using local library
Lua SWIG:          wrapper found
Python SWIG:       wrapper found
compiler version:  Apple clang version 14.0.0 (clang-1400.0.28.1)
```