### PR TITLE
Fix `trace list -r` (relative times)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed `trace list -r` (relative times) not working unless `-u` (microseconds) was specified, and made `--frame` respect `-u` and `-r` options (@nvx)
  - Added detection of magic Gen4 GTU (@DidierA)
  - Added luascript `hf_i2c_plus_2k_utils` - Script for dumping/modifying user memory of sectors 0 and 1 (@flamebarke) 
  - Added `hf mfu esave` - saves emulator memory to mfu dump file (@DidierA)

--- a/client/src/cmdtrace.c
+++ b/client/src/cmdtrace.c
@@ -815,8 +815,8 @@ static uint16_t printTraceLine(uint16_t tracepos, uint16_t traceLen, uint8_t *tr
                                  );
                 } else {
                     PrintAndLogEx(NORMAL, " %10u | %10u | Tag |%-*s | %s| %s",
-                                  (hdr->timestamp - first_hdr->timestamp),
-                                  (end_of_transmission_timestamp - first_hdr->timestamp),
+                                  time1,
+                                  time2,
                                   72 + crc_format_string_offset,
                                   line[j],
                                   (j == num_lines - 1) ? crc : "    ",
@@ -838,8 +838,8 @@ static uint16_t printTraceLine(uint16_t tracepos, uint16_t traceLen, uint8_t *tr
                 } else {
                     PrintAndLogEx(NORMAL,
                                   _YELLOW_(" %10u") " | " _YELLOW_("%10u") " | " _YELLOW_("Rdr") " |" _YELLOW_("%-*s")" | " _YELLOW_("%s") "| " _YELLOW_("%s"),
-                                  (hdr->timestamp - first_hdr->timestamp),
-                                  (end_of_transmission_timestamp - first_hdr->timestamp),
+                                  time1,
+                                  time2,
                                   72 + crc_format_string_offset,
                                   line[j],
                                   (j == num_lines - 1) ? crc : "    ",
@@ -889,11 +889,26 @@ static uint16_t printTraceLine(uint16_t tracepos, uint16_t traceLen, uint8_t *tr
 
         tracelog_hdr_t *next_hdr = (tracelog_hdr_t *)(trace + tracepos);
 
-        PrintAndLogEx(NORMAL, " %10u | %10u | %s |fdt (Frame Delay Time): " _YELLOW_("%d"),
-                      (end_of_transmission_timestamp - first_hdr->timestamp),
-                      (next_hdr->timestamp - first_hdr->timestamp),
-                      "   ",
-                      (next_hdr->timestamp - end_of_transmission_timestamp));
+        uint32_t time1 = end_of_transmission_timestamp - first_hdr->timestamp;
+        uint32_t time2 = next_hdr->timestamp - first_hdr->timestamp;
+        if (prev_eot) {
+            time1 = 0;
+            time2 = next_hdr->timestamp - end_of_transmission_timestamp;
+        }
+
+        if (use_us) {
+            PrintAndLogEx(NORMAL, " %10.1f | %10.1f | %s |fdt (Frame Delay Time): " _YELLOW_("%.1f"),
+                (float)time1 / 13.56,
+                (float)time2 / 13.56,
+                "   ",
+                (float)(next_hdr->timestamp - end_of_transmission_timestamp) / 13.56);
+        } else {
+            PrintAndLogEx(NORMAL, " %10u | %10u | %s |fdt (Frame Delay Time): " _YELLOW_("%d"),
+                time1,
+                time2,
+                "   ",
+                (next_hdr->timestamp - end_of_transmission_timestamp));
+        }
     }
 
     return tracepos;


### PR DESCRIPTION
Fix `trace list -r` (relative times) not working unless the `-u` (micoseconds) flag was also provided.

Also makes the `--frame` option respect microseconds and relative times as well.