### PR TITLE
Add the missing change of definition

### DIFF
--- a/include/pmflash.h
+++ b/include/pmflash.h
@@ -91,9 +91,9 @@ typedef struct {
     uint8_t signature[FLASH_MEM_SIGNATURE_LEN];
 } PACKED rdv40_validation_t;
 
-// SPIFFS current allocates 128kb of the 256kb available.
+// SPIFFS current allocates 192KB of the 256KB available.
 #ifndef FLASH_SPIFFS_ALLOCATED_SIZE
-# define FLASH_SPIFFS_ALLOCATED_SIZE (1024 * 128)
+# define FLASH_SPIFFS_ALLOCATED_SIZE (1024 * 192)
 #endif
 
 #endif // __PMFLASH_H


### PR DESCRIPTION
for commit 79cfa1d8faa56c390a045d779b997633b357c515 
(Although this definition is unused)