### PR TITLE
hf mf sim: reduce 50ms threshold to 6ms for reset to idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Now `script run hf_mf_ultimatecard.lua -u` supports 10bytes UID (@alejandro12120)
  - Update documentation for installation on macOS with MacPorts (@linuxgemini)
  - Added possible Paxton id to hitag2 tag info output
+ - Changed `hf mf sim` - reduce 50ms threshold to 6ms for reset to idle #1974 (@net147)
 
 ## [Nitride.4.16191][2023-01-29]
  - Changed `build_all_firmwares.sh` to fit GENERIC 256kb firmware images (@doegox)

--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -2084,8 +2084,8 @@ int EmGetCmd(uint8_t *received, uint16_t *len, uint8_t *par) {
                     if (timer == 0) {
                         timer = GetTickCount();
                     } else {
-                        // 50ms no field --> card to idle state
-                        if (GetTickCountDelta(timer) > 50) {
+                        // 6ms no field --> card to idle state
+                        if (GetTickCountDelta(timer) > 6) {
                             return 2;
                         }
                     }


### PR DESCRIPTION
Fixes reader not being able to detect the simulated card on second Inventory command due to the RF field being powered off for only 6ms before being turned on again to reset the card to idle state.

Closes #1974