### PR TITLE
cmdscript.c: explicitly include ctype header

### DIFF
--- a/client/src/cmdscript.c
+++ b/client/src/cmdscript.c
@@ -22,6 +22,7 @@
 #ifdef HAVE_PYTHON
 //#define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#include <ctype.h>
 #include <wchar.h>
 #endif
 


### PR DESCRIPTION
Brought to attention by preparation for Fedora 41 packaging @ https://bugzilla.redhat.com/show_bug.cgi?id=2245823