### PR TITLE
Fix the USB enumeration process for large external flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed the USB enumeration process (@wh201906)
  - Fixed `hf mf rdsc` - now correctly gets size in bytes when sector is larger than 32 (@iceman1001)
  - Changed `hf mf supercard` - Support editing UID and recovery of keys from second generation card (@AloneLiberty)
  - Added iClass credit key to default iClass key table and reorganized key order (@GuruSteve)

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -2722,12 +2722,6 @@ void  __attribute__((noreturn)) AppMain(void) {
     usart_init(USART_BAUD_RATE, USART_PARITY);
 #endif
 
-    // This is made as late as possible to ensure enumeration without timeout
-    // against device such as http://www.hobbytronics.co.uk/usb-host-board-v2
-    usb_disable();
-    usb_enable();
-    allow_send_wtx = true;
-
 #ifdef WITH_FLASH
     // If flash is not present, BUSY_TIMEOUT kicks in, let's do it after USB
     loadT55xxConfig();
@@ -2735,8 +2729,17 @@ void  __attribute__((noreturn)) AppMain(void) {
     //
     // Enforce a spiffs check/garbage collection at boot so we are likely to never
     // fall under the 2 contigous free blocks availables
+    // This is a time-consuming process on large flash.
     rdv40_spiffs_check();
 #endif
+
+    // This is made as late as possible to ensure enumeration without timeout
+    // against device such as http://www.hobbytronics.co.uk/usb-host-board-v2
+    // In other words, keep the interval between usb_enable() and the main loop as short as possible.
+    // (AT91F_CDC_Enumerate() will be called in the main loop)
+    usb_disable();
+    usb_enable();
+    allow_send_wtx = true;
 
     for (;;) {
         WDT_HIT();


### PR DESCRIPTION
The `rdv40_spiffs_check()` is a time-consuming process for large external flash. 
When running it between `usb_enable()` and the main loop, the enumeration will excess the timeout, just as the original comment says.