### PR TITLE
use Amiibo PACK if simulator PWD matches generated Amiibo PWD

### DIFF
--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -1229,6 +1229,17 @@ bool SimulateIso14443aInit(uint8_t tagType, uint16_t flags, uint8_t *data, tag_r
 
     AddCrc14A(rPPS, sizeof(rPPS) - 2);
 
+    if (tagType == 7) {
+        uint8_t pwd[4];
+        uint8_t gen_pwd[4];
+        uint16_t start = (*pages - 1) * 4 + MFU_DUMP_PREFIX_LENGTH;
+        emlGetMemBt(pwd, start, sizeof(pwd));
+        Uint4byteToMemBe(gen_pwd, ul_ev1_pwdgenB(data));
+        if (memcmp(pwd, gen_pwd, sizeof(pwd)) == 0) {
+            rPACK[0] = 0x80;
+            rPACK[1] = 0x80;
+        }
+    }
     AddCrc14A(rPACK, sizeof(rPACK) - 2);
 
     static tag_response_info_t responses_init[] = {


### PR DESCRIPTION
I had pulled down and compiled latest after working through https://github.com/RfidResearchGroup/proxmark3/issues/1861 a week or so ago.

Last night, I dusted off my old 2DS XL and noticed that the Amiibo simulator wasn't working in the latest build.  I thought it must be my 2DS XL, but tested it on my kids' Switch and it wasn't working either.

It looks like in a63257799a0092460f86cce8bb3ded3e13cd2de2, the PACK was hardcoded to 00000000.

This patch will pull the PACK from the emulator memory and Amiibo simulation can work well again.

Do let me know if this not the preferred approach.

Thanks!