### PR TITLE
Add `--ms` option in `hw status`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Added `--ms` option in `hw status` to specify the timeout of connection speed test (@wh201906)
  - Added `hf mf ginfo` command for get info about Gen4 GTU configuration (@merlokk)
  - Added support for loading Flipper PICOPASS dump files (@iceman1001)
  - Fixed unknown chip identification (@jmichelp)
@@ -101,7 +102,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Fixed compiling liblua on iOS (@The-SamminAter)
  - Changed `hf_mf_luxeo_dump.lua` - now have list of keys to iterate (@iceman1001)
  - Fixed the timeout of TCP connections (@wh201906)
- - Changed the connection timeout configurable (@wh201906)
+ - Added `hw timeout` - make the connection timeout configurable (@wh201906)
 
 ## [Seven.4.16717][2023-06-25]
  - Change `hf 14a info` - now identifes QL88 tags (@iceman1001)
@@ -341,6 +342,8 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Added new standalone mode `lf_em4100rsww` (@zabszk)
  - Fixed `hf 15 slixdisable` wrong pass id (@r1ddl3rz)
  - Added `script run hf_mf_hid_sim.lua` (@micsen)
+ - Added flashmem support in `HF_14BSNIFF` standalone mode (@wh201906)
+ - Changed `HF_14ASNIFF` standalone mode - now supports Proxmark3 without flashmem (@wh201906)
 
 ## [Frostbit.4.14831][2022-01-11]
  - Changed Wiegand format lookup - now case-insensitive (@iceman1001)

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -2662,7 +2662,6 @@ static void PacketReceived(PacketCommandNG *packet) {
             break;
         }
         case CMD_STATUS: {
-            Dbprintf("Packet Len:%d", packet->length);
             if (packet->length == 4)
                 SendStatus(packet->data.asDwords[0]);
             else

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -369,11 +369,10 @@ static void print_debug_level(void) {
 
 // measure the Connection Speed by sending SpeedTestBufferSize bytes to client and measuring the elapsed time.
 // Note: this mimics GetFromBigbuf(), i.e. we have the overhead of the PacketCommandNG structure included.
-static void printConnSpeed(void) {
+static void printConnSpeed(uint32_t testTimeout) {
     DbpString(_CYAN_("Transfer Speed"));
     Dbprintf("  Sending packets to client...");
 
-#define CONN_SPEED_TEST_MIN_TIME 500 // in milliseconds
     uint8_t *test_data = BigBuf_get_addr();
     uint32_t start_time = GetTickCount();
     uint32_t delta_time = 0;
@@ -381,7 +380,7 @@ static void printConnSpeed(void) {
 
     LED_B_ON();
 
-    while (delta_time < CONN_SPEED_TEST_MIN_TIME) {
+    while (delta_time < testTimeout) {
         reply_ng(CMD_DOWNLOADED_BIGBUF, PM3_SUCCESS, test_data, PM3_CMD_DATA_SIZE);
         bytes_transferred += PM3_CMD_DATA_SIZE;
         delta_time = GetTickCountDelta(start_time);
@@ -396,7 +395,7 @@ static void printConnSpeed(void) {
 /**
   * Prints runtime information about the PM3.
 **/
-static void SendStatus(void) {
+static void SendStatus(int32_t speedTestTimeout) {
     BigBuf_print_status();
     Fpga_print_status();
 #ifdef WITH_FLASH
@@ -412,7 +411,7 @@ static void SendStatus(void) {
 #ifdef WITH_ISO14443a
     printHf14aConfig();   // HF 14a config
 #endif
-    printConnSpeed();
+    printConnSpeed(speedTestTimeout);
     DbpString(_CYAN_("Various"));
 
     print_stack_usage();
@@ -2663,7 +2662,11 @@ static void PacketReceived(PacketCommandNG *packet) {
             break;
         }
         case CMD_STATUS: {
-            SendStatus();
+            Dbprintf("Packet Len:%d", packet->length);
+            if (packet->length == 4)
+                SendStatus(packet->data.asDwords[0]);
+            else
+                SendStatus(CONN_SPEED_TEST_MIN_TIME_DEFAULT);
             break;
         }
         case CMD_TIA: {

--- a/armsrc/appmain.h
+++ b/armsrc/appmain.h
@@ -37,6 +37,9 @@ int tearoff_hook(void);
 // ADC Vref = 3300mV,  (240k-10M):240k voltage divider,  140800 mV
 #define MAX_ADC_LF_VOLTAGE 140800
 
+// Default connection speed test timeout, used in hw status
+#define CONN_SPEED_TEST_MIN_TIME_DEFAULT 500 // in milliseconds
+
 extern int ToSendMax;
 extern uint8_t ToSend[];
 

--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -813,7 +813,7 @@ static int CmdStatus(const char *Cmd) {
     CLIParserInit(&ctx, "hw status",
                   "Show runtime status information about the connected Proxmark3",
                   "hw status\n"
-                  "hw status -t 1000 -> Test connection speed with 1000ms timeout\n"
+                  "hw status --ms 1000 -> Test connection speed with 1000ms timeout\n"
                  );
 
     void *argtable[] = {

--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -812,19 +812,29 @@ static int CmdStatus(const char *Cmd) {
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "hw status",
                   "Show runtime status information about the connected Proxmark3",
-                  "hw status"
+                  "hw status\n"
+                  "hw status -t 1000 -> Test connection speed with 1000ms timeout\n"
                  );
 
     void *argtable[] = {
         arg_param_begin,
+        arg_int0("m", "ms", "<ms>", "speed test timeout in micro seconds"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
+    int32_t speedTestTimeout = arg_get_int_def(ctx, 1, -1);
     CLIParserFree(ctx);
+
     clearCommandBuffer();
     PacketResponseNG resp;
-    SendCommandNG(CMD_STATUS, NULL, 0);
-    if (WaitForResponseTimeout(CMD_STATUS, &resp, 2000) == false) {
+    if (speedTestTimeout < 0) {
+        speedTestTimeout = 0;
+        SendCommandNG(CMD_STATUS, NULL, 0);
+    } else {
+        SendCommandNG(CMD_STATUS, (uint8_t *)&speedTestTimeout, sizeof(speedTestTimeout));
+    }
+
+    if (WaitForResponseTimeout(CMD_STATUS, &resp, 2000 + speedTestTimeout) == false) {
         PrintAndLogEx(WARNING, "Status command timeout. Communication speed test timed out");
         return PM3_ETIMEOUT;
     }


### PR DESCRIPTION
It's helpful to get a stable speed test result by extending the timeout.
I've tested the compatibility. Both the old client and old firmware can be used with the new client and new firmware.