### PR TITLE
Fix typo in hf_legic_clone.lua

### DIFF
--- a/client/luascripts/hf_legic_clone.lua
+++ b/client/luascripts/hf_legic_clone.lua
@@ -168,7 +168,7 @@ local function help()
     print(example)
 end
 -- read LEGIC data
-local function readlegicdata(offset, length, iv)
+local function readlegicdata(offset, len, iv)
     -- Read data
     local d0 = ('%04X%04X%02X'):format(offset, len, iv)
     local c = Command:newNG{cmd = cmds.CMD_HF_LEGIC_READER, data = d0}


### PR DESCRIPTION
variable "length" was used parameter in function, but later called as "len"