### PR TITLE
Updated verbiage WRT iClass info (KeyAccess) to make it clearer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Changed `hf iclass view` - show credentials on a decrypted dump (@natesales)
  - Show NTAG213TT tamper info in `hf mfu info` and add commands for configuring it's tamper feature (@mjaksn)
  - Add Mifare Classic EV1 signature write support to gen4 magic tag lua script (@augustozanellato)
+ - 
 
 ## [Nitride.4.16191][2023-01-29]
  - Changed `build_all_firmwares.sh` to fit GENERIC 256kb firmware images (@doegox)
@@ -176,7 +177,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Added new standalone mode `lf_em4100rsww` (@zabszk)
  - Fixed `hf 15 slixdisable` wrong pass id (@r1ddl3rz)
  - Added `script run hf_mf_hid_sim.lua` (@micsen)
-
+ - Changed verbiage on `hf iclass info` KeyAccess area to be congruent with AA1 and AA2 areas (@GuruSteve)
 
 ## [Frostbit.4.14831][2022-01-11]
  - Changed Wiegand format lookup - now case-insensitive (@iceman1001)

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -594,17 +594,17 @@ static void mem_app_config(const picopass_hdr_t *hdr) {
     PrintAndLogEx(INFO, " * Kd, Debit key, AA1    Kc, Credit key, AA2 *");
     uint8_t keyAccess = isset(mem, 0x01);
     if (keyAccess) {
-        PrintAndLogEx(INFO, "    Read A....... debit");
-        PrintAndLogEx(INFO, "    Read B....... credit");
-        PrintAndLogEx(INFO, "    Write A...... debit");
-        PrintAndLogEx(INFO, "    Write B...... credit");
+        PrintAndLogEx(INFO, "    Read AA1....... debit");
+        PrintAndLogEx(INFO, "    Write AA1...... debit");
+        PrintAndLogEx(INFO, "    Read AA2....... credit");
+        PrintAndLogEx(INFO, "    Write AA2...... credit");
         PrintAndLogEx(INFO, "    Debit........ debit or credit");
         PrintAndLogEx(INFO, "    Credit....... credit");
     } else {
-        PrintAndLogEx(INFO, "    Read A....... debit or credit");
-        PrintAndLogEx(INFO, "    Read B....... debit or credit");
-        PrintAndLogEx(INFO, "    Write A...... credit");
-        PrintAndLogEx(INFO, "    Write B...... credit");
+        PrintAndLogEx(INFO, "    Read AA1....... debit or credit");
+        PrintAndLogEx(INFO, "    Write AA1...... credit");
+        PrintAndLogEx(INFO, "    Read AA2....... debit or credit");
+        PrintAndLogEx(INFO, "    Write AA2...... credit");
         PrintAndLogEx(INFO, "    Debit........ debit or credit");
         PrintAndLogEx(INFO, "    Credit....... credit");
     }


### PR DESCRIPTION
Picopass supports 2 KeyAccess configurations.  While the datasheet refers to the configurations as "Read/Write A/B", in practice, A and B themselves refer to the AA1 and AA2 areas of picopass storage.

I have updated the verbiage to be congruent with practice.

Discord discussion link: https://discord.com/channels/738045391416852520/738046308929110076/1083511261758771260