### PR TITLE
Add iclass reader ASK support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Add `--shallow` option to `hf iclass` reader commands to do shallow (ASK) reader modulation instead of OOK (@nvx)
  - Improved NXP SLI/SLIX series tag identification (@nvx)
  - Fixed buffer overflow in "lf em 4x05 sniff" (@HeinrichsH)
  - Fixed potential NULL array printing (@jmichel)

--- a/armsrc/Standalone/hf_iceclass.c
+++ b/armsrc/Standalone/hf_iceclass.c
@@ -322,6 +322,7 @@ static int reader_dump_mode(void) {
             .use_credit_key = false,
             .do_auth = true,
             .send_reply = false,
+            .shallow_mod = false,
         };
         memcpy(auth.key, legacy_aa1_key, sizeof(auth.key));
 
@@ -333,7 +334,7 @@ static int reader_dump_mode(void) {
 
         // select tag.
         uint32_t eof_time = 0;
-        bool res = select_iclass_tag(hdr, auth.use_credit_key, &eof_time);
+        bool res = select_iclass_tag(hdr, auth.use_credit_key, &eof_time, false);
         if (res == false) {
             switch_off();
             continue;
@@ -382,7 +383,7 @@ static int reader_dump_mode(void) {
 
         // main read loop
         for (uint16_t i = start_block; i <= app1_limit; i++) {
-            if (iclass_read_block(i, card_data + (8 * i), &start_time, &eof_time)) {
+            if (iclass_read_block(i, card_data + (8 * i), &start_time, &eof_time, false)) {
                 dumped++;
             }
         }
@@ -394,7 +395,7 @@ static int reader_dump_mode(void) {
             auth.use_credit_key = true;
             memcpy(auth.key, aa2_key, sizeof(auth.key));
 
-            res = select_iclass_tag(hdr, auth.use_credit_key, &eof_time);
+            res = select_iclass_tag(hdr, auth.use_credit_key, &eof_time, false);
             if (res) {
 
                 // sanity check of CSN.
@@ -408,7 +409,7 @@ static int reader_dump_mode(void) {
                     start_time = eof_time + DELAY_ICLASS_VICC_TO_VCD_READER;
 
                     for (uint16_t i = app1_limit + 1; i <= app2_limit; i++) {
-                        if (iclass_read_block(i, card_data + (8 * i), &start_time, &eof_time)) {
+                        if (iclass_read_block(i, card_data + (8 * i), &start_time, &eof_time, false)) {
                             dumped++;
                         }
                     }
@@ -458,6 +459,7 @@ static int dump_sim_mode(void) {
             .use_credit_key = false,
             .do_auth = true,
             .send_reply = false,
+            .shallow_mod = false,
         };
         memcpy(auth.key, legacy_aa1_key, sizeof(auth.key));
 
@@ -469,7 +471,7 @@ static int dump_sim_mode(void) {
 
         // select tag.
         uint32_t eof_time = 0;
-        bool res = select_iclass_tag(hdr, auth.use_credit_key, &eof_time);
+        bool res = select_iclass_tag(hdr, auth.use_credit_key, &eof_time, false);
         if (res == false) {
             switch_off();
             continue;
@@ -518,7 +520,7 @@ static int dump_sim_mode(void) {
 
         // main read loop
         for (uint16_t i = start_block; i <= app1_limit; i++) {
-            if (iclass_read_block(i, card_data + (8 * i), &start_time, &eof_time)) {
+            if (iclass_read_block(i, card_data + (8 * i), &start_time, &eof_time, false)) {
                 dumped++;
             }
         }
@@ -530,7 +532,7 @@ static int dump_sim_mode(void) {
             auth.use_credit_key = true;
             memcpy(auth.key, aa2_key, sizeof(auth.key));
 
-            res = select_iclass_tag(hdr, auth.use_credit_key, &eof_time);
+            res = select_iclass_tag(hdr, auth.use_credit_key, &eof_time, false);
             if (res) {
 
                 // sanity check of CSN.
@@ -544,7 +546,7 @@ static int dump_sim_mode(void) {
                     start_time = eof_time + DELAY_ICLASS_VICC_TO_VCD_READER;
 
                     for (uint16_t i = app1_limit + 1; i <= app2_limit; i++) {
-                        if (iclass_read_block(i, card_data + (8 * i), &start_time, &eof_time)) {
+                        if (iclass_read_block(i, card_data + (8 * i), &start_time, &eof_time, false)) {
                             dumped++;
                         }
                     }

--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -1245,23 +1245,23 @@ send:
 }
 
 // THE READER CODE
-static void iclass_send_as_reader(uint8_t *frame, int len, uint32_t *start_time, uint32_t *end_time) {
+static void iclass_send_as_reader(uint8_t *frame, int len, uint32_t *start_time, uint32_t *end_time, bool shallow_mod) {
     CodeIso15693AsReader(frame, len);
     tosend_t *ts = get_tosend();
-    TransmitTo15693Tag(ts->buf, ts->max, start_time);
+    TransmitTo15693Tag(ts->buf, ts->max, start_time, shallow_mod);
     *end_time = *start_time + (32 * ((8 * ts->max) - 4)); // subtract the 4 padding bits after EOF
     LogTrace_ISO15693(frame, len, (*start_time * 4), (*end_time * 4), NULL, true);
 }
 
 static bool iclass_send_cmd_with_retries(uint8_t *cmd, size_t cmdsize, uint8_t *resp, size_t max_resp_size,
                                          uint8_t expected_size, uint8_t tries, uint32_t *start_time,
-                                         uint16_t timeout, uint32_t *eof_time) {
+                                         uint16_t timeout, uint32_t *eof_time, bool shallow_mod) {
 
     uint16_t resp_len = 0;
     int res;
     while (tries-- > 0) {
 
-        iclass_send_as_reader(cmd, cmdsize, start_time, eof_time);
+        iclass_send_as_reader(cmd, cmdsize, start_time, eof_time, shallow_mod);
 
         if (resp == NULL) {
             return true;
@@ -1282,7 +1282,7 @@ static bool iclass_send_cmd_with_retries(uint8_t *cmd, size_t cmdsize, uint8_t *
  * @return false = fail
  *         true = Got all.
  */
-static bool select_iclass_tag_ex(picopass_hdr_t *hdr, bool use_credit_key, uint32_t *eof_time, uint8_t *status) {
+static bool select_iclass_tag_ex(picopass_hdr_t *hdr, bool use_credit_key, uint32_t *eof_time, uint8_t *status, bool shallow_mod) {
 
     static uint8_t act_all[] = { ICLASS_CMD_ACTALL };
     static uint8_t identify[] = { ICLASS_CMD_READ_OR_IDENTIFY, 0x00, 0x73, 0x33 };
@@ -1299,7 +1299,7 @@ static bool select_iclass_tag_ex(picopass_hdr_t *hdr, bool use_credit_key, uint3
 
     // wakeup
     uint32_t start_time = GetCountSspClk();
-    iclass_send_as_reader(act_all, 1, &start_time, eof_time);
+    iclass_send_as_reader(act_all, 1, &start_time, eof_time, shallow_mod);
     int res;
     uint16_t resp_len = 0;
     res = GetIso15693AnswerFromTag(resp, sizeof(resp), ICLASS_READER_TIMEOUT_ACTALL, eof_time, false, true, &resp_len);
@@ -1308,7 +1308,7 @@ static bool select_iclass_tag_ex(picopass_hdr_t *hdr, bool use_credit_key, uint3
 
     // send Identify
     start_time = *eof_time + DELAY_ICLASS_VICC_TO_VCD_READER;
-    iclass_send_as_reader(identify, 1, &start_time, eof_time);
+    iclass_send_as_reader(identify, 1, &start_time, eof_time, shallow_mod);
 
     // expect a 10-byte response here, 8 byte anticollision-CSN and 2 byte CRC
     res = GetIso15693AnswerFromTag(resp, sizeof(resp), ICLASS_READER_TIMEOUT_OTHERS, eof_time, false, true, &resp_len);
@@ -1320,7 +1320,7 @@ static bool select_iclass_tag_ex(picopass_hdr_t *hdr, bool use_credit_key, uint3
 
     // select the card
     start_time = *eof_time + DELAY_ICLASS_VICC_TO_VCD_READER;
-    iclass_send_as_reader(select, sizeof(select), &start_time, eof_time);
+    iclass_send_as_reader(select, sizeof(select), &start_time, eof_time, shallow_mod);
 
     // expect a 10-byte response here, 8 byte CSN and 2 byte CRC
     res = GetIso15693AnswerFromTag(resp, sizeof(resp), ICLASS_READER_TIMEOUT_OTHERS, eof_time, false, true, &resp_len);
@@ -1332,7 +1332,7 @@ static bool select_iclass_tag_ex(picopass_hdr_t *hdr, bool use_credit_key, uint3
 
     // card selected, now read config (block1) (only 8 bytes no CRC)
     start_time = *eof_time + DELAY_ICLASS_VICC_TO_VCD_READER;
-    iclass_send_as_reader(read_conf, sizeof(read_conf), &start_time, eof_time);
+    iclass_send_as_reader(read_conf, sizeof(read_conf), &start_time, eof_time, shallow_mod);
 
     // expect a 8-byte response here
     res = GetIso15693AnswerFromTag(resp, sizeof(resp), ICLASS_READER_TIMEOUT_OTHERS, eof_time, false, true, &resp_len);
@@ -1350,7 +1350,7 @@ static bool select_iclass_tag_ex(picopass_hdr_t *hdr, bool use_credit_key, uint3
 
         // read App Issuer Area block 5
         start_time = *eof_time + DELAY_ICLASS_VICC_TO_VCD_READER;
-        iclass_send_as_reader(read_aia, sizeof(read_aia), &start_time, eof_time);
+        iclass_send_as_reader(read_aia, sizeof(read_aia), &start_time, eof_time, shallow_mod);
 
         // expect a 10-byte response here
         res = GetIso15693AnswerFromTag(resp, sizeof(resp), ICLASS_READER_TIMEOUT_OTHERS, eof_time, false, true, &resp_len);
@@ -1364,7 +1364,7 @@ static bool select_iclass_tag_ex(picopass_hdr_t *hdr, bool use_credit_key, uint3
 
         // card selected, now read e-purse (cc) (block2) (only 8 bytes no CRC)
         start_time = *eof_time + DELAY_ICLASS_VICC_TO_VCD_READER;
-        iclass_send_as_reader(read_check_cc, sizeof(read_check_cc), &start_time, eof_time);
+        iclass_send_as_reader(read_check_cc, sizeof(read_check_cc), &start_time, eof_time, shallow_mod);
 
         // expect a 8-byte response here
         res = GetIso15693AnswerFromTag(resp, sizeof(resp), ICLASS_READER_TIMEOUT_OTHERS, eof_time, false, true, &resp_len);
@@ -1386,7 +1386,7 @@ static bool select_iclass_tag_ex(picopass_hdr_t *hdr, bool use_credit_key, uint3
         read_aia[3] = 0x10;
 
         start_time = *eof_time + DELAY_ICLASS_VICC_TO_VCD_READER;
-        iclass_send_as_reader(read_aia, sizeof(read_aia), &start_time, eof_time);
+        iclass_send_as_reader(read_aia, sizeof(read_aia), &start_time, eof_time, shallow_mod);
 
         // expect a 10-byte response here
         res = GetIso15693AnswerFromTag(resp, sizeof(resp), ICLASS_READER_TIMEOUT_OTHERS, eof_time, false, true, &resp_len);
@@ -1402,9 +1402,9 @@ static bool select_iclass_tag_ex(picopass_hdr_t *hdr, bool use_credit_key, uint3
     return true;
 }
 
-bool select_iclass_tag(picopass_hdr_t *hdr, bool use_credit_key, uint32_t *eof_time) {
+bool select_iclass_tag(picopass_hdr_t *hdr, bool use_credit_key, uint32_t *eof_time, bool shallow_mod) {
     uint8_t result = 0;
-    return select_iclass_tag_ex(hdr, use_credit_key, eof_time, &result);
+    return select_iclass_tag_ex(hdr, use_credit_key, eof_time, &result, shallow_mod);
 }
 
 // Reader iClass Anticollission
@@ -1413,6 +1413,7 @@ void ReaderIClass(uint8_t flags) {
 
     // flag to use credit key
     bool use_credit_key = ((flags & FLAG_ICLASS_READER_CREDITKEY) == FLAG_ICLASS_READER_CREDITKEY);
+    bool shallow_mod = (flags & FLAG_ICLASS_READER_SHALLOW_MOD);
 
     if ((flags & FLAG_ICLASS_READER_INIT) == FLAG_ICLASS_READER_INIT) {
         Iso15693InitReader();
@@ -1427,7 +1428,7 @@ void ReaderIClass(uint8_t flags) {
     uint32_t eof_time = 0;
     picopass_hdr_t hdr = {0};
 
-    if (select_iclass_tag_ex(&hdr, use_credit_key, &eof_time, &res) == false) {
+    if (select_iclass_tag_ex(&hdr, use_credit_key, &eof_time, &res, shallow_mod) == false) {
         reply_ng(CMD_HF_ICLASS_READER, PM3_ERFTRANS, NULL, 0);
         goto out;
     }
@@ -1498,7 +1499,7 @@ bool authenticate_iclass_tag(iclass_auth_req_t *payload, picopass_hdr_t *hdr, ui
         cmd_check[7] = pmac[2];
         cmd_check[8] = pmac[3];
     }
-    return iclass_send_cmd_with_retries(cmd_check, sizeof(cmd_check), resp_auth, sizeof(resp_auth), 4, 2, start_time, ICLASS_READER_TIMEOUT_OTHERS, eof_time);
+    return iclass_send_cmd_with_retries(cmd_check, sizeof(cmd_check), resp_auth, sizeof(resp_auth), 4, 2, start_time, ICLASS_READER_TIMEOUT_OTHERS, eof_time, payload->shallow_mod);
 }
 
 
@@ -1515,6 +1516,8 @@ void iClass_Authentication_fast(iclass_chk_t *p) {
         reply_ng(CMD_HF_ICLASS_CHKKEYS, PM3_ESOFT, NULL, 0);
         return;
     }
+
+    bool shallow_mod = p->shallow_mod;
 
     uint8_t check[9] = { ICLASS_CMD_CHECK };
     uint8_t resp[ICLASS_BUFFER_SIZE] = {0};
@@ -1537,7 +1540,7 @@ void iClass_Authentication_fast(iclass_chk_t *p) {
     bool isOK = false;
 
     uint32_t start_time = 0, eof_time = 0;
-    if (select_iclass_tag(&hdr, p->use_credit_key, &eof_time) == false)
+    if (select_iclass_tag(&hdr, p->use_credit_key, &eof_time, shallow_mod) == false)
         goto out;
 
     start_time = eof_time + DELAY_ICLASS_VICC_TO_VCD_READER;
@@ -1566,14 +1569,14 @@ void iClass_Authentication_fast(iclass_chk_t *p) {
         check[8] = keys[i].mac[3];
 
         // expect 4bytes, 3 retries times..
-        isOK = iclass_send_cmd_with_retries(check, sizeof(check), resp, sizeof(resp), 4, 2, &start_time, ICLASS_READER_TIMEOUT_OTHERS, &eof_time);
+        isOK = iclass_send_cmd_with_retries(check, sizeof(check), resp, sizeof(resp), 4, 2, &start_time, ICLASS_READER_TIMEOUT_OTHERS, &eof_time, shallow_mod);
         if (isOK)
             goto out;
 
         start_time = eof_time + DELAY_ICLASS_VICC_TO_VCD_READER;
         // Auth Sequence MUST begin with reading e-purse. (block2)
         // Card selected, now read e-purse (cc) (block2) (only 8 bytes no CRC)
-        iclass_send_as_reader(readcheck_cc, sizeof(readcheck_cc), &start_time, &eof_time);
+        iclass_send_as_reader(readcheck_cc, sizeof(readcheck_cc), &start_time, &eof_time, shallow_mod);
         LED_B_OFF();
     }
 
@@ -1586,11 +1589,11 @@ out:
 // Tries to read block.
 // retries 3times.
 // reply 8 bytes block
-bool iclass_read_block(uint16_t blockno, uint8_t *data, uint32_t *start_time, uint32_t *eof_time) {
+bool iclass_read_block(uint16_t blockno, uint8_t *data, uint32_t *start_time, uint32_t *eof_time, bool shallow_mod) {
     uint8_t resp[10];
     uint8_t c[] = {ICLASS_CMD_READ_OR_IDENTIFY, blockno, 0x00, 0x00};
     AddCrc(c + 1, 1);
-    bool isOK = iclass_send_cmd_with_retries(c, sizeof(c), resp, sizeof(resp), 10, 2, start_time, ICLASS_READER_TIMEOUT_OTHERS, eof_time);
+    bool isOK = iclass_send_cmd_with_retries(c, sizeof(c), resp, sizeof(resp), 10, 2, start_time, ICLASS_READER_TIMEOUT_OTHERS, eof_time, shallow_mod);
     if (isOK)
         memcpy(data, resp, 8);
     return isOK;
@@ -1602,6 +1605,7 @@ bool iclass_read_block(uint16_t blockno, uint8_t *data, uint32_t *start_time, ui
 void iClass_ReadBlock(uint8_t *msg) {
 
     iclass_auth_req_t *payload = (iclass_auth_req_t *)msg;
+    bool shallow_mod = payload->shallow_mod;
 
     iclass_readblock_resp_t response = { .isOK = true };
     memset(response.data, 0, sizeof(response.data));
@@ -1614,7 +1618,7 @@ void iClass_ReadBlock(uint8_t *msg) {
     // select tag.
     uint32_t eof_time = 0;
     picopass_hdr_t hdr = {0};
-    bool res = select_iclass_tag(&hdr, payload->use_credit_key, &eof_time);
+    bool res = select_iclass_tag(&hdr, payload->use_credit_key, &eof_time, shallow_mod);
     if (res == false) {
         if (payload->send_reply) {
             response.isOK = res;
@@ -1642,7 +1646,7 @@ void iClass_ReadBlock(uint8_t *msg) {
 
     // read data
     uint8_t resp[10];
-    res = iclass_send_cmd_with_retries(cmd_read, sizeof(cmd_read), resp, sizeof(resp), 10, 3, &start_time, ICLASS_READER_TIMEOUT_OTHERS, &eof_time);
+    res = iclass_send_cmd_with_retries(cmd_read, sizeof(cmd_read), resp, sizeof(resp), 10, 3, &start_time, ICLASS_READER_TIMEOUT_OTHERS, &eof_time, shallow_mod);
     if (res) {
         memcpy(response.data, resp, sizeof(response.data));
         if (payload->send_reply) {
@@ -1670,6 +1674,7 @@ void iClass_Dump(uint8_t *msg) {
 
     iclass_dump_req_t *cmd = (iclass_dump_req_t *)msg;
     iclass_auth_req_t *req = &cmd->req;
+    bool shallow_mod = req->shallow_mod;
 
     uint8_t *dataout = BigBuf_malloc(ICLASS_16KS_SIZE);
     if (dataout == NULL) {
@@ -1689,7 +1694,7 @@ void iClass_Dump(uint8_t *msg) {
     picopass_hdr_t hdr = {0};
     memset(&hdr, 0xff, sizeof(picopass_hdr_t));
 
-    bool res = select_iclass_tag(&hdr, req->use_credit_key, &eof_time);
+    bool res = select_iclass_tag(&hdr, req->use_credit_key, &eof_time, shallow_mod);
     if (res == false) {
         if (req->send_reply) {
             reply_ng(CMD_HF_ICLASS_DUMP, PM3_ETIMEOUT, NULL, 0);
@@ -1724,7 +1729,7 @@ void iClass_Dump(uint8_t *msg) {
         uint8_t c[] = {ICLASS_CMD_READ_OR_IDENTIFY, i, 0x00, 0x00};
         AddCrc(c + 1, 1);
 
-        res = iclass_send_cmd_with_retries(c, sizeof(c), resp, sizeof(resp), 10, 3, &start_time, ICLASS_READER_TIMEOUT_OTHERS, &eof_time);
+        res = iclass_send_cmd_with_retries(c, sizeof(c), resp, sizeof(resp), 10, 3, &start_time, ICLASS_READER_TIMEOUT_OTHERS, &eof_time, shallow_mod);
         if (res) {
             memcpy(dataout + (8 * i), resp, 8);
         } else {
@@ -1759,7 +1764,7 @@ void iClass_Dump(uint8_t *msg) {
     BigBuf_free();
 }
 
-static bool iclass_writeblock_ext(uint8_t blockno, uint8_t *data, uint8_t *mac, bool use_mac) {
+static bool iclass_writeblock_ext(uint8_t blockno, uint8_t *data, uint8_t *mac, bool use_mac, bool shallow_mod) {
 
     // write command: cmd, 1 blockno, 8 data, 4 mac
     uint8_t write[14] = { 0x80 | ICLASS_CMD_UPDATE, blockno };
@@ -1775,7 +1780,7 @@ static bool iclass_writeblock_ext(uint8_t blockno, uint8_t *data, uint8_t *mac, 
 
     uint8_t resp[10] = {0};
     uint32_t eof_time = 0, start_time = 0;
-    bool isOK = iclass_send_cmd_with_retries(write, write_len, resp, sizeof(resp), 10, 3, &start_time, ICLASS_READER_TIMEOUT_UPDATE, &eof_time);
+    bool isOK = iclass_send_cmd_with_retries(write, write_len, resp, sizeof(resp), 10, 3, &start_time, ICLASS_READER_TIMEOUT_UPDATE, &eof_time, shallow_mod);
     if (isOK == false) {
         return false;
     }
@@ -1807,6 +1812,7 @@ void iClass_WriteBlock(uint8_t *msg) {
     LED_A_ON();
 
     iclass_writeblock_req_t *payload = (iclass_writeblock_req_t *)msg;
+    bool shallow_mod = payload->req.shallow_mod;
 
     uint8_t write[14] = { 0x80 | ICLASS_CMD_UPDATE, payload->req.blockno };
     uint8_t write_len = 14;
@@ -1816,7 +1822,7 @@ void iClass_WriteBlock(uint8_t *msg) {
     // select tag.
     uint32_t eof_time = 0;
     picopass_hdr_t hdr = {0};
-    uint8_t res = select_iclass_tag(&hdr, payload->req.use_credit_key, &eof_time);
+    uint8_t res = select_iclass_tag(&hdr, payload->req.use_credit_key, &eof_time, shallow_mod);
     if (res == false) {
         goto out;
     }
@@ -1871,7 +1877,7 @@ void iClass_WriteBlock(uint8_t *msg) {
     uint8_t tries = 3;
     while (tries-- > 0) {
 
-        iclass_send_as_reader(write, write_len, &start_time, &eof_time);
+        iclass_send_as_reader(write, write_len, &start_time, &eof_time, shallow_mod);
 
         if (tearoff_hook() == PM3_ETEAROFF) { // tearoff occurred
             res = false;
@@ -1939,6 +1945,8 @@ void iClass_Restore(iclass_restore_req_t *msg) {
         return;
     }
 
+    bool shallow_mod = msg->req.shallow_mod;
+
     LED_A_ON();
     Iso15693InitReader();
 
@@ -1947,7 +1955,7 @@ void iClass_Restore(iclass_restore_req_t *msg) {
     picopass_hdr_t hdr = {0};
 
     // select
-    bool res = select_iclass_tag(&hdr, msg->req.use_credit_key, &eof_time);
+    bool res = select_iclass_tag(&hdr, msg->req.use_credit_key, &eof_time, shallow_mod);
     if (res == false) {
         goto out;
     }
@@ -1988,7 +1996,7 @@ void iClass_Restore(iclass_restore_req_t *msg) {
         }
 
         // data + mac
-        if (iclass_writeblock_ext(item.blockno, item.data, mac, use_mac)) {
+        if (iclass_writeblock_ext(item.blockno, item.data, mac, use_mac, shallow_mod)) {
             Dbprintf("Write block [%3d/0x%02X] " _GREEN_("successful"), item.blockno, item.blockno);
             written++;
         } else {

--- a/armsrc/iclass.h
+++ b/armsrc/iclass.h
@@ -38,8 +38,8 @@ void iClass_Authentication_fast(iclass_chk_t *p);
 bool iclass_auth(iclass_auth_req_t *payload, uint8_t *out);
 
 void iClass_ReadBlock(uint8_t *msg);
-bool iclass_read_block(uint16_t blockno, uint8_t *data, uint32_t *start_time, uint32_t *eof_time);
+bool iclass_read_block(uint16_t blockno, uint8_t *data, uint32_t *start_time, uint32_t *eof_time, bool shallow_mod);
 
-bool select_iclass_tag(picopass_hdr_t *hdr, bool use_credit_key, uint32_t *eof_time);
+bool select_iclass_tag(picopass_hdr_t *hdr, bool use_credit_key, uint32_t *eof_time, bool shallow_mod);
 bool authenticate_iclass_tag(iclass_auth_req_t *payload, picopass_hdr_t *hdr, uint32_t *start_time, uint32_t *eof_time, uint8_t *mac_out);
 #endif

--- a/armsrc/iso15693.c
+++ b/armsrc/iso15693.c
@@ -262,9 +262,9 @@ void CodeIso15693AsTag(const uint8_t *cmd, size_t len) {
 }
 
 // Transmit the command (to the tag) that was placed in cmd[].
-void TransmitTo15693Tag(const uint8_t *cmd, int len, uint32_t *start_time) {
+void TransmitTo15693Tag(const uint8_t *cmd, int len, uint32_t *start_time, bool shallow_mod) {
 
-    FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_READER | FPGA_HF_READER_MODE_SEND_FULL_MOD);
+    FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_READER | (shallow_mod ? FPGA_HF_READER_MODE_SEND_SHALLOW_MOD : FPGA_HF_READER_MODE_SEND_FULL_MOD));
 
     if (*start_time < DELAY_ARM_TO_TAG) {
         *start_time = DELAY_ARM_TO_TAG;
@@ -1585,7 +1585,7 @@ void AcquireRawAdcSamplesIso15693(void) {
     tosend_t *ts = get_tosend();
 
     uint32_t start_time = 0;
-    TransmitTo15693Tag(ts->buf, ts->max, &start_time);
+    TransmitTo15693Tag(ts->buf, ts->max, &start_time, false);
 
     // wait for last transfer to complete
     while (!(AT91C_BASE_SSC->SSC_SR & AT91C_SSC_TXEMPTY)) ;
@@ -1899,7 +1899,7 @@ int SendDataTag(uint8_t *send, int sendlen, bool init, bool speed_fast, uint8_t 
     }
 
     tosend_t *ts = get_tosend();
-    TransmitTo15693Tag(ts->buf, ts->max, &start_time);
+    TransmitTo15693Tag(ts->buf, ts->max, &start_time, false);
 
     if (tearoff_hook() == PM3_ETEAROFF) { // tearoff occurred
         *resp_len = 0;
@@ -1922,7 +1922,7 @@ int SendDataTagEOF(uint8_t *recv, uint16_t max_recv_len, uint32_t start_time, ui
 
     CodeIso15693AsReaderEOF();
     tosend_t *ts = get_tosend();
-    TransmitTo15693Tag(ts->buf, ts->max, &start_time);
+    TransmitTo15693Tag(ts->buf, ts->max, &start_time, false);
     uint32_t end_time = start_time + 32 * (8 * ts->max - 4); // subtract the 4 padding bits after EOF
     LogTrace_ISO15693(NULL, 0, (start_time * 4), (end_time * 4), NULL, true);
 

--- a/armsrc/iso15693.h
+++ b/armsrc/iso15693.h
@@ -40,7 +40,7 @@ void CodeIso15693AsTag(const uint8_t *cmd, size_t len);
 
 void TransmitTo15693Reader(const uint8_t *cmd, size_t len, uint32_t *start_time, uint32_t slot_time, bool slow);
 int GetIso15693CommandFromReader(uint8_t *received, size_t max_len, uint32_t *eof_time);
-void TransmitTo15693Tag(const uint8_t *cmd, int len, uint32_t *start_time);
+void TransmitTo15693Tag(const uint8_t *cmd, int len, uint32_t *start_time, bool shallow_mod);
 int GetIso15693AnswerFromTag(uint8_t *response, uint16_t max_len, uint16_t timeout, uint32_t *eof_time, bool fsk, bool recv_speed, uint16_t *resp_len);
 
 //void RecordRawAdcSamplesIso15693(void);

--- a/client/src/cmdhf.c
+++ b/client/src/cmdhf.c
@@ -123,7 +123,7 @@ int CmdHFSearch(const char *Cmd) {
     PROMPT_CLEARLINE;
     PrintAndLogEx(INPLACE, " Searching for iCLASS / PicoPass tag...");
     if (IfPm3Iclass()) {
-        if (read_iclass_csn(false, false) == PM3_SUCCESS) {
+        if (read_iclass_csn(false, false, false) == PM3_SUCCESS) {
             PrintAndLogEx(SUCCESS, "\nValid " _GREEN_("iCLASS tag / PicoPass tag") " found\n");
             res = PM3_SUCCESS;
         }

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -285,7 +285,7 @@ static int generate_config_card(const iclass_config_card_item_t *o,  uint8_t *ke
 
     // get header from card
     PrintAndLogEx(INFO, "trying to read a card..");
-    int res = read_iclass_csn(false, false);
+    int res = read_iclass_csn(false, false, false);
     if (res == PM3_SUCCESS) {
         cc = &iclass_last_known_card;
         // calc diversified key for selected card
@@ -905,18 +905,24 @@ static int CmdHFiClassInfo(const char *Cmd) {
 
     void *argtable[] = {
         arg_param_begin,
+        arg_lit0(NULL, "shallow", "use shallow (ASK) reader modulation instead of OOK"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
+    bool shallow_mod = arg_get_lit(ctx, 1);
     CLIParserFree(ctx);
-    return info_iclass();
+    return info_iclass(shallow_mod);
 }
 
-int read_iclass_csn(bool loop, bool verbose) {
+int read_iclass_csn(bool loop, bool verbose, bool shallow_mod) {
 
     iclass_card_select_t payload = {
         .flags = (FLAG_ICLASS_READER_INIT | FLAG_ICLASS_READER_CLEARTRACE)
     };
+
+    if (shallow_mod) {
+        payload.flags |= FLAG_ICLASS_READER_SHALLOW_MOD;
+    }
 
     int res = PM3_SUCCESS;
 
@@ -973,17 +979,19 @@ static int CmdHFiClassReader(const char *Cmd) {
     void *argtable[] = {
         arg_param_begin,
         arg_lit0("@", NULL, "optional - continuous reader mode"),
+        arg_lit0(NULL, "shallow", "use shallow (ASK) reader modulation instead of OOK"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
     bool cm = arg_get_lit(ctx, 1);
+    bool shallow_mod = arg_get_lit(ctx, 2);
     CLIParserFree(ctx);
 
     if (cm) {
         PrintAndLogEx(INFO, "Press " _GREEN_("<Enter>") " to exit");
     }
 
-    return read_iclass_csn(cm, true);
+    return read_iclass_csn(cm, true, shallow_mod);
 }
 
 static int CmdHFiClassELoad(const char *Cmd) {
@@ -1547,11 +1555,15 @@ static int CmdHFiClassEncryptBlk(const char *Cmd) {
     return PM3_SUCCESS;
 }
 
-static bool select_only(uint8_t *CSN, uint8_t *CCNR, bool verbose) {
+static bool select_only(uint8_t *CSN, uint8_t *CCNR, bool verbose, bool shallow_mod) {
 
     iclass_card_select_t payload = {
         .flags = (FLAG_ICLASS_READER_INIT | FLAG_ICLASS_READER_CLEARTRACE)
     };
+
+    if (shallow_mod) {
+        payload.flags |= FLAG_ICLASS_READER_SHALLOW_MOD;
+    }
 
     clearCommandBuffer();
     PacketResponseNG resp;
@@ -1608,6 +1620,7 @@ static int CmdHFiClassDump(const char *Cmd) {
         arg_lit0(NULL, "nr", "replay of NR/MAC"),
         arg_lit0("z", "dense", "dense dump output style"),
         arg_lit0(NULL, "force", "force unsecure card read"),
+        arg_lit0(NULL, "shallow", "use shallow (ASK) reader modulation instead of OOK"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
@@ -1693,6 +1706,7 @@ static int CmdHFiClassDump(const char *Cmd) {
     bool use_replay = arg_get_lit(ctx, 8);
     bool dense_output = g_session.dense_output || arg_get_lit(ctx, 9);
     bool force = arg_get_lit(ctx, 10);
+    bool shallow_mod = arg_get_lit(ctx, 11);
 
     CLIParserFree(ctx);
 
@@ -1711,6 +1725,11 @@ static int CmdHFiClassDump(const char *Cmd) {
     iclass_card_select_t payload_rdr = {
         .flags = (FLAG_ICLASS_READER_INIT | FLAG_ICLASS_READER_CLEARTRACE)
     };
+
+    if (shallow_mod) {
+        payload_rdr.flags |= FLAG_ICLASS_READER_SHALLOW_MOD;
+    }
+
     clearCommandBuffer();
     PacketResponseNG resp;
     SendCommandNG(CMD_HF_ICLASS_READER, (uint8_t *)&payload_rdr, sizeof(iclass_card_select_t));
@@ -1790,6 +1809,7 @@ static int CmdHFiClassDump(const char *Cmd) {
         .req.use_replay = use_replay,
         .req.send_reply = true,
         .req.do_auth = auth,
+        .req.shallow_mod = shallow_mod,
         .end_block = app_limit1,
     };
     memcpy(payload.req.key, key, 8);
@@ -1950,7 +1970,7 @@ write_dump:
     return PM3_SUCCESS;
 }
 
-static int iclass_write_block(uint8_t blockno, uint8_t *bldata, uint8_t *macdata, uint8_t *KEY, bool use_credit_key, bool elite, bool rawkey, bool replay, bool verbose, bool use_secure_pagemode) {
+static int iclass_write_block(uint8_t blockno, uint8_t *bldata, uint8_t *macdata, uint8_t *KEY, bool use_credit_key, bool elite, bool rawkey, bool replay, bool verbose, bool use_secure_pagemode, bool shallow_mod) {
 
     iclass_writeblock_req_t payload = {
         .req.use_raw = rawkey,
@@ -1960,6 +1980,7 @@ static int iclass_write_block(uint8_t blockno, uint8_t *bldata, uint8_t *macdata
         .req.blockno = blockno,
         .req.send_reply = true,
         .req.do_auth = use_secure_pagemode,
+        .req.shallow_mod = shallow_mod,
     };
     memcpy(payload.req.key, KEY, 8);
     memcpy(payload.data, bldata, sizeof(payload.data));
@@ -2004,6 +2025,7 @@ static int CmdHFiClass_WriteBlock(const char *Cmd) {
         arg_lit0(NULL, "raw", "no computations applied to key"),
         arg_lit0(NULL, "nr", "replay of NR/MAC"),
         arg_lit0("v", "verbose", "verbose output"),
+        arg_lit0(NULL, "shallow", "use shallow (ASK) reader modulation instead of OOK"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, false);
@@ -2072,6 +2094,7 @@ static int CmdHFiClass_WriteBlock(const char *Cmd) {
     bool rawkey = arg_get_lit(ctx, 8);
     bool use_replay = arg_get_lit(ctx, 9);
     bool verbose = arg_get_lit(ctx, 10);
+    bool shallow_mod = arg_get_lit(ctx, 11);
 
     CLIParserFree(ctx);
 
@@ -2080,7 +2103,7 @@ static int CmdHFiClass_WriteBlock(const char *Cmd) {
         return PM3_EINVARG;
     }
 
-    int isok = iclass_write_block(blockno, data, mac, key, use_credit_key, elite, rawkey, use_replay, verbose, auth);
+    int isok = iclass_write_block(blockno, data, mac, key, use_credit_key, elite, rawkey, use_replay, verbose, auth, shallow_mod);
     switch (isok) {
         case PM3_SUCCESS:
             PrintAndLogEx(SUCCESS, "Wrote block %3d/0x%02X successful", blockno, blockno);
@@ -2116,6 +2139,7 @@ static int CmdHFiClassRestore(const char *Cmd) {
         arg_lit0(NULL, "elite", "elite computations applied to key"),
         arg_lit0(NULL, "raw", "no computations applied to key"),
         arg_lit0("v", "verbose", "verbose output"),
+        arg_lit0(NULL, "shallow", "use shallow (ASK) reader modulation instead of OOK"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, false);
@@ -2165,6 +2189,7 @@ static int CmdHFiClassRestore(const char *Cmd) {
     bool elite = arg_get_lit(ctx, 7);
     bool rawkey = arg_get_lit(ctx, 8);
     bool verbose = arg_get_lit(ctx, 9);
+    bool shallow_mod = arg_get_lit(ctx, 10);
 
     CLIParserFree(ctx);
 
@@ -2215,6 +2240,7 @@ static int CmdHFiClassRestore(const char *Cmd) {
     payload->req.blockno = startblock;
     payload->req.send_reply = true;
     payload->req.do_auth = true;
+    payload->req.shallow_mod = shallow_mod;
     memcpy(payload->req.key, key, 8);
 
     payload->item_cnt = (endblock - startblock + 1);
@@ -2268,7 +2294,7 @@ static int CmdHFiClassRestore(const char *Cmd) {
     return resp.status;
 }
 
-static int iclass_read_block(uint8_t *KEY, uint8_t blockno, uint8_t keyType, bool elite, bool rawkey, bool replay, bool verbose, bool auth, uint8_t *out) {
+static int iclass_read_block(uint8_t *KEY, uint8_t blockno, uint8_t keyType, bool elite, bool rawkey, bool replay, bool verbose, bool auth, bool shallow_mod, uint8_t *out) {
 
     iclass_auth_req_t payload = {
         .use_raw = rawkey,
@@ -2278,6 +2304,7 @@ static int iclass_read_block(uint8_t *KEY, uint8_t blockno, uint8_t keyType, boo
         .blockno = blockno,
         .send_reply = true,
         .do_auth = auth,
+        .shallow_mod = shallow_mod,
     };
     memcpy(payload.key, KEY, 8);
 
@@ -2331,6 +2358,7 @@ static int CmdHFiClass_ReadBlock(const char *Cmd) {
         arg_lit0(NULL, "raw", "no computations applied to key"),
         arg_lit0(NULL, "nr", "replay of NR/MAC"),
         arg_lit0("v", "verbose", "verbose output"),
+        arg_lit0(NULL, "shallow", "use shallow (ASK) reader modulation instead of OOK"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, false);
@@ -2381,6 +2409,7 @@ static int CmdHFiClass_ReadBlock(const char *Cmd) {
     bool rawkey = arg_get_lit(ctx, 6);
     bool use_replay = arg_get_lit(ctx, 7);
     bool verbose = arg_get_lit(ctx, 8);
+    bool shallow_mod = arg_get_lit(ctx, 9);
 
     CLIParserFree(ctx);
 
@@ -2400,7 +2429,7 @@ static int CmdHFiClass_ReadBlock(const char *Cmd) {
     }
 
     uint8_t data[8] = {0};
-    int res = iclass_read_block(key, blockno, keyType, elite, rawkey, use_replay, verbose, auth, data);
+    int res = iclass_read_block(key, blockno, keyType, elite, rawkey, use_replay, verbose, auth, shallow_mod, data);
     if (res != PM3_SUCCESS)
         return res;
 
@@ -2975,7 +3004,7 @@ static int CmdHFiClassCalcNewKey(const char *Cmd) {
 
     if (givenCSN == false) {
         uint8_t CCNR[12] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-        if (select_only(csn, CCNR, true) == false) {
+        if (select_only(csn, CCNR, true, false) == false) {
             DropField();
             return PM3_ESOFT;
         }
@@ -3173,6 +3202,7 @@ static int CmdHFiClassCheckKeys(const char *Cmd) {
         arg_lit0(NULL, "credit", "key is assumed to be the credit key"),
         arg_lit0(NULL, "elite", "elite computations applied to key"),
         arg_lit0(NULL, "raw", "no computations applied to key (raw)"),
+        arg_lit0(NULL, "shallow", "use shallow (ASK) reader modulation instead of OOK"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, false);
@@ -3184,6 +3214,7 @@ static int CmdHFiClassCheckKeys(const char *Cmd) {
     bool use_credit_key = arg_get_lit(ctx, 2);
     bool use_elite = arg_get_lit(ctx, 3);
     bool use_raw = arg_get_lit(ctx, 4);
+    bool shallow_mod = arg_get_lit(ctx, 5);
 
     CLIParserFree(ctx);
 
@@ -3213,7 +3244,7 @@ static int CmdHFiClassCheckKeys(const char *Cmd) {
 
     bool got_csn = false;
     for (uint8_t i = 0; i < ICLASS_AUTH_RETRY; i++) {
-        got_csn = select_only(CSN, CCNR, false);
+        got_csn = select_only(CSN, CCNR, false, shallow_mod);
         if (got_csn == false)
             PrintAndLogEx(WARNING, "one more try");
         else
@@ -3295,6 +3326,7 @@ static int CmdHFiClassCheckKeys(const char *Cmd) {
         }
         packet->use_credit_key = use_credit_key;
         packet->count = curr_chunk_cnt;
+        packet->shallow_mod = shallow_mod;
         // copy chunk of pre calculated macs to packet
         memcpy(packet->items, (pre + chunk_offset), (4 * curr_chunk_cnt));
 
@@ -3799,6 +3831,7 @@ static int CmdHFiClassEncode(const char *Cmd) {
         arg_u64_0(NULL, "fc", "<dec>", "facility code"),
         arg_u64_0(NULL, "cn", "<dec>", "card number"),
         arg_str0("w",   "wiegand", "<format>", "see " _YELLOW_("`wiegand list`") " for available formats"),
+        arg_lit0(NULL, "shallow", "use shallow (ASK) reader modulation instead of OOK"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, false);
@@ -3842,6 +3875,8 @@ static int CmdHFiClassEncode(const char *Cmd) {
     char format[16] = {0};
     int format_len = 0;
     CLIParamStrToBuf(arg_get_str(ctx, 9), (uint8_t *)format, sizeof(format), &format_len);
+
+    bool shallow_mod = arg_get_lit(ctx, 10);
 
     CLIParserFree(ctx);
 
@@ -3964,7 +3999,7 @@ static int CmdHFiClassEncode(const char *Cmd) {
     int isok = PM3_SUCCESS;
     // write
     for (uint8_t i = 0; i < 4; i++) {
-        isok = iclass_write_block(6 + i, credential + (i * 8), NULL, key, use_credit_key, elite, rawkey, false, false, auth);
+        isok = iclass_write_block(6 + i, credential + (i * 8), NULL, key, use_credit_key, elite, rawkey, false, false, auth, shallow_mod);
         switch (isok) {
             case PM3_SUCCESS:
                 PrintAndLogEx(SUCCESS, "Write block %d/0x0%x ( " _GREEN_("ok") " )  --> " _YELLOW_("%s"), 6 + i, 6 + i, sprint_hex_inrow(credential + (i * 8), 8));
@@ -4135,11 +4170,16 @@ int CmdHFiClass(const char *Cmd) {
 // DESFIRE|                       |                                   |
 //}
 
-int info_iclass(void) {
+int info_iclass(bool shallow_mod) {
 
     iclass_card_select_t payload = {
         .flags = (FLAG_ICLASS_READER_INIT | FLAG_ICLASS_READER_CLEARTRACE)
     };
+
+    if (shallow_mod) {
+        payload.flags |= FLAG_ICLASS_READER_SHALLOW_MOD;
+    }
+
     clearCommandBuffer();
     PacketResponseNG resp;
     SendCommandNG(CMD_HF_ICLASS_READER, (uint8_t *)&payload, sizeof(iclass_card_select_t));

--- a/client/src/cmdhficlass.h
+++ b/client/src/cmdhficlass.h
@@ -24,8 +24,8 @@
 
 int CmdHFiClass(const char *Cmd);
 
-int info_iclass(void);
-int read_iclass_csn(bool loop, bool verbose);
+int info_iclass(bool shallow_mod);
+int read_iclass_csn(bool loop, bool verbose, bool shallow_mod);
 void printIclassDumpContents(uint8_t *iclass_dump, uint8_t startblock, uint8_t endblock, size_t filesize, bool dense_output);
 void HFiClassCalcDivKey(uint8_t *CSN, uint8_t *KEY, uint8_t *div_key, bool elite);
 

--- a/include/iclass_cmd.h
+++ b/include/iclass_cmd.h
@@ -32,6 +32,7 @@
 //#define FLAG_ICLASS_READER_ONLY_ONCE   0x04
 #define FLAG_ICLASS_READER_CREDITKEY   0x08
 #define FLAG_ICLASS_READER_AIA         0x10
+#define FLAG_ICLASS_READER_SHALLOW_MOD 0x20
 
 // iCLASS reader status flags
 #define FLAG_ICLASS_NULL               0x00
@@ -60,6 +61,7 @@ typedef struct {
     bool use_replay;
     bool send_reply;
     bool do_auth;
+    bool shallow_mod;
     uint8_t blockno;
 } PACKED iclass_auth_req_t;
 
@@ -103,6 +105,7 @@ typedef struct iclass_premac {
 
 typedef struct {
     bool use_credit_key;
+    bool shallow_mod;
     uint8_t count;
     iclass_premac_t items[];
 } PACKED iclass_chk_t;


### PR DESCRIPTION
Add `--shallow` option to `hf iclass` reader commands to do shallow (ASK) reader modulation instead of OOK.

ISO 15693 requires cards to support both OOK and 10% modulation index ASK. iClass/Picopass cards surprisingly also support this too. Older iClass readers and newer OmniKeys (eg Gen2) readers use ASK, while newer iClass readers (iClass SE branded stuff and Signo) ad older OmniKeys (eg Gen1) do OOK.

Having the ability to quickly switch between OOK and ASK is handy when developing card emulator tools when you want to ensure both modes are working as expected.

In the future adding the `--shallow` option ot `hf 15` commands would be handy too, but just starting with the `hf iclass` commands for the moment.