### PR TITLE
Add a option to clear the scrollback buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Fixed broken `lf em 4x70 brute` command (@adite)
  - Fixed the lf sampling when bits_per_sample is less than 8 (@wh201906)
  - Added `lf em 4x70 brute` command (@adite)
+ - Added `--back` option to `clear` command to clear the scrollback buffer (@wh201906)
 
 
 ## [Nitride.4.16191][2023-01-29]

--- a/client/src/cmdmain.c
+++ b/client/src/cmdmain.c
@@ -300,15 +300,23 @@ static int CmdClear(const char *Cmd) {
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "clear",
                   "Clear the Proxmark3 client terminal screen",
-                  "clear"
+                  "clear      -> clear the terminal screen\n"
+                  "clear -b   -> clear the terminal screen and the scrollback buffer"
                  );
     void *argtable[] = {
         arg_param_begin,
+        arg_lit0("b", "back", "also clear the scrollback buffer"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
+    bool scrollback = arg_get_lit(ctx, 1);
     CLIParserFree(ctx);
-    PrintAndLogEx(NORMAL, _CLEAR_ _TOP_ "");
+
+    if (!scrollback)
+        PrintAndLogEx(NORMAL, _CLEAR_ _TOP_ "");
+    else
+        PrintAndLogEx(NORMAL, _CLEAR_ _TOP_ _CLEAR_SCROLLBACK_ "");
+
     return PM3_SUCCESS;
 }
 

--- a/include/ansi.h
+++ b/include/ansi.h
@@ -58,6 +58,7 @@
 #define _BACK_BRIGHT_WHITE_(s)   "\x1b[47;1m" s AEND
 
 #define _CLEAR_ "\x1b[2J"
+#define _CLEAR_SCROLLBACK_ "\x1b[3J"
 #define _TOP_   "\x1b[1;1f"
 
 #if defined(HAVE_READLINE)


### PR DESCRIPTION
When running `clear` in pm3 client, the scrollback buffer is not cleared. This behavior is different from a lot of the shells'.
This PR adds a `-b` option to clear the scrollback buffer.