### PR TITLE
Buffer size too conservative

### DIFF
--- a/armsrc/i2c.c
+++ b/armsrc/i2c.c
@@ -54,7 +54,7 @@ static void __attribute__((optimize("O0"))) I2CSpinDelayClk(uint16_t delay) {
 #define I2C_DELAY_XCLK(x) I2CSpinDelayClk((x))
 
 // The SIM module v4 supports up to 384 bytes for the length.
-#define  ISO7816_MAX_FRAME 260
+#define  ISO7816_MAX_FRAME 270
 
 // try i2c bus recovery at 100kHz = 5us high, 5us low
 void I2C_recovery(void) {

--- a/client/src/cmdsmartcard.c
+++ b/client/src/cmdsmartcard.c
@@ -337,7 +337,7 @@ static int smart_responseEx(uint8_t *out, int maxoutlen, bool verbose) {
         }
         int ofs = totallen;
         maxoutlen -= totallen;
-        PrintAndLogEx(INFO, "Keeping data (%d bytes): %s", ofs, sprint_hex(out, ofs));
+        PrintAndLogEx(DEBUG, "Keeping data (%d bytes): %s", ofs, sprint_hex(out, ofs));
 
         int len = out[datalen - 1];
         if (len == 0 || len > MAX_APDU_SIZE) {


### PR DESCRIPTION
Sadly I did the maths wrong: when asking 256 bytes APDU data, it creates a buffer of 261 bytes. Off-by-one. Putting 270 for the peace of mind.
Tested against PIV with big objects and it works nicely.