### PR TITLE
Fix pm3-flash-all -p XXX

### DIFF
--- a/pm3
+++ b/pm3
@@ -441,6 +441,7 @@ done
 
 # if a port is already provided, let's just run the command as such
 for ARG; do
+    shift
     if [ "$ARG" == "-p" ]; then
         CMD "$@"
         exit $?


### PR DESCRIPTION
Currently `pm3-flash-all -p <port>` fails, as it passes the `-p` as the port to the $CMD:
```bash
$ pm3-flash-all -p /dev/ttyS3
[=] Session log /home/marcos/.proxmark3/logs/log_20230203.txt
[+] About to use the following files:
[+]    /usr/local/bin/../share/proxmark3/firmware/bootrom.elf
[+]    /usr/local/bin/../share/proxmark3/firmware/fullimage.elf
[+] Loading ELF file /usr/local/bin/../share/proxmark3/firmware/bootrom.elf
[+] ELF file version Iceman/master/v4.16191-22-g23a3590bb 2023-02-03 14:27:45 a86d9d107

[+] Loading ELF file /usr/local/bin/../share/proxmark3/firmware/fullimage.elf
[+] ELF file version Iceman/master/v4.16191-22-g23a3590bb 2023-02-03 14:27:46 a86d9d107

[+] Waiting for Proxmark3 to appear on -p
 🕑  59^C
```
Note how it expects the device to "appear on -p" instead of "appear on /dev/ttyS3"

Adding that missing shift fixes the issue.