### PR TITLE
Auth both key A and key B with default password in `hf mf restore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Changed `hf mf restore` - Auth both key A and key B with default password (@wh201906)
  - Changed `nfc decode -f` - now can detect and convert MFC dumpfiles to NDEF byte arrays (@iceman1001)
  - Changed `nfc decode` - now handles EXTERNAL RECORDS better (@iceman1001)
  - Fixed `nfc decode` - now handles NDEF Signature version1 records better (@iceman1001)


### PR DESCRIPTION
For some blank card with ACL `FF 07 80`, you can't write data with key B.