### PR TITLE
feat: add standalone ICECLASS read/sim mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Add ICECLASS standalone read/sim mode (@natesales)
  - Fixed `lf em 4x70 brute` - now works as expected (@adite)
  - Fixed the lf sampling when bits_per_sample is less than 8 (@wh201906)
  - Added `lf em 4x70 brute` command (@adite)

--- a/armsrc/Standalone/hf_iceclass.c
+++ b/armsrc/Standalone/hf_iceclass.c
@@ -723,6 +723,7 @@ void RunMod(void) {
                 break;
             }
             case ICE_STATE_READ_SIM: {
+                DbpString("-=[ enter " _CYAN_("`read & sim`") " mode, read cards, then sim after button press ]=-");
                 DbpString("Entering reader dump mode");
                 reader_dump_mode();
                 SpinDelay(1200); // debounce button press

--- a/armsrc/Standalone/hf_iceclass.c
+++ b/armsrc/Standalone/hf_iceclass.c
@@ -43,9 +43,10 @@
 #define ICE_STATE_ATTACK      2
 #define ICE_STATE_READER      3
 #define ICE_STATE_CONFIGCARD  4
-#define ICE_STATE_DUMP_SIM  5
+#define ICE_STATE_DUMP_SIM    5
+#define ICE_STATE_READ_SIM    6
 
-#define HF_ICLASS_NUM_MODES 6
+#define HF_ICLASS_NUM_MODES 7
 
 // ====================================================
 // Select which standalone function to be active.
@@ -56,6 +57,7 @@
 //#define ICE_USE               ICE_STATE_READER
 //#define ICE_USE               ICE_STATE_CONFIGCARD
 //#define ICE_USE               ICE_STATE_DUMP_SIM
+//#define ICE_USE               ICE_STATE_READ_SIM
 
 // ====================================================
 
@@ -719,6 +721,15 @@ void RunMod(void) {
 
                 mode = ICE_STATE_NONE;
                 break;
+            }
+            case ICE_STATE_READ_SIM: {
+                DbpString("Entering reader dump mode");
+                reader_dump_mode();
+                SpinDelay(1200); // debounce button press
+                DbpString("Entering fullsim mode");
+                fullsim_mode();
+                DbpString("Exiting fullsim mode");
+                LEDsoff();
             }
         }
     }


### PR DESCRIPTION
This standalone mode starts by reading iCLASS credentials to flash, then after a button press, switches to emulating a previously saved credential.