### PR TITLE
Fix typo in smart info

### DIFF
--- a/client/src/cmdsmartcard.c
+++ b/client/src/cmdsmartcard.c
@@ -719,7 +719,7 @@ static int CmdSmartInfo(const char *Cmd) {
 
     // print header
     PrintAndLogEx(INFO, "--- " _CYAN_("Smartcard Information") " ---------");
-    PrintAndLogEx(INFO, "ISO7618-3 ATR... %s", sprint_hex(card.atr, card.atr_len));
+    PrintAndLogEx(INFO, "ISO7816-3 ATR... %s", sprint_hex(card.atr, card.atr_len));
     // convert bytes to str.
     char *hexstr = calloc((card.atr_len << 1) + 1, sizeof(uint8_t));
     if (hexstr == NULL) {


### PR DESCRIPTION
When using the `smart info` command it printed _ISO7618_ instead of _ISO7816_.