### PR TITLE
Fix client build on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed the client build on Android (@wh201906)
  - Added TCP connection support on Windows (@wh201906)
  - Added `data num` - easy convert between dec/hex/bin (@iceman1001)
  - Fixed `hf mfdes info` - now handles incorrect tag answers better (@didiera)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -163,11 +163,12 @@ endif (NOT SKIPJANSSONSYSTEM EQUAL 1)
 
 if(EMBED_BZIP2)
     set(BZIP2_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/deps/bzip2/src/bzip2)
+    # Specify SOURCE_DIR will cause some errors
     ExternalProject_Add(bzip2
         GIT_REPOSITORY        https://android.googlesource.com/platform/external/bzip2
         GIT_TAG               platform-tools-30.0.2
         PREFIX                deps/bzip2
-        SOURCE_DIR            ${CMAKE_CURRENT_SOURCE_DIR}/deps/bzip2
+        # SOURCE_DIR            ${CMAKE_CURRENT_SOURCE_DIR}/deps/bzip2
         CONFIGURE_COMMAND     mkdir -p ${BZIP2_BUILD_DIR} && git archive --format tar HEAD | tar -C ${BZIP2_BUILD_DIR} -x
         BUILD_IN_SOURCE       ON
         BUILD_COMMAND         make -C ${BZIP2_BUILD_DIR} -j4 CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} LD=${CMAKE_C_COMPILER} AR=${CMAKE_AR} RANLIB=${CMAKE_RANLIB} ${CFLAGS_EXTERNAL_LIB} libbz2.a

--- a/client/deps/hardnested.cmake
+++ b/client/deps/hardnested.cmake
@@ -17,7 +17,7 @@ target_compile_definitions(pm3rrg_rdv4_hardnested_nosimd PRIVATE NOSIMD_BUILD)
 ## Mingw platforms: AMD64
 set(X86_CPUS x86 x86_64 i686 AMD64)
 set(ARM64_CPUS arm64 aarch64)
-set(ARM32_CPUS armel armv7-a)
+set(ARM32_CPUS armel armhf armv7-a)
 
 message(STATUS "CMAKE_SYSTEM_PROCESSOR := ${CMAKE_SYSTEM_PROCESSOR}")
 

--- a/client/deps/hardnested.cmake
+++ b/client/deps/hardnested.cmake
@@ -17,7 +17,7 @@ target_compile_definitions(pm3rrg_rdv4_hardnested_nosimd PRIVATE NOSIMD_BUILD)
 ## Mingw platforms: AMD64
 set(X86_CPUS x86 x86_64 i686 AMD64)
 set(ARM64_CPUS arm64 aarch64)
-set(ARM32_CPUS armel armhf)
+set(ARM32_CPUS armel armv7-a)
 
 message(STATUS "CMAKE_SYSTEM_PROCESSOR := ${CMAKE_SYSTEM_PROCESSOR}")
 


### PR DESCRIPTION
Tested with:

- cmake 3.10.2.4988404/3.24.1
- ndk 25.2.9519653


Build command:
```
cmake \
    -DCMAKE_TOOLCHAIN_FILE=/home/gitpod/androidsdk/ndk/25.2.9519653/build/cmake/android.toolchain.cmake \
    -DANDROID_ABI=armeabi-v7a \
    -DANDROID_NATIVE_API_LEVEL=android-19 \
    -DSKIPBT=1 -DSKIPPYTHON=1 -DSKIPPTHREAD=1
```

(armeabi-v7a, arm64-v8a, x86 and x86_64 are all tested)
(I didn't test other versions of NDK, but they should work.)

***
This is for [RFIDtools](https://github.com/RfidResearchGroup/RFIDtools).
The Android build has been broken for a while.
<details>
<summary>preview</summary>

![image](https://user-images.githubusercontent.com/62299611/224372282-b9a18f1f-0713-40a8-89a2-b89b4310f7a9.png)


</details>
