### PR TITLE
fix lto-type-mismatch in guidummy.cpp

### DIFF
--- a/client/src/guidummy.cpp
+++ b/client/src/guidummy.cpp
@@ -30,7 +30,7 @@ extern "C" void ShowGraphWindow(void) {
 extern "C" void HideGraphWindow(void) {}
 extern "C" void RepaintGraphWindow(void) {}
 
-extern "C" void ShowPictureWindow(char *fn) {
+extern "C" void ShowPictureWindow(char *fn, int len) {
     static int warned = 0;
 
     if (!warned) {


### PR DESCRIPTION
link time optimization requires all functions named the same to actually operate the same.  I am pretty sure this fixes it without breaking anything.

Fixes: https://github.com/RfidResearchGroup/proxmark3/issues/2058
src/proxgui.h:35:6: error: type of ‘ShowPictureWindow’ does not match original declaration [-Werror=lto-type-mismatch]
   35 | void ShowPictureWindow(uint8_t *data, int len);
      |      ^
src/guidummy.cpp:33:17: note: type mismatch in parameter 2
   33 | extern "C" void ShowPictureWindow(char *fn) {
      |                 ^
src/guidummy.cpp:33:17: note: type ‘void’ should match type ‘int’
src/guidummy.cpp:33:17: note: ‘ShowPictureWindow’ was previously declared here