### PR TITLE
hf mf sim: reduce 6ms threshold to 4ms for reset to idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Changed `hf mf sim` - reduce 6ms threshold to 4ms for reset to idle #1974 (@net147)
  - Rebuilt the Spartan-2 `fpga_*.bit` files to include the `hi_iso14443a.v` update (@d18c7db)
  - Added minor orphaned change from `hi_iso14443a.v` in `fpga-xc3s100e` to `hi_iso14443a.v` in `fpga-xc2s30` (@d18c7db)
  - Added python3 script to convert amiibo nfc Flipper Zero files to eml files to be used with Proxmark3 (@OscarAkaElvis)

--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -2084,8 +2084,8 @@ int EmGetCmd(uint8_t *received, uint16_t *len, uint8_t *par) {
                     if (timer == 0) {
                         timer = GetTickCount();
                     } else {
-                        // 6ms no field --> card to idle state
-                        if (GetTickCountDelta(timer) > 6) {
+                        // 4ms no field --> card to idle state
+                        if (GetTickCountDelta(timer) > 4) {
                             return 2;
                         }
                     }


### PR DESCRIPTION
Fixes some readers not being able to detect the simulated card on second Inventory command due to the RF field being powered off for a short time before being turned on again to reset the card to idle state.

Closes #1974