### PR TITLE
Prep spiffs for bigger data files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Changed spiffs write/apped to send in 8192 chucks to ensure its eraised (@mwalker)
+ - Fixed spiffs dump to ensure to fails correctly if no big_buff was allocated (@mwalker)
  - Change Client Makefile to respect global flags (@blshkv)
  - Change Makefile, honors global CC values (@blshkv)
  - Fixed bad memory handling in MifareSim device side (@iceman1001)

--- a/armsrc/flashmem.c
+++ b/armsrc/flashmem.c
@@ -22,6 +22,7 @@
 #include "ticks.h"
 #include "dbprint.h"
 #include "string.h"
+#include "spiffs.h"
 
 /* here: use NCPS2 @ PA10: */
 #define SPI_CSR_NUM      2
@@ -449,6 +450,9 @@ bool Flash_WipeMemoryPage(uint8_t page) {
     Flash_CheckBusy(BUSY_TIMEOUT);
 
     FlashStop();
+
+    // let spiffs check and update its info post flash erase
+    rdv40_spiffs_check ();
     return true;
 }
 // Wipes flash memory completely, fills with 0xFF

--- a/armsrc/spiffs.c
+++ b/armsrc/spiffs.c
@@ -436,7 +436,7 @@ int rdv40_spiffs_lazy_mount_rollback(int changed) {
 // Note: Writing in 8192 byte chucks helps to ensure "free space" has been erased by GC (Garbage collection)
 int rdv40_spiffs_write(const char *filename, uint8_t *src, uint32_t size, RDV40SpiFFSSafetyLevel level) {
     RDV40_SPIFFS_SAFE_FUNCTION(
-        uint16_t idx;
+        uint32_t idx;
         if (size <= 8192) {
             // write small file
             write_to_spiffs(filename, src, size);
@@ -459,7 +459,7 @@ int rdv40_spiffs_write(const char *filename, uint8_t *src, uint32_t size, RDV40S
 
 int rdv40_spiffs_append(const char *filename, uint8_t *src, uint32_t size, RDV40SpiFFSSafetyLevel level) {
     RDV40_SPIFFS_SAFE_FUNCTION(
-        uint16_t idx;
+        uint32_t idx;
         // Append any 8192 byte chunks
         for (idx = 0; idx < (size/8192);  idx++) {
             append_to_spiffs(filename, &src[8192 * idx], 8192);

--- a/armsrc/spiffs.c
+++ b/armsrc/spiffs.c
@@ -433,26 +433,26 @@ int rdv40_spiffs_lazy_mount_rollback(int changed) {
 // statement or some function taking function parameters
 // TODO : forbid writing to a filename which already exists as lnk !
 // TODO : forbid writing to a filename.lnk which already exists without lnk !
-// Note: Writing in 8192 byte chucks helps to ensure "free space" has been erased by GC (Garbage collection)
+// Note: Writing in SPIFFS_WRITE_CHUNK_SIZE (8192) byte chucks helps to ensure "free space" has been erased by GC (Garbage collection)
 int rdv40_spiffs_write(const char *filename, uint8_t *src, uint32_t size, RDV40SpiFFSSafetyLevel level) {
     RDV40_SPIFFS_SAFE_FUNCTION(
         uint32_t idx;
-        if (size <= 8192) {
+        if (size <= SPIFFS_WRITE_CHUNK_SIZE) {
             // write small file
             write_to_spiffs(filename, src, size);
             size = 0;
         } else { //
-            // write first 8192 bytes
+            // write first SPIFFS_WRITE_CHUNK_SIZE bytes
             // need to write the first chuck of data, then append
-            write_to_spiffs(filename, src, 8192);
+            write_to_spiffs(filename, src, SPIFFS_WRITE_CHUNK_SIZE);
         }
-        // append remaing 8192 byte chuncks
-        for (idx = 1; idx < (size / 8192);  idx++) {
-            append_to_spiffs(filename, &src[8192 * idx], 8192);
+        // append remaing SPIFFS_WRITE_CHUNK_SIZE byte chuncks
+        for (idx = 1; idx < (size / SPIFFS_WRITE_CHUNK_SIZE);  idx++) {
+            append_to_spiffs(filename, &src[SPIFFS_WRITE_CHUNK_SIZE * idx], SPIFFS_WRITE_CHUNK_SIZE);
         }
         // append remaing bytes
-        if (((int64_t)size - (8192 * idx)) > 0) {
-            append_to_spiffs(filename, &src[8192 * idx], size - (8192 * idx));
+        if (((int64_t)size - (SPIFFS_WRITE_CHUNK_SIZE * idx)) > 0) {
+            append_to_spiffs(filename, &src[SPIFFS_WRITE_CHUNK_SIZE * idx], size - (SPIFFS_WRITE_CHUNK_SIZE * idx));
         }
     )
 }
@@ -460,13 +460,13 @@ int rdv40_spiffs_write(const char *filename, uint8_t *src, uint32_t size, RDV40S
 int rdv40_spiffs_append(const char *filename, uint8_t *src, uint32_t size, RDV40SpiFFSSafetyLevel level) {
     RDV40_SPIFFS_SAFE_FUNCTION(
         uint32_t idx;
-        // Append any 8192 byte chunks
-        for (idx = 0; idx < (size/8192);  idx++) {
-            append_to_spiffs(filename, &src[8192 * idx], 8192);
+        // Append any SPIFFS_WRITE_CHUNK_SIZE byte chunks
+        for (idx = 0; idx < (size/SPIFFS_WRITE_CHUNK_SIZE);  idx++) {
+            append_to_spiffs(filename, &src[SPIFFS_WRITE_CHUNK_SIZE * idx], SPIFFS_WRITE_CHUNK_SIZE);
         }
         // Append remain bytes
-        if (((int64_t)size - (8192 * idx)) > 0) {
-            append_to_spiffs(filename, &src[8192 * idx], size - (8192 * idx));
+        if (((int64_t)size - (SPIFFS_WRITE_CHUNK_SIZE * idx)) > 0) {
+            append_to_spiffs(filename, &src[SPIFFS_WRITE_CHUNK_SIZE * idx], size - (SPIFFS_WRITE_CHUNK_SIZE * idx));
         }
     )
 }

--- a/armsrc/spiffs.h
+++ b/armsrc/spiffs.h
@@ -129,6 +129,8 @@ void rdv40_spiffs_safe_wipe(void);
 
 #define SPIFFS_ERR_TEST                 -10100
 
+// Amount of data to write/append to a file in one go.
+#define SPIFFS_WRITE_CHUNK_SIZE 8192
 
 // spiffs file descriptor index type. must be signed
 typedef s16_t spiffs_file;

--- a/client/src/comms.c
+++ b/client/src/comms.c
@@ -856,6 +856,8 @@ static bool dl_it(uint8_t *dest, uint32_t bytes, PacketResponseNG *response, siz
 
             if (response->cmd == CMD_ACK)
                 return true;
+            if (response->cmd == CMD_SPIFFS_DOWNLOAD && response->status == PM3_EMALLOC)
+                return false;
             // Spiffs // fpgamem-plot download is converted to NG,
             if (response->cmd == CMD_SPIFFS_DOWNLOAD || response->cmd == CMD_FPGAMEM_DOWNLOAD)
                 return true;


### PR DESCRIPTION
- added spiffs check after flase wipe to force it to update its status
- added spiffs write and append to write in 8192 byte chunks to allow spiffs space to be freed in time.
- fixed spiffs dump to correctly handle issues if it could not allocate bugbuff space.