### PR TITLE
Support double-quoted arguments in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Add support for quoted arguments in the CLI, allowing spaces in them which
+   are removed automatically (@jmichelp)
  - Added UDP support on Windows (@wh201906)
  - Added client communication timeout to preferences (@iceman1001)
  - Added IPv6 support (@wh201906)

--- a/client/deps/cliparser/cliparser.c
+++ b/client/deps/cliparser/cliparser.c
@@ -222,32 +222,13 @@ int CLIParserParseStringEx(CLIParserContext *ctx, const char *str, void *vargtab
                 break;
             case PS_QUOTE:
                 if (str[i] == '"') {
-                    // Now let's compact the argument by removing spaces
-                    if (spaceptr != NULL) {
-                        // We've seen at least 1 space
-                        char *cur_ptr = spaceptr;
-                        while (spaceptr < bufptr) {
-                            if (isSpace(*spaceptr) == false) {
-                                *cur_ptr = *spaceptr;
-                                cur_ptr++;
-                            }
-                            spaceptr++;
-                        }
-                        *cur_ptr = 0;
-                        // Rollback bufptr
-                        bufptr = cur_ptr;
-                        spaceptr = NULL;
-                    }
-                    *bufptr = 0x00;
+                    *bufptr++ = 0x00;
                     state = PS_FIRST;
                 } else {
-                    if (isSpace(str[i]) && spaceptr == NULL) {
-                        // Store first encountered space for later
-                        spaceptr = bufptr;
+                    if (isSpace(str[i]) == false) {
+                        *bufptr++ = str[i];
                     }
-                    *bufptr = str[i];
                 }
-                bufptr++;
                 break;
         }
         if (bufptr > bufptrend) {


### PR DESCRIPTION
When a quoted command argument is seen, it will take all characters until the next double-quote (no supported escape sequence here for simplicity), skipping spaces (space, tab, etc.) inside.

This is meant to allow copy/pasting of formatted code, especially hex-encoded values. This doesn't add the capability to pass argument containing spaces (e.g. filenames).


This means that the following commands should behave the same:
```
pm3> wiegand encode --fc 101 --cn 1337
pm3> wiegand encode --fc "1 0 1" --cn "1    3    3   7"
```

Or a more realistic/useful example, when copy/pasting hex formatted values from other commands:
```
pm3> hf iclass calcnewkey --old 1122334455667788 --new 2233445566778899
pm3> hf iclass calcnewkey --old "11 22 33 44 55 66 77 88" --new "22 33 44 55 66 77 88 99"
```
