### PR TITLE
Improve iClass SIO and legacy credential detection reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Changed iClass SIO and Legacy credential detection to be more reliable (@nvx)
  - Added `hf iclass esetblk` - set iClass emulator memory block data (@nvx)
  - Added cryptorf regressiontests (@iceman1001)
  - Fixed `cryptorf/sma_multi` - local state used in multithread (@iceman1001)

--- a/client/src/util.c
+++ b/client/src/util.c
@@ -1289,6 +1289,25 @@ int byte_strstr(const uint8_t *src, size_t srclen, const uint8_t *pattern, size_
     return -1;
 }
 
+int byte_strrstr(const uint8_t *src, size_t srclen, const uint8_t *pattern, size_t plen) {
+    for (int i = srclen - plen; i >= 0; i--) {
+        // compare only first byte
+        if (src[i] != pattern[0])
+            continue;
+
+        // try to match rest of the pattern
+        for (int j = plen - 1; j >= 1; j--) {
+
+            if (src[i + j] != pattern[j])
+                break;
+
+            if (j == 1)
+                return i;
+        }
+    }
+    return -1;
+}
+
 void sb_append_char(smartbuf *sb, unsigned char c) {
     if (sb->idx >= sb->size) {
         sb->size *= 2;

--- a/client/src/util.h
+++ b/client/src/util.h
@@ -155,6 +155,7 @@ uint32_t leadingzeros32(uint32_t a);
 uint64_t leadingzeros64(uint64_t a);
 
 int byte_strstr(const uint8_t *src, size_t srclen, const uint8_t *pattern, size_t plen);
+int byte_strrstr(const uint8_t *src, size_t srclen, const uint8_t *pattern, size_t plen);
 
 struct smartbuf {
     char *ptr;

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -3403,7 +3403,7 @@
             "options": [
                 "-h, --help This help",
                 "-f, --file <fn> filename of dump (bin/eml/json)",
-                "--first <dec> Begin printing from this block (default block 6)",
+                "--first <dec> Begin printing from this block (default first user block - 6 or 3 on non secured chips)",
                 "--last <dec> End printing at this block (default 0, ALL)",
                 "-v, --verbose verbose output",
                 "-z, --dense dense dump output style"
@@ -11834,6 +11834,6 @@
     "metadata": {
         "commands_extracted": 686,
         "extracted_by": "PM3Help2JSON v1.00",
-        "extracted_on": "2023-08-22T17:13:49"
+        "extracted_on": "2023-08-22T23:15:58"
     }
 }


### PR DESCRIPTION
Now relies on the legacy config block for SR detection and the end-of-SIO detection no longer partially cuts off the SIO for any dumps I have.

The previous code would cut off some SIOs mid way through if they happened to contain the wrong bytes mid way through.

Also fixes a couple of super minor display quirks I noticed while running `hf iclass view` on all my dumps - for example if the stars aligned on a SE dump it could in some cases try and decode block 7 as if it were a legacy dump resulting in rather confusing output, and a case where `hf iclass decrypt` would attempt to use a card helper even if the flag wasn't set (again if the stars aligned with the right block data).