### PR TITLE
mfkey: add explicit -lpthread link directive to Makefile for linux builds

### DIFF
--- a/tools/mfkey/Makefile
+++ b/tools/mfkey/Makefile
@@ -19,6 +19,7 @@ endif
 # macOS doesn't like these compiler params
 ifneq ($(platform),Darwin)
     MYCFLAGS += --param max-completely-peeled-insns=1000 --param max-completely-peel-times=10000
+    MYLDLIBS += -lpthread -latomic
 endif
 
 mfkey32 : $(OBJDIR)/mfkey32.o $(MYOBJS)


### PR DESCRIPTION
`nested_util.c` requires pthread support. Prior to release 2.34 of glibc (around Aug 2021), libpthread was a separate library that needed to be explicitly supplied to the linker. Add the directive to make all linux builds happy.