### PR TITLE
Cleanup arm-side reader-mode mifare classic block read/write code.

### DIFF
--- a/armsrc/Standalone/hf_colin.c
+++ b/armsrc/Standalone/hf_colin.c
@@ -821,7 +821,7 @@ int e_MifareECardLoad(uint32_t numofsectors, uint8_t keytype) {
         }
 
         for (uint8_t blockNo = 0; isOK && blockNo < NumBlocksPerSector(s); blockNo++) {
-            if (isOK && mifare_classic_readblock(pcs, colin_cjcuid, FirstBlockOfSector(s) + blockNo, dataoutbuf)) {
+            if (isOK && mifare_classic_readblock(pcs, FirstBlockOfSector(s) + blockNo, dataoutbuf)) {
                 isOK = false;
                 break;
             };
@@ -838,7 +838,7 @@ int e_MifareECardLoad(uint32_t numofsectors, uint8_t keytype) {
         }
     }
 
-    int res = mifare_classic_halt(pcs, colin_cjcuid);
+    int res = mifare_classic_halt(pcs);
     (void)res;
 
     crypto1_deinit(pcs);
@@ -986,7 +986,7 @@ int saMifareCSetBlock(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_t *data
                 break;
             };
 
-            if (mifare_classic_halt(NULL, colin_cjcuid)) {
+            if (mifare_classic_halt(NULL)) {
                 DbprintfEx(FLAG_NEWLINE, "Halt error");
                 break;
             };
@@ -1006,7 +1006,7 @@ int saMifareCSetBlock(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_t *data
                 break;
             };
 
-            if (mifare_classic_halt(NULL, colin_cjcuid)) {
+            if (mifare_classic_halt(NULL)) {
                 DbprintfEx(FLAG_NEWLINE, "Halt error");
                 break;
             };
@@ -1043,7 +1043,7 @@ int saMifareCSetBlock(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_t *data
         };
 
         if (workFlags & 0x04) {
-            if (mifare_classic_halt(NULL, colin_cjcuid)) {
+            if (mifare_classic_halt(NULL)) {
                 cjSetCursFRight();
 
                 DbprintfEx(FLAG_NEWLINE, "Halt error");

--- a/armsrc/Standalone/hf_mattyrun.c
+++ b/armsrc/Standalone/hf_mattyrun.c
@@ -109,7 +109,7 @@ static int saMifareCSetBlock(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_
                 break;
             };
 
-            if (mifare_classic_halt(NULL, mattyrun_cuid)) {
+            if (mifare_classic_halt(NULL)) {
                 DbprintfEx(FLAG_NEWLINE, "Halt error");
                 break;
             };
@@ -129,7 +129,7 @@ static int saMifareCSetBlock(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_
                 break;
             };
 
-            if (mifare_classic_halt(NULL, mattyrun_cuid)) {
+            if (mifare_classic_halt(NULL)) {
                 DbprintfEx(FLAG_NEWLINE, "Halt error");
                 break;
             };
@@ -165,7 +165,7 @@ static int saMifareCSetBlock(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_
         };
 
         if (workFlags & 0x04) {
-            if (mifare_classic_halt(NULL, mattyrun_cuid)) {
+            if (mifare_classic_halt(NULL)) {
                 DbprintfEx(FLAG_NEWLINE, "Halt error");
                 break;
             };
@@ -267,7 +267,7 @@ static int saMifareECardLoad(uint32_t numofsectors, uint8_t keytype) {
 
         // failure to read one block,  skips to next sector.
         for (uint8_t blockNo = 0; blockNo < NumBlocksPerSector(s); blockNo++) {
-            if (mifare_classic_readblock(pcs, mattyrun_cuid, FirstBlockOfSector(s) + blockNo, dataoutbuf)) {
+            if (mifare_classic_readblock(pcs, FirstBlockOfSector(s) + blockNo, dataoutbuf)) {
                 retval = PM3_ESOFT;
                 break;
             };
@@ -283,7 +283,7 @@ static int saMifareECardLoad(uint32_t numofsectors, uint8_t keytype) {
         }
     }
 
-    int res = mifare_classic_halt(pcs, mattyrun_cuid);
+    int res = mifare_classic_halt(pcs);
     (void)res;
 
 out:

--- a/armsrc/mifarecmd.h
+++ b/armsrc/mifarecmd.h
@@ -19,19 +19,18 @@
 
 #include "common.h"
 
-void MifareReadBlock(uint8_t blockNo, uint8_t keyType, uint8_t *datain);
+int16_t mifare_cmd_readblocks(uint8_t key_auth_cmd, uint8_t *key, uint8_t read_cmd, uint8_t block_no, uint8_t count, uint8_t *block_data);
+int16_t mifare_cmd_writeblocks(uint8_t key_auth_cmd, uint8_t *key, uint8_t write_cmd, uint8_t block_no, uint8_t count, uint8_t *block_data);
+void MifareReadSector(uint8_t sector_no, uint8_t key_type, uint8_t *key);
+void MifareValue(uint8_t arg0, uint8_t arg1, uint8_t arg2, uint8_t *datain);
 
 void MifareUReadBlock(uint8_t arg0, uint8_t arg1, uint8_t *datain);
 void MifareUC_Auth(uint8_t arg0, uint8_t *keybytes);
 void MifareUReadCard(uint8_t arg0, uint16_t arg1, uint8_t arg2, uint8_t *datain);
-void MifareReadSector(uint8_t arg0, uint8_t arg1, uint8_t *datain);
-void MifareWriteBlock(uint8_t arg0, uint8_t arg1, uint8_t *datain);
-void MifareValue(uint8_t arg0, uint8_t arg1, uint8_t arg2, uint8_t *datain);
 void MifareUWriteBlockCompat(uint8_t arg0, uint8_t arg1, uint8_t *datain);
-
 void MifareUWriteBlock(uint8_t arg0, uint8_t arg1, uint8_t *datain);
-void MifareNested(uint8_t blockNo, uint8_t keyType, uint8_t targetBlockNo, uint8_t targetKeyType, bool calibrate, uint8_t *key);
 
+void MifareNested(uint8_t blockNo, uint8_t keyType, uint8_t targetBlockNo, uint8_t targetKeyType, bool calibrate, uint8_t *key);
 void MifareStaticNested(uint8_t blockNo, uint8_t keyType, uint8_t targetBlockNo, uint8_t targetKeyType, uint8_t *key);
 
 void MifareAcquireEncryptedNonces(uint32_t arg0, uint32_t arg1, uint32_t flags, uint8_t *datain);
@@ -57,11 +56,6 @@ int DoGen3Cmd(uint8_t *cmd, uint8_t cmd_len);
 void MifareGen3UID(uint8_t uidlen, uint8_t *uid); // Gen 3 magic card set UID without manufacturer block
 void MifareGen3Blk(uint8_t block_len, uint8_t *block); // Gen 3 magic card overwrite manufacturer block
 void MifareGen3Freez(void); // Gen 3 magic card lock further UID changes
-
-// MFC GEN4 GDM
-void MifareReadConfigBlockGDM(uint8_t *key);
-void MifareWriteConfigBlockGDM(uint8_t *datain);
-void MifareWriteBlockGDM(uint8_t blockno, uint8_t keytype, uint8_t *key, uint8_t *datain);
 
 // MFC GEN4 GTU
 void MifareG4ReadBlk(uint8_t blockno, uint8_t *pwd, uint8_t workFlags);

--- a/armsrc/mifareutil.h
+++ b/armsrc/mifareutil.h
@@ -72,17 +72,15 @@ uint16_t mifare_sendcmd_short(struct Crypto1State *pcs, uint8_t crypted, uint8_t
 // mifare classic
 int mifare_classic_auth(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t keyType, uint64_t ui64Key, uint8_t isNested);
 int mifare_classic_authex(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t keyType, uint64_t ui64Key, uint8_t isNested, uint32_t *ntptr, uint32_t *timing);
-int mifare_classic_authex_2(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t keyType, uint64_t ui64Key, uint8_t isNested, uint32_t *ntptr, uint32_t *timing, bool is_gdm);
+int mifare_classic_authex_cmd(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t cmd, uint64_t ui64Key, uint8_t isNested, uint32_t *ntptr, uint32_t *timing);
 
-int mifare_classic_readblock(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t *blockData);
-int mifare_classic_readblock_ex(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t *blockData, uint8_t iso_byte);
+int mifare_classic_readblock(struct Crypto1State *pcs, uint8_t blockNo, uint8_t *blockData);
+int mifare_classic_readblock_ex(struct Crypto1State *pcs, uint8_t blockNo, uint8_t *blockData, uint8_t iso_byte);
 
-int mifare_classic_halt(struct Crypto1State *pcs, uint32_t uid);
-int mifare_classic_halt_ex(struct Crypto1State *pcs);
-int mifare_classic_writeblock(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t *blockData);
-int mifare_classic_writeblock_ex(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t *blockData, bool is_gdm);
-int mifare_classic_value(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t *blockData, uint8_t action);
-int mifare_classic_write_cfg_block_gdm(struct Crypto1State *pcs, uint32_t uid, uint8_t *blockData);
+int mifare_classic_halt(struct Crypto1State *pcs);
+int mifare_classic_writeblock(struct Crypto1State *pcs, uint8_t blockNo, uint8_t *blockData);
+int mifare_classic_writeblock_ex(struct Crypto1State *pcs, uint8_t blockNo, uint8_t *blockData, uint8_t cmd);
+int mifare_classic_value(struct Crypto1State *pcs, uint8_t blockNo, uint8_t *blockData, uint8_t action);
 
 // Ultralight/NTAG...
 int mifare_ul_ev1_auth(uint8_t *keybytes, uint8_t *pack);

--- a/client/src/cmdtrace.c
+++ b/client/src/cmdtrace.c
@@ -910,11 +910,19 @@ static uint16_t printTraceLine(uint16_t tracepos, uint16_t traceLen, uint8_t *tr
             uint8_t crcc = iso14443A_CRC_check(hdr->isResponse, mfData, mfDataLen);
 
             //iceman: colorise crc bytes here will need a refactor of code from above.
-            PrintAndLogEx(NORMAL, "            |            |  *  |%-*s | %-4s| %s",
-                          str_padder,
-                          sprint_hex_inrow_spaces(mfData, mfDataLen, 2),
-                          (crcc == 0 ? _RED_(" !! ") : (crcc == 1 ? _GREEN_(" ok ") : "    ")),
-                          explanation);
+            if (hdr->isResponse) {
+                PrintAndLogEx(NORMAL, "            |            |  *  |%-*s | %-4s| %s",
+                              str_padder,
+                              sprint_hex_inrow_spaces(mfData, mfDataLen, 2),
+                              (crcc == 0 ? _RED_(" !! ") : (crcc == 1 ? _GREEN_(" ok ") : "    ")),
+                              explanation);
+            } else {
+                PrintAndLogEx(NORMAL, "            |            |  *  |" _YELLOW_("%-*s")" | " _YELLOW_("%s") "| " _YELLOW_("%s"),
+                              str_padder,
+                              sprint_hex_inrow_spaces(mfData, mfDataLen, 2),
+                              (crcc == 0 ? _RED_(" !! ") : (crcc == 1 ? _GREEN_(" ok ") : "    ")),
+                              explanation);
+            }
         }
     }
 

--- a/include/protocols.h
+++ b/include/protocols.h
@@ -191,12 +191,13 @@ ISO 7816-4 Basic interindustry commands. For command APDU's.
 #define MIFARE_CMD_TRANSFER         0xB0
 
 #define MIFARE_MAGIC_GDM_AUTH_KEY   0x80
+#define MIFARE_MAGIC_GDM_READBLOCK  0x38
 #define MIFARE_MAGIC_GDM_WRITEBLOCK 0xA8
 #define MIFARE_MAGIC_GDM_READ_CFG   0xE0
 #define MIFARE_MAGIC_GDM_WRITE_CFG  0xE1
 
 #define MIFARE_EV1_PERSONAL_UID     0x40
-#define MIFARE_EV1_SETMODE          0x43
+#define MIFARE_EV1_SETMOD           0x43
 #define MIFARE_EV1_UIDF0            0x00
 #define MIFARE_EV1_UIDF1            0x40
 #define MIFARE_EV1_UIDF2            0x20


### PR DESCRIPTION
There was a bunch of duplicate code doing the same thing for reading and writing blocks for mifare classic on the arm side where the only difference was a single byte for the command (normal vs magic vs magic config). This cleans up a lot of that duplication retaining all functionality while culling a few hundred lines of code while making the remaining functions more generic which will be super handy in the near future adding support for some new types of magic cards.

I've avoided changing the RPC interface between the armsrc and client, but with the new functions there is an opportunity to simplify that interface in the future for reading and writing blocks. As hinted by the addition to a define in protocols.h I discovered a GDM read block backdoor command while working on this. Curious to seek more feedback for how we want to do things going forward with the RPC interface if it's worth making more generic interfaces for the client for these sorts of things or if we'd rather keep the RPC commands specific for each combination of regular vs backdoor auth vs magic wakeup, regular vs backdoor vs config read/write (as you can imagine the possibilities for each combination start to go up rather fast - new magic tags mean more of these combinations are being seen in the wild).

While I was cleaning things up, I also took the opportunity to remove the now-unused cuid parameter to a lot of the mifare_classic_* functions.

I also fixed up a few minor typos and replaced some magic numbers with their corresponding `#define`s that I noticed while going through the armsrc mifare code as well.

I also fixed an inconsistency with the colour of decrypted MFC lines in the trace output that I noticed while testing this code (I hope this is minor enough to slip in the same PR else I can carve it out into a separate one if you want).

The new functions I added that replaced the old `Mifare(Read|Write)(Config)?Block(GDM)?` I named `mifare_cmd_(read|write)blocks` rather than following the existing CamelCase as per https://github.com/RfidResearchGroup/proxmark3/blob/master/CONTRIBUTING.md#identifiers - but I'm happy to change this back around if needed. Wasn't sure if the intention was to eventually move all functions to `lower_underscore_case` as they're touched or not.