### PR TITLE
Add installation guide for macOS Ventura Beta users

### DIFF
--- a/doc/md/Installation_Instructions/Mac-OS-X-Homebrew-Installation-Instructions.md
+++ b/doc/md/Installation_Instructions/Mac-OS-X-Homebrew-Installation-Instructions.md
@@ -29,6 +29,7 @@ Early users of macOS Ventura and Xcode 14.0 might run into an error saying that 
 
 If (and only if) you run into that error, here is the fix:
 - RE-download the *latest* Command Line Tools of Xcode Beta 14 and install them (again). (https://developer.apple.com/download/all/)
+- Run `sudo xcode-select -s /Applications/Xcode-beta.app` in Terminal.
 - Proceed with Brew installation
 That should normally fix the issue.
 

--- a/doc/md/Installation_Instructions/Mac-OS-X-Homebrew-Installation-Instructions.md
+++ b/doc/md/Installation_Instructions/Mac-OS-X-Homebrew-Installation-Instructions.md
@@ -25,14 +25,17 @@
 ## macOS Ventura Beta users
 ^[Top](#top)
 
-Users of macOS Ventura Beta can no longer use Xcode versions lower than 14.0. (*Technically* they can by `Show Package Contents` and running `/Contents/MacOS/Xcode` but this is not recommended or recognized by Brew installations)
+Early users of macOS Ventura and Xcode 14.0 might run into an error saying that Xcode 14.0 is out-of-date (even though you have the latest Xcode Beta installed).
 
-Therefore you need to download Xcode 14.0 Beta and open it to install the correct Command Line Tools. (https://developer.apple.com/download/all/)
+If (and only if) you run into that error, here is the fix:
+- RE-download the *latest* Command Line Tools of Xcode Beta 14 and install them (again). (https://developer.apple.com/download/all/)
+- Proceed with Brew installation
+That should normally fix the issue.
 
-Important: you need to rename `Xcode-beta.app` to `Xcode.app` (Note: If you still need Xcode 13.0 for signing and uploading apps to App Store rename `Xcode.app` to `Xcode-2.app`).
-
-Continue installation as detailed below.
-
+Alternatively, and only if the issue still persists after following the steps above, you can use this *temporary and ugly* fix:
+- Try renaming `Xcode-beta.app` to `Xcode.app` (Note: If you still need Xcode 13.0 for signing and uploading apps to App Store rename `Xcode.app` to `Xcode-2.app`)
+- Proceed with Brew installation
+- IMPORTANT: Reverse renaming done in first step.
 
 ## Apple Silicon (M1) Notes
 ^[Top](#top)

--- a/doc/md/Installation_Instructions/Mac-OS-X-Homebrew-Installation-Instructions.md
+++ b/doc/md/Installation_Instructions/Mac-OS-X-Homebrew-Installation-Instructions.md
@@ -7,6 +7,7 @@
 # Table of Contents
 - [Mac OS X - Homebrew automatic installation](#mac-os-x---homebrew-automatic-installation)
 - [Table of Contents](#table-of-contents)
+  - [macOS Ventura Beta users](#macos-ventura-beta-users)
   - [Apple Silicon (M1) Notes](#apple-silicon-m1-notes)
   - [Install Proxmark3 tools](#install-proxmark3-tools)
   - [Upgrade HomeBrew tap formula](#upgrade-homebrew-tap-formula)
@@ -19,6 +20,18 @@
     - [the button trick](#the-button-trick)
   - [Run it](#run-it)
 
+
+
+## macOS Ventura Beta users
+^[Top](#top)
+
+Users of macOS Ventura Beta can no longer use Xcode versions lower than 14.0. (*Technically* they can by `Show Package Contents` and running `/Contents/MacOS/Xcode` but this is not recommended or recognized by Brew installations)
+
+Therefore you need to download Xcode 14.0 Beta and open it to install the correct Command Line Tools. (https://developer.apple.com/download/all/)
+
+Important: you need to rename `Xcode-beta.app` to `Xcode.app` (Note: If you still need Xcode 13.0 for signing and uploading apps to App Store rename `Xcode.app` to `Xcode-2.app`).
+
+Continue installation as detailed below.
 
 
 ## Apple Silicon (M1) Notes


### PR DESCRIPTION
Add a note for macOS Ventura users on how to install with Xcode 14.0, notably that you need to rename Xcode-beta.app to Xcode.app in order for installation to succeed.

Installation succeeded on macOS Ventura Beta 4 using method described.