### PR TITLE
Changed hf iclass view/decrypt to detect SIO lengths better and show if legacy credentials are encrypted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Changed `hf iclass view/decrypt` to detect SIO lengths better and show if legacy credentials are encrypted (@nvx)
  - Changed the json file formats for mfc, 14b, 15, legic, cryptorf, ndef (@iceman1001)
  - Depricated the EML file format when saving dump files. (@iceman1001)
  - Added `sim014.bin` - new sim module firmware v4.42 with improved ISO7816 Protocol T0 support (@gentilkiwi)


### PR DESCRIPTION
It now does some super basic parsing of the ASN.1 to determine the length rather than pattern matching. I also feed this information into the block view to correctly highlight the SIO blocks rather than always assuming it's the same number of blocks.

I also added some bounds checking for safety and tweaked the legacy block display to show "HID CFG" for block 6, and "Enc Cred" if the legacy block is encrypted instead of just always showing "Cred".

This fixes the bug mentioned in discord where it would fail to show custom keyed SIOs correctly