### PR TITLE
Fix client build with Python 3.12

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -273,7 +273,7 @@ ifneq ($(SKIPPYTHON),1)
     PYTHONLDLIBS = $(shell $(PKG_CONFIG_ENV) pkg-config --libs python3 2>/dev/null)
     ifneq ($(PYTHONLDLIBS),)
         PYTHONLIBLD = $(PYTHONLDLIBS)
-        PYTHONLIBINC = $(PYTHONINCLUDES)
+        PYTHONLIBINC = $(subst -I,-isystem ,$(PYTHONINCLUDES))
         PYTHON_FOUND = 1
     else
         # since python3.8, applications willing to embed python must use -embed:
@@ -281,7 +281,7 @@ ifneq ($(SKIPPYTHON),1)
         PYTHONLDLIBS = $(shell $(PKG_CONFIG_ENV) pkg-config --libs python3-embed 2>/dev/null)
         ifneq ($(PYTHONLDLIBS),)
             PYTHONLIBLD = $(PYTHONLDLIBS)
-            PYTHONLIBINC = $(PYTHONINCLUDES)
+            PYTHONLIBINC = $(subst -I,-isystem ,$(PYTHONINCLUDES))
             PYTHON_FOUND = 1
         endif
     endif


### PR DESCRIPTION
This fixes issue #2182

The issue is caused by upstream bug
https://github.com/python/cpython/issues/106560
The fix is like this
https://github.com/intel-media-ci/gstreamer/commit/bbdf6d46539061bf171319ae51999f061148ecbc