### PR TITLE
Fixed keyroll mode for hf ic configcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Additional fixes to configcard code for keyroll mode based on nfc-iclass output (@Antiklesys)
  - Added `bind` option for network connections to specify the outbound address and port (@wh201906)
  - Changed `lf em 4x05 dump` - now supports the `--ns` nosave parameter (@iceman1001)
  - Fixed some wrong synchronization waits in usb_write() to increase the communication speed (@wh201906)

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -424,7 +424,7 @@ static int generate_config_card(const iclass_config_card_item_t *o,  uint8_t *ke
             memcpy(data + (0x0D * 8), lkey, sizeof(enckey1));
         }
         // encrypted 0xFF
-        for (uint8_t i = 0x0D; i < 0x14; i++) {
+        for (uint8_t i = 0x0E; i < 0x14; i++) {
             memcpy(data + (i * 8), ffs, sizeof(ffs));
         }
         PrintAndLogEx(NORMAL, "( " _GREEN_("ok") " )");
@@ -450,7 +450,7 @@ static int generate_config_card(const iclass_config_card_item_t *o,  uint8_t *ke
         // encrypted partial keyroll key 15
         PrintAndLogEx(INFO, "Setting encrypted partial key15... " NOLF);
         memset(foo, 0xFF, sizeof(foo));
-        foo[0] = lkey[7];
+        foo[0] = key[7];
         if (IsCardHelperPresent(false) != false) {
             if (Encrypt(foo, enckey2) == false) {
                 PrintAndLogEx(WARNING, "failed to encrypt partial 2");


### PR DESCRIPTION
Was able to compare the output of nfc-iclass and I identified two bugs in the generation of blocks 0x0D (was being overwritten with FF, it seems this was an original bug in the original pm3 code?) Fixed the porting for block 15 generation.