### PR TITLE
Update Troubleshooting, libQt5Core.so.5 not found

### DIFF
--- a/doc/md/Installation_Instructions/Troubleshooting.md
+++ b/doc/md/Installation_Instructions/Troubleshooting.md
@@ -224,7 +224,7 @@ Try running it with
 ## libQt5Core.so.5 not found
 ^[Top](#top)
 
-On WSL1 / updated to Ubuntu 20.04,  there is a slight chance you experience problems when compiling the repo with QT5.
+On WSL1 / updated to Ubuntu 20.04 and 22.04,  there is a slight chance you experience problems when compiling the repo with QT5.
 The following steps is needed to make the development environment happy again.   
 ```
 sudo apt reinstall qtbase5-dev


### PR DESCRIPTION
Update the version number of Ubuntu which has the same problem

I checked newer Ubuntu version 22.04 WSL 1 still have problem and solved by same solution sudo strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5