### PR TITLE
Increase the USB speed by fixing synchronization waits in usb_write()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 
 ## [unreleased][unreleased]
  - Changed `lf em 4x05 dump` - now supports the `--ns` nosave parameter (@iceman1001)
+ - Fixed some wrong synchronization waits in usb_write() to increase the communication speed (@wh201906)
  - Added new command `data bmap` - breaks down a hexvalue to a binary template (@iceman1001)
  - Changed aid_desfire.json - added entreis from the Metrodroid project (@iceman1001)
  - Changed mad.json - added entries from the Metrodroid project (@iceman1001)

--- a/common_arm/usb_cdc.c
+++ b/common_arm/usb_cdc.c
@@ -777,7 +777,7 @@ int usb_write(const uint8_t *data, const size_t len) {
     }
 
     UDP_SET_EP_FLAGS(AT91C_EP_IN, AT91C_UDP_TXPKTRDY);
-    while (pUdp->UDP_CSR[AT91C_EP_IN] & AT91C_UDP_TXPKTRDY) {};
+    while (!(pUdp->UDP_CSR[AT91C_EP_IN] & AT91C_UDP_TXPKTRDY)) {};
 
     while (length) {
         // Send next chunk
@@ -810,9 +810,9 @@ int usb_write(const uint8_t *data, const size_t len) {
 
 
     if (len % AT91C_EP_IN_SIZE == 0) {
-
+        // like AT91F_USB_SendZlp(), in non ping-pong mode
         UDP_SET_EP_FLAGS(AT91C_EP_IN, AT91C_UDP_TXPKTRDY);
-        while (!(pUdp->UDP_CSR[AT91C_EP_IN] & AT91C_UDP_TXPKTRDY)) {};
+        while (!(pUdp->UDP_CSR[AT91C_EP_IN] & AT91C_UDP_TXCOMP)) {};
 
         UDP_CLEAR_EP_FLAGS(AT91C_EP_IN, AT91C_UDP_TXCOMP);
         while (pUdp->UDP_CSR[AT91C_EP_IN] & AT91C_UDP_TXCOMP) {};
@@ -869,6 +869,8 @@ void AT91F_USB_SendData(AT91PS_UDP pudp, const char *pData, uint32_t length) {
 //*----------------------------------------------------------------------------
 void AT91F_USB_SendZlp(AT91PS_UDP pudp) {
     UDP_SET_EP_FLAGS(AT91C_EP_CONTROL, AT91C_UDP_TXPKTRDY);
+    // for non ping-pong operation, wait until the FIFO is released
+    // the flag for FIFO released is AT91C_UDP_TXCOMP rather than AT91C_UDP_TXPKTRDY
     while (!(pudp->UDP_CSR[AT91C_EP_CONTROL] & AT91C_UDP_TXCOMP)) {};
     UDP_CLEAR_EP_FLAGS(AT91C_EP_CONTROL, AT91C_UDP_TXCOMP);
     while (pudp->UDP_CSR[AT91C_EP_CONTROL] & AT91C_UDP_TXCOMP) {};

--- a/common_arm/usb_cdc.c
+++ b/common_arm/usb_cdc.c
@@ -797,7 +797,7 @@ int usb_write(const uint8_t *data, const size_t len) {
         while (pUdp->UDP_CSR[AT91C_EP_IN] & AT91C_UDP_TXCOMP) {};
 
         UDP_SET_EP_FLAGS(AT91C_EP_IN, AT91C_UDP_TXPKTRDY);
-        while (pUdp->UDP_CSR[AT91C_EP_IN] & AT91C_UDP_TXPKTRDY) {};
+        while (!(pUdp->UDP_CSR[AT91C_EP_IN] & AT91C_UDP_TXPKTRDY)) {};
     }
 
     // Wait for the end of transfer
@@ -812,7 +812,7 @@ int usb_write(const uint8_t *data, const size_t len) {
     if (len % AT91C_EP_IN_SIZE == 0) {
 
         UDP_SET_EP_FLAGS(AT91C_EP_IN, AT91C_UDP_TXPKTRDY);
-        while (!(pUdp->UDP_CSR[AT91C_EP_IN] & AT91C_UDP_TXCOMP)) {};
+        while (!(pUdp->UDP_CSR[AT91C_EP_IN] & AT91C_UDP_TXPKTRDY)) {};
 
         UDP_CLEAR_EP_FLAGS(AT91C_EP_IN, AT91C_UDP_TXCOMP);
         while (pUdp->UDP_CSR[AT91C_EP_IN] & AT91C_UDP_TXCOMP) {};


### PR DESCRIPTION
Transfer speed before this fix:
616448, 618496, 618496, 615424, 615424 -> average: 616857.6 bytes/s
Transfer speed after this fix:
~~707584, 709632, 707584, 709632, 710656 -> average: 709017.6 bytes/s (+14.9%)~~
722944, 733184, 732160, 731136, 733184 -> average: 730521.6 bytes/s (+18.4%)
Tested by running `hw status`