### PR TITLE
Fix logic

### DIFF
--- a/client/src/cmdhfmfp.c
+++ b/client/src/cmdhfmfp.c
@@ -1024,7 +1024,7 @@ static int MFPKeyCheck(uint8_t startSector, uint8_t endSector, uint8_t startKeyA
 
                 for (int retry = 0; retry < 4; retry++) {
                     res = MifareAuth4(NULL, keyn, keyList[i], selectCard, true, false, false, true);
-                    if (res == PM3_SUCCESS || PM3_EWRONGANSWER)
+                    if (res == PM3_SUCCESS || res == PM3_EWRONGANSWER)
                         break;
 
                     if (verbose)


### PR DESCRIPTION
In commit 1bb78e02a4e788ee27ee72f3208b6e7fe08ec9d9, the code will always break the loop because the `PM3_EWRONGANSWER` is treated as a condition rather than a value, and the value of it is not 0.
I guess the condition there should be `res == PM3_SUCCESS || res == PM3_EWRONGANSWER`