### PR TITLE
Add alternative chip ID

### DIFF
--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -45,6 +45,7 @@ static void lookup_chipid_short(uint32_t iChipID, uint32_t mem_used) {
         case 0x270B0A40:
             asBuff = "AT91SAM7S512 Rev A";
             break;
+        case 0x270B0A4E:
         case 0x270B0A4F:
             asBuff = "AT91SAM7S512 Rev B";
             break;
@@ -153,6 +154,7 @@ static void lookupChipID(uint32_t iChipID, uint32_t mem_used) {
         case 0x270B0A40:
             asBuff = "AT91SAM7S512 Rev A";
             break;
+        case 0x270B0A4E:
         case 0x270B0A4F:
             asBuff = "AT91SAM7S512 Rev B";
             break;


### PR DESCRIPTION
I couldn't find this exact chip ID on any datasheet but that's the ID I have on my genuine PM3 RDV4 and I was tired of seeing `Unknown` :)

The last 5 bits of the chip ID only indicate the version of the chip (Section 26.5.10 page 235 of the datasheet from 2012) so I arbitrarily merge the 0xE version with the 0xF and identify them as rev B.