### PR TITLE
Fix pthreads on older gcc

### DIFF
--- a/tools/mfkey/Makefile
+++ b/tools/mfkey/Makefile
@@ -9,6 +9,11 @@ INSTALLTOOLS = $(BINS)
 
 include ../../Makefile.host
 
+# nested_util.c needs pthread support.  Older glibc needs it externally
+ifneq ($(SKIPPTHREAD),1)
+    MYLDLIBS += -lpthread
+endif
+
 # checking platform can be done only after Makefile.host
 ifneq (,$(findstring MINGW,$(platform)))
     # Mingw uses by default Microsoft printf, we want the GNU printf (e.g. for %z)


### PR DESCRIPTION
- Used $(SKIPPTHREAD) test result from client/CMakeLists.txt
- Tested on Debian Linux 11 (bullseye), build issue resolved
