### PR TITLE
doc(macos-macports): refactor macports docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Added `hf legic einfo` - views emulator menory (@0xdeb)
  - Changed `hf legic view` - now also print the decoded info of the dump file (@0xdeb)
  - Now `script run hf_mf_ultimatecard.lua -u` supports 10bytes UID (@alejandro12120)
+ - Update documentation for installation on macOS with MacPorts (@linuxgemini)
 
 ## [Nitride.4.16191][2023-01-29]
  - Changed `build_all_firmwares.sh` to fit GENERIC 256kb firmware images (@doegox)

--- a/doc/md/Installation_Instructions/Mac-OS-X-MacPorts-Installation-Instructions.md
+++ b/doc/md/Installation_Instructions/Mac-OS-X-MacPorts-Installation-Instructions.md
@@ -2,7 +2,6 @@
 <a id="Top"></a>
 
 # Mac OS X - MacPorts automatic installation
-<b><h3>These insturctions won't work on Apple Silicon yet!</h3> An arm64 native build of arm-none-eabi-gcc is still not available (as of 2021-11-26).</b>
 
 # Table of Contents
 - [Mac OS X - MacPorts automatic installation](#mac-os-x---macports-automatic-installation)
@@ -23,70 +22,82 @@
 
 1. Have MacPorts installed. Visit https://www.macports.org/ for more information.
 
-    * MacPorts may require a bit more setup. You first need to set up your PATH variable:
-
-    ```bash
-    export "/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/local/sbin:$PATH"
-    ```
-
-   For a somewhat seamless development environment:
-
-    ```bash
-    export C_INCLUDE_PATH="/opt/local/include"
-    export CPLUS_INCLUDE_PATH="/opt/local/include"
-    export LIBRARY_PATH="/opt/local/lib"
-    export LDFLAGS="-L/opt/local/lib"
-    export CFLAGS="-I/opt/local/include"
-    export CPPFLAGS="-isystem/opt/local/include -I/opt/local/include"
-    ```
-
-## Installing latest releases
+## Installing stable releases directly
 ^[Top](#top)
 
-Packaging for latest releases are available on MacPorts with the port name `proxmark3-iceman`, with a variant for PM3GENERIC firmwares available as `+pm3generic`.
+Packaging for latest releases are available on MacPorts with the port name [`proxmark3-iceman`](https://ports.macports.org/port/proxmark3-iceman/details/), with a variant for PM3GENERIC firmwares available as `+pm3generic`.
 
 Installing is as simple as `sudo port install proxmark3-iceman` and if you want to install for PM3GENERIC, you can run `sudo port install proxmark3-iceman +pm3generic` instead.
+
 
 ## Build from source
 ^[Top](#top)
 
 These instructions will show how to setup the environment on OSX to the point where you'll be able to clone and compile the repo by yourself, as on Linux, Windows, etc.
 
-1. Have MacPorts installed. See above for details.
+1. Have MacPorts installed. Visit https://www.macports.org/ for more information.
+
+    * Since you're going to compile directly; this will require a bit more setup, you first need to set up your PATH variable (we assume your MacPorts prefix is located at its default, which is `/opt/local`) in your shell rc file:
+
+      ```bash
+      export MACPORTS_PREFIX="/opt/local"
+      # we assume you'll use GNU coreutils; which is also a required dependency for proxmark3
+      # install it with `sudo port install coreutils`
+      export "$MACPORTS_PREFIX/libexec/gnubin:$MACPORTS_PREFIX/bin:$MACPORTS_PREFIX/sbin:$PATH"
+      ```
+
+      For a somewhat seamless development environment, you can use these in your shell rc file:
+
+      ```bash
+      export C_INCLUDE_PATH="$MACPORTS_PREFIX/include:$C_INCLUDE_PATH"
+      export CPLUS_INCLUDE_PATH="$MACPORTS_PREFIX/include:$CPLUS_INCLUDE_PATH"
+      export LIBRARY_PATH="$MACPORTS_PREFIX/lib:$LIBRARY_PATH"
+      export LDFLAGS="-L$MACPORTS_PREFIX/lib $LDFLAGS"
+      export CFLAGS="-I$MACPORTS_PREFIX/include $CFLAGS"
+      export CPPFLAGS="-isystem$MACPORTS_PREFIX/include -I$MACPORTS_PREFIX/include $CPPFLAGS"
+      export PKG_CONFIG_PATH="$MACPORTS_PREFIX/lib/pkgconfig:$MACPORTS_PREFIX/share/pkgconfig:$PKG_CONFIG_PATH"
+      ```
 
 2. Install dependencies:
 
-    ```
-    sudo port install readline qt5 qt5-qtbase pkgconfig arm-none-eabi-gcc arm-none-eabi-binutils lua52 coreutils openssl@3
+    ```bash
+    sudo port install readline jansson lua52 python311 bzip2 openssl11 arm-none-eabi-gcc arm-none-eabi-binutils coreutils qt5 qt5-qtbase pkgconfig
     ```
 
 3. Clamp Python version for pkg-config
 
     MacPorts doesn't handle Python version defaults when it comes to pkg-config. So even if you have done:
 
-    ```
-    sudo port install python39 cython39
+    ```bash
+    sudo port install python311 cython311
 
-    sudo port select --set python python39  # this also makes calls to "python" operate on python3.9
-    sudo port select --set python3 python39
-    sudo port select --set cython cython39 
+    sudo port select --set python python311  # this also makes calls to "python" operate on python3.11
+    sudo port select --set python3 python311
+    sudo port select --set cython cython311
     ```
 
     This won't set a default python3.pc (and python3-embed.pc) under the MacPorts pkgconfig includes folder.
 
     To fix that, follow these steps:
 
-    ```
+    ```bash
     cd /opt/local/lib/pkgconfig
-    sudo ln -svf python3.pc python-3.9.pc
-    sudo ln -svf python3-embed.pc python-3.9-embed.pc
+    sudo ln -svf python3.pc python-3.11.pc
+    sudo ln -svf python3-embed.pc python-3.11-embed.pc
+    ```
+
+    _Or_ you can use a framework definition in your shell rc file:
+
+    ```bash
+    export MACPORTS_FRAMEWORKS_DIR="$MACPORTS_PREFIX/Library/Frameworks"
+    export PYTHON_FRAMEWORK_DIR="$MACPORTS_FRAMEWORKS_DIR:/Python.framework/Versions/3.11"
+    export PKG_CONFIG_PATH="$PYTHON_FRAMEWORK_DIR:$PKG_CONFIG_PATH"
     ```
 
 4. (optional) Install makefile dependencies:
 
-    ```
-    sudo port install recode
-    sudo port install astyle
+    ```bash
+    sudo port install recode astyle
     ```
 
 
@@ -103,7 +114,7 @@ cd proxmark3
 
 Now you're ready to follow the [compilation instructions](/doc/md/Use_of_Proxmark/0_Compilation-Instructions.md).
 From there, you can follow the original instructions. 
-_Take extra note to instructions if you don't have a Proxmark3 RDV4 device._
+_Take extra note to instructions if you **don't** have a Proxmark3 RDV4 device._
 
 To flash on OS X, better to enter the bootloader mode manually, else you may experience errors.
 
@@ -125,4 +136,3 @@ If you want to manually select serial port, remember that the Proxmark3 port is 
 ```sh
 proxmark3 /dev/ttyACM0  =>  proxmark3 /dev/tty.usbmodemiceman1
 ```
-


### PR DESCRIPTION
Since mid-2022, arm64 builds of stable releases are working. So its been a while not updating this doc :)