### PR TITLE
Fix gallagher KDF generation for Admin Cards aka Reader Config Cards

### DIFF
--- a/common/generator.c
+++ b/common/generator.c
@@ -491,7 +491,8 @@ int mfdes_kdf_input_gallagher(uint8_t *uid, uint8_t uidLen, uint8_t keyNo, uint3
 
     int len = 0;
     // If the keyNo == 1 or the aid is 000000, then omit the UID.
-    if (keyNo != 1 && aid != 0x000000) {
+    // On the other hand, if the aid is 1f81f4 (config card) always include the UID.
+    if ((keyNo != 1 && aid != 0x000000) || (aid == 0x1f81f4)) {
         if (*kdfInputLen < (4 + uidLen)) {
             return PM3_EINVARG;
         }


### PR DESCRIPTION
Admin Cards (also called Reader Config Cards in some places) use slightly different KDF rules.

Verified functionality against a real system.