### PR TITLE
Fixed esetblk command description

### DIFF
--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -1284,7 +1284,7 @@ static int CmdHFiClassESetBlk(const char *Cmd) {
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "hf iclass esetblk",
                   "Sets an individual block in emulator memory.",
-                  "hf iclass esetblk -b 7 -d 0000000000000000");
+                  "hf iclass esetblk --blk 7 -d 0000000000000000");
 
     void *argtable[] = {
         arg_param_begin,

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -3173,7 +3173,7 @@
             "command": "hf iclass esetblk",
             "description": "Sets an individual block in emulator memory.",
             "notes": [
-                "hf iclass esetblk -b 7 -d 0000000000000000"
+                "hf iclass esetblk --blk 7 -d 0000000000000000"
             ],
             "offline": false,
             "options": [


### PR DESCRIPTION
Fixed command help file as it incorrectly shows -b instead of --blk