### PR TITLE
Fix potential memory leak in VAS implementation

### DIFF
--- a/client/src/cmdhfvas.c
+++ b/client/src/cmdhfvas.c
@@ -195,6 +195,7 @@ static int LoadReaderPrivateKey(uint8_t *buf, size_t bufLen, mbedtls_ecp_keypair
 
     if (mbedtls_ecp_check_pubkey(&privKey->grp, &privKey->Q)) {
         PrintAndLogEx(FAILED, "VAS protocol requires an elliptic key on the P-256 curve");
+        tlvdb_free(derRoot);
         return PM3_EINVARG;
     }
 

--- a/client/src/cmdhfvas.c
+++ b/client/src/cmdhfvas.c
@@ -187,10 +187,9 @@ static int LoadReaderPrivateKey(uint8_t *buf, size_t bufLen, mbedtls_ecp_keypair
         return PM3_EINVARG;
     }
 
-    tlvdb_free(derRoot);
-
     if (mbedtls_ecp_point_read_binary(&privKey->grp, &privKey->Q, pubkeyCoordsTlv->value + 1, 65)) {
         PrintAndLogEx(FAILED, "Failed to read in public key coordinates");
+        tlvdb_free(derRoot);
         return PM3_EINVARG;
     }
 
@@ -199,6 +198,7 @@ static int LoadReaderPrivateKey(uint8_t *buf, size_t bufLen, mbedtls_ecp_keypair
         return PM3_EINVARG;
     }
 
+    tlvdb_free(derRoot);
     return PM3_SUCCESS;
 }
 


### PR DESCRIPTION
If I'm not mistaken, premature call to `tlvdb_free ` before `mbedtls_ecp_point_read_binary` caused the latter to get deleted memory, which could have caused a segfault.