### PR TITLE
Wait a bit longer for the smartcard.

### DIFF
--- a/armsrc/i2c.c
+++ b/armsrc/i2c.c
@@ -235,9 +235,9 @@ static bool I2C_WaitForSim(void) {
 
     // 8051 speaks with smart card.
     // 1000*50*3.07 = 153.5ms
-    // 1000*90*3.07 = 276.3ms
+    // 1000*110*3.07 = 337.7ms
     // 1byte transfer == 1ms with max frame being 256bytes
-    return WaitSCL_H_delay(1000 * 90);
+    return WaitSCL_H_delay(1000 * 110);
 }
 
 // send i2c STOP


### PR DESCRIPTION
For the max 256-byte frame, SIM wasn't ready early enough, corrupting the reception buffer with 5 spurious bytes.
Empirically, 109 clock cycles is the minimum value that worked. Adding 1 clock cycle as a safety buffer.