### PR TITLE
Fix changelog reminder

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Changelog Reminder
       uses: peterjgrainger/action-changelog-reminder@v1.2.0
       with:
-        changelog_regex: '/CHANGELOG.md'
+        changelog_regex: 'CHANGELOG.md'
         customPrMessage: 'You are welcome to add an entry to the CHANGELOG.md as well'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The current changelog reminder workflow always comments 
`You are welcome to add an entry to the CHANGELOG.md as well`
even if the PR contains the changelog entry.
This PR fixes it.