### PR TITLE
add -i to hf emrtd info

### DIFF
--- a/client/src/cmdhfemrtd.h
+++ b/client/src/cmdhfemrtd.h
@@ -63,7 +63,7 @@ typedef struct emrtd_pacesdp_s {
 int CmdHFeMRTD(const char *Cmd);
 
 int dumpHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_available, const char *path);
-int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_available);
+int infoHF_EMRTD(char *documentnumber, char *dob, char *expiry, bool BAC_available, bool only_fast);
 int infoHF_EMRTD_offline(const char *path);
 
 #ifdef __cplusplus

--- a/client/src/proxgui.cpp
+++ b/client/src/proxgui.cpp
@@ -67,11 +67,13 @@ extern "C" void RepaintGraphWindow(void) {
 
 
 // hook up picture viewer
-extern "C" void ShowPictureWindow(char *fn) {
+extern "C" void ShowPictureWindow(uint8_t *data, int len) {
     // No support for jpeg2000 in Qt Image since a while...
     // https://doc.qt.io/qt-5/qtimageformats-index.html
-    if (strlen(fn) > 4 && !strcmp(fn + strlen(fn) - 4, ".jp2"))
+    QImage img = QImage::fromData(data, len);
+    if (img.isNull()) {
         return;
+    }
     if (!gui) {
         // Show a notice if X11/XQuartz isn't available
 #if defined(__MACH__) && defined(__APPLE__)
@@ -82,7 +84,7 @@ extern "C" void ShowPictureWindow(char *fn) {
         return;
     }
 
-    gui->ShowPictureWindow(fn);
+    gui->ShowPictureWindow(img);
 }
 
 extern "C" void ShowBase64PictureWindow(char *b64) {

--- a/client/src/proxgui.h
+++ b/client/src/proxgui.h
@@ -32,7 +32,7 @@ void HideGraphWindow(void);
 void RepaintGraphWindow(void);
 
 // hook up picture viewer
-void ShowPictureWindow(char *fn);
+void ShowPictureWindow(uint8_t *data, int len);
 void ShowBase64PictureWindow(char *b64);
 void HidePictureWindow(void);
 void RepaintPictureWindow(void);

--- a/client/src/proxguiqt.cpp
+++ b/client/src/proxguiqt.cpp
@@ -65,8 +65,8 @@ void ProxGuiQT::HideGraphWindow(void) {
 }
 
 // emit picture viewer signals
-void ProxGuiQT::ShowPictureWindow(char *fn) {
-    emit ShowPictureWindowSignal(fn);
+void ProxGuiQT::ShowPictureWindow(const QImage &img) {
+    emit ShowPictureWindowSignal(img);
 }
 
 void ProxGuiQT::ShowBase64PictureWindow(char *b64) {
@@ -116,23 +116,13 @@ void ProxGuiQT::_HideGraphWindow(void) {
 }
 
 // picture viewer
-void ProxGuiQT::_ShowPictureWindow(char *fn) {
+void ProxGuiQT::_ShowPictureWindow(const QImage &img) {
 
     if (!plotapp)
         return;
 
-    if (fn == NULL)
+    if (img.isNull())
         return;
-
-    size_t slen = strlen(fn);
-    if (slen == 0)
-        return;
-
-    char *myfn = (char *)calloc(slen + 1, sizeof(uint8_t));
-    if (myfn == NULL)
-        return;
-
-    memcpy(myfn, fn, slen);
 
     if (!pictureWidget) {
 
@@ -143,12 +133,7 @@ void ProxGuiQT::_ShowPictureWindow(char *fn) {
         pictureWidget = new PictureWidget();
     }
 
-    QPixmap pm;
-    if (pm.load(myfn) == false) {
-        qWarning("Failed to load %s", myfn);
-    }
-    free(myfn);
-    free(fn);
+    QPixmap pm = QPixmap::fromImage(img);
 
     //QPixmap newPixmap = pm.scaled(QSize(50,50),  Qt::KeepAspectRatio);
     //pm = pm.scaled(pictureController->lbl_pm->size(),  Qt::KeepAspectRatio);
@@ -264,7 +249,7 @@ void ProxGuiQT::MainLoop() {
     connect(this, SIGNAL(ExitSignal()), this, SLOT(_Exit()));
 
     // hook up picture viewer signals
-    connect(this, SIGNAL(ShowPictureWindowSignal(char *)), this, SLOT(_ShowPictureWindow(char *)));
+    connect(this, SIGNAL(ShowPictureWindowSignal(const QImage &)), this, SLOT(_ShowPictureWindow(const QImage &)));
     connect(this, SIGNAL(ShowBase64PictureWindowSignal(char *)), this, SLOT(_ShowBase64PictureWindow(char *)));
     connect(this, SIGNAL(RepaintPictureWindowSignal()), this, SLOT(_RepaintPictureWindow()));
     connect(this, SIGNAL(HidePictureWindowSignal()), this, SLOT(_HidePictureWindow()));

--- a/client/src/proxguiqt.h
+++ b/client/src/proxguiqt.h
@@ -156,7 +156,7 @@ class ProxGuiQT : public QObject {
     void HideGraphWindow(void);
 
     // hook up picture viewer
-    void ShowPictureWindow(char *fn);
+    void ShowPictureWindow(const QImage &img);
     void ShowBase64PictureWindow(char *b64);
     void HidePictureWindow(void);
     void RepaintPictureWindow(void);
@@ -170,7 +170,7 @@ class ProxGuiQT : public QObject {
     void _HideGraphWindow(void);
 
     // hook up picture viewer
-    void _ShowPictureWindow(char *fn);
+    void _ShowPictureWindow(const QImage &img);
     void _ShowBase64PictureWindow(char *b64);
     void _HidePictureWindow(void);
     void _RepaintPictureWindow(void);
@@ -185,7 +185,7 @@ class ProxGuiQT : public QObject {
     void ExitSignal(void);
 
     // hook up picture viewer signals
-    void ShowPictureWindowSignal(char *fn);
+    void ShowPictureWindowSignal(const QImage &img);
     void ShowBase64PictureWindowSignal(char *b64);
     void HidePictureWindowSignal(void);
     void RepaintPictureWindowSignal(void);


### PR DESCRIPTION
I was playing around with my Canadian passport and `hf emrtd info`.  I noticed there was Qt code to show pictures, but the code path wasn't being taken.

Here I add a `-i` / `--images` parameter to ignore the `fast` flag in the `dg_table`.

Qt's QImageReader is fairly smart so it'll know if any image is unsupported and constructs a null QImage if the data is an unknown format.  In my case, JP2 is supported, so the code to short-circuit the picture viewer is removed.

The temporary file creation/sleep code is also removed in favour of loading the image straight from the buffers passed to `emrtd_print_ef_dg2_info` and `emrtd_print_ef_dg5_info`.