### PR TITLE
Update cmdhfmf.c

### DIFF
--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -2508,7 +2508,7 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
 
     uint64_t select_status = resp.oldarg[0];
     if (select_status == 0) {
-        PrintAndLogEx(DEBUG, "iso14443a card select failed");
+        PrintAndLogEx(ERR, "iso14443a card select failed (Hint: check card possition)");
         return PM3_ECARDEXCHANGE;
     }
 


### PR DESCRIPTION
Changed line 2510 to change DEBUG to ERR and add a hint

Stops "hf mf autopwn" from giving no message when it fails do to not being able to read card. Now gives message and a hint.