### PR TITLE
Add Magic Gen4 GTU detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Added detection of magic Gen4 GTU (@DidierA)
  - Added luascript `hf_i2c_plus_2k_utils` - Script for dumping/modifying user memory of sectors 0 and 1 (@flamebarke) 
  - Added `hf mfu esave` - saves emulator memory to mfu dump file (@DidierA)
  - Added luascript `hf_mfu_ntag` - Script for configuring NTAG216 configuration pages (@flamebarke)

--- a/client/src/mifare/mifarehost.c
+++ b/client/src/mifare/mifarehost.c
@@ -1408,6 +1408,9 @@ int detect_mf_magic(bool is_mfc) {
         case MAGIC_GEN_3:
             PrintAndLogEx(SUCCESS, "Magic capabilities : possibly " _GREEN_("Gen 3 / APDU"));
             break;
+        case MAGIC_GEN_4GTU:
+            PrintAndLogEx(SUCCESS, "Magic capabilities : " _GREEN_("Gen 4 GTU"));
+            break;
         case MAGIC_GEN_UNFUSED:
             PrintAndLogEx(SUCCESS, "Magic capabilities : " _GREEN_("Write Once / FUID"));
             break;

--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -998,9 +998,14 @@ Can emulate MIFARE Classic, Ultralight/NTAG families, 14b UID & App Data
 ### Identify
 ^[Top](#top) ^^[Gen4](#g4top)
 
-👉 **TODO** Tag doesn't get identified correctly by latest Proxmark3 client (it might get mislabeled as MFC Gen2/CUID, Gen3/APDU or NTAG21x Modifiable, depending on configured UID/ATQA/SAK/ATS)
+👉 **TODO** If the password is not default, Tag doesn't get identified correctly by latest Proxmark3 client (it might get mislabeled as MFC Gen2/CUID, Gen3/APDU or NTAG21x Modifiable, depending on configured UID/ATQA/SAK/ATS)
 
-One can identify manually such card if the password is still the default one, with the command to get the current configuration:
+```
+hf 14a info
+[+] Magic capabilities : Gen 4 GTU
+```
+
+The card will be identified only if the password is the default one. One can identify manually such card if the password is still the default one, with the command to get the current configuration:
 ```
 hf 14a raw -s -c -t 1000 CF00000000C6
 ```
@@ -1108,6 +1113,14 @@ Default `<passwd>`: `00000000`
 ```
 # view contents of tag memory:
 hf mf gview
+# Read a specific block via backdoor command:
+hf mf ggetblk 
+# Write a specific block via backdoor command:
+hf mf gsetblk 
+# Load dump to tag:
+hf mf gload 
+# Save dump from tag:
+hf mf gsave
 ```
 👉 **TODO** `hf mf gview` is currently missing Ultralight memory maps 
 
@@ -1119,6 +1132,8 @@ hf 14a raw -s -c -t 1000 CF00000000CE01
 hf 14a raw -s -c -t 1000 CF00000000CE02
 ...
 ```
+
+👉 **TODO** In Mifare Ultralight / NTAG mode, the special writes (option -s, -e, -r) do not apply. Use `script run hf_mf_ultimatecard` for UID and signature, and `hf mfu wrbl` for PWD and PACK. 
 
 ### Change ATQA / SAK
 ^[Top](#top) ^^[Gen4](#g4top)

--- a/include/protocols.h
+++ b/include/protocols.h
@@ -252,6 +252,25 @@ ISO 7816-4 Basic interindustry commands. For command APDU's.
 #define MAGIC_SUPER         6
 #define MAGIC_NTAG21X       7
 #define MAGIC_GEN_3         8
+#define MAGIC_GEN_4GTU      9
+
+// Commands for configuration of Gen4 GTU cards.
+// see https://github.com/RfidResearchGroup/proxmark3/blob/master/doc/magic_cards_notes.md
+#define GEN_4GTU_CMD    0xCF // Prefix for all commands, followed by pasword (4b)
+#define GEN_4GTU_SHADOW 0x32 // Configure GTU shadow mode
+#define GEN_4GTU_ATS    0x34 // Configure ATS
+#define GEN_4GTU_ATQA   0x35 // Configure ATQA/SAK (swap ATQA bytes)
+#define GEN_4GTU_UIDLEN 0x68 // Configure UID length
+#define GEN_4GTU_ULEN   0x69 // (De)Activate Ultralight mode
+#define GEN_4GTU_ULMODE 0x6A // Select Ultralight mode
+#define GEN_4GTU_GETCNF 0xC6 // Dump configuration
+#define GEN_4GTU_TEST   0xCC // Factory test, returns 6666
+#define GEN_4GTU_WRITE  0xCD // Backdoor write 16b block
+#define GEN_4GTU_READ   0xCE // Backdoor read 16b block
+#define GEN_4GTU_SETCNF 0xF0 // Configure all params in one cmd
+#define GEN_4GTU_FUSCNF 0xF1 // Configure all params in one cmd and fuse the configuration permanently
+#define GEN_4GTU_CHPWD  0xFE // change password
+
 /**
 06 00 = INITIATE
 0E xx = SELECT ID (xx = Chip-ID)


### PR DESCRIPTION
Adds identification of magic gen4 GTU cards, using the dump configuration command. Card will only be detected if the password is default (00000000).

Added symbolic names for magic gen4 gtu protocol in `protocols.h` and changed src to use them.

Also changed the mifare classic wipe function in `hf_mf_ultimatecard.lua`  to erase the whole 4K memory and add all sector trailers.
