### PR TITLE
Fix wrong variable assignment

### DIFF
--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -7986,7 +7986,7 @@ static int CmdHF14AMfValue(const char *Cmd) {
         PrintAndLogEx(WARNING, "Input key type must be A or B");
         return PM3_EINVARG;
     } else if (arg_get_lit(ctx, 10)) {
-        keytype = MF_KEY_B;;
+        transferkeytype = MF_KEY_B;;
     }
 
     int keylen = 0;


### PR DESCRIPTION
Hi,
I fixed a bug in the `hf mf value` transfer attack that was recently implemented. 
Specifically, there was an issue with the `transferkeytype` being mistakenly assigned to `keytype`. This caused the command to fail when the attacked block had a key of type value `b`.  With this fix the attack should now function correctly.