### PR TITLE
Fix truncated FPGA upload due to incorrect integer size variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed truncated FPGA upload due to incorrect integer size variable (@d18c7db)
  - Changed `usart btfactory` - handles the new BT board with version "BT SPP V3.0" (@iceman1001) 
  - Changed `hf mf eview --sk` - now can extract keys and save to file (@iceman1001)
  - Changed `hf mf view --sk` - now can extract keys and save to file (@iceman1001)

--- a/armsrc/fpgaloader.c
+++ b/armsrc/fpgaloader.c
@@ -393,7 +393,7 @@ static int bitparse_find_section(int bitstream_version, char section_name, uint3
     while (numbytes < MAX_FPGA_BIT_STREAM_HEADER_SEARCH) {
         char current_name = get_from_fpga_stream(bitstream_version, compressed_fpga_stream, output_buffer);
         numbytes++;
-        uint16_t current_length = 0;
+        uint32_t current_length = 0;
         if (current_name < 'a' || current_name > 'e') {
             /* Strange section name, abort */
             break;


### PR DESCRIPTION
FPGA header section "e" contains a four byte (32 bit) "bitstream size" value which is assigned to a uitnt16 (!) current_length which is then assigned to a uint32 section_length

This results in loss of the high 16 bits and truncated FPGA uploads for image sizes over 64K . This is not something that was noticed with the Spartan 2 bitstreams which are only 42KB but pops up with bitstreams over 64KB such as Spartan 3 bitstreams of 170KB like the xc3s250e.

Should also have affected icopy-x with xc3s100e as they have bitstreams of 70KB but they probably have their own workaround in their forked repo.