### PR TITLE
Use unique USB Serial using flash's uniqueID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Enable unique USB serial numbers when built with `FLASH` -- **_UPDATES BOOTROM ALSO_**
  - Changed the readline package to v8.2 in the CMAKE files for the client (@iceman1001)
  - Add ICECLASS standalone read/sim mode (@natesales)
  - Added verbose flag to `hf iclass encode` (@natesales)

--- a/Makefile.platform.sample
+++ b/Makefile.platform.sample
@@ -5,6 +5,8 @@ PLATFORM=PM3RDV4
 #PLATFORM=PM3GENERIC
 # If you want more than one PLATFORM_EXTRAS option, separate them by spaces:
 #PLATFORM_EXTRAS=BTADDON
+#PLATFORM_EXTRAS=FLASH
+#PLATFORM_EXTRAS=BTADDON FLASH
 #STANDALONE=LF_SAMYRUN
 
 # Uncomment the lines below in order to make a 256KB image

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -2684,7 +2684,7 @@ void  __attribute__((noreturn)) AppMain(void) {
     if (FlashInit()) {
         uint64_t flash_uniqueID = 0;
         if (!Flash_CheckBusy(BUSY_TIMEOUT)) { // OK because firmware was built for devices with flash
-            Flash_UniqueID((uint8_t*)&(flash_uniqueID));
+            Flash_UniqueID((uint8_t*)(&flash_uniqueID));
         }
         FlashStop();
         usb_update_serial(flash_uniqueID);

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -2684,7 +2684,7 @@ void  __attribute__((noreturn)) AppMain(void) {
     if (FlashInit()) {
         uint64_t flash_uniqueID = 0;
         if (!Flash_CheckBusy(BUSY_TIMEOUT)) { // OK because firmware was built for devices with flash
-            Flash_UniqueID((uint8_t*)(&flash_uniqueID));
+            Flash_UniqueID((uint8_t *)(&flash_uniqueID));
         }
         FlashStop();
         usb_update_serial(flash_uniqueID);

--- a/armsrc/flashmem.c
+++ b/armsrc/flashmem.c
@@ -22,7 +22,7 @@
 #include "ticks.h"
 #include "dbprint.h"
 #include "string.h"
-#include "spiffs.h"
+#include "usb_cdc.h"
 
 /* here: use NCPS2 @ PA10: */
 #define SPI_CSR_NUM      2
@@ -436,7 +436,9 @@ out:
     return len;
 }
 
-
+// WARNING -- if callers are using a file system (such as SPIFFS),
+//            they should inform the file system of this change
+//            e.g., rdv40_spiffs_check()
 bool Flash_WipeMemoryPage(uint8_t page) {
     if (!FlashInit()) {
         if (g_dbglevel > 3) Dbprintf("Flash_WriteData init fail");
@@ -451,8 +453,6 @@ bool Flash_WipeMemoryPage(uint8_t page) {
 
     FlashStop();
 
-    // let spiffs check and update its info post flash erase
-    rdv40_spiffs_check();
     return true;
 }
 // Wipes flash memory completely, fills with 0xFF

--- a/bootrom/Makefile
+++ b/bootrom/Makefile
@@ -34,10 +34,16 @@ VERSIONSRC = version_pm3.c
 # THUMBSRC :=
 
 # stdint.h provided locally until GCC 4.5 becomes C99 compliant
-APP_CFLAGS = -I. -ffunction-sections -fdata-sections
+APP_CFLAGS = -I. -ffunction-sections -fdata-sections -DAS_BOOTROM
 
 # stack-protect , no-pie reduces size on Gentoo Hardened 8.2 gcc,  no-common makes sure uninitialized vars don't end up in COMMON area
 APP_CFLAGS += -fno-stack-protector -fno-pie -fno-common
+
+ifneq (,$(findstring WITH_FLASH,$(PLATFORM_DEFS)))
+	APP_CFLAGS += -DWITH_FLASH
+	APP_CFLAGS += -I../common_arm
+    THUMBSRC += flashmem.c ticks.c
+endif
 
 
 # Do not move this inclusion before the definition of {THUMB,ASM,ARM}SRC

--- a/bootrom/bootrom.c
+++ b/bootrom/bootrom.c
@@ -225,7 +225,7 @@ static void flash_mode(void) {
 #ifdef WITH_FLASH
     if (FlashInit()) { // checks for existence of flash also ... OK because bootrom was built for devices with flash
         uint64_t flash_uniqueID = 0;
-        Flash_UniqueID((uint8_t*)&flash_uniqueID);
+        Flash_UniqueID((uint8_t *)&flash_uniqueID);
         FlashStop();
         usb_update_serial(flash_uniqueID);
     }

--- a/bootrom/bootrom.c
+++ b/bootrom/bootrom.c
@@ -20,6 +20,10 @@
 #include "clocks.h"
 #include "usb_cdc.h"
 
+#ifdef WITH_FLASH
+#include "flashmem.h"
+#endif
+
 #include "proxmark3_arm.h"
 #define DEBUG 0
 
@@ -214,8 +218,18 @@ static void flash_mode(void) {
     bootrom_unlocked = false;
     uint8_t rx[sizeof(PacketCommandOLD)];
     g_common_area.command = COMMON_AREA_COMMAND_NONE;
-    if (!g_common_area.flags.button_pressed && BUTTON_PRESS())
+    if (!g_common_area.flags.button_pressed && BUTTON_PRESS()) {
         g_common_area.flags.button_pressed = 1;
+    }
+
+#ifdef WITH_FLASH
+    if (FlashInit()) { // checks for existence of flash also ... OK because bootrom was built for devices with flash
+        uint64_t flash_uniqueID = 0;
+        Flash_UniqueID((uint8_t*)&flash_uniqueID);
+        FlashStop();
+        usb_update_serial(flash_uniqueID);
+    }
+#endif
 
     usb_enable();
 

--- a/bootrom/ldscript-flash
+++ b/bootrom/ldscript-flash
@@ -53,6 +53,7 @@ SECTIONS
         *(.rodata.*)
         *(.data)
         *(.data.*)
+        *(.ramfunc)
         . = ALIGN(4);
     } >ram AT>bootphase2 :phase2
 

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -1407,7 +1407,7 @@ static int CmdHFiClassDecrypt(const char *Cmd) {
                 case DES:
                 case RFU:
                 case None:
-                    // Nothing to do for None anyway...
+                // Nothing to do for None anyway...
                 default:
                     continue;
             }

--- a/common_arm/Makefile.hal
+++ b/common_arm/Makefile.hal
@@ -114,6 +114,10 @@ endif
 
 # parsing additional PLATFORM_EXTRAS tokens
 PLATFORM_EXTRAS_TMP:=$(PLATFORM_EXTRAS)
+ifneq (,$(findstring FLASH,$(PLATFORM_EXTRAS_TMP)))
+    PLATFORM_DEFS += -DWITH_FLASH
+    PLATFORM_EXTRAS_TMP := $(strip $(filter-out FLASH,$(PLATFORM_EXTRAS_TMP)))
+endif
 ifneq (,$(findstring BTADDON,$(PLATFORM_EXTRAS_TMP)))
     PLATFORM_DEFS += -DWITH_FPC_USART_HOST
     PLATFORM_EXTRAS_TMP := $(strip $(filter-out BTADDON,$(PLATFORM_EXTRAS_TMP)))

--- a/common_arm/flashmem.c
+++ b/common_arm/flashmem.c
@@ -49,7 +49,7 @@ void FlashmemSetSpiBaudrate(uint32_t baudrate) {
 }
 
 // read ID out
-bool Flash_ReadID_90(flash_device_type_90_t* result) {
+bool Flash_ReadID_90(flash_device_type_90_t *result) {
 
     if (Flash_CheckBusy(BUSY_TIMEOUT)) return false;
 
@@ -354,20 +354,20 @@ void Flashmem_print_status(void) {
             DbpString("  Memory size............. " _GREEN_("2 mbits / 256 kb"));
         } else {
             Dbprintf("  Device ID............... " _YELLOW_("%02X / %02X (unknown)"),
-                device_type.manufacturer_id, device_type.device_id );
+                     device_type.manufacturer_id, device_type.device_id);
         }
     }
 
     uint8_t uid[8] = {0, 0, 0, 0, 0, 0, 0, 0};
     Flash_UniqueID(uid);
-    Dbprintf("  Unique ID (be).......... " _YELLOW_("0x%02X%02X%02X%02X%02X%02X%02X%02X" ),
-            uid[0], uid[1], uid[2], uid[3],
-            uid[4], uid[5], uid[6], uid[7]
+    Dbprintf("  Unique ID (be).......... " _YELLOW_("0x%02X%02X%02X%02X%02X%02X%02X%02X"),
+             uid[0], uid[1], uid[2], uid[3],
+             uid[4], uid[5], uid[6], uid[7]
             );
     if (g_dbglevel > 3) {
-        Dbprintf("  Unique ID (le).......... " _YELLOW_("0x%02X%02X%02X%02X%02X%02X%02X%02X" ),
-                uid[7], uid[6], uid[5], uid[4],
-                uid[3], uid[2], uid[1], uid[0]
+        Dbprintf("  Unique ID (le).......... " _YELLOW_("0x%02X%02X%02X%02X%02X%02X%02X%02X"),
+                 uid[7], uid[6], uid[5], uid[4],
+                 uid[3], uid[2], uid[1], uid[0]
                 );
     }
     FlashStop();

--- a/common_arm/flashmem.c
+++ b/common_arm/flashmem.c
@@ -367,7 +367,7 @@ void Flashmem_print_status(void) {
 
     uint8_t uid[8] = {0, 0, 0, 0, 0, 0, 0, 0};
     Flash_UniqueID(uid);
-    Dbprintf(         "  Unique ID............... " _YELLOW_("0x%02X%02X%02X%02X%02X%02X%02X%02X"),
+    Dbprintf("  Unique ID............... " _YELLOW_("0x%02X%02X%02X%02X%02X%02X%02X%02X"),
              uid[7], uid[6], uid[5], uid[4],
              uid[3], uid[2], uid[1], uid[0]
             );

--- a/common_arm/flashmem.h
+++ b/common_arm/flashmem.h
@@ -123,7 +123,12 @@ bool Flash_Erase4k(uint8_t block, uint8_t sector);
 //bool Flash_Erase32k(uint32_t address);
 bool Flash_Erase64k(uint8_t block);
 
-uint8_t Flash_ReadID(void);
+typedef struct {
+    uint8_t manufacturer_id;
+    uint8_t device_id;
+} flash_device_type_90_t; // to differentiate from JDEC ID via cmd 9F
+bool Flash_ReadID_90(flash_device_type_90_t* result);
+
 uint16_t Flash_ReadData(uint32_t address, uint8_t *out, uint16_t len);
 uint16_t Flash_ReadDataCont(uint32_t address, uint8_t *out, uint16_t len);
 uint16_t Flash_Write(uint32_t address, uint8_t *in, uint16_t len);

--- a/common_arm/flashmem.h
+++ b/common_arm/flashmem.h
@@ -112,55 +112,9 @@ uint16_t FlashSendLastByte(uint32_t data);
 
 
 #ifndef AS_BOOTROM
-    // Bootrom does not require these functions.
-    // Wrap in #ifndef to avoid accidental bloat of bootrom
-    // Bootrom needs only enough to get uniqueID from flash.
-    // It calls three functions.  Full call trees listed:
-    //
-    // FlashInit()
-    // |
-    // \____ FlashSetup()
-    // |      \____ leaf
-    // |
-    // \____ StartTicks()
-    // |      \____ leaf
-    // |
-    // \____ Flash_CheckBusy() [*]
-    // |     \____ WaitUS()
-    // |     |     \____ WaitTicks()
-    // |     |           \____ leaf
-    // |     |
-    // |     \____ StartCountUS()
-    // |     |     \____ leaf
-    // |     |
-    // |     \____ GetCountUS()
-    // |     |     \____ leaf
-    // |     |
-    // |     \____ Flash_ReadStat1()
-    // |           \____ FlashSendByte()
-    // |           |     \____ leaf
-    // |           |
-    // |           \____ FlashSendLastByte()
-    // |                 \____ FlashSendByte()
-    // |                       \____ leaf
-    // |
-    // \____ StopTicks()
-    //       \____ leaf
-    //
-    // Flash_UniqueID()
-    // \____ FlashCheckBusy()          (see FlashInit)
-    // \____ FlashSendByteByte()       (see FlashInit)
-    // \____ FlashSendByteLastByte()   (see FlashInit)
-    // 
-    //
-    // FlashStop() [*]
-
-
-
 void FlashmemSetSpiBaudrate(uint32_t baudrate);
 bool Flash_WaitIdle(void);
 void Flash_TransferAdresse(uint32_t address);
-
 
 void Flash_WriteEnable(void);
 bool Flash_WipeMemoryPage(uint8_t page);

--- a/common_arm/flashmem.h
+++ b/common_arm/flashmem.h
@@ -127,7 +127,7 @@ typedef struct {
     uint8_t manufacturer_id;
     uint8_t device_id;
 } flash_device_type_90_t; // to differentiate from JDEC ID via cmd 9F
-bool Flash_ReadID_90(flash_device_type_90_t* result);
+bool Flash_ReadID_90(flash_device_type_90_t *result);
 
 uint16_t Flash_ReadData(uint32_t address, uint8_t *out, uint16_t len);
 uint16_t Flash_ReadDataCont(uint32_t address, uint8_t *out, uint16_t len);

--- a/common_arm/ticks.c
+++ b/common_arm/ticks.c
@@ -20,7 +20,7 @@
 
 #include "proxmark3_arm.h"
 #ifndef AS_BOOTROM
-    #include "dbprint.h"
+#include "dbprint.h"
 #endif
 
 

--- a/common_arm/ticks.h
+++ b/common_arm/ticks.h
@@ -26,6 +26,19 @@
 #define GET_TICKS GetTicks()
 #endif
 
+void StartTicks(void);
+uint32_t GetTicks(void);
+void WaitUS(uint32_t us);
+void WaitTicks(uint32_t ticks);
+void StartCountUS(void);
+uint32_t RAMFUNC GetCountUS(void);
+void StopTicks(void);
+
+
+#ifndef AS_BOOTROM //////////////////////////////////////////////////////////////
+// Bootrom does not require these functions.
+// Wrap in #ifndef to avoid accidental bloat of bootrom
+
 void SpinDelay(int ms);
 void SpinDelayUs(int us);
 void SpinDelayUsPrecision(int us);  // precision 0.6us , running for 43ms before
@@ -34,8 +47,6 @@ void StartTickCount(void);
 uint32_t RAMFUNC GetTickCount(void);
 uint32_t RAMFUNC GetTickCountDelta(uint32_t start_ticks);
 
-void StartCountUS(void);
-uint32_t RAMFUNC GetCountUS(void);
 void ResetUSClock(void);
 void SpinDelayCountUs(uint32_t us);
 
@@ -44,12 +55,10 @@ void ResetSspClk(void);
 uint32_t RAMFUNC GetCountSspClk(void);
 uint32_t RAMFUNC GetCountSspClkDelta(uint32_t start);
 
-void StartTicks(void);
-uint32_t GetTicks(void);
-void WaitTicks(uint32_t ticks);
-void WaitUS(uint32_t us);
 void WaitMS(uint32_t ms);
 
-void StopTicks(void);
+#endif // #ifndef AS_BOOTROM
+
+
 
 #endif

--- a/common_arm/usb_cdc.c
+++ b/common_arm/usb_cdc.c
@@ -366,11 +366,56 @@ static const char StrProduct[] = {
     'p', 0, 'r', 0, 'o', 0, 'x', 0, 'm', 0, 'a', 0, 'r', 0, 'k', 0, '3', 0
 };
 
+#ifndef WITH_FLASH
 static const char StrSerialNumber[] = {
     14,         // Length
     0x03,       // Type is string
     'i', 0, 'c', 0, 'e', 0, 'm', 0, 'a', 0, 'n', 0
 };
+#else // WITH_FLASH is defined
+
+// Manually calculated size of descriptor with unique ID:
+// offset  0, lengt h 1: total length field
+// offset  1, length  1: descriptor type field
+// offset  2, length 12: 6x unicode chars (original string)
+// offset 14, length  4: 2x unicode chars (underscores)      [[ to avoid descriptor being (size % 8) == 0, OS bug workaround ]]
+// offset 18, length 32: 16x unicode chars (8-byte serial as hex characters)
+// ============================
+// total: 50 bytes
+
+#define USB_STRING_DESCRIPTOR_SERIAL_NUMBER_LENGTH  50
+char StrSerialNumber[] = {
+    14,         // Length is initially identical to non-unique version ... The length updated at boot, if unique serial is available
+    0x03,       // Type is string
+    'i', 0, 'c', 0, 'e', 0, 'm', 0, 'a', 0, 'n', 0,
+    '_', 0, '_', 0,
+    'x', 0, 'x', 0, 'x', 0, 'x', 0, 'x', 0, 'x', 0, 'x', 0, 'x', 0,
+    'x', 0, 'x', 0, 'x', 0, 'x', 0, 'x', 0, 'x', 0, 'x', 0, 'x', 0,
+};
+void usb_update_serial(uint64_t newSerialNumber) {
+    static bool configured = false; // TODO: enable by setting to false here...
+    if (configured) {
+        return;
+    }
+    // run this only once per boot... even if it fails to find serial number
+    configured = true;
+    if ((newSerialNumber == 0x0000000000000000) || (newSerialNumber == 0xFFFFFFFFFFFFFFFF)) {
+        return;
+    }
+    // Descriptor is, effectively, initially identical to non-unique serial
+    // number because it reports the shorter length in the first byte.
+    // Convert uniqueID's eight bytes to 16 unicode characters in the
+    // descriptor and, finally, update the descriptor's length, which 
+    // causes the serial number to become visible.
+    for (uint8_t i = 0; i < 16; i++) {
+        uint8_t nibble = (uint8_t)((newSerialNumber >> (60 - (4*i))) & 0xFu);
+        char c = nibble < 10 ? '0' + nibble : 'A' + (nibble-10);
+        StrSerialNumber[18+(2*i)] = c; // [ 18, 20, 22, .., 46, 48 ]
+    }
+    StrSerialNumber[0] = USB_STRING_DESCRIPTOR_SERIAL_NUMBER_LENGTH;
+}
+#endif
+
 
 // size includes their own field.
 static const char StrMS_OSDescriptor[] = {

--- a/common_arm/usb_cdc.c
+++ b/common_arm/usb_cdc.c
@@ -405,16 +405,16 @@ void usb_update_serial(uint64_t newSerialNumber) {
     // Descriptor is, effectively, initially identical to non-unique serial
     // number because it reports the shorter length in the first byte.
     // Convert uniqueID's eight bytes to 16 unicode characters in the
-    // descriptor and, finally, update the descriptor's length, which 
+    // descriptor and, finally, update the descriptor's length, which
     // causes the serial number to become visible.
     for (uint8_t i = 0; i < 8; i++) {
         // order of nibbles chosen to match display order from `hw status`
-        uint8_t nibble1 = (newSerialNumber >> ((8*i) + 4)) & 0xFu; // bitmasks [0xF0, 0xF000, 0xF00000, ... 0xF000000000000000]
-        uint8_t nibble2 = (newSerialNumber >> ((8*i) + 0)) & 0xFu; // bitmasks [0x0F, 0x0F00, 0x0F0000, ... 0x0F00000000000000]
-        char c1 = nibble1 < 10 ? '0' + nibble1 : 'A' + (nibble1-10);
-        char c2 = nibble2 < 10 ? '0' + nibble2 : 'A' + (nibble2-10);
-        StrSerialNumber[46-(4*i)] = c1; // [ 46, 42, .., 22, 18 ]
-        StrSerialNumber[48-(4*i)] = c2; // [ 48, 44, .., 24, 20 ]
+        uint8_t nibble1 = (newSerialNumber >> ((8 * i) + 4)) & 0xFu; // bitmasks [0xF0, 0xF000, 0xF00000, ... 0xF000000000000000]
+        uint8_t nibble2 = (newSerialNumber >> ((8 * i) + 0)) & 0xFu; // bitmasks [0x0F, 0x0F00, 0x0F0000, ... 0x0F00000000000000]
+        char c1 = nibble1 < 10 ? '0' + nibble1 : 'A' + (nibble1 - 10);
+        char c2 = nibble2 < 10 ? '0' + nibble2 : 'A' + (nibble2 - 10);
+        StrSerialNumber[46 - (4 * i)] = c1; // [ 46, 42, .., 22, 18 ]
+        StrSerialNumber[48 - (4 * i)] = c2; // [ 48, 44, .., 24, 20 ]
     }
     StrSerialNumber[0] = USB_STRING_DESCRIPTOR_SERIAL_NUMBER_LENGTH;
 }

--- a/common_arm/usb_cdc.c
+++ b/common_arm/usb_cdc.c
@@ -382,7 +382,6 @@ static const char StrSerialNumber[] = {
 // offset 18, length 32: 16x unicode chars (8-byte serial as hex characters)
 // ============================
 // total: 50 bytes
-
 #define USB_STRING_DESCRIPTOR_SERIAL_NUMBER_LENGTH  50
 char StrSerialNumber[] = {
     14,         // Length is initially identical to non-unique version ... The length updated at boot, if unique serial is available
@@ -399,6 +398,7 @@ void usb_update_serial(uint64_t newSerialNumber) {
     }
     // run this only once per boot... even if it fails to find serial number
     configured = true;
+    // reject serial number if all-zero or all-ones
     if ((newSerialNumber == 0x0000000000000000) || (newSerialNumber == 0xFFFFFFFFFFFFFFFF)) {
         return;
     }
@@ -407,10 +407,14 @@ void usb_update_serial(uint64_t newSerialNumber) {
     // Convert uniqueID's eight bytes to 16 unicode characters in the
     // descriptor and, finally, update the descriptor's length, which 
     // causes the serial number to become visible.
-    for (uint8_t i = 0; i < 16; i++) {
-        uint8_t nibble = (uint8_t)((newSerialNumber >> (60 - (4*i))) & 0xFu);
-        char c = nibble < 10 ? '0' + nibble : 'A' + (nibble-10);
-        StrSerialNumber[18+(2*i)] = c; // [ 18, 20, 22, .., 46, 48 ]
+    for (uint8_t i = 0; i < 8; i++) {
+        // order of nibbles chosen to match display order from `hw status`
+        uint8_t nibble1 = (newSerialNumber >> ((8*i) + 4)) & 0xFu; // bitmasks [0xF0, 0xF000, 0xF00000, ... 0xF000000000000000]
+        uint8_t nibble2 = (newSerialNumber >> ((8*i) + 0)) & 0xFu; // bitmasks [0x0F, 0x0F00, 0x0F0000, ... 0x0F00000000000000]
+        char c1 = nibble1 < 10 ? '0' + nibble1 : 'A' + (nibble1-10);
+        char c2 = nibble2 < 10 ? '0' + nibble2 : 'A' + (nibble2-10);
+        StrSerialNumber[46-(4*i)] = c1; // [ 46, 42, .., 22, 18 ]
+        StrSerialNumber[48-(4*i)] = c2; // [ 48, 44, .., 24, 20 ]
     }
     StrSerialNumber[0] = USB_STRING_DESCRIPTOR_SERIAL_NUMBER_LENGTH;
 }

--- a/common_arm/usb_cdc.c
+++ b/common_arm/usb_cdc.c
@@ -413,8 +413,8 @@ void usb_update_serial(uint64_t newSerialNumber) {
         uint8_t nibble2 = (newSerialNumber >> ((8 * i) + 0)) & 0xFu; // bitmasks [0x0F, 0x0F00, 0x0F0000, ... 0x0F00000000000000]
         char c1 = nibble1 < 10 ? '0' + nibble1 : 'A' + (nibble1 - 10);
         char c2 = nibble2 < 10 ? '0' + nibble2 : 'A' + (nibble2 - 10);
-        StrSerialNumber[18 + (4*i) + 0] = c1; // [ 18, 22, .., 42, 46 ]
-        StrSerialNumber[18 + (4*i) + 2] = c2; // [ 20, 24, .., 44, 48 ]
+        StrSerialNumber[18 + (4 * i) + 0] = c1; // [ 18, 22, .., 42, 46 ]
+        StrSerialNumber[18 + (4 * i) + 2] = c2; // [ 20, 24, .., 44, 48 ]
     }
     StrSerialNumber[0] = USB_STRING_DESCRIPTOR_SERIAL_NUMBER_LENGTH;
 }

--- a/common_arm/usb_cdc.c
+++ b/common_arm/usb_cdc.c
@@ -413,8 +413,8 @@ void usb_update_serial(uint64_t newSerialNumber) {
         uint8_t nibble2 = (newSerialNumber >> ((8 * i) + 0)) & 0xFu; // bitmasks [0x0F, 0x0F00, 0x0F0000, ... 0x0F00000000000000]
         char c1 = nibble1 < 10 ? '0' + nibble1 : 'A' + (nibble1 - 10);
         char c2 = nibble2 < 10 ? '0' + nibble2 : 'A' + (nibble2 - 10);
-        StrSerialNumber[46 - (4 * i)] = c1; // [ 46, 42, .., 22, 18 ]
-        StrSerialNumber[48 - (4 * i)] = c2; // [ 48, 44, .., 24, 20 ]
+        StrSerialNumber[18 + (4*i) + 0] = c1; // [ 18, 22, .., 42, 46 ]
+        StrSerialNumber[18 + (4*i) + 2] = c2; // [ 20, 24, .., 44, 48 ]
     }
     StrSerialNumber[0] = USB_STRING_DESCRIPTOR_SERIAL_NUMBER_LENGTH;
 }

--- a/common_arm/usb_cdc.h
+++ b/common_arm/usb_cdc.h
@@ -31,6 +31,7 @@ bool usb_poll_validate_length(void);
 uint32_t usb_read(uint8_t *data, size_t len);
 int usb_write(const uint8_t *data, const size_t len);
 uint32_t usb_read_ng(uint8_t *data, size_t len);
+void usb_update_serial(uint64_t newSerialNumber);
 
 void SetUSBreconnect(int value);
 int GetUSBreconnect(void);

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -3099,9 +3099,10 @@
                 "--fc <dec> facility code",
                 "--cn <dec> card number",
                 "-w, --wiegand <format> see `wiegand list` for available formats",
-                "--shallow use shallow (ASK) reader modulation instead of OOK"
+                "--shallow use shallow (ASK) reader modulation instead of OOK",
+                "-v verbose (print encoded blocks)"
             ],
-            "usage": "hf iclass encode [-h] [--bin <bin>] --ki <dec> [--credit] [--elite] [--raw] [--enckey <hex>] [--fc <dec>] [--cn <dec>] [-w <format>] [--shallow]"
+            "usage": "hf iclass encode [-hv] [--bin <bin>] --ki <dec> [--credit] [--elite] [--raw] [--enckey <hex>] [--fc <dec>] [--cn <dec>] [-w <format>] [--shallow]"
         },
         "hf iclass encrypt": {
             "command": "hf iclass encrypt",
@@ -11903,6 +11904,6 @@
     "metadata": {
         "commands_extracted": 749,
         "extracted_by": "PM3Help2JSON v1.00",
-        "extracted_on": "2023-02-18T01:26:44"
+        "extracted_on": "2023-02-18T20:20:19"
     }
 }

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -3099,10 +3099,9 @@
                 "--fc <dec> facility code",
                 "--cn <dec> card number",
                 "-w, --wiegand <format> see `wiegand list` for available formats",
-                "--shallow use shallow (ASK) reader modulation instead of OOK",
-                "-v verbose (print encoded blocks)"
+                "--shallow use shallow (ASK) reader modulation instead of OOK"
             ],
-            "usage": "hf iclass encode [-hv] [--bin <bin>] --ki <dec> [--credit] [--elite] [--raw] [--enckey <hex>] [--fc <dec>] [--cn <dec>] [-w <format>] [--shallow]"
+            "usage": "hf iclass encode [-h] [--bin <bin>] --ki <dec> [--credit] [--elite] [--raw] [--enckey <hex>] [--fc <dec>] [--cn <dec>] [-w <format>] [--shallow]"
         },
         "hf iclass encrypt": {
             "command": "hf iclass encrypt",
@@ -11507,7 +11506,7 @@
         },
         "script help": {
             "command": "script help",
-            "description": "This is a feature to run Lua/Cmd scripts. You can place scripts within the luascripts/cmdscripts folders. --------------------------------------------------------------------------------------- script list available offline: yes",
+            "description": "This is a feature to run Lua/Cmd/Python scripts. You can place scripts within the luascripts/cmdscripts/pyscripts folders. --------------------------------------------------------------------------------------- script list available offline: yes",
             "notes": [],
             "offline": true,
             "options": [],
@@ -11904,6 +11903,6 @@
     "metadata": {
         "commands_extracted": 749,
         "extracted_by": "PM3Help2JSON v1.00",
-        "extracted_on": "2023-02-11T10:42:29"
+        "extracted_on": "2023-02-18T01:26:44"
     }
 }


### PR DESCRIPTION
Fixes #1904 

Enabling flash is now possible via `PLATFORM_EXTRAS=FLASH`, even on PM3 Easy.

I haven't noticed any negative or unexpected behavior.   Tested:
**Hardware:** (2x) PM3 Easy, purchased from DT within the last year.
**OS:** Windows 11 (including full uninstall of device using NirSoft's [`usbdeview`](https://www.nirsoft.net/utils/usb_devices_view.html)).
**OS:** WSL2 under Windows11, using Kali distributions + `usbipd` for connectivity 


NOTE: This REQUIRES flashing bootloader.  Otherwise, the device will sometimes show up without any serial number, and sometimes with.  I think this may depend either on enumeration speed of OS vs. loading stage3 boot (main image), or soft-boot vs. full power loss.   Does not occur after flashing new bootloader.
