### PR TITLE
Change client/src/cmdhfmf.c to give better failure message

### DIFF
--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -2508,7 +2508,7 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
 
     uint64_t select_status = resp.oldarg[0];
     if (select_status == 0) {
-        PrintAndLogEx(DEBUG, "iso14443a card select failed");
+        PrintAndLogEx(ERR, "iso14443a card select failed (Hint: check card possition)");
         return PM3_ECARDEXCHANGE;
     }
 

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -2508,8 +2508,9 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
 
     uint64_t select_status = resp.oldarg[0];
     if (select_status == 0) {
-        PrintAndLogEx(DEBUG, "iso14443a card select failed");
+        // iso14443a card select failed
         PrintAndLogEx(FAILED, "No tag detected or other tag communication error");
+        PrintAndLogEx(HINT, "Hint: Try some distance or position of the card");
         return PM3_ECARDEXCHANGE;
     }
 

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -2509,7 +2509,7 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
     uint64_t select_status = resp.oldarg[0];
     if (select_status == 0) {
         PrintAndLogEx(DEBUG, "iso14443a card select failed");
-        PrintAndLogEx(HINT, "Card Select failed. Hint: Try some distance and/or change the position of the card");
+        PrintAndLogEx(FAILED, "No tag detected or other tag communication error");
         return PM3_ECARDEXCHANGE;
     }
 

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -2508,7 +2508,8 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
 
     uint64_t select_status = resp.oldarg[0];
     if (select_status == 0) {
-        PrintAndLogEx(HINT, "iso14443a card select failed (Hint: check card position)");
+        PrintAndLogEx(DEBUG, "iso14443a card select failed");
+        PrintAndLogEx(HINT, "Card Select failed. Hint: Try some distance and/or change the position of the card");
         return PM3_ECARDEXCHANGE;
     }
 

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -2508,7 +2508,7 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
 
     uint64_t select_status = resp.oldarg[0];
     if (select_status == 0) {
-        PrintAndLogEx(ERR, "iso14443a card select failed (Hint: check card possition)");
+        PrintAndLogEx(ERR, "iso14443a card select failed (Hint: check card position)");
         return PM3_ECARDEXCHANGE;
     }
 

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -2508,7 +2508,7 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
 
     uint64_t select_status = resp.oldarg[0];
     if (select_status == 0) {
-        PrintAndLogEx(ERR, "iso14443a card select failed (Hint: check card position)");
+        PrintAndLogEx(HINT, "iso14443a card select failed (Hint: check card position)");
         return PM3_ECARDEXCHANGE;
     }
 


### PR DESCRIPTION
Problem:
"hf mf autopwn" returns with no message if no card can be read
Solution:
Change a DEBUG message to ERR and have it give a hint