### PR TITLE
Add `piv scan` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Add command `piv scan` which tries to read all known containers on PIV (@jmichelp)
  - Add support for PIV commands, over wired and contactless interfaces (@jmichelp)
  - Add `--shallow` option to `hf iclass` reader commands to do shallow (ASK) reader modulation instead of OOK (@nvx)
  - Improved NXP SLI/SLIX series tag identification (@nvx)


### PR DESCRIPTION
The command iterates through all known containers and tries to read them.
If data is returned, it's printed.
If not, the error code tells wether the containers doesn't exist or if security conditions are not met (e.g. PIN code is required or container is only available on 1 interface and not the other).