### PR TITLE
Real-time LF sampling

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -856,7 +856,11 @@ static void PacketReceived(PacketCommandNG *packet) {
                 bool     verbose : 1;
             } PACKED;
             struct p *payload = (struct p *)packet->data.asBytes;
-            uint32_t bits = SampleLF(payload->verbose, payload->samples, true);
+            uint32_t bits;
+            if (!(payload->verbose))
+                bits = SampleLF(false, payload->samples, true);
+            else
+                bits = SampleLF_realtime();
             reply_ng(CMD_LF_ACQ_RAW_ADC, PM3_SUCCESS, (uint8_t *)&bits, sizeof(bits));
             break;
         }

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -851,12 +851,7 @@ static void PacketReceived(PacketCommandNG *packet) {
             break;
         }
         case CMD_LF_ACQ_RAW_ADC: {
-            struct p {
-                uint32_t samples  : 30;
-                bool     realtime : 1;
-                bool     verbose  : 1;
-            } PACKED;
-            struct p *payload = (struct p *)packet->data.asBytes;
+            lf_sample_config_t *payload = (lf_sample_config_t *)packet->data.asBytes;
             uint32_t bits;
             if (payload->realtime) {
                 bits = ReadLF_realtime(true);
@@ -886,12 +881,7 @@ static void PacketReceived(PacketCommandNG *packet) {
             break;
         }
         case CMD_LF_SNIFF_RAW_ADC: {
-            struct p {
-                uint32_t samples  : 30;
-                bool     realtime : 1;
-                bool     verbose  : 1;
-            } PACKED;
-            struct p *payload = (struct p *)packet->data.asBytes;
+            lf_sample_config_t *payload = (lf_sample_config_t *)packet->data.asBytes;
             uint32_t bits;
             if (payload->realtime) {
                 bits = ReadLF_realtime(false);

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -858,10 +858,11 @@ static void PacketReceived(PacketCommandNG *packet) {
             } PACKED;
             struct p *payload = (struct p *)packet->data.asBytes;
             uint32_t bits;
-            if (payload->realtime)
+            if (payload->realtime) {
                 bits = ReadLF_realtime(true);
-            else
+            } else {
                 bits = SampleLF(payload->verbose, payload->samples, true);
+            }
             reply_ng(CMD_LF_ACQ_RAW_ADC, PM3_SUCCESS, (uint8_t *)&bits, sizeof(bits));
             break;
         }
@@ -892,10 +893,11 @@ static void PacketReceived(PacketCommandNG *packet) {
             } PACKED;
             struct p *payload = (struct p *)packet->data.asBytes;
             uint32_t bits;
-            if (payload->realtime)
+            if (payload->realtime) {
                 bits = ReadLF_realtime(false);
-            else
+            } else {
                 bits = SniffLF(payload->verbose, payload->samples, true);
+            }
             reply_ng(CMD_LF_SNIFF_RAW_ADC, PM3_SUCCESS, (uint8_t *)&bits, sizeof(bits));
             break;
         }

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -851,7 +851,7 @@ static void PacketReceived(PacketCommandNG *packet) {
             break;
         }
         case CMD_LF_ACQ_RAW_ADC: {
-            lf_sample_config_t *payload = (lf_sample_config_t *)packet->data.asBytes;
+            lf_sample_payload_t *payload = (lf_sample_payload_t *)packet->data.asBytes;
             uint32_t bits;
             if (payload->realtime) {
                 bits = ReadLF_realtime(true);
@@ -881,7 +881,7 @@ static void PacketReceived(PacketCommandNG *packet) {
             break;
         }
         case CMD_LF_SNIFF_RAW_ADC: {
-            lf_sample_config_t *payload = (lf_sample_config_t *)packet->data.asBytes;
+            lf_sample_payload_t *payload = (lf_sample_payload_t *)packet->data.asBytes;
             uint32_t bits;
             if (payload->realtime) {
                 bits = ReadLF_realtime(false);

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -852,15 +852,16 @@ static void PacketReceived(PacketCommandNG *packet) {
         }
         case CMD_LF_ACQ_RAW_ADC: {
             struct p {
-                uint32_t samples : 31;
-                bool     verbose : 1;
+                uint32_t samples  : 30;
+                bool     realtime : 1;
+                bool     verbose  : 1;
             } PACKED;
             struct p *payload = (struct p *)packet->data.asBytes;
             uint32_t bits;
-            if (!(payload->verbose))
-                bits = SampleLF(false, payload->samples, true);
+            if (payload->realtime)
+                bits = ReadLF_realtime(true);
             else
-                bits = SampleLF_realtime();
+                bits = SampleLF(payload->verbose, payload->samples, true);
             reply_ng(CMD_LF_ACQ_RAW_ADC, PM3_SUCCESS, (uint8_t *)&bits, sizeof(bits));
             break;
         }
@@ -885,12 +886,16 @@ static void PacketReceived(PacketCommandNG *packet) {
         }
         case CMD_LF_SNIFF_RAW_ADC: {
             struct p {
-                uint32_t samples : 31;
-                bool     verbose : 1;
+                uint32_t samples  : 30;
+                bool     realtime : 1;
+                bool     verbose  : 1;
             } PACKED;
             struct p *payload = (struct p *)packet->data.asBytes;
-
-            uint32_t bits = SniffLF(payload->verbose, payload->samples, true);
+            uint32_t bits;
+            if (payload->realtime)
+                bits = ReadLF_realtime(false);
+            else
+                bits = SniffLF(payload->verbose, payload->samples, true);
             reply_ng(CMD_LF_SNIFF_RAW_ADC, PM3_SUCCESS, (uint8_t *)&bits, sizeof(bits));
             break;
         }

--- a/armsrc/cmd.c
+++ b/armsrc/cmd.c
@@ -90,7 +90,8 @@ static int reply_ng_internal(uint16_t cmd, int16_t status, const uint8_t *data, 
     txBufferNG.pre.length = (len & 0x7FFF);
 
     // Add the (optional) content to the frame, with a maximum size of PM3_CMD_DATA_SIZE
-    if (data && len) {
+    // bypass data copy when executing hw status
+    if (cmd != CMD_DOWNLOADED_BIGBUF && data && len) {
         for (size_t i = 0; i < len; i++) {
             txBufferNG.data[i] = data[i];
         }

--- a/armsrc/fpgaloader.c
+++ b/armsrc/fpgaloader.c
@@ -493,7 +493,7 @@ void FpgaDownloadAndGo(int bitstream_version) {
 #endif
 
     // Send waiting time extension request as this will take a while
-    send_wtx(1500);
+    send_wtx(FPGA_LOAD_WAIT_TIME);
 
     bool verbose = (g_dbglevel > 3);
 

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -450,6 +450,10 @@ int ReadLF_realtime(bool reader_field) {
     int return_value = PM3_SUCCESS;
 
     initSampleBuffer(&sample_size); // sample size in bytes
+    if (sample_size != 64) {
+        return PM3_EFAILED;
+    }
+
     sample_size <<= 3; // sample size in bits
     sample_size /= bits_per_sample; // sample count
 
@@ -505,8 +509,7 @@ int ReadLF_realtime(bool reader_field) {
             }
             last_byte = curr_byte;
 
-            if(samples.total_saved == size_threshold)
-            {
+            if(samples.total_saved == size_threshold) {
                 // request usb transmission and change FIFO bank
                 if (usb_write_request() == false) {
                     return_value = PM3_EIO;

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -306,7 +306,7 @@ uint32_t DoAcquisition(uint8_t decimation, uint8_t bits_per_sample, bool avg, in
 
         // only every 4000th times, in order to save time when collecting samples.
         // interruptible only when logging not yet triggered
-        if ((checked >= 4000) && trigger_hit == false) {
+        if (unlikely(trigger_hit == false && (checked >= 4000))) {
             if (data_available()) {
                 checked = -1;
                 break;
@@ -325,11 +325,11 @@ uint32_t DoAcquisition(uint8_t decimation, uint8_t bits_per_sample, bool avg, in
         if (AT91C_BASE_SSC->SSC_SR & AT91C_SSC_RXRDY) {
             volatile uint8_t sample = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
 
-            // Test point 8 (TP8) can be used to trigger oscilloscope
+            // (RDV4) Test point 8 (TP8) can be used to trigger oscilloscope
             if (ledcontrol) LED_D_OFF();
 
             // threshold either high or low values 128 = center 0.  if trigger = 178
-            if (trigger_hit == false) {
+            if (unlikely(trigger_hit == false)) {
                 if ((trigger_threshold > 0) && (sample < (trigger_threshold + 128)) && (sample > (128 - trigger_threshold))) {
                     if (cancel_after > 0) {
                         cancel_counter++;
@@ -338,11 +338,10 @@ uint32_t DoAcquisition(uint8_t decimation, uint8_t bits_per_sample, bool avg, in
                     }
                     continue;
                 }
+                trigger_hit = true;
             }
 
-            trigger_hit = true;
-
-            if (samples_to_skip > 0) {
+            if (unlikely(samples_to_skip > 0)) {
                 samples_to_skip--;
                 continue;
             }
@@ -464,7 +463,7 @@ int ReadLF_realtime(bool reader_field) {
 
         // only every 4000th times, in order to save time when collecting samples.
         // interruptible only when logging not yet triggered
-        if ((checked >= 4000) && trigger_hit == false) {
+        if (unlikely(trigger_hit == false && (checked >= 4000))) {
             if (data_available()) {
                 checked = -1;
                 break;
@@ -483,19 +482,18 @@ int ReadLF_realtime(bool reader_field) {
         if (AT91C_BASE_SSC->SSC_SR & AT91C_SSC_RXRDY) {
             volatile uint8_t sample = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
 
-            // Test point 8 (TP8) can be used to trigger oscilloscope
+            // (RDV4) Test point 8 (TP8) can be used to trigger oscilloscope
             LED_D_OFF();
 
             // threshold either high or low values 128 = center 0.  if trigger = 178
-            if (trigger_hit == false) {
+            if (unlikely(trigger_hit == false)) {
                 if ((trigger_threshold > 0) && (sample < (trigger_threshold + 128)) && (sample > (128 - trigger_threshold))) {
                     continue;
                 }
+                trigger_hit = true;
             }
 
-            trigger_hit = true;
-
-            if (samples_to_skip > 0) {
+            if (unlikely(samples_to_skip > 0)) {
                 samples_to_skip--;
                 continue;
             }

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -306,7 +306,7 @@ uint32_t DoAcquisition(uint8_t decimation, uint8_t bits_per_sample, bool avg, in
 
         // only every 4000th times, in order to save time when collecting samples.
         // interruptible only when logging not yet triggered
-        if (unlikely(trigger_hit == false && (checked >= 4000))) {
+        if (trigger_hit == false && (checked >= 4000)) {
             if (data_available()) {
                 checked = -1;
                 break;
@@ -329,7 +329,7 @@ uint32_t DoAcquisition(uint8_t decimation, uint8_t bits_per_sample, bool avg, in
             if (ledcontrol) LED_D_OFF();
 
             // threshold either high or low values 128 = center 0.  if trigger = 178
-            if (unlikely(trigger_hit == false)) {
+            if (trigger_hit == false) {
                 if ((trigger_threshold > 0) && (sample < (trigger_threshold + 128)) && (sample > (128 - trigger_threshold))) {
                     if (cancel_after > 0) {
                         cancel_counter++;
@@ -341,7 +341,7 @@ uint32_t DoAcquisition(uint8_t decimation, uint8_t bits_per_sample, bool avg, in
                 trigger_hit = true;
             }
 
-            if (unlikely(samples_to_skip > 0)) {
+            if (samples_to_skip > 0) {
                 samples_to_skip--;
                 continue;
             }
@@ -463,7 +463,7 @@ int ReadLF_realtime(bool reader_field) {
 
         // only every 4000th times, in order to save time when collecting samples.
         // interruptible only when logging not yet triggered
-        if (unlikely(trigger_hit == false && (checked >= 4000))) {
+        if (trigger_hit == false && (checked >= 4000)) {
             if (data_available()) {
                 checked = -1;
                 break;
@@ -486,14 +486,14 @@ int ReadLF_realtime(bool reader_field) {
             LED_D_OFF();
 
             // threshold either high or low values 128 = center 0.  if trigger = 178
-            if (unlikely(trigger_hit == false)) {
+            if (trigger_hit == false) {
                 if ((trigger_threshold > 0) && (sample < (trigger_threshold + 128)) && (sample > (128 - trigger_threshold))) {
                     continue;
                 }
                 trigger_hit = true;
             }
 
-            if (unlikely(samples_to_skip > 0)) {
+            if (samples_to_skip > 0) {
                 samples_to_skip--;
                 continue;
             }

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -441,8 +441,8 @@ int ReadLF_realtime(bool reader_field) {
     const uint8_t decimation = config.decimation;
 
     uint32_t sample_size = 64;
-    const int8_t size_threshold_table[9] = {0, 64, 64, 48, 64, 40, 48, 56, 64};
-    const int8_t size_threshold = size_threshold_table[decimation];
+    const int8_t size_threshold_table[9] = {0, 64, 64, 60, 64, 60, 60, 56, 64};
+    const int8_t size_threshold = size_threshold_table[bits_per_sample];
 
     // DoAcquisition() start
     uint8_t last_byte = 0;
@@ -500,8 +500,9 @@ int ReadLF_realtime(bool reader_field) {
 
             // write to USB FIFO if byte changed
             curr_byte = data.numbits >> 3;
-            if (curr_byte > last_byte)
+            if (curr_byte > last_byte) {
                 usb_write_byte_async(data.buffer[last_byte]);
+            }
             last_byte = curr_byte;
 
             if(samples.total_saved == size_threshold)

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -306,7 +306,7 @@ uint32_t DoAcquisition(uint8_t decimation, uint8_t bits_per_sample, bool avg, in
 
         // only every 4000th times, in order to save time when collecting samples.
         // interruptible only when logging not yet triggered
-        if (trigger_hit == false && (checked >= 4000)) {
+        if (unlikely(trigger_hit == false && (checked >= 4000))) {
             if (data_available()) {
                 checked = -1;
                 break;
@@ -329,7 +329,7 @@ uint32_t DoAcquisition(uint8_t decimation, uint8_t bits_per_sample, bool avg, in
             if (ledcontrol) LED_D_OFF();
 
             // threshold either high or low values 128 = center 0.  if trigger = 178
-            if (trigger_hit == false) {
+            if (unlikely(trigger_hit == false)) {
                 if ((trigger_threshold > 0) && (sample < (trigger_threshold + 128)) && (sample > (128 - trigger_threshold))) {
                     if (cancel_after > 0) {
                         cancel_counter++;
@@ -341,7 +341,7 @@ uint32_t DoAcquisition(uint8_t decimation, uint8_t bits_per_sample, bool avg, in
                 trigger_hit = true;
             }
 
-            if (samples_to_skip > 0) {
+            if (unlikely(samples_to_skip > 0)) {
                 samples_to_skip--;
                 continue;
             }
@@ -463,7 +463,7 @@ int ReadLF_realtime(bool reader_field) {
 
         // only every 4000th times, in order to save time when collecting samples.
         // interruptible only when logging not yet triggered
-        if (trigger_hit == false && (checked >= 4000)) {
+        if (unlikely(trigger_hit == false && (checked >= 4000))) {
             if (data_available()) {
                 checked = -1;
                 break;
@@ -486,14 +486,14 @@ int ReadLF_realtime(bool reader_field) {
             LED_D_OFF();
 
             // threshold either high or low values 128 = center 0.  if trigger = 178
-            if (trigger_hit == false) {
+            if (unlikely(trigger_hit == false)) {
                 if ((trigger_threshold > 0) && (sample < (trigger_threshold + 128)) && (sample > (128 - trigger_threshold))) {
                     continue;
                 }
                 trigger_hit = true;
             }
 
-            if (samples_to_skip > 0) {
+            if (unlikely(samples_to_skip > 0)) {
                 samples_to_skip--;
                 continue;
             }

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -526,7 +526,7 @@ int ReadLF_realtime(bool reader_field) {
 
             } else if (samples.total_saved == 1) {
                 // check if there is any data from client
-                if (usb_available_length() > 0) {
+                if (data_available_fast()) {
                     break;
                 }
             }

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -229,7 +229,7 @@ void logSample(uint8_t sample, uint8_t decimation, uint8_t bits_per_sample, bool
 
         // write the current byte
         data.buffer[data.numbits >> 3] |= sample >> bits_offset;
-        int numbits = data.numbits + bits_cap;
+        uint32_t numbits = data.numbits + bits_cap;
 
         // write the remaining bits to the next byte
         data.buffer[numbits >> 3] |= sample << (bits_cap);
@@ -521,7 +521,7 @@ int ReadLF_realtime(bool reader_field) {
                 // reset sample
                 last_byte = 0;
                 data.numbits = 0;
-                // data.position = 0; // unused?
+                samples.counter = size_threshold;
                 samples.total_saved = 0;
 
             } else if (samples.total_saved == 1) {

--- a/armsrc/lfsampling.h
+++ b/armsrc/lfsampling.h
@@ -52,7 +52,7 @@ void doT55x7Acquisition(size_t sample_size, bool ledcontrol);
 uint32_t SampleLF(bool verbose, uint32_t sample_size, bool ledcontrol);
 
 /**
-* SampleLF()/SniffLF() + ReadLF() + DoAcquisition_config() 
+* SampleLF()/SniffLF() + ReadLF() + DoAcquisition_config()
 * @return TBD
 **/
 int ReadLF_realtime(bool reader_field);

--- a/armsrc/lfsampling.h
+++ b/armsrc/lfsampling.h
@@ -50,7 +50,7 @@ void doT55x7Acquisition(size_t sample_size, bool ledcontrol);
 * @return number of bits sampled
 **/
 uint32_t SampleLF(bool verbose, uint32_t sample_size, bool ledcontrol);
-
+uint32_t SampleLF_realtime(void);
 /**
 * Initializes the FPGA for sniff-mode (field off), and acquires the samples.
 * @return number of bits sampled

--- a/armsrc/lfsampling.h
+++ b/armsrc/lfsampling.h
@@ -50,7 +50,13 @@ void doT55x7Acquisition(size_t sample_size, bool ledcontrol);
 * @return number of bits sampled
 **/
 uint32_t SampleLF(bool verbose, uint32_t sample_size, bool ledcontrol);
-uint32_t SampleLF_realtime(void);
+
+/**
+* SampleLF()/SniffLF() + ReadLF() + DoAcquisition_config() 
+* @return TBD
+**/
+int ReadLF_realtime(bool reader_field);
+
 /**
 * Initializes the FPGA for sniff-mode (field off), and acquires the samples.
 * @return number of bits sampled

--- a/armsrc/lfzx.c
+++ b/armsrc/lfzx.c
@@ -153,7 +153,7 @@ static void zx_get(bool ledcontrol) {
             volatile uint8_t sample = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
             (void)sample;
 
-            // Test point 8 (TP8) can be used to trigger oscilloscope
+            // (RDV4) Test point 8 (TP8) can be used to trigger oscilloscope
             if (ledcontrol) LED_D_OFF();
 
         }

--- a/armsrc/util.c
+++ b/armsrc/util.c
@@ -305,3 +305,11 @@ bool data_available(void) {
     return usb_poll_validate_length();
 #endif
 }
+
+bool data_available_fast(void) {
+#ifdef WITH_FPC_USART_HOST
+    return usb_available_length() > 0 || (usart_rxdata_available() > 0);
+#else
+    return usb_available_length() > 0;
+#endif
+}

--- a/armsrc/util.c
+++ b/armsrc/util.c
@@ -308,8 +308,8 @@ bool data_available(void) {
 
 bool data_available_fast(void) {
 #ifdef WITH_FPC_USART_HOST
-    return usb_available_length() > 0 || (usart_rxdata_available() > 0);
+    return usb_available_length() || (usart_rxdata_available() > 0);
 #else
-    return usb_available_length() > 0;
+    return usb_available_length();
 #endif
 }

--- a/armsrc/util.h
+++ b/armsrc/util.h
@@ -101,5 +101,6 @@ void SpinUp(uint32_t speed);
 int BUTTON_CLICKED(int ms);
 int BUTTON_HELD(int ms);
 bool data_available(void);
+bool data_available_fast(void);
 
 #endif

--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -1011,7 +1011,7 @@ static int CmdUndecimate(const char *Cmd) {
     CLIParserFree(ctx);
 
     //We have memory, don't we?
-    int swap[MAX_GRAPH_TRACE_LEN] = {0};
+    int *swap = calloc(MAX_GRAPH_TRACE_LEN, sizeof(int));
     uint32_t g_index = 0, s_index = 0;
     while (g_index < g_GraphTraceLen && s_index + factor < MAX_GRAPH_TRACE_LEN) {
         int count = 0;
@@ -1028,6 +1028,7 @@ static int CmdUndecimate(const char *Cmd) {
     memcpy(g_GraphBuffer, swap, s_index * sizeof(int));
     g_GraphTraceLen = s_index;
     RepaintGraphWindow();
+    free(swap);
     return PM3_SUCCESS;
 }
 

--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -1783,7 +1783,7 @@ int getSamplesEx(uint32_t start, uint32_t end, bool verbose, bool ignore_lf_conf
     return PM3_SUCCESS;
 }
 
-void getSamplesFromBufEx(uint8_t* data, size_t sample_num, uint8_t bits_per_sample, bool verbose) {
+void getSamplesFromBufEx(uint8_t *data, size_t sample_num, uint8_t bits_per_sample, bool verbose) {
 
     size_t max_num = MIN(sample_num, MAX_GRAPH_TRACE_LEN);
 

--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -1783,7 +1783,7 @@ int getSamplesEx(uint32_t start, uint32_t end, bool verbose, bool ignore_lf_conf
 
         BitstreamOut_t bout = { got, bits_per_sample * n,  0};
         uint32_t j = 0;
-        for (j = 0; j * bits_per_sample < n * 8 && j * bits_per_sample < MAX_GRAPH_TRACE_LEN * 8; j++) {
+        for (j = 0; j * bits_per_sample < n * 8 && j < MAX_GRAPH_TRACE_LEN; j++) {
             uint8_t sample = getByte(bits_per_sample, &bout);
             g_GraphBuffer[j] = ((int) sample) - 127;
         }
@@ -1792,7 +1792,7 @@ int getSamplesEx(uint32_t start, uint32_t end, bool verbose, bool ignore_lf_conf
         if (verbose) PrintAndLogEx(INFO, "Unpacked %d samples", j);
 
     } else {
-        for (uint32_t j = 0; j < n; j++) {
+        for (uint32_t j = 0; j < n && j < MAX_GRAPH_TRACE_LEN; j++) {
             g_GraphBuffer[j] = ((int)got[j]) - 127;
         }
         g_GraphTraceLen = n;

--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -1777,36 +1777,45 @@ int getSamplesEx(uint32_t start, uint32_t end, bool verbose, bool ignore_lf_conf
         bits_per_sample = sc->bits_per_sample;
     }
 
+    getSamplesFromBufEx(got, n, bits_per_sample, verbose);
+
+    return PM3_SUCCESS;
+}
+
+void getSamplesFromBufEx(uint8_t* data, size_t sample_num, uint8_t bits_per_sample, bool verbose) {
+
+    size_t max_num = MIN(sample_num, MAX_GRAPH_TRACE_LEN);
+
     if (bits_per_sample < 8) {
 
         if (verbose) PrintAndLogEx(INFO, "Unpacking...");
 
-        BitstreamOut_t bout = { got, bits_per_sample * n,  0};
-        uint32_t j = 0;
-        for (j = 0; j * bits_per_sample < n * 8 && j < MAX_GRAPH_TRACE_LEN; j++) {
+        BitstreamOut_t bout = {data, bits_per_sample * sample_num,  0};
+        size_t j = 0;
+        for (j = 0; j < max_num; j++) {
             uint8_t sample = getByte(bits_per_sample, &bout);
             g_GraphBuffer[j] = ((int) sample) - 127;
         }
         g_GraphTraceLen = j;
 
-        if (verbose) PrintAndLogEx(INFO, "Unpacked %d samples", j);
+        if (verbose) PrintAndLogEx(INFO, "Unpacked %zu samples", j);
 
     } else {
-        for (uint32_t j = 0; j < n && j < MAX_GRAPH_TRACE_LEN; j++) {
-            g_GraphBuffer[j] = ((int)got[j]) - 127;
+        for (size_t j = 0; j < max_num; j++) {
+            g_GraphBuffer[j] = ((int)data[j]) - 127;
         }
-        g_GraphTraceLen = n;
+        g_GraphTraceLen = max_num;
     }
 
-    uint8_t bits[g_GraphTraceLen];
+    uint8_t *bits = calloc(g_GraphTraceLen, sizeof(uint8_t));
     size_t size = getFromGraphBuf(bits);
     // set signal properties low/high/mean/amplitude and is_noise detection
     computeSignalProperties(bits, size);
+    free(bits);
 
     setClockGrid(0, 0);
     g_DemodBufferLen = 0;
     RepaintGraphWindow();
-    return PM3_SUCCESS;
 }
 
 static int CmdSamples(const char *Cmd) {
@@ -3585,4 +3594,3 @@ int CmdData(const char *Cmd) {
     clearCommandBuffer();
     return CmdsParse(CommandTable, Cmd);
 }
-

--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -1708,7 +1708,7 @@ int CmdHpf(const char *Cmd) {
     CLIExecWithReturn(ctx, Cmd, argtable, true);
     CLIParserFree(ctx);
 
-    uint8_t bits[g_GraphTraceLen];
+    uint8_t *bits = malloc(g_GraphTraceLen);
     size_t size = getFromGraphBuf(bits);
     removeSignalOffset(bits, size);
     // push it back to graph
@@ -1717,6 +1717,7 @@ int CmdHpf(const char *Cmd) {
     computeSignalProperties(bits, size);
 
     RepaintGraphWindow();
+    free(bits);
     return PM3_SUCCESS;
 }
 
@@ -2104,12 +2105,13 @@ static int CmdLoad(const char *Cmd) {
     PrintAndLogEx(SUCCESS, "loaded " _YELLOW_("%zu") " samples", g_GraphTraceLen);
 
     if (nofix == false) {
-        uint8_t bits[g_GraphTraceLen];
+        uint8_t *bits = malloc(g_GraphTraceLen);
         size_t size = getFromGraphBuf(bits);
 
         removeSignalOffset(bits, size);
         setGraphBuf(bits, size);
         computeSignalProperties(bits, size);
+        free(bits);
     }
 
     setClockGrid(0, 0);
@@ -2241,12 +2243,13 @@ int CmdNorm(const char *Cmd) {
         }
     }
 
-    uint8_t bits[g_GraphTraceLen];
+    uint8_t *bits = malloc(g_GraphTraceLen);
     size_t size = getFromGraphBuf(bits);
     // set signal properties low/high/mean/amplitude and is_noise detection
     computeSignalProperties(bits, size);
 
     RepaintGraphWindow();
+    free(bits);
     return PM3_SUCCESS;
 }
 
@@ -2387,12 +2390,13 @@ static int CmdDirectionalThreshold(const char *Cmd) {
     directionalThreshold(g_GraphBuffer, g_GraphBuffer, g_GraphTraceLen, up, down);
 
     // set signal properties low/high/mean/amplitude and isnoice detection
-    uint8_t bits[g_GraphTraceLen];
+    uint8_t *bits = malloc(g_GraphTraceLen);
     size_t size = getFromGraphBuf(bits);
     // set signal properties low/high/mean/amplitude and is_noice detection
     computeSignalProperties(bits, size);
 
     RepaintGraphWindow();
+    free(bits);
     return PM3_SUCCESS;
 }
 
@@ -2430,11 +2434,12 @@ static int CmdZerocrossings(const char *Cmd) {
         }
     }
 
-    uint8_t bits[g_GraphTraceLen];
+    uint8_t *bits = malloc(g_GraphTraceLen);
     size_t size = getFromGraphBuf(bits);
     // set signal properties low/high/mean/amplitude and is_noise detection
     computeSignalProperties(bits, size);
     RepaintGraphWindow();
+    free(bits);
     return PM3_SUCCESS;
 }
 
@@ -2743,11 +2748,12 @@ static int CmdDataIIR(const char *Cmd) {
 
     iceSimple_Filter(g_GraphBuffer, g_GraphTraceLen, k);
 
-    uint8_t bits[g_GraphTraceLen];
+    uint8_t *bits = malloc(g_GraphTraceLen);
     size_t size = getFromGraphBuf(bits);
     // set signal properties low/high/mean/amplitude and is_noise detection
     computeSignalProperties(bits, size);
     RepaintGraphWindow();
+    free(bits);
     return PM3_SUCCESS;
 }
 
@@ -3370,11 +3376,12 @@ static int CmdCenterThreshold(const char *Cmd) {
     centerThreshold(g_GraphBuffer, g_GraphBuffer, g_GraphTraceLen, up, down);
 
     // set signal properties low/high/mean/amplitude and isnoice detection
-    uint8_t bits[g_GraphTraceLen];
+    uint8_t *bits = malloc(g_GraphTraceLen);
     size_t size = getFromGraphBuf(bits);
     // set signal properties low/high/mean/amplitude and is_noice detection
     computeSignalProperties(bits, size);
     RepaintGraphWindow();
+    free(bits);
     return PM3_SUCCESS;
 }
 
@@ -3415,11 +3422,12 @@ static int CmdEnvelope(const char *Cmd) {
 
     envelope_square(g_GraphBuffer, g_GraphBuffer, g_GraphTraceLen);
 
-    uint8_t bits[g_GraphTraceLen];
+    uint8_t *bits = malloc(g_GraphTraceLen);
     size_t size = getFromGraphBuf(bits);
     // set signal properties low/high/mean/amplitude and is_noice detection
     computeSignalProperties(bits, size);
     RepaintGraphWindow();
+    free(bits);
     return PM3_SUCCESS;
 }
 

--- a/client/src/cmddata.h
+++ b/client/src/cmddata.h
@@ -86,6 +86,7 @@ int AutoCorrelate(const int *in, int *out, size_t len, size_t window, bool SaveG
 
 int getSamples(uint32_t n, bool verbose);
 int getSamplesEx(uint32_t start, uint32_t end, bool verbose, bool ignore_lf_config);
+void getSamplesFromBufEx(uint8_t* data, size_t sample_num, uint8_t bits_per_sample, bool verbose);
 
 void setClockGrid(uint32_t clk, int offset);
 int directionalThreshold(const int *in, int *out, size_t len, int8_t up, int8_t down);

--- a/client/src/cmddata.h
+++ b/client/src/cmddata.h
@@ -86,7 +86,7 @@ int AutoCorrelate(const int *in, int *out, size_t len, size_t window, bool SaveG
 
 int getSamples(uint32_t n, bool verbose);
 int getSamplesEx(uint32_t start, uint32_t end, bool verbose, bool ignore_lf_config);
-void getSamplesFromBufEx(uint8_t* data, size_t sample_num, uint8_t bits_per_sample, bool verbose);
+void getSamplesFromBufEx(uint8_t *data, size_t sample_num, uint8_t bits_per_sample, bool verbose);
 
 void setClockGrid(uint32_t clk, int offset);
 int directionalThreshold(const int *in, int *out, size_t len, int8_t up, int8_t down);

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -699,15 +699,8 @@ int CmdLFConfig(const char *Cmd) {
 static int lf_read_internal(bool realtime, bool verbose, uint32_t samples) {
     if (!g_session.pm3_present) return PM3_ENOTTY;
 
-    struct p {
-        // 64KB SRAM -> 524288 bits(max sample num) < 2^30
-        uint32_t samples  : 30;
-        bool     realtime : 1;
-        bool     verbose  : 1;
-    } PACKED;
-
-    struct p payload;
-    payload.samples = (samples & 0x3FFFFFFF);
+    lf_sample_config_t payload;
+    payload.samples = (samples > MAX_LF_SAMPLES) ? MAX_LF_SAMPLES : samples;
     payload.realtime = realtime;
     payload.verbose = verbose;
 
@@ -774,14 +767,8 @@ int CmdLFRead(const char *Cmd) {
 int lf_sniff(bool realtime, bool verbose, uint32_t samples) {
     if (!g_session.pm3_present) return PM3_ENOTTY;
 
-    struct p {
-        // 64KB SRAM -> 524288 bits(max sample num) < 2^ 30
-        uint32_t samples  : 30;
-        bool     realtime : 1;
-        bool     verbose  : 1;
-    } PACKED payload;
-
-    payload.samples = (samples & 0x3FFFFFFF);
+    lf_sample_config_t payload;
+    payload.samples = (samples > MAX_LF_SAMPLES) ? MAX_LF_SAMPLES : samples;
     payload.realtime = realtime;
     payload.verbose = verbose;
 

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -711,7 +711,7 @@ int lf_read(bool verbose, uint32_t samples) {
     clearCommandBuffer();
     SendCommandNG(CMD_LF_ACQ_RAW_ADC, (uint8_t *)&payload, sizeof(payload));
     PacketResponseNG resp;
-    if (gs_lf_threshold_set) {
+    if (gs_lf_threshold_set || verbose) {
         WaitForResponse(CMD_LF_ACQ_RAW_ADC, &resp);
     } else {
         if (!WaitForResponseTimeout(CMD_LF_ACQ_RAW_ADC, &resp, 2500)) {

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -696,7 +696,7 @@ int CmdLFConfig(const char *Cmd) {
     return lf_config(&config);
 }
 
-static int lf_read_internal(bool realtime, bool verbose, uint32_t samples) {
+static int lf_read_internal(bool realtime, bool verbose, uint64_t samples) {
     if (!g_session.pm3_present) return PM3_ENOTTY;
 
     lf_sample_config_t payload;
@@ -734,7 +734,7 @@ static int lf_read_internal(bool realtime, bool verbose, uint32_t samples) {
     return PM3_SUCCESS;
 }
 
-int lf_read(bool verbose, uint32_t samples) {
+int lf_read(bool verbose, uint64_t samples) {
     return lf_read_internal(false, verbose, samples);
 }
 
@@ -757,7 +757,7 @@ int CmdLFRead(const char *Cmd) {
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
-    uint32_t samples = arg_get_u32_def(ctx, 1, 0);
+    uint64_t samples = arg_get_u64_def(ctx, 1, 0);
     bool verbose = arg_get_lit(ctx, 2);
     bool cm = arg_get_lit(ctx, 3);
     bool realtime = arg_get_lit(ctx, 4);

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -696,11 +696,7 @@ int CmdLFConfig(const char *Cmd) {
     return lf_config(&config);
 }
 
-int lf_read(bool verbose, uint32_t samples) {
-    return lf_read_internal(false, verbose, samples);
-}
-
-int lf_read_internal(bool realtime, bool verbose, uint32_t samples) {
+static int lf_read_internal(bool realtime, bool verbose, uint32_t samples) {
     if (!g_session.pm3_present) return PM3_ENOTTY;
 
     struct p {
@@ -731,6 +727,10 @@ int lf_read_internal(bool realtime, bool verbose, uint32_t samples) {
     uint32_t size = (resp.data.asDwords[0] / 8);
     getSamples(size, verbose);
     return PM3_SUCCESS;
+}
+
+int lf_read(bool verbose, uint32_t samples) {
+    return lf_read_internal(false, verbose, samples);
 }
 
 int CmdLFRead(const char *Cmd) {

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -435,7 +435,7 @@ int CmdFlexdemod(const char *Cmd) {
 #endif
     int i, j, start, bit, sum;
 
-    int data[g_GraphTraceLen];
+    int *data = malloc(g_GraphTraceLen * sizeof(int));
     memcpy(data, g_GraphBuffer, g_GraphTraceLen);
 
     size_t size = g_GraphTraceLen;
@@ -456,6 +456,7 @@ int CmdFlexdemod(const char *Cmd) {
 
     if (start == size - LONG_WAIT) {
         PrintAndLogEx(WARNING, "nothing to wait for");
+        free(data);
         return PM3_ENODATA;
     }
 
@@ -499,6 +500,7 @@ int CmdFlexdemod(const char *Cmd) {
         }
     }
     RepaintGraphWindow();
+    free(data);
     return PM3_SUCCESS;
 }
 

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -723,7 +723,7 @@ static int lf_read_internal(bool realtime, bool verbose, uint64_t samples) {
         sample_bytes = (sample_bytes / 8) + (sample_bytes % 8 != 0);
         
         SendCommandNG(CMD_LF_ACQ_RAW_ADC, (uint8_t *)&payload, sizeof(payload));
-        sample_bytes = WaitForRawDataTimeout(realtimeBuf, sample_bytes, 1000, true);
+        sample_bytes = WaitForRawDataTimeout(realtimeBuf, sample_bytes, 1000 + FPGA_LOAD_WAIT_TIME, true);
         samples = sample_bytes * 8 / bits_per_sample;
         getSamplesFromBufEx(realtimeBuf, samples, bits_per_sample, verbose);
 
@@ -753,6 +753,7 @@ int lf_read(bool verbose, uint64_t samples) {
 }
 
 int CmdLFRead(const char *Cmd) {
+    // In real-time mode, the first few bytes might be the response of CMD_WTX rather than the real samples
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "lf read",
                   "Sniff low frequency signal.\n"
@@ -818,7 +819,7 @@ int lf_sniff(bool realtime, bool verbose, uint64_t samples) {
         sample_bytes = (sample_bytes / 8) + (sample_bytes % 8 != 0);
 
         SendCommandNG(CMD_LF_SNIFF_RAW_ADC, (uint8_t *)&payload, sizeof(payload));
-        sample_bytes = WaitForRawDataTimeout(realtimeBuf, sample_bytes, 1000, true);
+        sample_bytes = WaitForRawDataTimeout(realtimeBuf, sample_bytes, 1000 + FPGA_LOAD_WAIT_TIME, true);
         samples = sample_bytes * 8 / bits_per_sample;
         getSamplesFromBufEx(realtimeBuf, samples, bits_per_sample, verbose);
 
@@ -844,6 +845,7 @@ int lf_sniff(bool realtime, bool verbose, uint64_t samples) {
 }
 
 int CmdLFSniff(const char *Cmd) {
+    // In real-time mode, the first few bytes might be the response of CMD_WTX rather than the real samples
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "lf sniff",
                   "Sniff low frequency signal. You need to configure the LF part on the Proxmark3 device manually.\n"

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -734,7 +734,6 @@ static int lf_read_internal(bool realtime, bool verbose, uint64_t samples) {
         clearCommandBuffer();
         SendCommandNG(CMD_LF_ACQ_RAW_ADC, (uint8_t *)&payload, sizeof(payload));
         sample_bytes = WaitForRawDataTimeout(realtimeBuf, sample_bytes, 1000, true);
-        print_hex(realtimeBuf, 2048);
 
         // getSamplesEx() start
         if (current_config.bits_per_sample < 8) {
@@ -755,7 +754,7 @@ static int lf_read_internal(bool realtime, bool verbose, uint64_t samples) {
             for (size_t j = 0; j < sample_bytes && j < MAX_GRAPH_TRACE_LEN; j++) {
                 g_GraphBuffer[j] = ((int)realtimeBuf[j]) - 127;
             }
-            g_GraphTraceLen = sample_bytes;
+            g_GraphTraceLen = MIN(sample_bytes, MAX_GRAPH_TRACE_LEN);
         }
 
         uint8_t bits[g_GraphTraceLen];

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -749,7 +749,7 @@ static int lf_read_internal(bool realtime, bool verbose, uint64_t samples) {
             }
             g_GraphTraceLen = j;
 
-            if (verbose) PrintAndLogEx(INFO, "Unpacked %d samples", j);
+            if (verbose) PrintAndLogEx(INFO, "Unpacked %zu samples", j);
 
         } else {
             for (size_t j = 0; j < sample_bytes && j < MAX_GRAPH_TRACE_LEN; j++) {

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -718,10 +718,10 @@ static int lf_read_internal(bool realtime, bool verbose, uint64_t samples) {
 
     if (realtime) {
         uint8_t *realtimeBuf = calloc(samples, sizeof(uint8_t));
-        
+
         size_t sample_bytes = samples * bits_per_sample;
         sample_bytes = (sample_bytes / 8) + (sample_bytes % 8 != 0);
-        
+
         SendCommandNG(CMD_LF_ACQ_RAW_ADC, (uint8_t *)&payload, sizeof(payload));
         sample_bytes = WaitForRawDataTimeout(realtimeBuf, sample_bytes, 1000 + FPGA_LOAD_WAIT_TIME, true);
         samples = sample_bytes * 8 / bits_per_sample;
@@ -814,7 +814,7 @@ int lf_sniff(bool realtime, bool verbose, uint64_t samples) {
 
     if (realtime) {
         uint8_t *realtimeBuf = calloc(samples, sizeof(uint8_t));
-        
+
         size_t sample_bytes = samples * bits_per_sample;
         sample_bytes = (sample_bytes / 8) + (sample_bytes % 8 != 0);
 

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -742,7 +742,7 @@ static int lf_read_internal(bool realtime, bool verbose, uint64_t samples) {
 
             BitstreamOut_t bout = {realtimeBuf, sample_bytes * 8,  0};
             size_t j = 0;
-            for (j = 0; j * current_config.bits_per_sample < sample_bytes * 8 && j * current_config.bits_per_sample < MAX_GRAPH_TRACE_LEN * 8; j++) {
+            for (j = 0; j * current_config.bits_per_sample < sample_bytes * 8 && j < MAX_GRAPH_TRACE_LEN; j++) {
                 uint8_t sample = getByte(current_config.bits_per_sample, &bout);
                 g_GraphBuffer[j] = ((int) sample) - 127;
             }

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -698,20 +698,6 @@ int CmdLFConfig(const char *Cmd) {
     return lf_config(&config);
 }
 
-static bool _headBit(BitstreamOut_t *stream) {
-    int bytepos = stream->position >> 3; // divide by 8
-    int bitpos = (stream->position++) & 7; // mask out 00000111
-    return (*(stream->buffer + bytepos) >> (7 - bitpos)) & 1;
-}
-
-static uint8_t getByte(uint8_t bits_per_sample, BitstreamOut_t *b) {
-    uint8_t val = 0;
-    for (int i = 0 ; i < bits_per_sample; i++)
-        val |= (_headBit(b) << (7 - i));
-
-    return val;
-}
-
 static int lf_read_internal(bool realtime, bool verbose, uint64_t samples) {
     if (!g_session.pm3_present) return PM3_ENOTTY;
 
@@ -719,53 +705,24 @@ static int lf_read_internal(bool realtime, bool verbose, uint64_t samples) {
     payload.realtime = realtime;
     payload.verbose = verbose;
 
+    sample_config current_config;
+    int retval = lf_getconfig(&current_config);
+    if (retval != PM3_SUCCESS) {
+        PrintAndLogEx(ERR, "failed to get current device config");
+        return retval;
+    }
+    const uint8_t bits_per_sample = current_config.bits_per_sample;
+
     if (realtime) {
         uint8_t *realtimeBuf = calloc(samples, sizeof(uint8_t));
-
-        sample_config current_config;
-        int retval = lf_getconfig(&current_config);
-        if (retval != PM3_SUCCESS) {
-            PrintAndLogEx(ERR, "failed to get current device config");
-            return retval;
-        }
         
-        size_t sample_bytes = samples * current_config.bits_per_sample;
+        size_t sample_bytes = samples * bits_per_sample;
         sample_bytes = (sample_bytes / 8) + (sample_bytes % 8 != 0);
         clearCommandBuffer();
         SendCommandNG(CMD_LF_ACQ_RAW_ADC, (uint8_t *)&payload, sizeof(payload));
         sample_bytes = WaitForRawDataTimeout(realtimeBuf, sample_bytes, 1000, true);
 
-        // getSamplesEx() start
-        if (current_config.bits_per_sample < 8) {
-
-            if (verbose) PrintAndLogEx(INFO, "Unpacking...");
-
-            BitstreamOut_t bout = {realtimeBuf, sample_bytes * 8,  0};
-            size_t j = 0;
-            for (j = 0; j * current_config.bits_per_sample < sample_bytes * 8 && j < MAX_GRAPH_TRACE_LEN; j++) {
-                uint8_t sample = getByte(current_config.bits_per_sample, &bout);
-                g_GraphBuffer[j] = ((int) sample) - 127;
-            }
-            g_GraphTraceLen = j;
-
-            if (verbose) PrintAndLogEx(INFO, "Unpacked %zu samples", j);
-
-        } else {
-            for (size_t j = 0; j < sample_bytes && j < MAX_GRAPH_TRACE_LEN; j++) {
-                g_GraphBuffer[j] = ((int)realtimeBuf[j]) - 127;
-            }
-            g_GraphTraceLen = MIN(sample_bytes, MAX_GRAPH_TRACE_LEN);
-        }
-
-        uint8_t bits[g_GraphTraceLen];
-        size_t size = getFromGraphBuf(bits);
-        // set signal properties low/high/mean/amplitude and is_noise detection
-        computeSignalProperties(bits, size);
-
-        setClockGrid(0, 0);
-        g_DemodBufferLen = 0;
-        RepaintGraphWindow();
-        // getSamplesEx() end
+        getSamplesFromBufEx(realtimeBuf, samples, current_config.bits_per_sample, verbose);
 
         free(realtimeBuf);
     } else {
@@ -782,7 +739,7 @@ static int lf_read_internal(bool realtime, bool verbose, uint64_t samples) {
             }
         }
         // response is number of bits read
-        uint32_t size = (resp.data.asDwords[0] / 8);
+        uint32_t size = (resp.data.asDwords[0] / bits_per_sample);
         getSamples(size, verbose);
     }
 

--- a/client/src/cmdlf.h
+++ b/client/src/cmdlf.h
@@ -41,7 +41,8 @@ int CmdVchDemod(const char *Cmd);
 int CmdLFfind(const char *Cmd);
 
 int lf_read(bool verbose, uint32_t samples);
-int lf_sniff(bool verbose, uint32_t samples);
+int lf_read_internal(bool realtime, bool verbose, uint32_t samples);
+int lf_sniff(bool realtime, bool verbose, uint32_t samples);
 int lf_config(sample_config *config);
 int lf_getconfig(sample_config *config);
 int lfsim_upload_gb(void);

--- a/client/src/cmdlf.h
+++ b/client/src/cmdlf.h
@@ -41,7 +41,6 @@ int CmdVchDemod(const char *Cmd);
 int CmdLFfind(const char *Cmd);
 
 int lf_read(bool verbose, uint32_t samples);
-int lf_read_internal(bool realtime, bool verbose, uint32_t samples);
 int lf_sniff(bool realtime, bool verbose, uint32_t samples);
 int lf_config(sample_config *config);
 int lf_getconfig(sample_config *config);

--- a/client/src/cmdlf.h
+++ b/client/src/cmdlf.h
@@ -41,7 +41,7 @@ int CmdVchDemod(const char *Cmd);
 int CmdLFfind(const char *Cmd);
 
 int lf_read(bool verbose, uint64_t samples);
-int lf_sniff(bool realtime, bool verbose, uint32_t samples);
+int lf_sniff(bool realtime, bool verbose, uint64_t samples);
 int lf_config(sample_config *config);
 int lf_getconfig(sample_config *config);
 int lfsim_upload_gb(void);

--- a/client/src/cmdlf.h
+++ b/client/src/cmdlf.h
@@ -40,7 +40,7 @@ int CmdLFSniff(const char *Cmd);
 int CmdVchDemod(const char *Cmd);
 int CmdLFfind(const char *Cmd);
 
-int lf_read(bool verbose, uint32_t samples);
+int lf_read(bool verbose, uint64_t samples);
 int lf_sniff(bool realtime, bool verbose, uint32_t samples);
 int lf_config(sample_config *config);
 int lf_getconfig(sample_config *config);

--- a/client/src/cmdlfhid.c
+++ b/client/src/cmdlfhid.c
@@ -117,10 +117,11 @@ int demodHID(bool verbose) {
     //raw fsk demod no manchester decoding no start bit finding just get binary from wave
     uint32_t hi2 = 0, hi = 0, lo = 0;
 
-    uint8_t bits[g_GraphTraceLen];
+    uint8_t *bits = malloc(g_GraphTraceLen);
     size_t size = getFromGraphBuf(bits);
     if (size == 0) {
         PrintAndLogEx(DEBUG, "DEBUG: Error - " _RED_("HID not enough samples"));
+        free(bits);
         return PM3_ESOFT;
     }
     //get binary from fsk wave
@@ -146,6 +147,7 @@ int demodHID(bool verbose) {
 
     setDemodBuff(bits, size, idx);
     setClockGrid(50, waveIdx + (idx * 50));
+    free(bits);
 
     if (hi2 == 0 && hi == 0 && lo == 0) {
         PrintAndLogEx(DEBUG, "DEBUG: Error - " _RED_("HID no values found"));

--- a/client/src/cmdlfindala.c
+++ b/client/src/cmdlfindala.c
@@ -403,7 +403,7 @@ static int CmdIndalaDemodAlt(const char *Cmd) {
 
     // worst case with g_GraphTraceLen=40000 is < 4096
     // under normal conditions it's < 2048
-    uint8_t data[MAX_GRAPH_TRACE_LEN] = {0};
+    uint8_t *data = calloc(MAX_GRAPH_TRACE_LEN, sizeof(uint8_t));
     size_t datasize = getFromGraphBuf(data);
 
     uint8_t rawbits[4096] = {0};
@@ -446,6 +446,7 @@ static int CmdIndalaDemodAlt(const char *Cmd) {
             count = 0;
         }
     }
+    free(data);
 
     if (rawbit > 0) {
         PrintAndLogEx(INFO, "Recovered %d raw bits, expected: %zu", rawbit, g_GraphTraceLen / 32);

--- a/client/src/cmdlfio.c
+++ b/client/src/cmdlfio.c
@@ -66,10 +66,11 @@ static int CmdIOProxWatch(const char *Cmd) {
 int demodIOProx(bool verbose) {
     (void) verbose; // unused so far
     int idx = 0, retval = PM3_SUCCESS;
-    uint8_t bits[MAX_GRAPH_TRACE_LEN] = {0};
+    uint8_t *bits = calloc(MAX_GRAPH_TRACE_LEN, sizeof(uint8_t));
     size_t size = getFromGraphBuf(bits);
     if (size < 65) {
         PrintAndLogEx(DEBUG, "DEBUG: Error - IO prox not enough samples in GraphBuffer");
+        free(bits);
         return PM3_ESOFT;
     }
     //get binary from fsk wave
@@ -93,6 +94,7 @@ int demodIOProx(bool verbose) {
                 PrintAndLogEx(DEBUG, "DEBUG: Error - IO prox error demoding fsk %d", idx);
             }
         }
+        free(bits);
         return PM3_ESOFT;
     }
     setDemodBuff(bits, size, idx);
@@ -103,6 +105,7 @@ int demodIOProx(bool verbose) {
             PrintAndLogEx(DEBUG, "DEBUG: Error - IO prox data not found - FSK Bits: %zu", size);
             if (size > 92) PrintAndLogEx(DEBUG, "%s", sprint_bytebits_bin_break(bits, 92, 16));
         }
+        free(bits);
         return PM3_ESOFT;
     }
 
@@ -156,6 +159,7 @@ int demodIOProx(bool verbose) {
         printDemodBuff(0, false, false, true);
         printDemodBuff(0, false, false, false);
     }
+    free(bits);
     return retval;
 }
 

--- a/client/src/cmdlfparadox.c
+++ b/client/src/cmdlfparadox.c
@@ -103,10 +103,11 @@ static uint8_t GetParadoxBits(const uint32_t fc, const uint32_t cn, unsigned int
 int demodParadox(bool verbose, bool oldChksum) {
     (void) verbose; // unused so far
     //raw fsk demod no manchester decoding no start bit finding just get binary from wave
-    uint8_t bits[MAX_GRAPH_TRACE_LEN] = {0};
+    uint8_t *bits = calloc(MAX_GRAPH_TRACE_LEN, sizeof(uint8_t));
     size_t size = getFromGraphBuf(bits);
     if (size == 0) {
         PrintAndLogEx(DEBUG, "DEBUG: Error - Paradox not enough samples");
+        free(bits);
         return PM3_ESOFT;
     }
 
@@ -124,7 +125,8 @@ int demodParadox(bool verbose, bool oldChksum) {
             PrintAndLogEx(DEBUG, "DEBUG: Error - Paradox preamble not found");
         else
             PrintAndLogEx(DEBUG, "DEBUG: Error - Paradox error demoding fsk %d", idx);
-
+        
+        free(bits);
         return PM3_ESOFT;
     }
 
@@ -175,6 +177,7 @@ int demodParadox(bool verbose, bool oldChksum) {
 
     if (hi2 == 0 && hi == 0 && lo == 0) {
         PrintAndLogEx(DEBUG, "DEBUG: Error - Paradox no value found");
+        free(bits);
         return PM3_ESOFT;
     }
 
@@ -230,6 +233,7 @@ int demodParadox(bool verbose, bool oldChksum) {
         printDemodBuff(0, false, false, false);
     }
 
+    free(bits);
     return PM3_SUCCESS;
 }
 

--- a/client/src/cmdlfparadox.c
+++ b/client/src/cmdlfparadox.c
@@ -125,7 +125,7 @@ int demodParadox(bool verbose, bool oldChksum) {
             PrintAndLogEx(DEBUG, "DEBUG: Error - Paradox preamble not found");
         else
             PrintAndLogEx(DEBUG, "DEBUG: Error - Paradox error demoding fsk %d", idx);
-        
+
         free(bits);
         return PM3_ESOFT;
     }

--- a/client/src/cmdlfpyramid.c
+++ b/client/src/cmdlfpyramid.c
@@ -43,10 +43,11 @@ static int CmdHelp(const char *Cmd);
 int demodPyramid(bool verbose) {
     (void) verbose; // unused so far
     //raw fsk demod no manchester decoding no start bit finding just get binary from wave
-    uint8_t bits[MAX_GRAPH_TRACE_LEN] = {0};
+    uint8_t *bits = calloc(MAX_GRAPH_TRACE_LEN, sizeof(uint8_t));
     size_t size = getFromGraphBuf(bits);
     if (size == 0) {
         PrintAndLogEx(DEBUG, "DEBUG: Error - Pyramid not enough samples");
+        free(bits);
         return PM3_ESOFT;
     }
     //get binary from fsk wave
@@ -65,6 +66,7 @@ int demodPyramid(bool verbose) {
             PrintAndLogEx(DEBUG, "DEBUG: Error - Pyramid: size not correct: %zu", size);
         else
             PrintAndLogEx(DEBUG, "DEBUG: Error - Pyramid: error demoding fsk idx: %d", idx);
+        free(bits);
         return PM3_ESOFT;
     }
     setDemodBuff(bits, size, idx);
@@ -113,6 +115,7 @@ int demodPyramid(bool verbose) {
             PrintAndLogEx(DEBUG, "DEBUG: Error - Pyramid: parity check failed - IDX: %d, hi3: %08X", idx, rawHi3);
         else
             PrintAndLogEx(DEBUG, "DEBUG: Error - Pyramid: at parity check - tag size does not match Pyramid format, SIZE: %zu, IDX: %d, hi3: %08X", size, idx, rawHi3);
+        free(bits);
         return PM3_ESOFT;
     }
 
@@ -181,6 +184,7 @@ int demodPyramid(bool verbose) {
         printDemodBuff(0, false, false, false);
     }
 
+    free(bits);
     return PM3_SUCCESS;
 }
 

--- a/client/src/comms.h
+++ b/client/src/comms.h
@@ -96,10 +96,14 @@ void clearCommandBuffer(void);
 
 #define FLASHMODE_SPEED 460800
 bool IsCommunicationThreadDead(void);
+bool SetCommunicationReceiveMode(bool isRawMode);
+void SetCommunicationRawReceiveBuffer(uint8_t* buffer, size_t len);
+size_t GetCommunicationRawReceiveNum(void);
 bool OpenProxmark(pm3_device_t **dev, const char *port, bool wait_for_port, int timeout, bool flash_mode, uint32_t speed);
 int TestProxmark(pm3_device_t *dev);
 void CloseProxmark(pm3_device_t *dev);
 
+size_t WaitForRawData(uint8_t* buffer, size_t len, size_t ms_timeout, bool show_process);
 bool WaitForResponseTimeoutW(uint32_t cmd, PacketResponseNG *response, size_t ms_timeout, bool show_warning);
 bool WaitForResponseTimeout(uint32_t cmd, PacketResponseNG *response, size_t ms_timeout);
 bool WaitForResponse(uint32_t cmd, PacketResponseNG *response);
@@ -111,5 +115,3 @@ bool GetFromDevice(DeviceMemType_t memtype, uint8_t *dest, uint32_t bytes, uint3
 }
 #endif
 #endif
-
-

--- a/client/src/comms.h
+++ b/client/src/comms.h
@@ -97,13 +97,13 @@ void clearCommandBuffer(void);
 #define FLASHMODE_SPEED 460800
 bool IsCommunicationThreadDead(void);
 bool SetCommunicationReceiveMode(bool isRawMode);
-void SetCommunicationRawReceiveBuffer(uint8_t* buffer, size_t len);
+void SetCommunicationRawReceiveBuffer(uint8_t *buffer, size_t len);
 size_t GetCommunicationRawReceiveNum(void);
 bool OpenProxmark(pm3_device_t **dev, const char *port, bool wait_for_port, int timeout, bool flash_mode, uint32_t speed);
 int TestProxmark(pm3_device_t *dev);
 void CloseProxmark(pm3_device_t *dev);
 
-size_t WaitForRawData(uint8_t* buffer, size_t len, size_t ms_timeout, bool show_process);
+size_t WaitForRawDataTimeout(uint8_t *buffer, size_t len, size_t ms_timeout, bool show_process);
 bool WaitForResponseTimeoutW(uint32_t cmd, PacketResponseNG *response, size_t ms_timeout, bool show_warning);
 bool WaitForResponseTimeout(uint32_t cmd, PacketResponseNG *response, size_t ms_timeout);
 bool WaitForResponse(uint32_t cmd, PacketResponseNG *response);

--- a/client/src/graph.h
+++ b/client/src/graph.h
@@ -42,7 +42,7 @@ int GetNrzClock(const char *str, bool verbose);
 int GetFskClock(const char *str, bool verbose);
 bool fskClocks(uint8_t *fc1, uint8_t *fc2, uint8_t *rf1, int *firstClockEdge);
 
-#define MAX_GRAPH_TRACE_LEN (40000 * 8)
+#define MAX_GRAPH_TRACE_LEN (40000 * 16)
 #define GRAPH_SAVE 1
 #define GRAPH_RESTORE 0
 

--- a/client/src/graph.h
+++ b/client/src/graph.h
@@ -42,7 +42,7 @@ int GetNrzClock(const char *str, bool verbose);
 int GetFskClock(const char *str, bool verbose);
 bool fskClocks(uint8_t *fc1, uint8_t *fc2, uint8_t *rf1, int *firstClockEdge);
 
-#define MAX_GRAPH_TRACE_LEN (40000 * 16)
+#define MAX_GRAPH_TRACE_LEN (40000 * 32)
 #define GRAPH_SAVE 1
 #define GRAPH_RESTORE 0
 

--- a/common_arm/usb_cdc.c
+++ b/common_arm/usb_cdc.c
@@ -654,7 +654,7 @@ inline uint16_t usb_available_length(void) {
 bool usb_poll_validate_length(void) {
     if (!usb_check()) return false;
     if (!(pUdp->UDP_CSR[AT91C_EP_OUT] & btReceiveBank)) return false;
-    return usb_available_length() > 0;
+    return ((pUdp->UDP_CSR[AT91C_EP_OUT] & AT91C_UDP_RXBYTECNT) >> 16) > 0;
 }
 
 /*
@@ -676,7 +676,7 @@ uint32_t usb_read(uint8_t *data, size_t len) {
 
         if (pUdp->UDP_CSR[AT91C_EP_OUT] & bank) {
 
-            packetSize = usb_available_length();
+            packetSize = ((pUdp->UDP_CSR[AT91C_EP_OUT] & AT91C_UDP_RXBYTECNT) >> 16);
             packetSize = MIN(packetSize, len);
             len -= packetSize;
             while (packetSize--)
@@ -732,7 +732,7 @@ uint32_t usb_read_ng(uint8_t *data, size_t len) {
 
         if ((pUdp->UDP_CSR[AT91C_EP_OUT] & bank)) {
 
-            uint32_t available = usb_available_length();
+            uint32_t available = ((pUdp->UDP_CSR[AT91C_EP_OUT] & AT91C_UDP_RXBYTECNT) >> 16);
             packetSize = MIN(available, len);
             available -= packetSize;
             len -= packetSize;

--- a/common_arm/usb_cdc.c
+++ b/common_arm/usb_cdc.c
@@ -833,8 +833,9 @@ inline bool usb_write_request(void)
     while (pUdp->UDP_CSR[AT91C_EP_IN] & AT91C_UDP_TXCOMP) {};
 
     // can we write?
-    if ((pUdp->UDP_CSR[AT91C_EP_IN] & AT91C_UDP_TXPKTRDY) != 0) 
+    if ((pUdp->UDP_CSR[AT91C_EP_IN] & AT91C_UDP_TXPKTRDY) != 0) {
         return false;
+    }
 
     // start of transmission
     UDP_SET_EP_FLAGS(AT91C_EP_IN, AT91C_UDP_TXPKTRDY);

--- a/common_arm/usb_cdc.h
+++ b/common_arm/usb_cdc.h
@@ -30,6 +30,8 @@ bool usb_poll(void);
 bool usb_poll_validate_length(void);
 uint32_t usb_read(uint8_t *data, size_t len);
 int usb_write(const uint8_t *data, const size_t len);
+void usb_write_byte_async(uint8_t data);
+bool usb_write_request(void);
 uint32_t usb_read_ng(uint8_t *data, size_t len);
 void usb_update_serial(uint64_t newSerialNumber);
 

--- a/common_arm/usb_cdc.h
+++ b/common_arm/usb_cdc.h
@@ -27,11 +27,14 @@ void usb_disable(void);
 void usb_enable(void);
 bool usb_check(void);
 bool usb_poll(void);
+uint16_t usb_available_length(void);
 bool usb_poll_validate_length(void);
 uint32_t usb_read(uint8_t *data, size_t len);
 int usb_write(const uint8_t *data, const size_t len);
-void usb_write_byte_async(uint8_t data);
-bool usb_write_request(void);
+int async_usb_write_start(void);
+void async_usb_write_pushByte(uint8_t data);
+bool async_usb_write_requestWrite(void);
+int async_usb_write_stop(void);
 uint32_t usb_read_ng(uint8_t *data, size_t len);
 void usb_update_serial(uint64_t newSerialNumber);
 

--- a/include/common.h
+++ b/include/common.h
@@ -196,6 +196,9 @@ extern bool g_tearoff_enabled;
 #define CLEAR_BIT(data, i) *(data + (i / 8)) &= ~(1 << (7 - (i % 8)))
 #define FLIP_BIT(data, i)  *(data + (i / 8)) ^= (1 << (7 - (i % 8)))
 
+// time for decompressing and loading the image to the FPGA
+#define FPGA_LOAD_WAIT_TIME (1500)
+
 // GCC extension
 // from client/deps/tinycbor/compilersupport_p.h
 #ifdef __GNUC__

--- a/include/common.h
+++ b/include/common.h
@@ -196,4 +196,18 @@ extern bool g_tearoff_enabled;
 #define CLEAR_BIT(data, i) *(data + (i / 8)) &= ~(1 << (7 - (i % 8)))
 #define FLIP_BIT(data, i)  *(data + (i / 8)) ^= (1 << (7 - (i % 8)))
 
+// GCC extension
+// from client/deps/tinycbor/compilersupport_p.h
+#ifdef __GNUC__
+#ifndef likely
+#  define likely(x)     __builtin_expect(!!(x), 1)
+#endif
+#ifndef unlikely
+#  define unlikely(x)   __builtin_expect(!!(x), 0)
+#endif
+#else
+#  define likely(x)     (x)
+#  define unlikely(x)   (x)
+#endif
+
 #endif

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -283,7 +283,7 @@ typedef struct {
     uint32_t samples  : LF_SAMPLES_BITS;
     bool     realtime : 1;
     bool     verbose  : 1;
-} PACKED lf_sample_config_t;
+} PACKED lf_sample_payload_t;
 
 typedef struct {
     uint8_t blockno;

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -274,6 +274,17 @@ typedef struct {
     uint8_t data[];
 } PACKED lf_hitag_t;
 
+// For CMD_LF_SNIFF_RAW_ADC and CMD_LF_ACQ_RAW_ADC
+#define LF_SAMPLES_BITS 30
+#define MAX_LF_SAMPLES ((((uint32_t)1u) << LF_SAMPLES_BITS) - 1)
+
+typedef struct {
+    // 64KB SRAM -> 524288 bits(max sample num) < 2^30
+    uint32_t samples  : LF_SAMPLES_BITS;
+    bool     realtime : 1;
+    bool     verbose  : 1;
+} PACKED lf_sample_config_t;
+
 typedef struct {
     uint8_t blockno;
     uint8_t keytype;


### PR DESCRIPTION
1. The client side doesn't handle these samples. To get the samples, you need to run socat with -x option to log the data, then plot it somewhere.
2. ~~When starting bulk tranfer, \~3 samples will lost due to the time cost.~~ Some of the USB transfer payload can be distributed into every sample. (Done in 523fde21a4ce0e62ed299cce3ed2cb6814f67ffa)
3. ~~I use the verbose option as a flag for real-time sampling~~ (`-r` for real-time sampling)