### PR TITLE
Fix the timeout of TCP connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed timeout of TCP connections (@wh201906)
 
 ## [Seven.4.16717][2023-06-25]
  - Change `hf 14a info` - now identifes QL88 tags (@iceman1001)


### PR DESCRIPTION
I just found that the timeout of TCP connections is overwritten in TestProxmark()
Here is the test output
<details><summary>Details</summary>

```
[=] Using UART port tcp:192.168.0.1:1234
Current timeout(us):500000
...
Current timeout(us):500000
[=] Communicating with PM3 over USB-CDC over TCP


  8888888b.  888b     d888  .d8888b.   
  888   Y88b 8888b   d8888 d88P  Y88b  
  888    888 88888b.d88888      .d88P  
  888   d88P 888Y88888P888     8888"  
  8888888P"  888 Y888P 888      "Y8b.  
  888        888  Y8P  888 888    888  
  888        888   "   888 Y88b  d88P 
  888        888       888  "Y8888P"    [ ☕ ]


Current timeout(us):20000
...
Current timeout(us):20000
  [ Proxmark3 RFID instrument ]

Current timeout(us):20000
...
Current timeout(us):20000
[!] ⚠️  Received packet frame with variable part too short? 182/412
Current timeout(us):20000
Current timeout(us):20000

```

</details> 