### PR TITLE
Improve ECP annotation, add mobile AIDs

### DIFF
--- a/client/resources/aidlist.json
+++ b/client/resources/aidlist.json
@@ -2206,5 +2206,61 @@
         "Name": "SL Resekort",
         "Description": "transport card",
         "Type": "transport"
+    },
+    {
+        "AID": "4F53452E5641532E3031",
+        "Vendor": "Apple, Google",
+        "Country": "",
+        "Name": "Value-Added Services (OSE.VAS.01)",
+        "Description": "Used by Apple VAS and Google SmartTap",
+        "Type": "loyalty"
+    },
+    {
+        "AID": "A000000476D0000101",
+        "Vendor": "Google",
+        "Country": "",
+        "Name": "Google SmartTap 1.3 (Deprecated)",
+        "Description": "",
+        "Type": "loyalty"
+    },
+    {
+        "AID": "A000000476D0000111",
+        "Vendor": "Google",
+        "Country": "",
+        "Name": "Google SmartTap 2.0",
+        "Description": "",
+        "Type": "loyalty"
+    },
+    {
+        "AID": "A0000002480400",
+        "Vendor": "ISO/IEC JTC1/SC17",
+        "Country": "",
+        "Name": "Personal identification (mDL)",
+        "Description": "ISO/IEC 18013-5:2021 compliant Mobile driving licence (mDL) application.",
+        "Type": "identity"
+    },
+    {
+        "AID": "A000000676",
+        "Vendor": "Blackboard",
+        "Country": "United States",
+        "Name": "Student ID",
+        "Description": "Student ID cards",
+        "Type": "identity"
+    },
+    {
+        "AID": "A000000809434343444B467631",
+        "Vendor": "Car Connectivity Consortium (CCC)",
+        "Country": "",
+        "Name": "Digital Car Key",
+        "Description": "",
+        "Type": "access"
+    },
+    {
+        "AID": "A0000008580101",
+        "Vendor": "Apple",
+        "Country": "",
+        "Name": "Apple Home Key",
+        "Description": "NFC Home Key for select HomeKit-compatible locks",
+        "Type": "access"
     }
 ]


### PR DESCRIPTION
This PR includes 2 commits:

1) Improve annotations:
ECP2 payload can have varying length, if it didn't match the frame was not annotated, this is fixed now.
Reader type is now added to annotation if it is known.


2) Add AIDs used by mobile-first applets:
Note that some of them might not appear when testing via `hf 14a info --aidsearch`  because the device bails-out after a dozen of failed SELECTs. I've decided to add them for public knowledge nonetheless.