### PR TITLE
Desfire : check length of tag answers

### DIFF
--- a/armsrc/mifaredesfire.c
+++ b/armsrc/mifaredesfire.c
@@ -182,6 +182,12 @@ void MifareDesfireGetInformation(void) {
         return;
     }
 
+    if (len < sizeof(payload.versionHW)+1) {
+        Dbprintf("Tag answer to MFDES_GET_VERSION was too short: data in Hardware Information is probably invalid.");
+        print_result("Answer", resp, len);
+        memset(resp+len, 0xFF, sizeof(payload.versionHW)+1 - len); // clear remaining bytes
+    }
+
     memcpy(payload.versionHW, resp + 1, sizeof(payload.versionHW));
 
     // ADDITION_FRAME 1
@@ -194,6 +200,13 @@ void MifareDesfireGetInformation(void) {
         switch_off();
         return;
     }
+
+    if (len < sizeof(payload.versionSW)+1) {
+        Dbprintf("Tag answer to MFDES_ADDITIONAL_FRAME 1 was too short: data in Software Information is probably invalid.");
+        print_result("Answer", resp, len);
+        memset(resp+len, 0xFF, sizeof(payload.versionSW)+1 - len); // clear remaining bytes
+    }
+
     memcpy(payload.versionSW, resp + 1,  sizeof(payload.versionSW));
 
     // ADDITION_FRAME 2
@@ -204,6 +217,12 @@ void MifareDesfireGetInformation(void) {
         reply_ng(CMD_HF_DESFIRE_INFO, PM3_ESOFT, (uint8_t *)&payload, sizeof(payload));
         switch_off();
         return;
+    }
+
+    if (len < sizeof(payload.details)+1) {
+        Dbprintf("Tag answer to MFDES_ADDITIONAL_FRAME 2 was too short: data in Batch number and Production date is probably invalid");
+        print_result("Answer", resp, len);
+        memset(resp+len, 0xFF, sizeof(payload.details)+1 - len); // clear remaining bytes
     }
 
     memcpy(payload.details, resp + 1,  sizeof(payload.details));


### PR DESCRIPTION
While experimenting with an ultimate magic card with ATQ, SAK and RATS set to mimick a DESFire tag, I noticed `hf mfdes info` returns strange values in different locations.
Actualy, the tag replies `6D 00` (instruction code not supported) to some commands, and this was interpreted as valid data.

This PR adds information on the wrong length of the answers, but keeps going on and adds FF where no data has been received, to cover the most use cases.
