### PR TITLE
Improve sampling performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Modified `hf iclass configcard` to only support online mode (@Antiklesys)
  - Modified `hf iclass configcard` command to generate config cards without a cardhelper module by porting the contents of blocks 6 & 7 from nfc-iclass (@Antiklesys)
  - Fixed `hf iclass info` command showing incorrectly in offline mode (@Antiklesys)
+ - Changed lf sampling - improved the performance (@yah01)
 
 ## [Raccoon.4.17140][2023-09-09]
  - Changed text and adjust pm3_test case for mf_aes_brute (@doegox)


### PR DESCRIPTION
This improves the performance of sampling for `bps < 8`, makes it perform better on low-end machines.

@wh201906 did a benchmark for this