### PR TITLE
Fix `ExchangeAPDUSC()` in `cmdsmartcard.c`

### DIFF
--- a/client/src/cmdsmartcard.c
+++ b/client/src/cmdsmartcard.c
@@ -1417,6 +1417,10 @@ int ExchangeAPDUSC(bool verbose, uint8_t *datain, int datainlen, bool activateCa
         SendCommandNG(CMD_SMART_RAW, (uint8_t *)payload, sizeof(smart_card_raw_t) + 5);
         datain[4] = 0;
         len = smart_responseEx(dataout, maxdataoutlen, verbose);
+        if (len < 0) {
+            free(payload);
+            return 1;
+        }
     }
 
     free(payload);


### PR DESCRIPTION
This fixes #2184
`ExchangeAPDUSC()` in `cmdsmartcard.c` doesn't return 1 if the retry fails, which is different from the behavior of the first try.
`Iso7816ExchangeEx()` will treat the negative length as the valid one when the failed retry occurs. This causes overflow when accessing `result[*result_len]`