### PR TITLE
improve const correctness

### DIFF
--- a/armsrc/cmd.c
+++ b/armsrc/cmd.c
@@ -131,7 +131,7 @@ static int reply_ng_internal(uint16_t cmd, int16_t status, const uint8_t *data, 
     return PM3_SUCCESS;
 }
 
-int reply_ng(uint16_t cmd, int16_t status, uint8_t *data, size_t len) {
+int reply_ng(uint16_t cmd, int16_t status, const uint8_t *data, size_t len) {
     return reply_ng_internal(cmd, status, data, len, true);
 }
 

--- a/armsrc/cmd.h
+++ b/armsrc/cmd.h
@@ -28,7 +28,7 @@ extern bool g_reply_via_fpc;
 extern bool g_reply_via_usb;
 
 int reply_old(uint64_t cmd, uint64_t arg0, uint64_t arg1, uint64_t arg2, void *data, size_t len);
-int reply_ng(uint16_t cmd, int16_t status, uint8_t *data, size_t len);
+int reply_ng(uint16_t cmd, int16_t status, const uint8_t *data, size_t len);
 int reply_mix(uint64_t cmd, uint64_t arg0, uint64_t arg1, uint64_t arg2, void *data, size_t len);
 int receive_ng(PacketCommandNG *rx);
 


### PR DESCRIPTION
Small change to allow `reply_ng()` to accept a `const` buffer.

This does not restrict callers from using non-const buffers, and `reply_ng_internal()` is already properly marked as `const`.

This change also improves the function's contract by guaranteeing to callers that `reply_ng()` will not modify the data buffer.  Compilers can use this to further optimize code.  In short, it's good for all the reasons that `const` is generally good for.