### PR TITLE
Add paxton id to hitag2 info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Changed `hf legic view` - now also print the decoded info of the dump file (@0xdeb)
  - Now `script run hf_mf_ultimatecard.lua -u` supports 10bytes UID (@alejandro12120)
  - Update documentation for installation on macOS with MacPorts (@linuxgemini)
+ - Added possible Paxton id to hitag2 tag info output
 
 ## [Nitride.4.16191][2023-01-29]
  - Changed `build_all_firmwares.sh` to fit GENERIC 256kb firmware images (@doegox)

--- a/client/src/cmdlfhitag.c
+++ b/client/src/cmdlfhitag.c
@@ -324,6 +324,37 @@ static int CmdLFHitagSim(const char *Cmd) {
     return PM3_SUCCESS;
 }
 
+
+static void printHitag2PaxtonDowngrade(const uint8_t *data) {
+
+    uint64_t bytes = 0;
+    uint64_t num = 0;
+    uint64_t paxton_id = 0;
+    uint16_t skip = 48;
+    uint16_t digit = 0;
+    uint64_t mask = 0xF80000000000;
+
+    for (int i = 16; i < 22; i++) {
+        bytes = (bytes * 0x100) + data[i];
+    }
+
+    for (int j = 0; j< 8; j++) {
+        num = bytes & mask;
+        skip -= 5;
+        mask = mask >> 5;
+        digit = (num >> skip & 15);
+        paxton_id = (paxton_id * 10) + digit;
+
+        if (j == 5) {
+            skip -= 2;
+            mask = mask >> 2;
+        }
+    }
+
+    PrintAndLogEx(INFO, "-------- " _CYAN_("Possible de-scramble patterns") " ---------");
+    PrintAndLogEx(SUCCESS, "Paxton id: %lu | 0x%lx", paxton_id, paxton_id);
+}
+
 static void printHitag2Configuration(uint8_t config) {
 
     char msg[100];
@@ -630,6 +661,8 @@ static int CmdLFHitagReader(const char *Cmd) {
 
         // print data
         print_hex_break(data, 48, 4);
+
+        printHitag2PaxtonDowngrade(data);
     }
     return PM3_SUCCESS;
 }


### PR DESCRIPTION
### Added Paxton ID to HITAG2 reader output

Not sure if it belongs here or a separate command. Let me know if you think it needs better formatting etc.

Example output:
```
pm3 --> lf hitag read --21 -k BDF5E846
[+]  UID: 466d9713

[=] Hitag2 tag information 

[=] ------------------------------------
[+] Config byte : 0x06 [ 00000110 ]
[+] Encoding    : Manchester
[+] Version     : Hitag2
[+] Coding in HITAG 2 operation: manchester
[+] Tag is in   : Password mode
[+] Page 6,7    : RW
[+] Page 4,5    : RW
[+] Page 3      : RW
[+] Page 1,2    : RW
[=] ------------------------------------
[=] 00 | 46 6D 97 13 | Fm..
[=] 01 | BD F5 E8 46 | ...F
[=] 02 | 20 F0 4F 4E |  .ON
[=] 03 | 06 F9 07 C2 | ....
[=] 04 | 9D AD 91 08 | ....
[=] 05 | B0 BF 00 03 | ....
[=] 06 | 00 30 00 06 | .0..
[=] 07 | 75 EB 00 10 | u...
[=] 08 | 00 00 00 00 | ....
[=] 09 | 00 00 00 00 | ....
[=] 10 | 00 00 00 00 | ....
[=] 11 | 00 00 00 00 | ....
[=] -------- Possible de-scramble patterns ---------
[+] Paxton id: 36692262 | 0x22fe126
```