### PR TITLE
Prevent double-enumeration under WSL2

### DIFF
--- a/pm3
+++ b/pm3
@@ -68,11 +68,12 @@ function get_pm3_list_Linux {
             fi
         fi
         # WSL2 with usbipd detection - doesn't report same things as WSL1
-
         if grep -q "proxmark.org" "/sys/class/tty/${DEV#/dev/}/../../../manufacturer" 2>/dev/null; then
-            PM3LIST+=("$DEV")
-            if [ ${#PM3LIST[*]} -ge "$N" ]; then
-                return
+            if !( echo "${PM3LIST[*]}" | grep -q "${DEV}" ); then
+                PM3LIST+=("$DEV")
+                if [ ${#PM3LIST[*]} -ge "$N" ]; then
+                    return
+                fi
             fi
         fi
     done
@@ -474,7 +475,7 @@ fi
 
 HOSTOS=$(uname | awk '{print toupper($0)}')
 if [ "$HOSTOS" = "LINUX" ]; then
-    if uname -a|grep -qi Microsoft; then
+    if uname -a|grep -q Microsoft; then
         # First try finding it using the PATH environment variable
         PSHEXE=$(command -v powershell.exe 2>/dev/null)
 

--- a/pm3
+++ b/pm3
@@ -69,7 +69,7 @@ function get_pm3_list_Linux {
         fi
         # WSL2 with usbipd detection - doesn't report same things as WSL1
         if grep -q "proxmark.org" "/sys/class/tty/${DEV#/dev/}/../../../manufacturer" 2>/dev/null; then
-            if !( echo "${PM3LIST[*]}" | grep -q "${DEV}" ); then
+            if echo "${PM3LIST[*]}" | grep -qv "${DEV}"; then
                 PM3LIST+=("$DEV")
                 if [ ${#PM3LIST[*]} -ge "$N" ]; then
                     return
@@ -475,7 +475,8 @@ fi
 
 HOSTOS=$(uname | awk '{print toupper($0)}')
 if [ "$HOSTOS" = "LINUX" ]; then
-    if uname -a|grep -q Microsoft; then
+    # Detect when running under WSL1 (but exclude WSL2)
+    if uname -a | grep -qi Microsoft && uname -a | grep -qvi WSL2; then
         # First try finding it using the PATH environment variable
         PSHEXE=$(command -v powershell.exe 2>/dev/null)
 


### PR DESCRIPTION
This makes enumeration under WSL2 work correctly.

I leaves in the workaround someone added (which does not affect all systems?).
At the same time, it explicitly avoids double-enumeration when the exact same device name is found.