### PR TITLE
print_sr_blocks(): don't assume uid is at begining of dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Changed `hf 14b dump, view` to get correct chip type in case of SRT512 and friends (@DidierA)
  - Added `hf 15 eview` and `hf 15 esave` - Retrieve emulator image for ISO15693 simulation (@markus-oehme-pg40)
  - Changed `hf 15 sim` - now supports reader writes (@markus-oehme-pg40)
  - Added `hf 15 eload` - specify memory image for ISO15693 simulation (@markus-oehme-pg40)

--- a/client/src/cmdhf14b.h
+++ b/client/src/cmdhf14b.h
@@ -25,6 +25,7 @@
 int CmdHF14B(const char *Cmd);
 int CmdHF14BNdefRead(const char *Cmd);
 
+uint8_t * get_uid_from_filename(const char *filename);
 int exchange_14b_apdu(uint8_t *datain, int datainlen, bool activate_field, bool leave_signal_on, uint8_t *dataout, int maxdataoutlen, int *dataoutlen, int user_timeout);
 int select_card_14443b_4(bool disconnect, iso14b_card_select_t *card);
 


### PR DESCRIPTION
`print_sr_dump()` assumes uid is at begining of dump. This is not true for SRT512 tags (the uid is not stored anywhere in the data, it is obtained b sending `Get_UID()` to the chip), and this PR is an attempt to fix this.  
The UID is used to guess the chip type, and interpret the system block. A wong guess of the chip ID results in an inaccurate display of which blocks are write protected.

This fix adds and `uid` parameter to `print_sr_blocks()`, and provides it to the call if we are dumping a tag. If we are reading a dump file, it attempts to extract the uid from the file name, assuming uid has a len of 8 bytes, and the file has the standard format of `hf-14b-xxxxx.*`

This works for my limited test case (one SRT512 tag). If extracting the uid from the data works for some cases then this fix probably breaks them, and an alternative should be found. Is there a standard way to store the UID in the dump file?
