### PR TITLE
Updated discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The official PM3-GUI from Gaucho will not work. Not to mention is quite old and 
 
 ## Official channels
 Where do you find the community?
-   - [RFID Hacking community discord server](https://discord.gg/iceman)
+   - [RFID Hacking community discord server](https://discord.gg/xEvexdKmpF)
    - [Proxmark3 IRC channel](https://web.libera.chat/?channels=#proxmark3)
    - [Proxmark3 sub reddit](https://www.reddit.com/r/proxmark3/)
    - [Proxmark3 forum](http://www.proxmark.org/forum/index.php)


### PR DESCRIPTION
User (Genoff) spotted the discord link doesnt work anymore, added a new invite link: https://discord.gg/xEvexdKmpF

Signed-off-by: Andrew MacPherson <andrew@andrewmohawk.com>