### PR TITLE
Fixed command to be online only

### DIFF
--- a/doc/commands.json
+++ b/doc/commands.json
@@ -3018,7 +3018,7 @@
                 "hf iclass configcard --ci 1 -> view config card setting in slot 1",
                 "hf iclass configcard -g --ci 0 -> generate config file from slot 0"
             ],
-            "offline": true,
+            "offline": false,
             "options": [
                 "-h, --help This help",
                 "--ci <dec> use config slot at index",


### PR DESCRIPTION
As all the commands require cardhelper it is not possible to run this command without being in online mode.