### PR TITLE
Fix compiling liblua on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fix compiling liblua on iOS (@The-SamminAter)
  - Fixed the timeout of TCP connections (@wh201906)
  - Made the connection timeout configurable (@wh201906)
 

--- a/client/deps/liblua/luaconf.h
+++ b/client/deps/liblua/luaconf.h
@@ -10,9 +10,6 @@
 
 #if defined(__APPLE__)
 #include "TargetConditionals.h"
-#if TARGET_OS_IOS || TARGET_OS_WATCH || TARGET_OS_TV
-#define system(s) ((s)==NULL ? 0 : -1)
-#endif // end iOS
 #endif
 
 #include <limits.h>


### PR DESCRIPTION
iOS can, in fact, use the system() stdlib call.

If I had to guess, this wasn't an issue before because it didn't know the target was IOS? Not really sure, but removing this makes sense, and I can now successfully compile the client.