### PR TITLE
Fix the types of parameters in BitstreamOut_t

### DIFF
--- a/armsrc/optimized_cipherutils.h
+++ b/armsrc/optimized_cipherutils.h
@@ -39,14 +39,14 @@
 
 typedef struct {
     uint8_t *buffer;
-    uint8_t numbits;
-    uint8_t position;
+    uint32_t numbits;
+    uint32_t position;
 } BitstreamIn_t;
 
 typedef struct {
     uint8_t *buffer;
-    uint8_t numbits;
-    uint8_t position;
+    uint32_t numbits;
+    uint32_t position;
 } BitstreamOut_t;
 
 bool headBit(BitstreamIn_t *stream);

--- a/client/src/loclass/cipherutils.h
+++ b/client/src/loclass/cipherutils.h
@@ -42,14 +42,14 @@
 
 typedef struct {
     uint8_t *buffer;
-    uint8_t numbits;
-    uint8_t position;
+    uint32_t numbits;
+    uint32_t position;
 } BitstreamIn_t;
 
 typedef struct {
     uint8_t *buffer;
-    uint8_t numbits;
-    uint8_t position;
+    uint32_t numbits;
+    uint32_t position;
 } BitstreamOut_t;
 
 bool headBit(BitstreamIn_t *stream);


### PR DESCRIPTION
`BitstreamOut_t` in `client/src/loclass/cipherutils.h` is also used in `client/src/cmddata.c` for  down-sampling. 
However, the max number of `numbits` and `position` is 255(limited by uint8_t), which is too small. So I changed the type from uint8_t to uint32_t, keeping the struct the same with the one in `armsrc/lfsampling.h`