### PR TITLE
Use defined return value

### DIFF
--- a/client/src/cmdsmartcard.c
+++ b/client/src/cmdsmartcard.c
@@ -1402,7 +1402,7 @@ int ExchangeAPDUSC(bool verbose, uint8_t *datain, int datainlen, bool activateCa
     int len = smart_responseEx(dataout, maxdataoutlen, verbose);
     if (len < 0) {
         free(payload);
-        return 1;
+        return PM3_ESOFT;
     }
 
     // retry
@@ -1419,13 +1419,13 @@ int ExchangeAPDUSC(bool verbose, uint8_t *datain, int datainlen, bool activateCa
         len = smart_responseEx(dataout, maxdataoutlen, verbose);
         if (len < 0) {
             free(payload);
-            return 1;
+            return PM3_ESOFT;
         }
     }
 
     free(payload);
     *dataoutlen = len;
-    return 0;
+    return PM3_SUCCESS;
 }
 
 bool smart_select(bool verbose, smart_card_atr_t *atr) {

--- a/client/src/iso7816/iso7816core.c
+++ b/client/src/iso7816/iso7816core.c
@@ -153,7 +153,7 @@ int Iso7816ExchangeEx(Iso7816CommandChannel channel, bool activate_field, bool l
                 res = ExchangeAPDUSC(false, data, datalen, activate_field, leave_field_on, result, (int)max_result_len, (int *)result_len);
             }
 
-            if (res) {
+            if (res != PM3_SUCCESS) {
                 return res;
             }
             break;


### PR DESCRIPTION
As @iceman1001 suggested in https://github.com/RfidResearchGroup/proxmark3/pull/2186#issuecomment-1826192861

I've checked all the usages of `ExchangeAPDUSC()`. Only the call in `Iso7816ExchangeEx()` uses the return value of `ExchangeAPDUSC()`, and the code there can handle the negative return value (`PM3_Exxx`)