### PR TITLE
MIFARE Plus traces: Adds MAC, UnMACed to annotations, and code factorisation

### DIFF
--- a/client/src/cmdhflist.h
+++ b/client/src/cmdhflist.h
@@ -57,6 +57,9 @@ void annotateIso14443b(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize);
 void annotateIso14443a(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize, bool is_response);
 void annotateMfDesfire(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize);
 const char *mfpGetAnnotationForCode(uint8_t code);
+const char *mfpGetEncryptedForCode(uint8_t code);
+const char *mfpGetResponseMacedForCode(uint8_t code);
+const char *mfpGetCommandMacedForCode(uint8_t code);
 void annotateMfPlus(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize);
 void annotateMifare(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize,
                     const uint8_t *parity, uint8_t paritysize, bool isResponse);


### PR DESCRIPTION
This adds `MAC_MAced` `NoMAC_UnMACed`,  and so on to the relevant commands, according to the datasheet.
example:
```
|     |39  ca  9e  2a  4d  03  7a  ae  6e                                       |  ok | WRITE ENCRYPTED(68) MAC
| Tag |0b  07  90  e8  74  62  db  46  e7  72  de  63  bd                       |  ok | 
| Rdr |0a  07  31  48  00  03  be  e0  5c  44  65  7e  3a  1e  8c  d7           |  ok | READ ENCRYPTED(72-74) MAC_MACed
```

This was also the occasion to refactor code by moving more messages to the lookup table.