### PR TITLE
Fix the example of msleep

### DIFF
--- a/client/src/cmdmain.c
+++ b/client/src/cmdmain.c
@@ -250,7 +250,7 @@ static int CmdMsleep(const char *Cmd) {
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "msleep",
                   "Sleep for given amount of milliseconds",
-                  "msleep 100"
+                  "msleep -t 100"
                  );
 
     void *argtable[] = {


### PR DESCRIPTION
The `-t`(or `--ms`) tag is necessary when using cliparser
```
[usb] pm3 --> msleep 100
msleep: unexpected argument "100"
[!] ⚠️  Try 'msleep --help' for more information.

[usb] pm3 --> msleep -t 100
[usb] pm3 --> 

```