### PR TITLE
Fix tlv doublefree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed `hf 14a apdu` double-free when parsing tlv fails
  - Fixed the client build on Android (@wh201906)
  - Added TCP connection support on Windows (@wh201906)
  - Added `data num` - easy convert between dec/hex/bin (@iceman1001)

--- a/client/src/emv/tlv.c
+++ b/client/src/emv/tlv.c
@@ -199,7 +199,6 @@ struct tlvdb *tlvdb_parse(const unsigned char *buf, size_t len) {
 err:
     tlvdb_free(&root->db);
 
-    free(root);
     return NULL;
 }
 
@@ -236,7 +235,6 @@ struct tlvdb *tlvdb_parse_multi(const unsigned char *buf, size_t len) {
 err:
     tlvdb_free(&root->db);
 
-    free(root);
     return NULL;
 }
 


### PR DESCRIPTION
`&root->db` and `root` are the same pointer, double free will crash the client when tlv parsing fails