### PR TITLE
Legic info command for other sources, out of bounds memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Add Mifare Classic EV1 signature write support to gen4 magic tag lua script (@augustozanellato)
  - Added XOR key extraction and flag to Guardall G-Prox II (@GuruSteve)
  - Changed verbiage on `hf iclass info` KeyAccess area to be congruent with AA1 and AA2 areas (@GuruSteve)
- - Added `hf legic info` command for other sources: `hf legic einfo`, `hf legic dinfo`
+ - Added `hf legic info` command for other sources: `hf legic einfo`, `hf legic view` (@0xdeb)
  - 
 
 ## [Nitride.4.16191][2023-01-29]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Add Mifare Classic EV1 signature write support to gen4 magic tag lua script (@augustozanellato)
  - Added XOR key extraction and flag to Guardall G-Prox II (@GuruSteve)
  - Changed verbiage on `hf iclass info` KeyAccess area to be congruent with AA1 and AA2 areas (@GuruSteve)
+ - Added `hf legic info` command for other sources: `hf legic einfo`, `hf legic dinfo`
  - 
 
 ## [Nitride.4.16191][2023-01-29]

--- a/client/src/cmdhflegic.c
+++ b/client/src/cmdhflegic.c
@@ -1367,35 +1367,8 @@ static int CmdLegicView(const char *Cmd) {
     PrintAndLogEx(INFO, "## |  0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F | ascii");
     PrintAndLogEx(INFO, "---+-------------------------------------------------+-----------------");
     print_hex_break(dump, bytes_read, 16);
-    free(dump);
-    return PM3_SUCCESS;
-}
 
-static int CmdLegicDInfo(const char *Cmd) {
-    CLIParserContext *ctx;
-    CLIParserInit(&ctx, "hf legic view",
-                  "Print a LEGIC Prime dump file (bin/eml/json)",
-                  "hf legic view -f hf-legic-01020304-dump.bin"
-                 );
-    void *argtable[] = {
-        arg_param_begin,
-        arg_str1("f", "file", "<fn>", "Filename of dump"),
-        arg_param_end
-    };
-    CLIExecWithReturn(ctx, Cmd, argtable, false);
-    int fnlen = 0;
-    char filename[FILE_PATH_SIZE];
-    CLIParamStrToBuf(arg_get_str(ctx, 1), (uint8_t *)filename, FILE_PATH_SIZE, &fnlen);
-    CLIParserFree(ctx);
-
-    // read dump file
-    uint8_t *dump = NULL;
-    size_t bytes_read = 0;
-    int res = pm3_load_dump(filename, (void **)&dump, &bytes_read, LEGIC_PRIME_MIM1024);
-    if (res != PM3_SUCCESS) {
-        return res;
-    }
-
+    PrintAndLogEx(NORMAL, "");
     decode_and_print_memory(bytes_read, dump);
 
     free(dump);
@@ -1421,8 +1394,7 @@ static command_t CommandTable[] =  {
     {"einfo",   CmdLegicEInfo,    IfPm3Legicrf,    "Display deobfuscated and decoded emulator memory"},
     {"-----------", CmdHelp,      AlwaysAvailable, "--------------------- " _CYAN_("utils") " ---------------------"},
     {"crc",     CmdLegicCalcCrc,  AlwaysAvailable, "Calculate Legic CRC over given bytes"},
-    {"view",    CmdLegicView,     AlwaysAvailable, "Display content from tag dump file"},
-    {"dinfo",   CmdLegicDInfo,     AlwaysAvailable, "Display deobfuscated and decoded content from tag dump file"},
+    {"view",    CmdLegicView,     AlwaysAvailable, "Display deobfuscated and decoded content from tag dump file"},
     {NULL, NULL, NULL, NULL}
 };
 


### PR DESCRIPTION
The `hf legic info` command was only available when reading directly from a card. The command displays deobfuscated and decoded legic data. 

This command is generally really useful and should also be executable on a dump file and on the emulator's memory. 
Changes:
- Extract method `static int decode_and_print_memory(uint16_t card_size, const uint8_t *input_buffer)` from `CmdLegicInfo`
- Call this function from the newly created commands:
  - `CmdLegicEInfo` (`hf legic einfo`): Display deobfuscated and decoded emulator memory
  - `CmdLegicDInfo` (`hf legic dinfo`): Display deobfuscated and decoded content from tag dump file

This PR also implements a couple of checks to prevent out of bounds memory access. Previously when the card contained invalid data (e.g. too large segment length) the client application would perform a out of bounds read and segfault. 