### PR TITLE
Fix uint32_t overflow

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -389,7 +389,7 @@ static void printConnSpeed(uint32_t testTimeout) {
 
     Dbprintf("  Time elapsed................... %dms", delta_time);
     Dbprintf("  Bytes transferred.............. %d", bytes_transferred);
-    Dbprintf("  Transfer Speed PM3 -> Client... " _YELLOW_("%d") " bytes/s", 1000 * bytes_transferred / delta_time);
+    Dbprintf("  Transfer Speed PM3 -> Client... " _YELLOW_("%llu") " bytes/s", 1000 * (uint64_t)bytes_transferred / delta_time);
 }
 
 /**


### PR DESCRIPTION
If the timeout option of `hw status` is too large, the `1000 * bytes_transferred` will excess the range of `uint32_t` and give a wrong answer.
For USB connection, 20s of timeout can easily cause this bug.