### PR TITLE
Minor (useful) updates

### DIFF
--- a/client/src/proxmark3.h
+++ b/client/src/proxmark3.h
@@ -36,7 +36,7 @@
 #define PROXPROMPT_DEV_OFFLINE _RL_BOLD_RED_("offline")
 
 #define PROXHISTORY "history.txt"
-#define PROXLOG "log_%Y%m%d.txt"
+#define PROXLOG "log_%Y%m%d%H%M%S.txt"
 #define MAX_NESTED_CMDSCRIPT 10
 #define MAX_NESTED_LUASCRIPT 10
 

--- a/common/commonutil.c
+++ b/common/commonutil.c
@@ -161,75 +161,255 @@ uint64_t bytes_to_num(uint8_t *src, size_t len) {
 }
 
 uint16_t MemLeToUint2byte(const uint8_t *data) {
-    return (uint16_t)((uint16_t)
-               (data[1] << 8) + data[0]
-           );
+    return (uint16_t)(
+        (((uint16_t)(data[1])) << (8*1)) +
+        (((uint16_t)(data[0])) << (8*0))
+        );
 }
 
 uint32_t MemLeToUint3byte(const uint8_t *data) {
-    return (uint32_t)((uint32_t)
-               (data[2] << 16) + (data[1] << 8) + data[0]
-           );
+    return (uint32_t)(
+        (((uint32_t)(data[2])) << (8*2)) +
+        (((uint32_t)(data[1])) << (8*1)) +
+        (((uint32_t)(data[0])) << (8*0))
+        );
 }
 
 uint32_t MemLeToUint4byte(const uint8_t *data) {
-    return (uint32_t)((uint32_t)
-               (data[3] << 24) + (data[2] << 16) + (data[1] << 8) + data[0]
-           );
+    return (uint32_t)(
+        (((uint32_t)(data[3])) << (8*3)) +
+        (((uint32_t)(data[2])) << (8*2)) +
+        (((uint32_t)(data[1])) << (8*1)) +
+        (((uint32_t)(data[0])) << (8*0))
+        );
+}
+
+uint64_t MemLeToUint5byte(const uint8_t *data) {
+    return (uint64_t)(
+        (((uint64_t)(data[4])) << (8*4)) +
+        (((uint64_t)(data[3])) << (8*3)) +
+        (((uint64_t)(data[2])) << (8*2)) +
+        (((uint64_t)(data[1])) << (8*1)) +
+        (((uint64_t)(data[0])) << (8*0))
+        );
+}
+
+uint64_t MemLeToUint6byte(const uint8_t *data) {
+    return (uint64_t)(
+        (((uint64_t)(data[5])) << (8*5)) +
+        (((uint64_t)(data[4])) << (8*4)) +
+        (((uint64_t)(data[3])) << (8*3)) +
+        (((uint64_t)(data[2])) << (8*2)) +
+        (((uint64_t)(data[1])) << (8*1)) +
+        (((uint64_t)(data[0])) << (8*0))
+        );
+}
+
+uint64_t MemLeToUint7byte(const uint8_t *data) {
+    return (uint64_t)(
+        (((uint64_t)(data[6])) << (8*6)) +
+        (((uint64_t)(data[5])) << (8*5)) +
+        (((uint64_t)(data[4])) << (8*4)) +
+        (((uint64_t)(data[3])) << (8*3)) +
+        (((uint64_t)(data[2])) << (8*2)) +
+        (((uint64_t)(data[1])) << (8*1)) +
+        (((uint64_t)(data[0])) << (8*0))
+        );
+}
+
+uint64_t MemLeToUint8byte(const uint8_t *data) {
+    return (uint64_t)(
+        (((uint64_t)(data[7])) << (8*7)) +
+        (((uint64_t)(data[6])) << (8*6)) +
+        (((uint64_t)(data[5])) << (8*5)) +
+        (((uint64_t)(data[4])) << (8*4)) +
+        (((uint64_t)(data[3])) << (8*3)) +
+        (((uint64_t)(data[2])) << (8*2)) +
+        (((uint64_t)(data[1])) << (8*1)) +
+        (((uint64_t)(data[0])) << (8*0))
+        );
 }
 
 uint16_t MemBeToUint2byte(const uint8_t *data) {
-    return (uint16_t)((uint16_t)
-               (data[0] << 8) + data[1]
-           );
+    return (uint16_t)(
+        (((uint16_t)(data[0])) << (8*1)) +
+        (((uint16_t)(data[1])) << (8*0))
+        );
 }
 
 uint32_t MemBeToUint3byte(const uint8_t *data) {
-    return (uint32_t)((uint32_t)
-               (data[0] << 16) + (data[1] << 8) + data[2]
-           );
+    return (uint32_t)(
+        (((uint32_t)(data[0])) << (8*2)) +
+        (((uint32_t)(data[1])) << (8*1)) +
+        (((uint32_t)(data[2])) << (8*0))
+        );
 }
 
-inline uint32_t MemBeToUint4byte(const uint8_t *data) {
+uint32_t MemBeToUint4byte(const uint8_t *data) {
     return (uint32_t)(
-               (data[0] << 24) + (data[1] << 16) + (data[2] << 8) + data[3]
-           );
+        (((uint32_t)(data[0])) << (8*3)) +
+        (((uint32_t)(data[1])) << (8*2)) +
+        (((uint32_t)(data[2])) << (8*1)) +
+        (((uint32_t)(data[3])) << (8*0))
+        );
+}
+
+uint64_t MemBeToUint5byte(const uint8_t *data) {
+    return (uint64_t)(
+        (((uint64_t)(data[0])) << (8*4)) +
+        (((uint64_t)(data[1])) << (8*3)) +
+        (((uint64_t)(data[2])) << (8*2)) +
+        (((uint64_t)(data[3])) << (8*1)) +
+        (((uint64_t)(data[4])) << (8*0))
+        );
+}
+
+uint64_t MemBeToUint6byte(const uint8_t *data) {
+    return (uint64_t)(
+        (((uint64_t)(data[0])) << (8*5)) +
+        (((uint64_t)(data[1])) << (8*4)) +
+        (((uint64_t)(data[2])) << (8*3)) +
+        (((uint64_t)(data[3])) << (8*2)) +
+        (((uint64_t)(data[4])) << (8*1)) +
+        (((uint64_t)(data[5])) << (8*0))
+        );
+}
+
+uint64_t MemBeToUint7byte(const uint8_t *data) {
+    return (uint64_t)(
+        (((uint64_t)(data[0])) << (8*6)) +
+        (((uint64_t)(data[1])) << (8*5)) +
+        (((uint64_t)(data[2])) << (8*4)) +
+        (((uint64_t)(data[3])) << (8*3)) +
+        (((uint64_t)(data[4])) << (8*2)) +
+        (((uint64_t)(data[5])) << (8*1)) +
+        (((uint64_t)(data[6])) << (8*0))
+        );
+}
+
+uint64_t MemBeToUint8byte(const uint8_t *data) {
+    return (uint64_t)(
+        (((uint64_t)(data[0])) << (8*7)) +
+        (((uint64_t)(data[1])) << (8*6)) +
+        (((uint64_t)(data[2])) << (8*5)) +
+        (((uint64_t)(data[3])) << (8*4)) +
+        (((uint64_t)(data[4])) << (8*3)) +
+        (((uint64_t)(data[5])) << (8*2)) +
+        (((uint64_t)(data[6])) << (8*1)) +
+        (((uint64_t)(data[7])) << (8*0))
+        );
 }
 
 void Uint2byteToMemLe(uint8_t *data, uint16_t value) {
-    data[1] = (value >> 8) & 0xff;
-    data[0] = value & 0xff;
+    data[0] = (uint8_t)((value >> (8*0)) & 0xffu);
+    data[1] = (uint8_t)((value >> (8*1)) & 0xffu);
 }
 
 void Uint3byteToMemLe(uint8_t *data, uint32_t value) {
-    data[2] = (value >> 16) & 0xff;
-    data[1] = (value >> 8) & 0xff;
-    data[0] = value & 0xff;
+    data[0] = (uint8_t)((value >> (8*0)) & 0xffu);
+    data[1] = (uint8_t)((value >> (8*1)) & 0xffu);
+    data[2] = (uint8_t)((value >> (8*2)) & 0xffu);
 }
 
 void Uint4byteToMemLe(uint8_t *data, uint32_t value) {
-    data[3] = (value >> 24) & 0xff;
-    data[2] = (value >> 16) & 0xff;
-    data[1] = (value >> 8) & 0xff;
-    data[0] = value & 0xff;
+    data[0] = (uint8_t)((value >> (8*0)) & 0xffu);
+    data[1] = (uint8_t)((value >> (8*1)) & 0xffu);
+    data[2] = (uint8_t)((value >> (8*2)) & 0xffu);
+    data[3] = (uint8_t)((value >> (8*3)) & 0xffu);
+}
+
+void Uint5byteToMemLe(uint8_t *data, uint64_t value) {
+    data[0] = (uint8_t)((value >> (8*0)) & 0xffu);
+    data[1] = (uint8_t)((value >> (8*1)) & 0xffu);
+    data[2] = (uint8_t)((value >> (8*2)) & 0xffu);
+    data[3] = (uint8_t)((value >> (8*3)) & 0xffu);
+    data[4] = (uint8_t)((value >> (8*4)) & 0xffu);
+}
+
+void Uint6byteToMemLe(uint8_t *data, uint64_t value) {
+    data[0] = (uint8_t)((value >> (8*0)) & 0xffu);
+    data[1] = (uint8_t)((value >> (8*1)) & 0xffu);
+    data[2] = (uint8_t)((value >> (8*2)) & 0xffu);
+    data[3] = (uint8_t)((value >> (8*3)) & 0xffu);
+    data[4] = (uint8_t)((value >> (8*4)) & 0xffu);
+    data[5] = (uint8_t)((value >> (8*5)) & 0xffu);
+}
+
+void Uint7byteToMemLe(uint8_t *data, uint64_t value) {
+    data[0] = (uint8_t)((value >> (8*0)) & 0xffu);
+    data[1] = (uint8_t)((value >> (8*1)) & 0xffu);
+    data[2] = (uint8_t)((value >> (8*2)) & 0xffu);
+    data[3] = (uint8_t)((value >> (8*3)) & 0xffu);
+    data[4] = (uint8_t)((value >> (8*4)) & 0xffu);
+    data[5] = (uint8_t)((value >> (8*5)) & 0xffu);
+    data[6] = (uint8_t)((value >> (8*6)) & 0xffu);
+}
+
+void Uint8byteToMemLe(uint8_t *data, uint64_t value) {
+    data[0] = (uint8_t)((value >> (8*0)) & 0xffu);
+    data[1] = (uint8_t)((value >> (8*1)) & 0xffu);
+    data[2] = (uint8_t)((value >> (8*2)) & 0xffu);
+    data[3] = (uint8_t)((value >> (8*3)) & 0xffu);
+    data[4] = (uint8_t)((value >> (8*4)) & 0xffu);
+    data[5] = (uint8_t)((value >> (8*5)) & 0xffu);
+    data[6] = (uint8_t)((value >> (8*6)) & 0xffu);
+    data[7] = (uint8_t)((value >> (8*7)) & 0xffu);
 }
 
 void Uint2byteToMemBe(uint8_t *data, uint16_t value) {
-    data[0] = (value >> 8) & 0xff;
-    data[1] = value & 0xff;
+    data[0] = (uint8_t)((value >> (8*1)) & 0xffu);
+    data[1] = (uint8_t)((value >> (8*0)) & 0xffu);
 }
 
 void Uint3byteToMemBe(uint8_t *data, uint32_t value) {
-    data[0] = (value >> 16) & 0xff;
-    data[1] = (value >> 8) & 0xff;
-    data[2] = value & 0xff;
+    data[0] = (uint8_t)((value >> (8*2)) & 0xffu);
+    data[1] = (uint8_t)((value >> (8*1)) & 0xffu);
+    data[2] = (uint8_t)((value >> (8*0)) & 0xffu);
 }
 
 void Uint4byteToMemBe(uint8_t *data, uint32_t value) {
-    data[0] = (value >> 24) & 0xff;
-    data[1] = (value >> 16) & 0xff;
-    data[2] = (value >> 8) & 0xff;
-    data[3] = value & 0xff;
+    data[0] = (uint8_t)((value >> (8*3)) & 0xffu);
+    data[1] = (uint8_t)((value >> (8*2)) & 0xffu);
+    data[2] = (uint8_t)((value >> (8*1)) & 0xffu);
+    data[3] = (uint8_t)((value >> (8*0)) & 0xffu);
+}
+
+void Uint5byteToMemBe(uint8_t *data, uint64_t value) {
+    data[0] = (uint8_t)((value >> (8*4)) & 0xffu);
+    data[1] = (uint8_t)((value >> (8*3)) & 0xffu);
+    data[2] = (uint8_t)((value >> (8*2)) & 0xffu);
+    data[3] = (uint8_t)((value >> (8*1)) & 0xffu);
+    data[4] = (uint8_t)((value >> (8*0)) & 0xffu);
+}
+
+void Uint6byteToMemBe(uint8_t *data, uint64_t value) {
+    data[0] = (uint8_t)((value >> (8*5)) & 0xffu);
+    data[1] = (uint8_t)((value >> (8*4)) & 0xffu);
+    data[2] = (uint8_t)((value >> (8*3)) & 0xffu);
+    data[3] = (uint8_t)((value >> (8*2)) & 0xffu);
+    data[4] = (uint8_t)((value >> (8*1)) & 0xffu);
+    data[5] = (uint8_t)((value >> (8*0)) & 0xffu);
+}
+
+void Uint7byteToMemBe(uint8_t *data, uint64_t value) {
+    data[0] = (uint8_t)((value >> (8*6)) & 0xffu);
+    data[1] = (uint8_t)((value >> (8*5)) & 0xffu);
+    data[2] = (uint8_t)((value >> (8*4)) & 0xffu);
+    data[3] = (uint8_t)((value >> (8*3)) & 0xffu);
+    data[4] = (uint8_t)((value >> (8*2)) & 0xffu);
+    data[5] = (uint8_t)((value >> (8*1)) & 0xffu);
+    data[6] = (uint8_t)((value >> (8*0)) & 0xffu);
+}
+
+void Uint8byteToMemBe(uint8_t *data, uint64_t value) {
+    data[0] = (uint8_t)((value >> (8*7)) & 0xffu);
+    data[1] = (uint8_t)((value >> (8*6)) & 0xffu);
+    data[2] = (uint8_t)((value >> (8*5)) & 0xffu);
+    data[3] = (uint8_t)((value >> (8*4)) & 0xffu);
+    data[4] = (uint8_t)((value >> (8*3)) & 0xffu);
+    data[5] = (uint8_t)((value >> (8*2)) & 0xffu);
+    data[6] = (uint8_t)((value >> (8*1)) & 0xffu);
+    data[7] = (uint8_t)((value >> (8*0)) & 0xffu);
 }
 
 // RotateLeft - Ultralight, Desfire

--- a/common/commonutil.h
+++ b/common/commonutil.h
@@ -65,15 +65,34 @@ uint64_t bytes_to_num(uint8_t *src, size_t len);
 uint16_t MemLeToUint2byte(const uint8_t *data);
 uint32_t MemLeToUint3byte(const uint8_t *data);
 uint32_t MemLeToUint4byte(const uint8_t *data);
+uint64_t MemLeToUint5byte(const uint8_t *data);
+uint64_t MemLeToUint6byte(const uint8_t *data);
+uint64_t MemLeToUint7byte(const uint8_t *data);
+uint64_t MemLeToUint8byte(const uint8_t *data);
+
 uint16_t MemBeToUint2byte(const uint8_t *data);
 uint32_t MemBeToUint3byte(const uint8_t *data);
 uint32_t MemBeToUint4byte(const uint8_t *data);
+uint64_t MemBeToUint5byte(const uint8_t *data);
+uint64_t MemBeToUint6byte(const uint8_t *data);
+uint64_t MemBeToUint7byte(const uint8_t *data);
+uint64_t MemBeToUint8byte(const uint8_t *data);
+
 void Uint2byteToMemLe(uint8_t *data, uint16_t value);
 void Uint3byteToMemLe(uint8_t *data, uint32_t value);
 void Uint4byteToMemLe(uint8_t *data, uint32_t value);
+void Uint5byteToMemLe(uint8_t *data, uint64_t value);
+void Uint6byteToMemLe(uint8_t *data, uint64_t value);
+void Uint7byteToMemLe(uint8_t *data, uint64_t value);
+void Uint8byteToMemLe(uint8_t *data, uint64_t value);
+
 void Uint2byteToMemBe(uint8_t *data, uint16_t value);
 void Uint3byteToMemBe(uint8_t *data, uint32_t value);
 void Uint4byteToMemBe(uint8_t *data, uint32_t value);
+void Uint5byteToMemBe(uint8_t *data, uint64_t value);
+void Uint6byteToMemBe(uint8_t *data, uint64_t value);
+void Uint7byteToMemBe(uint8_t *data, uint64_t value);
+void Uint8byteToMemBe(uint8_t *data, uint64_t value);
 
 // rotate left byte array
 void rol(uint8_t *data, const size_t len);

--- a/doc/md/Installation_Instructions/Windows-WSL2-Installation-Instructions.md
+++ b/doc/md/Installation_Instructions/Windows-WSL2-Installation-Instructions.md
@@ -156,27 +156,18 @@ However, it may be necessary to give the `udev` service a kind reminder:
 
 ## Inform udev that it really, really should work
 
-The following workaround appears to work to get udev to apply the permissions
-appropriately.  Note that this may need to be run again, such as when the WSL2
-distributions have been restarted.  I don't know why ... but it's a small hiccup.
+As of August 2023, the following needs to be done anytime the WSL2 subsystem
+has been restarted (e.g., host machine reboot, first WSL2 console window, etc.).
+Otherwise, it appears that `udev` service will not see the arrival of devices,
+and therefore won't modify permissions on `/dev/ttyACM*` devices.
 
-```sh
-sudo udevadm trigger --action=change
-```
-
-General instructions suggested to use `sudo udevadm control --reload-rules`.  However,
-this may simply result in the following cryptic error message:
-
-```sh
-$ sudo udevadm control --reload-rules
-[sudo] password for root:
-Failed to send reload request: No such file or directory
-```
-
-_Note that the following should **NOT** be required:_
+After this is run once, `udev` appears to work correctly (at least until the
+host machine reboots or the last WSL console window is closed for a while).
+One workaround is to simply ensure you keep at least one WSL2 console open.
 
 ```sh
 sudo service udev restart
+sudo udevadm trigger --action=change
 ```
 
 ## Verify Device Exists


### PR DESCRIPTION
Three items:
1. Extend Little-endian and Big-endian functions to support 5-9 byte data.
2. Update WSL2 instructions for improved user experiences
3. Add hours / minutes / seconds to logfile

<details><summary>LE and BE functions</summary>
<p>

These functions are added because they are useful for em4x70 data structures.
These mirror functionality already existing for 2-4 byte versions:

```C
uint64_t MemLeToUint5byte(const uint8_t *data);
uint64_t MemLeToUint6byte(const uint8_t *data);
uint64_t MemLeToUint7byte(const uint8_t *data);
uint64_t MemLeToUint8byte(const uint8_t *data);
uint64_t MemBeToUint5byte(const uint8_t *data);
uint64_t MemBeToUint6byte(const uint8_t *data);
uint64_t MemBeToUint7byte(const uint8_t *data);
uint64_t MemBeToUint8byte(const uint8_t *data);
void Uint5byteToMemLe(uint8_t *data, uint64_t value);
void Uint6byteToMemLe(uint8_t *data, uint64_t value);
void Uint7byteToMemLe(uint8_t *data, uint64_t value);
void Uint8byteToMemLe(uint8_t *data, uint64_t value);
void Uint5byteToMemBe(uint8_t *data, uint64_t value);
void Uint6byteToMemBe(uint8_t *data, uint64_t value);
void Uint7byteToMemBe(uint8_t *data, uint64_t value);
void Uint8byteToMemBe(uint8_t *data, uint64_t value);
```

In addition, formatting was standardized to make code review of each function easier,
including aligning the columns and treating each byte on a separate code line.

</p>
</details> <details><summary>WSL2 Updates</summary>
<p>

Tracked down the minimum necessary for repeatable, reliably hot-plug support.
Previously, permissions would appear to randomly fail to be set properly, preventing
the client from talking to the device.

Turns out, the root cause is the shutdown of the `WSL2` subsystem.  When it's not in use, it's unloaded (after some undetermined set of requirements are met).  That means if there are no WSL2 terminals open, the next time one is opened might have behavior similar to a reboot, in that the WSL2 state is "fresh" again.

The good news is that the workarounds are simple.

</p>
</details> <details><summary>Logfile update</summary>
<p>

The prior code created a log file based on the date only (`log_YYYYmmdd.txt`).  When running multiple clients (e.g., one live on hardware, one disconnected; or multiple physical proxmark devices), the log files would fail to log everything.

This commit adjusts the log file to include hours, minutes and seconds (`log_YYYYmmddHHMMSS.txt`.  While not a 100% fix, as long as the clients are started at least a full second apart, each client will have its own private log file.  An alternative is to append random characters to the filename.  This may still be recommended later, but this should be good enough for most situations.

As an added bonus, it becomes easier to keep log files in order.


</p>
</details> 