### PR TITLE
Fix `make accessrights` for Fedora

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Fixed `pm3` shell script now automatically detects WSL2 with USBIPD serial ports (@iceman1001)
  - Fixed `trace list -c` - annotation of CRC bytes now is colored or squared if no ansi colors is supported (@iceman1001)
  - Fixed `trace list -t mf` - now also finds UID if anticollision is partial captured, to be used for mfkey (@iceman1001)
+ - Fixed `make accessrights` on Fedora (@mooey5775)
 
 ## [Radium.4.15864][2022-10-29]
  - Changed `lf indala sim` - now accepts fc / cn (@iceman1001)

--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,10 @@ ifneq ($(wildcard /etc/arch-release),)
 #If user is running ArchLinux, use specific command and group
 	$(Q)$(SUDO) $(USERMOD) uucp $(USER)
 	$(Q)$(GETENT_BL) >/dev/null && $(SUDO) $(USERMOD) bluetooth $(USER) || true
+else ifneq ($(wildcard /etc/fedora-release),)
+# If the user is running Fedora, use `usermod` with the dialout group
+	$(Q)$(SUDO) $(USERMOD) dialout $(USER)
+	$(Q)$(GETENT_BL) >/dev/null && $(SUDO) $(USERMOD) bluetooth $(USER) || true
 else
 	$(Q)$(SUDO) $(ADDUSER) $(USER) dialout
 	$(Q)$(GETENT_BL) >/dev/null && $(SUDO) $(ADDUSER) $(USER) bluetooth || true


### PR DESCRIPTION
Fixes #1795

Fedora doesn't allow the use of `adduser` to add users to groups. Instead, `usermod -aG` should be used, like in Arch, but with the dialout group instead of uucp.

As a brief discussion item before merge, should non-Arch distros just use `usermod` instead of `adduser`? This should work in general, and would get rid of the extra conditional. However, doing the testing for this might be difficult.