### PR TITLE
Fix Makefile regression from #1894

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed `Makefile` regression that broke `make install` (@henrygab)
  - Fixed `lf em 4x70 brute` - now works as expected (@adite)
  - Fixed the lf sampling when bits_per_sample is less than 8 (@wh201906)
  - Added `lf em 4x70 brute` command (@adite)

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,13 @@ ifneq (,$(INSTALLSIMFW))
 endif
 ifeq ($(platform),Linux)
 	$(Q)$(INSTALLSUDO) $(MKDIR) $(DESTDIR)$(UDEV_PREFIX)
-	$(Q)$(INSTALLSUDO) $(CP) driver/77-pm3-usb-device-blacklist.rules $(DESTDIR)$(UDEV_PREFIX)/77-pm3-usb-device-blacklist.rules
+# If user is running ArchLinux, use group 'uucp'
+# Else, use group 'dialout'
+	ifneq ($(wildcard /etc/arch-release),)
+		$(Q)$(INSTALLSUDO) $(CP) driver/77-pm3-usb-device-blacklist-uucp.rules    $(DESTDIR)$(UDEV_PREFIX)/77-pm3-usb-device-blacklist.rules
+	else
+		$(Q)$(INSTALLSUDO) $(CP) driver/77-pm3-usb-device-blacklist-dialout.rules $(DESTDIR)$(UDEV_PREFIX)/77-pm3-usb-device-blacklist.rules
+	endif
 endif
 
 uninstall: common/uninstall


### PR DESCRIPTION
Regression caused by #1894.
See also PR #1902, where this PR was confirmed to fix the issue.

<details><summary>Root Cause (click to expand)</summary><P/>

PR #1894 updated the udev rules to automatically assign a group owner, and to automatically give the group both read and write privileges.   However, ArchLinux uses a different group name for access rights (according to pre-existing Makefile rules) ... they need the group to be `uucp` instead of `dialout`.   Therefore, the udev rules were split into two ... one file for when using `uucp` and one file for when using `dialout`.   This worked, and the devices were getting assigned the right group names, and automatically were usable without using `sudo`.

Unfortunately, I failed to test the `make install` option, and also failed to notice that the file was referenced in that section.   Therefore, this caused a `make install` to fail, since the udev rules file it tries to copy no longer exists (it must select either the `uucp` or `dialout` file for the copy).

Keeping the final filename identical was an intentional choice, as it reduced visible changes after installation of the udev rules.

I reviewed the `uninstall` section also ... it does **_not_** appear to require any changes. 

</details>

This fix copies the existing logic to also select the proper udev rules to be copied in the `install` section of the Makefile.
