### PR TITLE
Fixing some ISO7816-4 logic.

### DIFF
--- a/client/src/cmdsmartcard.h
+++ b/client/src/cmdsmartcard.h
@@ -22,6 +22,11 @@
 #include "common.h"
 #include "pm3_cmd.h" // structs
 
+// On ARM side, ISO7816_MAX_FRAME is set to 255
+// This means we can't receive more than 250 bytes of data to leave enough room for
+// SW status code and surrounding metadata without creating a buffer overflow.
+#define MAX_APDU_SIZE 250
+
 int CmdSmartcard(const char *Cmd);
 
 bool smart_select(bool verbose, smart_card_atr_t *atr);


### PR DESCRIPTION
- Fixing overflow in BigBuffer if requesting to much data
- Fixing integer wrapping with the SIM module by capping APDU data length
- Fixing chaining logic which was loosing previously received data