### PR TITLE
Modified hf iclass calcnewkey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Modified `hf iclass calcnewkey` - Added calculations for old key elite and new key non elite (@Antiklesys)
  - Changed the CLI prompt to show tcp/udp if used (@iceman1001)
  - Changed `hw ping` - now shows transfer time (@doegox)
  - Added `hf mf encodehid` - writes HID legacy credential to a empty MFC (@iceman1001)

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -3215,6 +3215,7 @@ static int CmdHFiClassCalcNewKey(const char *Cmd) {
         arg_str0(NULL, "csn", "<hex>", "Specify a Card Serial Number (CSN) to diversify the key (if omitted will attempt to read a CSN)"),
         arg_lit0(NULL, "elite", "Elite computations applied to new key"),
         arg_lit0(NULL, "elite2", "Elite computations applied to both old and new key"),
+        arg_lit0(NULL, "oldelite", "Elite computations applied only to old key"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, false);
@@ -3304,6 +3305,11 @@ static int CmdHFiClassCalcNewKey(const char *Cmd) {
 
     if (arg_get_lit(ctx, 7)) {
         elite = true;
+        old_elite = true;
+    }
+
+    if (arg_get_lit(ctx, 8)) {
+        elite = false;
         old_elite = true;
     }
 

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -2986,10 +2986,10 @@
                 "--new <hex> Specify key as 8 hex bytes",
                 "--nki <dec> New key index to select key from memory 'hf iclass managekeys'",
                 "--csn <hex> Specify a Card Serial Number (CSN) to diversify the key (if omitted will attempt to read a CSN)",
-                "--elite Elite computations applied to new key",
-                "--elite2 Elite computations applied to both old and new key"
+                "--elite2 Elite computations applied to both old and new key",
+                "--oldelite Elite computations applied only to old key"
             ],
-            "usage": "hf iclass calcnewkey [-h] [--old <hex>] [--oki <dec>] [--new <hex>] [--nki <dec>] [--csn <hex>] [--elite] [--elite2]"
+            "usage": "hf iclass calcnewkey [-h] [--old <hex>] [--oki <dec>] [--new <hex>] [--nki <dec>] [--csn <hex>] [--elite] [--elite2] [--oldelite]"
         },
         "hf iclass chk": {
             "command": "hf iclass chk",


### PR DESCRIPTION
Added support for a scenario in which the old key is elite and the new key is not elite.