### PR TITLE
Make GetATQA/ISO14443-A polling method more flexible

### DIFF
--- a/armsrc/iso14443a.h
+++ b/armsrc/iso14443a.h
@@ -108,6 +108,24 @@ typedef enum {
     RESP_INDEX_PACK,
 } resp_index_t;
 
+// Defines a frame that will be used in a polling sequence
+// ECP Frames are up to (7 + 16) bytes long, this config should cover future and other cases
+typedef struct {
+    uint8_t frame[32];
+    uint8_t frame_length;
+    uint8_t last_byte_bits;
+    uint16_t extra_delay;
+} iso14a_polling_frame;
+
+// Defines polling sequence configuration
+// 4 magsafe, 1 wupa, 1 reqa, 1 ecp, 1 extra
+typedef struct {
+   iso14a_polling_frame frames[8]; 
+   uint8_t frame_count;
+   uint16_t extra_timeout;
+} iso14a_polling_parameters;
+
+
 #ifndef AddCrc14A
 # define AddCrc14A(data, len) compute_crc(CRC_14443_A, (data), (len), (data)+(len), (data)+(len)+1)
 #endif
@@ -148,6 +166,7 @@ void ReaderTransmitBitsPar(uint8_t *frame, uint16_t bits, uint8_t *par, uint32_t
 void ReaderTransmitPar(uint8_t *frame, uint16_t len, uint8_t *par, uint32_t *timing);
 uint16_t ReaderReceive(uint8_t *receivedAnswer, uint8_t *par);
 
+iso14a_polling_parameters iso14a_get_polling_parameters(bool use_ecp, bool use_magsafe);
 void iso14443a_setup(uint8_t fpga_minor_mode);
 int iso14_apdu(uint8_t *cmd, uint16_t cmd_len, bool send_chaining, void *data, uint8_t *res);
 int iso14443a_select_card(uint8_t *uid_ptr, iso14a_card_select_t *p_card, uint32_t *cuid_ptr, bool anticollision, uint8_t num_cascades, bool no_rats);

--- a/client/resources/ecplist.json
+++ b/client/resources/ecplist.json
@@ -58,7 +58,7 @@
     },
 
     {
-        "value": "6a02c3020602ffff",
+        "value": "6a02c3020002ffff",
         "name": "Access: Hotel: Hilton",
         "description": "TCI might be a wildcard before a reservation is made"
     },


### PR DESCRIPTION
Hello.
This change is more of a functioning proposal currently, but in case you're fine with it, it could be merged.

I've refactored the GetATQA method, allowing to pass different polling configurations to it using the newly defined `iso14a_polling_frame` and  `iso14a_polling_parameters` structs.

This allows to remove different proprietary, implementation-specific polling hacks (like ECP, MagSafe) that were once inside this method, and bring them to the outer layers (currently to `iso14443a_select_cardEx` and `iso14443a_fast_select_card` methods, in the future to the client). 
What I assume could be done in next PRs, is to bring the custom-configuration-forming logic (leave WUPA at arm side) to the client side, which could allow more flexibility when someone wants to implement new logic that requires using a custom polling frame or sequence of without cluttering the ARM side.  
An example that comes to mind, is that a VAS reading method could call select card with a VAS-specific ECP frame, which would improve the implementation as it allows to trigger a specific pass to appear on a screen even on a locked device.


I understand that polling method is very important in cases where timing is crucial and my changes might influence other parts of the system so it should be tested. I have tested mifare attacks with this change, seemed to work for me, but I think that a look from a more experienced developer is required to be fully sure.


As for improvements that can be tested already related to this change:
- ECP polling now works every time even without the S-BLOCK-DESELECT hack, thanks to an ability to add additional timeout delay that was needed for Apple Devices.
- Magsafe polling can now be combined with ECP polling using the `hf 14a reader --ecp --mag` making a super-polling loop. I've tested, seemed to work for me for MagSafe, MFC, iPhone detection.

