### PR TITLE
Reduce latency in local TCP connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Added `hf iclass creditepurse` command to allow crediting the epurse debit value (@nvx)
  - Modified `hf iclass configcard` to only support online mode @ATK
  - Modified `hf iclass configcard` command to generate config cards without a cardhelper module by porting the contents of blocks 7 & 7 from nfc-iclass @ATK
+ - Changed the timeout of local TCP connections (@wh201906)
 
 ## [Raccoon.4.17140][2023-09-09]
  - Changed text and adjust pm3_test case for mf_aes_brute (@doegox)

--- a/client/src/comms.c
+++ b/client/src/comms.c
@@ -678,7 +678,16 @@ int TestProxmark(pm3_device_t *dev) {
     if (g_conn.send_via_fpc_usart) {
         PrintAndLogEx(INFO, "PM3 UART serial baudrate: " _YELLOW_("%u") "\n", g_conn.uart_speed);
     } else {
-        int res = uart_reconfigure_timeouts(is_tcp_conn ? UART_TCP_CLIENT_RX_TIMEOUT_MS : UART_USB_CLIENT_RX_TIMEOUT_MS);
+        int res;
+        if (is_tcp_conn) {
+            if (memcmp(g_conn.serial_port_name + 4, "localhost", 9) == 0 || memcmp(g_conn.serial_port_name + 4, "127.0.0.1", 9) == 0) {
+                res = uart_reconfigure_timeouts(UART_USB_CLIENT_RX_TIMEOUT_MS * 2);
+            } else {
+                res = uart_reconfigure_timeouts(UART_TCP_CLIENT_RX_TIMEOUT_MS);
+            }
+        } else {
+            res = uart_reconfigure_timeouts(UART_USB_CLIENT_RX_TIMEOUT_MS);
+        }
         if (res != PM3_SUCCESS) {
             return res;
         }


### PR DESCRIPTION
Before PR #2022, the default communication timeout for TCP is accidentally set to 20ms, but it works  for Termux.
In PR #2022, I fixed the default timeout of TCP connections, but it increases the latency when running some commands in Termux. To reduce the latency, I added some code to detect whether the host address is `127.0.0.1` or `localhost`, and reduce the timeout if so.