### PR TITLE
Hf 14a sim : fix parsing error and add hint for ultralight EV1

### DIFF
--- a/client/src/cmdhf14a.c
+++ b/client/src/cmdhf14a.c
@@ -669,7 +669,7 @@ int CmdHF14ASim(const char *Cmd) {
                   "hf 14a sim -t 4                     -> ISO/IEC 14443-4\n"
                   "hf 14a sim -t 5                     -> MIFARE Tnp3xxx\n"
                   "hf 14a sim -t 6                     -> MIFARE Mini\n"
-                  "hf 14a sim -t 7                     -> Amiibo (NTAG 215),  pack 0x8080\n"
+                  "hf 14a sim -t 7                     -> MIFARE Ultralight EV1, Amiibo (NTAG 215),  pack 0x8080\n"
                   "hf 14a sim -t 8                     -> MIFARE Classic 4k\n"
                   "hf 14a sim -t 9                     -> FM11RF005SH Shanghai Metro\n"
                   "hf 14a sim -t 10                    -> ST25TA IKEA Rothult\n");

--- a/client/src/cmdhf14a.c
+++ b/client/src/cmdhf14a.c
@@ -662,17 +662,18 @@ static int CmdHF14ACUIDs(const char *Cmd) {
 int CmdHF14ASim(const char *Cmd) {
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "hf 14a sim",
-                  "Simulate ISO/IEC 14443 type A tag with 4,7 or 10 byte UID",
-                  "hf 14a sim -t 1 --uid 11223344      -> MIFARE Classic 1k\n"
-                  "hf 14a sim -t 2                     -> MIFARE Ultralight\n"
-                  "hf 14a sim -t 3                     -> MIFARE Desfire\n"
-                  "hf 14a sim -t 4                     -> ISO/IEC 14443-4\n"
-                  "hf 14a sim -t 5                     -> MIFARE Tnp3xxx\n"
-                  "hf 14a sim -t 6                     -> MIFARE Mini\n"
-                  "hf 14a sim -t 7                     -> MIFARE Ultralight EV1, Amiibo (NTAG 215),  pack 0x8080\n"
-                  "hf 14a sim -t 8                     -> MIFARE Classic 4k\n"
-                  "hf 14a sim -t 9                     -> FM11RF005SH Shanghai Metro\n"
-                  "hf 14a sim -t 10                    -> ST25TA IKEA Rothult\n");
+                  "Simulate ISO/IEC 14443 type A tag with 4,7 or 10 byte UID\n"
+                  "Use type 7 for Mifare Ultralight EV1, Amiibo (NTAG215 pack 0x8080)",
+                  "hf 14a sim -t 1 --uid 11223344  -> MIFARE Classic 1k\n"
+                  "hf 14a sim -t 2                 -> MIFARE Ultralight\n"
+                  "hf 14a sim -t 3                 -> MIFARE Desfire\n"
+                  "hf 14a sim -t 4                 -> ISO/IEC 14443-4\n"
+                  "hf 14a sim -t 5                 -> MIFARE Tnp3xxx\n"
+                  "hf 14a sim -t 6                 -> MIFARE Mini\n"
+                  "hf 14a sim -t 7                 -> MFUEV1 / NTAG 215 Amiibo\n"
+                  "hf 14a sim -t 8                 -> MIFARE Classic 4k\n"
+                  "hf 14a sim -t 9                 -> FM11RF005SH Shanghai Metro\n"
+                  "hf 14a sim -t 10                -> ST25TA IKEA Rothult\n");
 
     void *argtable[] = {
         arg_param_begin,

--- a/client/src/cmdhf14a.c
+++ b/client/src/cmdhf14a.c
@@ -715,7 +715,7 @@ int CmdHF14ASim(const char *Cmd) {
         useUIDfromEML = false;
     }
 
-    uint8_t exitAfterNReads = arg_get_int(ctx, 3);
+    uint8_t exitAfterNReads = arg_get_int_def(ctx, 3, 0);
 
     if (arg_get_lit(ctx, 4)) {
         flags |= FLAG_NR_AR_ATTACK;

--- a/client/src/cmdhfmfu.c
+++ b/client/src/cmdhfmfu.c
@@ -2730,8 +2730,8 @@ static int CmdHF14AMfUSim(const char *Cmd) {
                   "The UID from emulator memory will be used if not specified.\n"
                   "See `hf 14a sim -h` to see available types. You want 2 or 7 usually.",
                   "hf mfu sim -t 2 --uid 11223344556677        -> MIFARE Ultralight\n"
-                  "hf mfu sim -t 7 --uid 11223344556677 -n 5   -> Amiibo (NTAG 215),  pack 0x8080\n"
-                  "hf mfu sim -t 7                             -> Amiibo (NTAG 215),  pack 0x8080"
+                  "hf mfu sim -t 7 --uid 11223344556677 -n 5   -> MIFARE Ultralight EV1, Amiibo (NTAG 215),  pack 0x8080\n"
+                  "hf mfu sim -t 7                             -> MIFARE Ultralight EV1, Amiibo (NTAG 215),  pack 0x8080"
                  );
 
     void *argtable[] = {

--- a/client/src/cmdhfmfu.c
+++ b/client/src/cmdhfmfu.c
@@ -2730,8 +2730,8 @@ static int CmdHF14AMfUSim(const char *Cmd) {
                   "The UID from emulator memory will be used if not specified.\n"
                   "See `hf 14a sim -h` to see available types. You want 2 or 7 usually.",
                   "hf mfu sim -t 2 --uid 11223344556677        -> MIFARE Ultralight\n"
-                  "hf mfu sim -t 7 --uid 11223344556677 -n 5   -> MIFARE Ultralight EV1, Amiibo (NTAG 215),  pack 0x8080\n"
-                  "hf mfu sim -t 7                             -> MIFARE Ultralight EV1, Amiibo (NTAG 215),  pack 0x8080"
+                  "hf mfu sim -t 7 --uid 11223344556677 -n 5   -> MFUEV1 / NTAG 215 Amiibo\n"
+                  "hf mfu sim -t 7                             -> MFUEV1 / NTAG 215 Amiibo"
                  );
 
     void *argtable[] = {


### PR DESCRIPTION
`hf mfu sim -t 7` or `hf 14a sim -t 7`  without any other option was stopping after 7 reads, the proposed fix coreects that.
Also added a hint in the help text for Mifare Ultralight EV1 to type 7.
