### PR TITLE
Update armsrc and bootrom Makefiles to ensure the version always updates.

### DIFF
--- a/armsrc/Makefile
+++ b/armsrc/Makefile
@@ -185,7 +185,7 @@ showinfo:
 .DELETE_ON_ERROR:
 
 # version_pm3.c should be remade on every time fullimage.stage1.elf should be remade
-version_pm3.c: default_version_pm3.c $(OBJDIR)/fpga_version_info.o $(OBJDIR)/fpga_all.o $(THUMBOBJ) $(ARMOBJ)
+version_pm3.c: default_version_pm3.c $(OBJDIR)/fpga_version_info.o $(OBJDIR)/fpga_all.o $(THUMBOBJ) $(ARMOBJ) .FORCE
 	$(info [-] GEN $@)
 	$(Q)$(SH) ../tools/mkversion.sh > $@ || $(CP) $< $@
 
@@ -257,7 +257,7 @@ uninstall:
 	$(info [@] Uninstalling fullimage from $(DESTDIR)$(PREFIX)...)
 	$(Q)$(INSTALLSUDO) $(RM) $(DESTDIR)$(PREFIX)$(PATHSEP)$(INSTALLFWRELPATH)$(PATHSEP)$(INSTALLFWTAG)
 
-.PHONY: all clean help install uninstall
+.PHONY: all clean help install uninstall .FORCE
 help:
 	@echo Multi-OS Makefile, you are running on $(DETECTED_OS)
 	@echo Possible targets:

--- a/bootrom/Makefile
+++ b/bootrom/Makefile
@@ -48,7 +48,7 @@ INSTALLFW = $(OBJDIR)/bootrom.elf
 OBJS = $(OBJDIR)/bootrom.s19
 
 # version_pm3.c should be remade on every compilation
-version_pm3.c: default_version_pm3.c
+version_pm3.c: default_version_pm3.c .FORCE
 	$(info [=] GEN $@)
 	$(Q)$(SH) ../tools/mkversion.sh > $@ || $(PERL) ../tools/mkversion.pl > $@ || $(CP) $< $@
 
@@ -82,7 +82,7 @@ uninstall:
 	$(info [@] Uninstalling bootrom from $(DESTDIR)$(PREFIX)...)
 	$(Q)$(INSTALLSUDO) $(RM) $(foreach fw,$(INSTALLFW),$(DESTDIR)$(PREFIX)$(PATHSEP)$(INSTALLFWRELPATH)$(PATHSEP)$(notdir $(fw)))
 
-.PHONY: all clean help install showinfo
+.PHONY: all clean help install showinfo .FORCE
 help:
 	@echo Multi-OS Makefile, you are running on $(DETECTED_OS)
 	@echo Possible targets:


### PR DESCRIPTION
Update armsrc and bootrom Makefiles with a .FORCE PHONY target for version_pm3.c

This fixes issues in ProxSpace where the firmware .elf files are sometimes not rebuilt (ie, when only the client src changes, leading to firmware/client mismatch warnings).

Note this is just copying the pattern used in client/Makefile to {armsrc,recovery}/Makefile.