### PR TITLE
bugfix: wrong text in hf mfdes list when no data exists in trace

### DIFF
--- a/client/src/cmdhflist.c
+++ b/client/src/cmdhflist.c
@@ -898,7 +898,7 @@ void annotateMfDesfire(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize) {
                 snprintf(exp, size, "R-block NACK(%d)", (cmd[0] & 0x01));
         }
         // I-block 000xCN1x
-        else if ((cmd[0] & 0xC0) == 0x00) {
+        else if (((cmd[0] & 0xC0) == 0x00) && (cmdsize > 2)) {
 
             // PCB [CID] [NAD] [INF] CRC CRC
             int pos = 1;


### PR DESCRIPTION
I noticed when data is missing in the trace (probably due to buggy code on my side), and using `hf mfdes list`,  the hex part was correctly stating `<empty trace - possible error>`, but the Annotations  were displaying valid commands such as `READ RECCORDS` or `CREATE STD DATA FILE`. The `cmd` buffer was read despite `cmdsize` being 0. 
