### PR TITLE
Fix macOS errors while building after cryptoRF solvers was added.

### DIFF
--- a/tools/cryptorf/Makefile
+++ b/tools/cryptorf/Makefile
@@ -8,6 +8,12 @@ MYLDLIBS = -lpthread
 BINS = cm sm sma sma_multi
 INSTALLTOOLS = $(BINS)
 
+platform = $(shell uname)
+
+ifeq ($(platform),Darwin)
+CXXFLAGS = -std=c++14
+endif
+
 include ../../Makefile.host
 
 # checking platform can be done only after Makefile.host

--- a/tools/cryptorf/sma.cpp
+++ b/tools/cryptorf/sma.cpp
@@ -671,13 +671,12 @@ static inline void search_gc_candidates_left(const uint64_t lstate_before_gc, co
 
 void combine_valid_left_right_states(vector<cs_t> *plcstates, vector<cs_t> *prcstates, vector<uint64_t> *pgc_candidates) {
     vector<cs_t>::iterator itl, itr;
-    size_t pos, count;
+    size_t pos;
     uint64_t gc;
     bool valid;
 
     // Clean up the candidate list
     pgc_candidates->clear();
-    count = 0;
     for (itl = plcstates->begin(); itl != plcstates->end(); ++itl) {
         for (itr = prcstates->begin(); itr != prcstates->end(); ++itr) {
             valid = true;
@@ -700,7 +699,6 @@ void combine_valid_left_right_states(vector<cs_t> *plcstates, vector<cs_t> *prcs
 //        printf("%09llx - ",itl->l);
 //        printf("%07llx\n",itr->r);
             }
-            count++;
         }
     }
     printf("Found a total of " _YELLOW_("%llu")" combinations, ", ((unsigned long long)plcstates->size()) * prcstates->size());


### PR DESCRIPTION
I'm not sure if the count = 0 should have been deleted but it was also being reported as an error with the default make command.

Closes 2089