### PR TITLE
Correct some parsing of the "get nxp system information" data from icode tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1363,6 +1363,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Mifare simulation, `hf mf sim` (was broken a long time) (@pwpiwi)
  - Major improvements in LF area and data operations. (@marshmellow42, @iceman1001)
  - Issues regarding LF simulation (@pwpiwi)
+ - Issue interpreting NXP "get sys info" command return value for icode tags. (@mjacksn)
 
 ### Added
  - iClass functionality: full simulation of iclass tags, so tags can be simulated with data (not only CSN). Not yet support for write/update, but readers do not seem to enforce update. (@holiman).

--- a/client/src/cmdhf15.c
+++ b/client/src/cmdhf15.c
@@ -700,14 +700,14 @@ static int NxpSysInfo(uint8_t *uid) {
     }
 
     bool support_signature = (recv[5] & 0x01);
-    bool support_easmode = (recv[4] & 0x03);
+    bool support_easmode = (recv[4] & 0x04);
 
     PrintAndLogEx(INFO, "--------- " _CYAN_("NXP Sysinfo") " ---------");
     PrintAndLogEx(INFO, "  raw : %s", sprint_hex(recv, 8));
     PrintAndLogEx(INFO, "    Password protection configuration:");
     PrintAndLogEx(INFO, "      * Page L read%s password protected", ((recv[2] & 0x01) ? "" : " not"));
     PrintAndLogEx(INFO, "      * Page L write%s password protected", ((recv[2] & 0x02) ? "" : " not"));
-    PrintAndLogEx(INFO, "      * Page H read%s password protected", ((recv[2] & 0x08) ? "" : " not"));
+    PrintAndLogEx(INFO, "      * Page H read%s password protected", ((recv[2] & 0x10) ? "" : " not"));
     PrintAndLogEx(INFO, "      * Page H write%s password protected", ((recv[2] & 0x20) ? "" : " not"));
 
     PrintAndLogEx(INFO, "    Lock bits:");
@@ -720,16 +720,16 @@ static int NxpSysInfo(uint8_t *uid) {
     PrintAndLogEx(INFO, "      * User memory password protection%s supported", ((recv[4] & 0x01) ? "" : " not"));
     PrintAndLogEx(INFO, "      * Counter feature%s supported", ((recv[4] & 0x02) ? "" : " not"));
     PrintAndLogEx(INFO, "      * EAS ID%s supported by EAS ALARM command", support_easmode ? "" : " not");
-    PrintAndLogEx(INFO, "      * EAS password protection%s supported", ((recv[4] & 0x04) ? "" : " not"));
+    PrintAndLogEx(INFO, "      * EAS password protection%s supported", ((recv[4] & 0x08) ? "" : " not"));
     PrintAndLogEx(INFO, "      * AFI password protection%s supported", ((recv[4] & 0x10) ? "" : " not"));
     PrintAndLogEx(INFO, "      * Extended mode%s supported by INVENTORY READ command", ((recv[4] & 0x20) ? "" : " not"));
     PrintAndLogEx(INFO, "      * EAS selection%s supported by extended mode in INVENTORY READ command", ((recv[4] & 0x40) ? "" : " not"));
     PrintAndLogEx(INFO, "      * READ SIGNATURE command%s supported", support_signature ? "" : " not");
     PrintAndLogEx(INFO, "      * Password protection for READ SIGNATURE command%s supported", ((recv[5] & 0x02) ? "" : " not"));
-    PrintAndLogEx(INFO, "      * STAY QUIET PERSISTENT command%s supported", ((recv[5] & 0x03) ? "" : " not"));
+    PrintAndLogEx(INFO, "      * STAY QUIET PERSISTENT command%s supported", ((recv[5] & 0x04) ? "" : " not"));
     PrintAndLogEx(INFO, "      * ENABLE PRIVACY command%s supported", ((recv[5] & 0x10) ? "" : " not"));
     PrintAndLogEx(INFO, "      * DESTROY command%s supported", ((recv[5] & 0x20) ? "" : " not"));
-    PrintAndLogEx(INFO, "      * Additional 32 bits feature flags are%s transmitted", ((recv[5] & 0x80) ? "" : " not"));
+    PrintAndLogEx(INFO, "      * Additional 32 bits feature flags are%s transmitted", ((recv[7] & 0x80) ? "" : " not"));
 
     if (support_easmode) {
         reqlen = 0;


### PR DESCRIPTION
I believe that there were some minor issues with how the "nxp get info" command response was being interpreted. I tried to bring the code in line with the specification in the SLIX2 datasheet (page 33)