### PR TITLE
do not use LD if you aren't using ld

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -40,7 +40,6 @@ TARFLAGS += -C .. -f
 CROSS  ?= arm-none-eabi-
 CC ?= gcc
 CXX ?= g++
-LD = g++
 SH = sh
 BASH = bash
 PERL = perl

--- a/Makefile.host
+++ b/Makefile.host
@@ -86,8 +86,8 @@ $(BINDIR)/$(LIB_A): $(MYOBJS) $(MYCXXOBJS)
 	$(Q)$(RANLIB) $@
 
 $(BINDIR)/% : $(OBJDIR)/%.o $(MYOBJS) $(MYCXXOBJS) $(MYLIBS)
-	$(info [=] LD $(notdir $@))
-	$(Q)$(LD) $(LDFLAGS) $(MYOBJS) $(MYCXXOBJS) $< -o $@ $(MYLIBS) $(MYLDLIBS)
+	$(info [=] CXX $(notdir $@))
+	$(Q)$(CXX) $(LDFLAGS) $(MYOBJS) $(MYCXXOBJS) $< -o $@ $(MYLIBS) $(MYLDLIBS)
 
 %.o: %.c
 $(OBJDIR)/%.o : %.c $(OBJDIR)/%.d | $(OBJDIR)

--- a/client/Makefile
+++ b/client/Makefile
@@ -758,9 +758,9 @@ all-static: LDLIBS:=-static $(LDLIBS)
 all-static: $(BINS)
 
 proxmark3: $(OBJS) $(STATICLIBS) lualibs/pm3_cmd.lua lualibs/mfc_default_keys.lua
-	$(info [=] LD $@)
-#	$(Q)$(LD) $(PM3LDFLAGS) $(OBJS) $(STATICLIBS) $(LDLIBS) -o $@
-	$(Q)$(LD) $(PM3CFLAGS) $(PM3LDFLAGS) $(OBJS) $(STATICLIBS) $(LDLIBS) -o $@
+	$(info [=] CXX $@)
+#	$(Q)$(CXX) $(PM3LDFLAGS) $(OBJS) $(STATICLIBS) $(LDLIBS) -o $@
+	$(Q)$(CXX) $(PM3CFLAGS) $(PM3LDFLAGS) $(OBJS) $(STATICLIBS) $(LDLIBS) -o $@
 
 src/proxgui.cpp: src/ui/ui_overlays.h src/ui/ui_image.h
 


### PR DESCRIPTION
All the uses of LD actually wanted g++, so just use CXX and remove an
unused LD define

Closes: https://github.com/pentoo/pentoo-overlay/issues/1259
Fixes: https://github.com/RfidResearchGroup/proxmark3/pull/1758