### PR TITLE
Implement uncompressed hardnested tables loader

### DIFF
--- a/client/src/cmdhfmfhard.c
+++ b/client/src/cmdhfmfhard.c
@@ -52,6 +52,7 @@
 
 #define STATE_FILES_DIRECTORY           "hardnested_tables/"
 #define STATE_FILE_TEMPLATE             "bitflip_%d_%03" PRIx16 "_states.bin.bz2"
+#define STATE_FILE_TEMPLATE_RAW         "bitflip_%d_%03" PRIx16 "_states.bin"
 
 #define DEBUG_KEY_ELIMINATION
 // #define DEBUG_REDUCTION
@@ -260,10 +261,13 @@ static void init_bitflip_bitarrays(void) {
 
     char state_files_path[strlen(get_my_executable_directory()) + strlen(STATE_FILES_DIRECTORY) + strlen(STATE_FILE_TEMPLATE) + 1];
     char state_file_name[strlen(STATE_FILE_TEMPLATE) + 1];
+    char state_file_raw_name[strlen(STATE_FILE_TEMPLATE_RAW) + 1];
 
     for (odd_even_t odd_even = EVEN_STATE; odd_even <= ODD_STATE; odd_even++) {
         num_effective_bitflips[odd_even] = 0;
         for (uint16_t bitflip = 0x001; bitflip < 0x400; bitflip++) {
+            bool open_uncompressed = false;
+
             bitflip_bitarrays[odd_even][bitflip] = NULL;
             count_bitflip_bitarrays[odd_even][bitflip] = 1 << 24;
 
@@ -273,14 +277,21 @@ static void init_bitflip_bitarrays(void) {
 
             char *path;
             if (searchFile(&path, RESOURCES_SUBDIR, state_files_path, "", true) != PM3_SUCCESS) {
-                continue;
+                snprintf(state_file_raw_name, sizeof(state_file_raw_name), STATE_FILE_TEMPLATE_RAW, odd_even, bitflip);
+                strncpy(state_files_path, STATE_FILES_DIRECTORY, sizeof(state_files_path) - 1);
+                strncat(state_files_path, state_file_raw_name, sizeof(state_files_path) - (strlen(STATE_FILES_DIRECTORY) + 1));
+                if (searchFile(&path, RESOURCES_SUBDIR, state_files_path, "", true) == PM3_SUCCESS) {
+                    open_uncompressed = true;
+                } else {
+                    continue;
+                }
             }
 
             FILE *statesfile = fopen(path, "rb");
             free(path);
             if (statesfile == NULL) {
                 continue;
-            } else {
+            } else if (!open_uncompressed) {
                 fseek(statesfile, 0, SEEK_END);
                 int fsize = ftell(statesfile);
                 if (fsize == -1) {
@@ -335,6 +346,52 @@ static void init_bitflip_bitarrays(void) {
 #endif
                 }
                 BZ2_bzDecompressEnd(&compressed_stream);
+            } else {
+                fseek(statesfile, 0, SEEK_END);
+                int fsize = ftell(statesfile);
+                if (fsize == -1) {
+                    PrintAndLogEx(ERR, "File read error with %s. Aborting...\n", state_file_name);
+                    fclose(statesfile);
+                    exit(5);
+                }
+                uint32_t filesize = (uint32_t)fsize;
+                rewind(statesfile);
+
+                uint32_t count = 0;
+                size_t bytesread = fread(&count, 1, sizeof(count), statesfile);
+                if (bytesread != 4) {
+                    PrintAndLogEx(ERR, "File read error with %s. Aborting...\n", state_file_name);
+                    fclose(statesfile);
+                    exit(5);
+                }
+
+                if ((float)count / (1 << 24) < IGNORE_BITFLIP_THRESHOLD) {
+                    uint32_t *bitset = (uint32_t *)malloc_bitarray(sizeof(uint32_t) * (1 << 19));
+                    if (bitset == NULL) {
+                        PrintAndLogEx(ERR, "Out of memory error in init_bitflip_statelists(). Aborting...\n");
+                        fclose(statesfile);
+                        exit(4);
+                    }
+
+                    bytesread = fread(bitset, 1, filesize-sizeof(count), statesfile);
+                    if (bytesread != filesize-sizeof(count)) {
+                        PrintAndLogEx(ERR, "File read error with %s. Aborting...\n", state_file_name);
+                        fclose(statesfile);
+                        exit(5);
+                    }
+
+                    effective_bitflip[odd_even][num_effective_bitflips[odd_even]++] = bitflip;
+                    bitflip_bitarrays[odd_even][bitflip] = bitset;
+                    count_bitflip_bitarrays[odd_even][bitflip] = count;
+#if defined (DEBUG_REDUCTION)
+                    PrintAndLogEx(INFO, "(%03" PRIx16 " %s:%5.1f%%) ", bitflip, odd_even ? "odd " : "even", (float)count / (1 << 24) * 100.0);
+                    line++;
+                    if (line == 8) {
+                        PrintAndLogEx(NORMAL, "");
+                        line = 0;
+                    }
+#endif
+                }
             }
         }
         effective_bitflip[odd_even][num_effective_bitflips[odd_even]] = 0x400; // EndOfList marker


### PR DESCRIPTION
This PR implements loading of uncompressed hardnested bitflip tables. It allows us to shave 2-3 seconds off a single hardnested attack, which is quite convenient.

To maintain compatibility with the current behaviour, this implementation tries loading the bz2 files first, and if it fails, proceeds with trying to load the uncompressed .bin files.