### PR TITLE
More header parser sanity checks, get name from compiled bitstream header not from filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Add more bitstream header parser sanity checks, get bitstream name from compiled bitstream header not from filename (@d18c7db)
  - Fixed truncated FPGA upload due to incorrect integer size variable (@d18c7db)
  - Changed `usart btfactory` - handles the new BT board with version "BT SPP V3.0" (@iceman1001) 
  - Changed `hf mf eview --sk` - now can extract keys and save to file (@iceman1001)

--- a/tools/fpga_compress/fpga_compress.c
+++ b/tools/fpga_compress/fpga_compress.c
@@ -282,7 +282,8 @@ static int bitparse_find_section(FILE *infile, char section_name, unsigned int *
                 /* Four byte length field */
                 for (int i = 0; i < 4; i++) {
                     tmp = fgetc(infile);
-                    if (tmp < 0) {
+                    /* image length sanity check, should be under 300KB */
+                    if ( (tmp < 0) || (tmp > 300*1024) ) {
                         break;
                     }
                     current_length += tmp << (24 - (i * 8));
@@ -292,7 +293,8 @@ static int bitparse_find_section(FILE *infile, char section_name, unsigned int *
             default: /* Fall through, two byte length field */
                 for (int i = 0; i < 2; i++) {
                     tmp = fgetc(infile);
-                    if (tmp < 0) {
+                    /* if name, date or time fields are too long, we probably shouldn't parse them */
+                    if ( (tmp < 0) || (tmp > 32) ){
                         break;
                     }
                     current_length += tmp << (8 - (i * 8));
@@ -334,14 +336,23 @@ static int FpgaGatherVersion(FILE *infile, char *infile_name, char *dst, int len
         }
     }
 
-    if (!memcmp("fpga_lf", basename(infile_name), 7))
-        strncat(dst, "LF", len - strlen(dst) - 1);
-    else if (!memcmp("fpga_hf_15", basename(infile_name), 10))
-        strncat(dst, "HF 15", len - strlen(dst) - 1);
-    else if (!memcmp("fpga_hf.", basename(infile_name), 8))
-        strncat(dst, "HF", len - strlen(dst) - 1);
-    else if (!memcmp("fpga_felica", basename(infile_name), 7))
-        strncat(dst, "HF FeliCa", len - strlen(dst) - 1);
+    if (bitparse_find_section(infile, 'a', &fpga_info_len)) {
+        for (uint32_t i = 0; i < fpga_info_len; i++) {
+            char c = (char)fgetc(infile);
+            if (i < sizeof(tempstr)) {
+                tempstr[i] = c;
+            }
+        }
+
+        if (!memcmp("fpga_lf", tempstr, 7))
+            strncat(dst, "LF", len - strlen(dst) - 1);
+        else if (!memcmp("fpga_hf_15", tempstr, 10))
+            strncat(dst, "HF 15", len - strlen(dst) - 1);
+        else if (!memcmp("fpga_hf", tempstr, 7))
+            strncat(dst, "HF", len - strlen(dst) - 1);
+        else if (!memcmp("fpga_felica", tempstr, 11))
+            strncat(dst, "HF FeliCa", len - strlen(dst) - 1);
+        }
 
     strncat(dst, " image ", len - strlen(dst) - 1);
     if (bitparse_find_section(infile, 'b', &fpga_info_len)) {


### PR DESCRIPTION
Bitstream field e, "bitstream size" should never be more than 300KB but length field is 32 bit so sanity check that in case of a corrupt field or parsing error generates a huge size.

The text fields (a, b, c, d) in the header representing "top level module name", "fpga type", "date" and "time" respectively are rarely needed to be bigger than 60 characters but field size is 16 bit also allowing huge sizes. Add sanity restriction in case a corrupt field or parsing error results in crazy size. (There was already a check for these for <255 but even 255 is a really big size, we maybe don't want that big a string in fpga_version_info.c since it's only just dates times and module/fpga names).

Generated fpga_version_info.c file gets the bitstream names from the bitstream file names, makes more sense to pull them from the header (ends up with same result in version file). There were some minor (non affecting) errors in original string compares "fpga_felica" was only comparing 7 characters, "fpga_hf." had a dot in it.