### PR TITLE
'Fix' writing on hitag2 in password mode

### DIFF
--- a/armsrc/hitag2.c
+++ b/armsrc/hitag2.c
@@ -655,6 +655,7 @@ static bool hitag2_password(uint8_t *rx, const size_t rxlen, uint8_t *tx, size_t
     *txlen = 0;
 
     if (bPwd && (bAuthenticating == false) && write) {
+        SpinDelay(2);
         if (hitag2_write_page(rx, rxlen, tx, txlen) == false) {
             return false;
         }


### PR DESCRIPTION
Hitag 2 write commands are frequently failing;

Given the following command
`lf hitag write --27 -k 4d494b52 -p 4 -d 11111111`

The context of page 4 may be `11 11 11 11`, `FF FF FF FF`, or a random value.

This needs more investigation, but it seems like a bandage for the issue described above.