### PR TITLE
DRAFT - Skeleton template leaves PM3 in bad state?

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1232,8 +1232,8 @@ static void PacketReceived(PacketCommandNG *packet) {
             break;
         }
         case CMD_LF_EM4X70_NEW_COMMAND_XYZZY: {
-            Dbprintf("received CMD_LF_EM4x70_NEW_COMMAND_XYZZY command with %d bytes payload", packet->length);
             em4x70_NEW_COMMAND_XYZZY((em4x70_data_t *)packet->data.asBytes, true);
+            break;
         }
 #endif
 

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1231,6 +1231,10 @@ static void PacketReceived(PacketCommandNG *packet) {
             em4x70_brute((em4x70_data_t *)packet->data.asBytes, true);
             break;
         }
+        case CMD_LF_EM4X70_NEW_COMMAND_XYZZY: {
+            Dbprintf("received CMD_LF_EM4x70_NEW_COMMAND_XYZZY command with %d bytes payload", packet->length);
+            em4x70_NEW_COMMAND_XYZZY((em4x70_data_t *)packet->data.asBytes, true);
+        }
 #endif
 
 #ifdef WITH_ZX8211

--- a/armsrc/em4x70.c
+++ b/armsrc/em4x70.c
@@ -846,7 +846,7 @@ void em4x70_NEW_COMMAND_XYZZY(em4x70_data_t *etd, bool ledcontrol) {
     //       validation of the options validity should occur herein,
     //       even if most implemented commands today do not do this.
 
-    bool status = true;
+    bool status = false;
 
 
 
@@ -878,13 +878,14 @@ void em4x70_NEW_COMMAND_XYZZY(em4x70_data_t *etd, bool ledcontrol) {
         }
     }
  
+
+
+    //StopTicks();
+    //lf_finalize(ledcontrol);
+    //Dbprintf("*** " __FILE__ " @ %4d    final call to reply_ng.  (compiled at %s)", __LINE__, __TIME__);
+
     // Normally, this would be data retrieved from the transponder in some way...s
     uint8_t results[4] = { 0x48, 0x47, 0x21, 0x00 };
-
-
-    StopTicks();
-    lf_finalize(ledcontrol);
-    Dbprintf("*** " __FILE__ " @ %4d    final call to reply_ng.  (compiled at %s)", __LINE__, __TIME__);
     reply_ng(CMD_LF_EM4X70_NEW_COMMAND_XYZZY, 1, results, 4);
 }
 

--- a/armsrc/em4x70.c
+++ b/armsrc/em4x70.c
@@ -834,6 +834,53 @@ void em4x70_brute(em4x70_data_t *etd, bool ledcontrol) {
     reply_ng(CMD_LF_EM4X70_BRUTE, status, response, sizeof(response));
 }
 
+// TODO: Check known output filter bits to reduce attempts needed.
+// PROBLEM: Requires two (modifiable) 128k bit tables to store two
+//          bits for each of the 2^20 possibilities.  Won't fit in
+//          current ProxMark3 hardware.
+//          (PM3 Easy and PM3 RDV4 are each 512k flash / 64k ram)
+//
+void em4x70_NEW_COMMAND_XYZZY(em4x70_data_t *etd, bool ledcontrol) {
+
+    // NOTE: the  etd  parameter stores all the options to be used for this command.
+    //       validation of the options validity should occur herein,
+    //       even if most implemented commands today do not do this.
+
+    bool status = true;
+
+    command_parity = etd->parity;
+
+    // Minimally, need to setup FPGA for LF reading, and call init_tag() (resets the 'tag' global variable)
+    init_tag();
+    em4x70_setup_read();
+
+    // Find the Tag
+    if (status) {
+        status = get_signalproperties();
+        if (!status) {
+            Dbprintf(_RED_("Failed to get signal properties."));
+        }
+    }
+    if (status) {
+        status = find_em4x70_tag();
+        if (!status) {
+            Dbprintf(_RED_("Failed to find tag."));
+        }
+    }
+    Dbprintf(_BRIGHT_RED_("WHY DOES THIS LEAVE THE PM3 IN A NON-RESPONSIVE STATE?"));
+    status = false;
+
+    // Normally, this would be data retrieved from the transponder in some way...s
+    uint8_t results[4] = { 0x48, 0x47, 0x21, 0x00 };
+
+
+    StopTicks();
+    lf_finalize(ledcontrol);
+    reply_ng(CMD_LF_EM4X70_NEW_COMMAND_XYZZY, status, results, 4);
+    Dbprintf("*** " __FILE__ " @ %4d    Function exit.", __LINE__);
+}
+
+
 void em4x70_write_pin(em4x70_data_t *etd, bool ledcontrol) {
 
     uint8_t status = 0;

--- a/armsrc/em4x70.c
+++ b/armsrc/em4x70.c
@@ -854,6 +854,9 @@ void em4x70_NEW_COMMAND_XYZZY(em4x70_data_t *etd, bool ledcontrol) {
     init_tag();
     em4x70_setup_read();
 
+    Dbprintf(_BRIGHT_RED_("WHY DOES THIS LEAVE THE PM3 IN A NON-RESPONSIVE STATE?"));
+    status = false;
+
     // Find the Tag
     if (status) {
         status = get_signalproperties();
@@ -867,9 +870,7 @@ void em4x70_NEW_COMMAND_XYZZY(em4x70_data_t *etd, bool ledcontrol) {
             Dbprintf(_RED_("Failed to find tag."));
         }
     }
-    Dbprintf(_BRIGHT_RED_("WHY DOES THIS LEAVE THE PM3 IN A NON-RESPONSIVE STATE?"));
-    status = false;
-
+ 
     // Normally, this would be data retrieved from the transponder in some way...s
     uint8_t results[4] = { 0x48, 0x47, 0x21, 0x00 };
 

--- a/armsrc/em4x70.c
+++ b/armsrc/em4x70.c
@@ -876,8 +876,8 @@ void em4x70_NEW_COMMAND_XYZZY(em4x70_data_t *etd, bool ledcontrol) {
 
     StopTicks();
     lf_finalize(ledcontrol);
-    reply_ng(CMD_LF_EM4X70_NEW_COMMAND_XYZZY, status, results, 4);
-    Dbprintf("*** " __FILE__ " @ %4d    Function exit.", __LINE__);
+    Dbprintf("*** " __FILE__ " @ %4d    final call to reply_ng.", __LINE__);
+    reply_ng(CMD_LF_EM4X70_NEW_COMMAND_XYZZY, PM3_SUCCESS, results, 4);
 }
 
 

--- a/armsrc/em4x70.c
+++ b/armsrc/em4x70.c
@@ -846,16 +846,8 @@ void em4x70_NEW_COMMAND_XYZZY(em4x70_data_t *etd, bool ledcontrol) {
     //       validation of the options validity should occur herein,
     //       even if most implemented commands today do not do this.
 
-    bool status = false;
-
-
-
+    bool status = true;
     command_parity = etd->parity;
-
-    if (status) {
-        Dbprintf(_BRIGHT_RED_("WHY DOES THIS LEAVE THE PM3 IN A NON-RESPONSIVE STATE?"));
-        status = false;
-    }
 
 
     // Minimally, need to setup FPGA for LF reading, and call init_tag() (resets the 'tag' global variable)
@@ -877,15 +869,15 @@ void em4x70_NEW_COMMAND_XYZZY(em4x70_data_t *etd, bool ledcontrol) {
             Dbprintf(_RED_("Failed to find tag."));
         }
     }
- 
 
-
-    //StopTicks();
-    //lf_finalize(ledcontrol);
-    //Dbprintf("*** " __FILE__ " @ %4d    final call to reply_ng.  (compiled at %s)", __LINE__, __TIME__);
-
-    // Normally, this would be data retrieved from the transponder in some way...s
+    // do the real stuff here...
+    Dbprintf("*** This command is just a placeholder");
+    // Normally, this would be data retrieved from the transponder in some way...
     uint8_t results[4] = { 0x48, 0x47, 0x21, 0x00 };
+
+    StopTicks();
+    lf_finalize(ledcontrol);
+
     reply_ng(CMD_LF_EM4X70_NEW_COMMAND_XYZZY, 1, results, 4);
 }
 

--- a/armsrc/em4x70.c
+++ b/armsrc/em4x70.c
@@ -876,8 +876,8 @@ void em4x70_NEW_COMMAND_XYZZY(em4x70_data_t *etd, bool ledcontrol) {
 
     StopTicks();
     lf_finalize(ledcontrol);
-    Dbprintf("*** " __FILE__ " @ %4d    final call to reply_ng.", __LINE__);
-    reply_ng(CMD_LF_EM4X70_NEW_COMMAND_XYZZY, PM3_SUCCESS, results, 4);
+    Dbprintf("*** " __FILE__ " @ %4d    final call to reply_ng.  (compiled at %s)", __LINE__, __TIME__);
+    reply_ng(CMD_LF_EM4X70_NEW_COMMAND_XYZZY, 1, results, 4);
 }
 
 

--- a/armsrc/em4x70.c
+++ b/armsrc/em4x70.c
@@ -848,14 +848,21 @@ void em4x70_NEW_COMMAND_XYZZY(em4x70_data_t *etd, bool ledcontrol) {
 
     bool status = true;
 
+
+
     command_parity = etd->parity;
 
-    // Minimally, need to setup FPGA for LF reading, and call init_tag() (resets the 'tag' global variable)
-    init_tag();
-    em4x70_setup_read();
+    if (status) {
+        Dbprintf(_BRIGHT_RED_("WHY DOES THIS LEAVE THE PM3 IN A NON-RESPONSIVE STATE?"));
+        status = false;
+    }
 
-    Dbprintf(_BRIGHT_RED_("WHY DOES THIS LEAVE THE PM3 IN A NON-RESPONSIVE STATE?"));
-    status = false;
+
+    // Minimally, need to setup FPGA for LF reading, and call init_tag() (resets the 'tag' global variable)
+    if (status) {
+        init_tag();
+        em4x70_setup_read();
+    }
 
     // Find the Tag
     if (status) {

--- a/armsrc/em4x70.h
+++ b/armsrc/em4x70.h
@@ -37,5 +37,6 @@ void em4x70_unlock(em4x70_data_t *etd, bool ledcontrol);
 void em4x70_auth(em4x70_data_t *etd, bool ledcontrol);
 void em4x70_write_pin(em4x70_data_t *etd, bool ledcontrol);
 void em4x70_write_key(em4x70_data_t *etd, bool ledcontrol);
+void em4x70_NEW_COMMAND_XYZZY(em4x70_data_t *etd, bool ledcontrol);
 
 #endif /* EM4x70_H */

--- a/client/src/cmdlfem4x70.h
+++ b/client/src/cmdlfem4x70.h
@@ -31,6 +31,7 @@ int CmdEM4x70Unlock(const char *Cmd);
 int CmdEM4x70Auth(const char *Cmd);
 int CmdEM4x70WritePIN(const char *Cmd);
 int CmdEM4x70WriteKey(const char *Cmd);
+int CmdEM4x70_NEW_COMMAND_XYZZY(const char *Cmd);
 
 int em4x70_info(void);
 bool detect_4x70_block(void);

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -486,6 +486,8 @@ typedef struct {
 #define CMD_LF_EM4X70_WRITEPIN                                            0x0264
 #define CMD_LF_EM4X70_WRITEKEY                                            0x0265
 #define CMD_LF_EM4X70_BRUTE                                               0x0266
+#define CMD_LF_EM4X70_NEW_COMMAND_XYZZY                                   0x026F // This must be a unique number...
+
 // Sampling configuration for LF reader/sniffer
 #define CMD_LF_SAMPLING_SET_CONFIG                                        0x021D
 #define CMD_LF_FSK_SIMULATE                                               0x021E


### PR DESCRIPTION
This draft PR is not intended to be integrated.

I had hoped to have a nice skeleton of the minimum needed to add a new sub-command.

However, even this minimal skeleton, after calling the new command, leaves the proxmark3 device in a state where it refuses to accept additional commands.  Pressing the side button clears this error state.

I welcome any thoughts on this.