### PR TITLE
Change "Mac OS X" to "macOS" in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ The Proxmark3 is the swiss-army tool of RFID, allowing for interactions with the
 | :------------------: | :------------------: |
 | [Linux - Setup and Build](/doc/md/Installation_Instructions/Linux-Installation-Instructions.md) | [Compilation Instructions](/doc/md/Use_of_Proxmark/0_Compilation-Instructions.md)|
 | [Linux - Important notes on ModemManager](/doc/md/Installation_Instructions/ModemManager-Must-Be-Discarded.md) | [Validating Proxmark3 Client Functionality](/doc/md/Use_of_Proxmark/1_Validation.md)|
-| [Mac OS X - Homebrew & Upgrading HomeBrew Tap Formula](/doc/md/Installation_Instructions/Mac-OS-X-Homebrew-Installation-Instructions.md) | [First Use and Verification](/doc/md/Use_of_Proxmark/2_Configuration-and-Verification.md)|
-| [Mac OS X - MacPorts](/doc/md/Installation_Instructions/Mac-OS-X-MacPorts-Installation-Instructions.md) | [Commands & Features](/doc/md/Use_of_Proxmark/3_Commands-and-Features.md)|
-| [Mac OS X - Setup and Build](/doc/md/Installation_Instructions/Mac-OS-X-Compile-From-Source-Instructions.md) ||
+| [macOS - Homebrew & Upgrading HomeBrew Tap Formula](/doc/md/Installation_Instructions/macOS-Homebrew-Installation-Instructions.md) | [First Use and Verification](/doc/md/Use_of_Proxmark/2_Configuration-and-Verification.md)|
+| [macOS - MacPorts](/doc/md/Installation_Instructions/macOS-MacPorts-Installation-Instructions.md) | [Commands & Features](/doc/md/Use_of_Proxmark/3_Commands-and-Features.md)|
+| [macOS - Setup and Build](/doc/md/Installation_Instructions/macOS-Compile-From-Source-Instructions.md) ||
 | [Windows - Setup and Build](/doc/md/Installation_Instructions/Windows-Installation-Instructions.md) ||
 | [Termux / Android - Setup and Build](/doc/termux_notes.md) ||
 | [Blue Shark Manual](/doc/bt_manual_v10.md) | [Command Cheat Sheet](/doc/cheatsheet.md)|
@@ -184,7 +184,7 @@ This repo compiles nicely on
    - Windows/MinGW environment
    - Ubuntu, ParrotOS, Gentoo, Pentoo, Kali, NetHunter, Arch Linux, Fedora, Debian, Raspbian
    - Android / Termux
-   - Mac OS X / Homebrew (or MacPorts, experimental) / Apple Silicon M1
+   - macOS / Homebrew (or MacPorts, experimental) / Apple Silicon M1
    - Docker container
       - [ Iceman repo based ubuntu 18.04 container ](https://hub.docker.com/r/secopsconsult/proxmark3)
       - [ Iceman fork based container v1.7 ](https://hub.docker.com/r/iceman1001/proxmark3/)

--- a/doc/md/Installation_Instructions/Troubleshooting.md
+++ b/doc/md/Installation_Instructions/Troubleshooting.md
@@ -38,7 +38,7 @@ client/proxmark3 <YOUR_PORT_HERE> ...
 Refer to the installation guide specific to your OS for details about ports.
 
 * [Linux](/doc/md/Installation_Instructions/Linux-Installation-Instructions.md)
-* [Mac OSX](/doc/md/Installation_Instructions/Mac-OS-X-Homebrew-Installation-Instructions.md)
+* [macOS](/doc/md/Installation_Instructions/macOS-Homebrew-Installation-Instructions.md)
 * [Windows](/doc/md/Installation_Instructions/Windows-Installation-Instructions.md)
 
 Note that with the Bluetooth adapter, you *have to* use directly the client, and flasher over Bluetooth is not possible.

--- a/doc/md/Installation_Instructions/macOS-Compile-From-Source-Instructions.md
+++ b/doc/md/Installation_Instructions/macOS-Compile-From-Source-Instructions.md
@@ -1,9 +1,9 @@
 <a id="Top"></a>
 
-# Mac OS X - Compilation from source instructions
+# macOS - Compilation from source instructions
 
 # Table of Contents
-- [Mac OS X - Compilation from source instructions](x#mac-os-x---compilation-from-source-instructions)
+- [macOS - Compilation from source instructions](#macos---compilation-from-source-instructions)
 - [Table of Contents](#table-of-contents)
   - [Follow Homebrew developer instructions](#follow-homebrew-developer-instructions)
   - [(optional) Running without sudo](#optional-running-without-sudo)
@@ -12,7 +12,7 @@
 ## Follow Homebrew developer instructions
 ^[Top](#top)
 
-Follow the instructions here [developer instructions](/doc/md/Installation_Instructions/Mac-OS-X-Homebrew-Installation-Instructions.md#homebrew-mac-os-x-developer-installation) and you are done. 
+Follow the instructions here [developer instructions](/doc/md/Installation_Instructions/macOS-Homebrew-Installation-Instructions.md#homebrew-macos-developer-installation) and you are done. 
 
 ## (optional) Running without sudo
 ^[Top](#top)

--- a/doc/md/Installation_Instructions/macOS-Homebrew-Installation-Instructions.md
+++ b/doc/md/Installation_Instructions/macOS-Homebrew-Installation-Instructions.md
@@ -1,11 +1,11 @@
 
 <a id="Top"></a>
 
-# Mac OS X - Homebrew automatic installation
+# macOS - Homebrew automatic installation
 
 
 # Table of Contents
-- [Mac OS X - Homebrew automatic installation](#mac-os-x---homebrew-automatic-installation)
+- [macOS - Homebrew automatic installation](#macos---homebrew-automatic-installation)
 - [Table of Contents](#table-of-contents)
   - [macOS Ventura Beta users](#macos-ventura-beta-users)
   - [Apple Silicon (M1) Notes](#apple-silicon-m1-notes)
@@ -14,7 +14,7 @@
   - [Flash the BOOTROM & FULLIMAGE](#flash-the-bootrom--fullimage)
   - [Run the client](#run-the-client)
   - [Next steps](#next-steps)
-- [Homebrew (Mac OS X), developer installation](#homebrew-mac-os-x-developer-installation)
+- [Homebrew (macOS), developer installation](#homebrew-macos-developer-installation)
 - [Clone the Iceman repository](#clone-the-iceman-repository)
   - [Compile the project](#compile-the-project)
     - [the button trick](#the-button-trick)
@@ -151,7 +151,7 @@ For the next steps, please read the following pages:
 
 
 
-# Homebrew (Mac OS X), developer installation
+# Homebrew (macOS), developer installation
 ^[Top](#top)
 
 These instructions will show how to setup the environment on OSX to the point where you'll be able to clone and compile the repo by yourself, as on Linux, Windows, etc.

--- a/doc/md/Installation_Instructions/macOS-MacPorts-Installation-Instructions.md
+++ b/doc/md/Installation_Instructions/macOS-MacPorts-Installation-Instructions.md
@@ -1,10 +1,10 @@
 
 <a id="Top"></a>
 
-# Mac OS X - MacPorts automatic installation
+# macOS - MacPorts automatic installation
 
 # Table of Contents
-- [Mac OS X - MacPorts automatic installation](#mac-os-x---macports-automatic-installation)
+- [macOS - MacPorts automatic installation](#macOS---macports-automatic-installation)
 - [Table of Contents](#table-of-contents)
   - [Main prerequisite](#main-prerequisite)
   - [Installing latest releases](#installing-latest-releases)


### PR DESCRIPTION
In 2012, Apple changed the name of their operating system from "Mac OS X" to  "OS X" and later (in 2106) to "macOS".  This PR updates all references in the documentation from the outdated "Mac OS X" to the new name - "macOS".