### PR TITLE
gcc 11.2.1 - missing includes / correction for LEGIC CRC16 calculation

### DIFF
--- a/client/src/cmdhflegic.c
+++ b/client/src/cmdhflegic.c
@@ -682,7 +682,7 @@ static int CmdLegicCalcCrc(const char *Cmd) {
 
     switch (type) {
         case 16:
-            init_table(CRC_LEGIC);
+            init_table(CRC_LEGIC_16);
             PrintAndLogEx(SUCCESS, "Legic crc16: %X", crc16_legic(data, data_len, mcc[0]));
             break;
         default:

--- a/tools/mfd_aes_brute/mfd_aes_brute.c
+++ b/tools/mfd_aes_brute/mfd_aes_brute.c
@@ -33,6 +33,7 @@
 #include <time.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <inttypes.h>
 #include "util_posix.h"
 
 #define AEND  "\x1b[0m"

--- a/tools/mfd_aes_brute/mfd_multi_brute.c
+++ b/tools/mfd_aes_brute/mfd_multi_brute.c
@@ -35,6 +35,7 @@
 #include <time.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <inttypes.h>
 //#include <mbedtls/aes.h>
 #include "util_posix.h"
 #include "randoms.h"


### PR DESCRIPTION
- fix: missing includes when building with "gcc (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9)"

- correct LEGIC 16bit CRC calculation "hf legic crc" in proxmark3 CLI
  Use init_table(CRC_LEGIC_**_16_**) to be consistent with l_crc16legic in client/src/scripting.c
  With this change, correct Legic Cash CRC16 checksums are calculated.