### PR TITLE
Get the hitag2 dump command working as per docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Fixed `trace list -t mf` - now also finds UID if anticollision is partial captured, to be used for mfkey (@iceman1001)
  - Added `hf mf gload, gsave, ggetblk, gsetblk` for Gen4 GTU in mifare classic mode (@DidierA)
  - Fixed SPI flash overflow when loading dictionnaries into flash. Breaking change: added 1 more sector for Mifare - dictionnaries should be loaded again (@jmichelp)
+ - Fixed `lf hitag dump` - Should now work as described in the command help (@natmchugh)
 
 ## [Radium.4.15864][2022-10-29]
  - Changed `lf indala sim` - now accepts fc / cn (@iceman1001)


### PR DESCRIPTION

I decided to try and understand some of the simpler hitag commands and this one looked like the simplest non working one. The command as written in the client didn't seem to be sending any commands. Hopefully I've understood it correctly and not broken anything.

**Example usage**
```
[usb] pm3 --> lf hitag dump -h

Read all card memory and save to fileIn password mode the default key is 4D494B52 (MIKR)                                                                  
In crypto mode the default key is 4F4E4D494B52 (ONMIKR)  format: ISK high + ISK low.                                                                      

usage:
    lf hitag dump [-h] [-f <fn>] [-k <hex>] [--nrar <hex>]

options:
    -h, --help                     This help
    -f, --file <fn>                specify file name
    -k, --key <hex>                key, 4 or 6 hex bytes
    --nrar <hex>                   nonce / answer reader, 8 hex bytes

examples/notes:
    lf hitag dump -k 4F4E4D494B52 
    lf hitag dump -k 4D494B52  
[usb] pm3 --> lf hitag dump -k AAAAAAAAAAAA -f testy
[=] Authenticating in crypto mode
[#] hitag2_crypto: key=0x555555555555 uid=0x48a41956
[#] Read successful!
[+] Dumping tag memory...
[=] 00 | 6A 98 25 12 | j.%.
[=] 01 | AA AA AA AA | ....
[=] 02 | 00 00 AA AA | ....
[=] 03 | 0E 91 34 08 | ..4.
[=] 04 | DE AD BE EF | ....
[=] 05 | 55 55 55 55 | UUUU
[=] 06 | AA AA AA AA | ....
[=] 07 | 55 55 55 55 | UUUU
[=] 08 | 00 00 00 00 | ....
[=] 09 | 00 00 00 00 | ....
[=] 10 | 00 00 00 00 | ....
[=] 11 | 00 00 00 00 | ....
[+] saved 48 bytes to binary file testy.bin
[+] saved 12 blocks to text file testy.eml
[+] saved to json file testy.json
```