### PR TITLE
Add `hf iclass creditepurse` command to allow crediting the epurse debit value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Added `hf iclass creditepurse` command to allow crediting the epurse debit value (@nvx)
 
 ## [Raccoon.4.17140][2023-09-09]
  - Changed text and adjust pm3_test case for mf_aes_brute (@doegox)

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1940,6 +1940,10 @@ static void PacketReceived(PacketCommandNG *packet) {
             iClass_Restore((iclass_restore_req_t *)packet->data.asBytes);
             break;
         }
+        case CMD_HF_ICLASS_CREDIT_EPURSE: {
+            iclass_credit_epurse((iclass_credit_epurse_t *)packet->data.asBytes);
+            break;
+        }
 #endif
 
 #ifdef WITH_HFSNIFF

--- a/armsrc/iclass.h
+++ b/armsrc/iclass.h
@@ -25,6 +25,7 @@ void SniffIClass(uint8_t jam_search_len, uint8_t *jam_search_string);
 void ReaderIClass(uint8_t flags);
 
 void iClass_WriteBlock(uint8_t *msg);
+void iclass_credit_epurse(iclass_credit_epurse_t *payload);
 void iClass_Dump(uint8_t *msg);
 
 void iClass_Restore(iclass_restore_req_t *msg);

--- a/client/src/pm3line_vocabulary.h
+++ b/client/src/pm3line_vocabulary.h
@@ -276,6 +276,7 @@ const static vocabulary_t vocabulary[] = {
     { 0, "hf iclass sniff" },
     { 1, "hf iclass view" },
     { 0, "hf iclass wrbl" },
+    { 0, "hf iclass creditepurse" },
     { 0, "hf iclass chk" },
     { 1, "hf iclass loclass" },
     { 1, "hf iclass lookup" },

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -3029,6 +3029,26 @@
             ],
             "usage": "hf iclass configcard [-hglp] [--ci <dec>] [--ki <dec>]"
         },
+        "hf iclass creditepurse": {
+            "command": "hf iclass creditepurse",
+            "description": "Credit the epurse on an iCLASS tag. The provided key must be the credit key. The first two bytes of the epurse are the debit value (big endian) and may be any value except FFFF. The remaining two bytes of the epurse are the credit value and must be smaller than the previous value.",
+            "notes": [
+                "hf iclass creditepurse -d FEFFFFFF -k 001122334455667B",
+                "hf iclass creditepurse -d FEFFFFFF --ki 0"
+            ],
+            "offline": false,
+            "options": [
+                "-h, --help This help",
+                "-k, --key <hex> Credit key as 8 hex bytes",
+                "--ki <dec> Key index to select key from memory 'hf iclass managekeys'",
+                "-d, --data <hex> data to write as 8 hex bytes",
+                "--elite elite computations applied to key",
+                "--raw no computations applied to key",
+                "-v, --verbose verbose output",
+                "--shallow use shallow (ASK) reader modulation instead of OOK"
+            ],
+            "usage": "hf iclass creditepurse [-hv] [-k <hex>] [--ki <dec>] -d <hex> [--elite] [--raw] [--shallow]"
+        },
         "hf iclass decrypt": {
             "command": "hf iclass decrypt",
             "description": "3DES decrypt data This is a naive implementation, it tries to decrypt every block after block 6. Correct behaviour would be to decrypt only the application areas where the key is valid, which is defined by the configuration block. OBS! In order to use this function, the file `iclass_decryptionkey.bin` must reside in the resources directory. The file should be 16 bytes binary data or... make sure your cardhelper is placed in the sim module",
@@ -8786,7 +8806,7 @@
                 "-1, --ht1 Card type Hitag 1",
                 "-2, --ht2 Card type Hitag 2",
                 "-s, --hts Card type Hitag S",
-                "-m, --htm Card type Hitag \u03bc"
+                "-m, --htm Card type Hitag \u00ce\u00bc"
             ],
             "usage": "lf hitag eload [-h12sm] -f <fn>"
         },
@@ -11835,8 +11855,8 @@
         }
     },
     "metadata": {
-        "commands_extracted": 686,
+        "commands_extracted": 687,
         "extracted_by": "PM3Help2JSON v1.00",
-        "extracted_on": "2023-09-07T18:12:46"
+        "extracted_on": "2023-09-10T12:59:25"
     }
 }

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -415,6 +415,7 @@ Check column "offline" for their availability.
 |`hf iclass sniff        `|N       |`Eavesdrop Picopass / iCLASS communication`
 |`hf iclass view         `|Y       |`Display content from tag dump file`
 |`hf iclass wrbl         `|N       |`Write Picopass / iCLASS block`
+|`hf iclass creditepurse `|N       |`Credit epurse value`
 |`hf iclass chk          `|N       |`Check keys`
 |`hf iclass loclass      `|Y       |`Use loclass to perform bruteforce reader attack`
 |`hf iclass lookup       `|Y       |`Uses authentication trace to check for key in dictionary file`

--- a/include/iclass_cmd.h
+++ b/include/iclass_cmd.h
@@ -87,6 +87,12 @@ typedef struct {
     uint8_t mac[4];
 } PACKED iclass_writeblock_req_t;
 
+// iCLASS write block request data structure
+typedef struct {
+    iclass_auth_req_t req;
+    uint8_t epurse[4];
+} PACKED iclass_credit_epurse_t;
+
 // iCLASS dump data structure
 typedef struct {
     uint8_t blockno;

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -565,7 +565,7 @@ typedef struct {
 
 #define CMD_HF_EPA_COLLECT_NONCE                                          0x038A
 #define CMD_HF_EPA_REPLAY                                                 0x038B
-#define CMD_HF_EPA_PACE_SIMULATE                                          0x039C
+#define CMD_HF_EPA_PACE_SIMULATE                                          0x038C
 
 #define CMD_HF_LEGIC_INFO                                                 0x03BC
 #define CMD_HF_LEGIC_ESET                                                 0x03BD
@@ -581,6 +581,7 @@ typedef struct {
 #define CMD_HF_ICLASS_EML_MEMSET                                          0x0398
 #define CMD_HF_ICLASS_CHKKEYS                                             0x039A
 #define CMD_HF_ICLASS_RESTORE                                             0x039B
+#define CMD_HF_ICLASS_CREDIT_EPURSE                                       0x039C
 
 // For ISO1092 / FeliCa
 #define CMD_HF_FELICA_SIMULATE                                            0x03A0


### PR DESCRIPTION
Note that this can not be achieved with simple `hf iclass wrbl` commands as it requires two writes back ot back without dropping the field.

Note since the recharging value must be decreased this sadly does not allow complete rollback of the epurse value to a prior state.