### PR TITLE
Fix units

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,21 +102,21 @@ We define generic Proxmark3 platforms as following devices.
 When it comes to these new unknown models we are depending on the community to report in if this repo works and what they did to make it work.
 
 
-**256kb flash memory size of generic Proxmark3 platforms**
+**256KB flash memory size of generic Proxmark3 platforms**
 
 > ⚠ **Note**: 
 > You need to keep a eye on how large your ARM chip built-in flash memory is. 
-> With 512kb you are fine but if its 256kb you need to compile this repo with even less functionality.
+> With 512KB you are fine but if its 256KB you need to compile this repo with even less functionality.
 > When running the `./pm3-flash-all` you can see which size your device have if you have the bootloader from this repo installed. 
 > Otherwise you will find the size reported in the start message when running the Proxmark3 client `./pm3`.
 >
-> [OBS! Read the 256kb flash memory advisory](/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md#256kb-versions)
+> [OBS! Read the 256KB flash memory advisory](/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md#256KB-versions)
 
 
 # What has changed?
 
 Proxmark3 RDV4 hardware modifications:
-  * added flash memory 256kb
+  * added flash memory 256KB
   * added smart card module
   * added FPC connector for peripherals such as Bluetooth+battery addon
   * improved antennas

--- a/bootrom/bootrom.c
+++ b/bootrom/bootrom.c
@@ -310,10 +310,10 @@ void BootROM(void) {
     LED_B_OFF();
     LED_A_OFF();
 
-    // Set the first 256kb memory flashspeed
+    // Set the first 256KB memory flashspeed
     AT91C_BASE_EFC0->EFC_FMR = AT91C_MC_FWS_1FWS | MC_FLASH_MODE_MASTER_CLK_IN_MHZ(48);
 
-    // 9 = 256, 10+ is 512kb
+    // 9 = 256, 10+ is 512KB
     uint8_t id = (*(AT91C_DBGU_CIDR) & 0xF00) >> 8;
     if (id > 9)
         AT91C_BASE_EFC1->EFC_FMR = AT91C_MC_FWS_1FWS | MC_FLASH_MODE_MASTER_CLK_IN_MHZ(48);

--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -133,7 +133,7 @@ static void lookup_chipid_short(uint32_t iChipID, uint32_t mem_used) {
             break;
     }
 
-    PrintAndLogEx(NORMAL, "    Memory.... " _YELLOW_("%u") " Kb ( " _YELLOW_("%2.0f%%") " used )"
+    PrintAndLogEx(NORMAL, "    Memory.... " _YELLOW_("%u") " KB ( " _YELLOW_("%2.0f%%") " used )"
                   , mem_avail
                   , mem_avail == 0 ? 0.0f : (float)mem_used / (mem_avail * 1024) * 100
                  );

--- a/doc/ext_flash_notes.md
+++ b/doc/ext_flash_notes.md
@@ -19,9 +19,9 @@ External 256kbytes flash is a unique feature of the RDV4 edition.
 
 Flash memory is
 
-* 256kb (0x40000= 262144)
-* divided into 4 pages of 64kb (0x10000 = 65536)
-* 4 pages divided into 16 sectors of 4kb (0x1000 = 4096), so last sector is at 0x3F000
+* 256KB (0x40000= 262144)
+* divided into 4 pages of 64KB (0x10000 = 65536)
+* 4 pages divided into 16 sectors of 4KB (0x1000 = 4096), so last sector is at 0x3F000
 
 Therefore a flash address can be interpreted as such:
 ```

--- a/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md
+++ b/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md
@@ -10,7 +10,7 @@
   - [PLATFORM](#platform)
   - [PLATFORM_EXTRAS](#platform_extras)
   - [STANDALONE](#standalone)
-  - [256kb versions](#256kb-versions)
+  - [256KB versions](#256KB-versions)
   - [Next step](#next-step)
 
 
@@ -48,10 +48,10 @@ make SKIPBT=1
 ## Firmware
 ^[Top](#top)
 
-By default, the firmware is of course tuned for the Proxmark3 RDV4 device, which has built-in support for 256kb onboard flash SPI memory, Sim module (smart card support), FPC connector.
+By default, the firmware is of course tuned for the Proxmark3 RDV4 device, which has built-in support for 256KB onboard flash SPI memory, Sim module (smart card support), FPC connector.
 These features make it very different from all other Proxmark3 devices, there is non other like this one.
 
-**Recommendation**: if you don't have a RDV4, we strongly recommend your device to have at least a 512kb arm chip, since this repo is crossing 256kb limit. There is still a way to skip parts to make it fit on a 256kb device, see below.
+**Recommendation**: if you don't have a RDV4, we strongly recommend your device to have at least a 512KB arm chip, since this repo is crossing 256KB limit. There is still a way to skip parts to make it fit on a 256KB device, see below.
 
 If you need to tune things and save the configuration, create a file `Makefile.platform` in the root directory of the repository, see `Makefile.platform.sample`.
 For an up-to-date exhaustive list of options, you can run `make PLATFORM=`.
@@ -73,7 +73,7 @@ The MCU version (256 or 512) will be detected automatically during flashing.
 
 Known issues:
 
-* 256kb Arm chip devices: The compiled firmware image from this repo may/will be too large for your device. 
+* 256KB Arm chip devices: The compiled firmware image from this repo may/will be too large for your device. 
 * PM3 Evo: it has a different led/button pin assignment.  It tends to be messed up.
 * Proxmark Pro:  it has different fpga and unknown pin assignments.  Unsupported.
 
@@ -136,10 +136,10 @@ Here are the supported values you can assign to `STANDALONE` in `Makefile.platfo
 
 By default `STANDALONE=LF_SAMYRUN`.
 
-## 256kb versions
+## 256KB versions
 ^[Top](#top)
 
-If you own a Proxmark3 Easy with only 256kb, you can use a few definitions to help you getting a smaller firmware.
+If you own a Proxmark3 Easy with only 256KB, you can use a few definitions to help you getting a smaller firmware.
 
 First thing is of course to use the `PLATFORM=PM3GENERIC`.
 Adding `PLATFORM_SIZE=256` will provoke an error during compilation of the recovery image if your image is too big, so you can detect the problem before trying to flash the Proxmark3, e.g.
@@ -155,22 +155,22 @@ a series of `SKIP_*` allow to skip some of the functionalities and to get a smal
 
 | Definitions         | Rough estimation of the saved space |
 |---------------------|-------------------------------------|
-|STANDALONE=          | 3.6kb
-|SKIP_LF=1            | 25.8kb
-|SKIP_HITAG=1         | 24.2kb
-|SKIP_EM4x50=1        | 2.9kb
-|SKIP_ISO15693=1      | 3.2kb
-|SKIP_LEGICRF=1       | 3.9kb
-|SKIP_ISO14443b=1     | 3.7kb
-|SKIP_ISO14443a=1     | 63.0kb
-|SKIP_ICLASS=1        | 10.5kb
-|SKIP_FELICA=1        | 4.0kb
-|SKIP_NFCBARCODE=1    | 1.4kb
-|SKIP_HFSNIFF=1       | 0.5kb
-|SKIP_HFPLOT=1        | 0.3kb
-|SKIP_ZX8211=1        | 0.3kb
+|STANDALONE=          | 3.6KB
+|SKIP_LF=1            | 25.8KB
+|SKIP_HITAG=1         | 24.2KB
+|SKIP_EM4x50=1        | 2.9KB
+|SKIP_ISO15693=1      | 3.2KB
+|SKIP_LEGICRF=1       | 3.9KB
+|SKIP_ISO14443b=1     | 3.7KB
+|SKIP_ISO14443a=1     | 63.0KB
+|SKIP_ICLASS=1        | 10.5KB
+|SKIP_FELICA=1        | 4.0KB
+|SKIP_NFCBARCODE=1    | 1.4KB
+|SKIP_HFSNIFF=1       | 0.5KB
+|SKIP_HFPLOT=1        | 0.3KB
+|SKIP_ZX8211=1        | 0.3KB
 
-So for example, at the time of writing, this is a valid `Makefile.platform` compiling an image for 256k:
+So for example, at the time of writing, this is a valid `Makefile.platform` compiling an image for 256KB:
 ```
 PLATFORM=PM3GENERIC
 PLATFORM_SIZE=256


### PR DESCRIPTION
According to the [Wikipedia](https://en.wikipedia.org/wiki/Kilobyte), 
`kb` means kilobits in base 10, 1kb=1000b
`KB` means kilobytes in base 2, 1KB=1024B

Some unit symbols in the documents and codes are misleading, so I fixed them.