### PR TITLE
Fix iClass dump truncating the AA2 area and improve dump reliability by fixing cmd retry delays.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed `hf iclass dump` truncating AA2 blocks and improve reliability (@nvx)
  - Added some info about UMC in "doc/magic_cards_notes.md" (@temskiy)
 
 ## [Faraday.4.17511][2023-11-13]

--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -1254,6 +1254,12 @@ static bool iclass_send_cmd_with_retries(uint8_t *cmd, size_t cmdsize, uint8_t *
         if (res == PM3_SUCCESS && expected_size == resp_len) {
             return true;
         }
+
+        // Timed out waiting for the tag to reply, but perhaps the tag did hear the command and is attempting to reply
+        // So wait long enough for the tag to encode it's reply plus required frame delays on each side before retrying
+        // And then double it, because in practice it seems to make it much more likely to succeed
+        // Response time calculation from expected_size lifted from GetIso15693AnswerFromTag
+        *start_time = *eof_time + ((DELAY_ICLASS_VICC_TO_VCD_READER + DELAY_ISO15693_VCD_TO_VICC_READER + (expected_size * 8 * 8 * 16)) * 2);
     }
     return false;
 }
@@ -1739,7 +1745,7 @@ void iClass_Dump(uint8_t *msg) {
         } PACKED response;
 
         response.isOK = dumpsuccess;
-        response.block_cnt = i;
+        response.block_cnt = i - cmd->start_block;
         response.bb_offset = dataout - BigBuf_get_addr();
         reply_ng(CMD_HF_ICLASS_DUMP, PM3_SUCCESS, (uint8_t *)&response, sizeof(response));
     }

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -2067,17 +2067,15 @@ static int CmdHFiClassDump(const char *Cmd) {
         return PM3_ETIMEOUT;
     }
 
-    if (pagemap == PICOPASS_NON_SECURE_PAGEMODE) {
-        // all memory available
-        memcpy(tag_data + (8 * 3), tempbuf + (8 * 3), (blocks_read * 8));
-    } else {
+    if (pagemap != PICOPASS_NON_SECURE_PAGEMODE) {
         // div key KD
-        memcpy(tag_data + (8 * 3), tempbuf + (8 * 3), 8);
-        // AIA data
-        memcpy(tag_data + (8 * 5), tempbuf + (8 * 5), 8);
-        // AA1 data
-        memcpy(tag_data + (8 * 6), tempbuf + (8 * 6), ((blocks_read - 6) * 8));
+        memcpy(tag_data + (PICOPASS_BLOCK_SIZE * 3),
+            tempbuf + (PICOPASS_BLOCK_SIZE * 3), PICOPASS_BLOCK_SIZE);
     }
+    // all memory available
+    memcpy(tag_data + (PICOPASS_BLOCK_SIZE * payload.start_block),
+           tempbuf + (PICOPASS_BLOCK_SIZE * payload.start_block),
+           blocks_read * PICOPASS_BLOCK_SIZE);
 
     uint16_t bytes_got = (app_limit1 + 1) * 8;
 
@@ -2135,12 +2133,14 @@ static int CmdHFiClassDump(const char *Cmd) {
         }
 
         // div key KC
-        memcpy(tag_data + (8 * 4), tempbuf + (8 * 4), 8);
+        memcpy(tag_data + (PICOPASS_BLOCK_SIZE * 4), tempbuf + (PICOPASS_BLOCK_SIZE * 4), PICOPASS_BLOCK_SIZE);
 
         // AA2 data
-        memcpy(tag_data + (8 * (app_limit1 + 1)), tempbuf + (8 * (app_limit1 + 1)), (blocks_read * 8));
+        memcpy(tag_data + (PICOPASS_BLOCK_SIZE * payload.start_block),
+            tempbuf + (PICOPASS_BLOCK_SIZE * payload.start_block),
+            blocks_read * PICOPASS_BLOCK_SIZE);
 
-        bytes_got = (blocks_read * 8);
+        bytes_got += (blocks_read * PICOPASS_BLOCK_SIZE);
 
         aa2_success = true;
     }
@@ -3036,7 +3036,7 @@ void printIclassDumpContents(uint8_t *iclass_dump, uint8_t startblock, uint8_t e
     int sio_start_block = 0, sio_end_block = 0;
     if (sio_start && sio_length > 0) {
         sio_start_block = (sio_start - iclass_dump) / PICOPASS_BLOCK_SIZE;
-        sio_end_block = sio_start_block + (sio_length + PICOPASS_BLOCK_SIZE - 1) / PICOPASS_BLOCK_SIZE - 1;
+        sio_end_block = sio_start_block + ((sio_length + PICOPASS_BLOCK_SIZE - 1) / PICOPASS_BLOCK_SIZE) - 1;
     }
 
     int i = startblock;
@@ -3107,7 +3107,7 @@ void printIclassDumpContents(uint8_t *iclass_dump, uint8_t startblock, uint8_t e
 
             regular_print_block = true;
         } else {
-            const char *info_ks[] = {"CSN", "Config", "E-purse", "Debit", "Credit", "AIA", "User"};
+            const char *info_ks[] = {"CSN", "Config", "E-purse", "Debit", "Credit", "AIA", "User", "User AA2"};
 
             if (i >= 6 && i <= 9 && is_legacy) {
                 // legacy credential
@@ -3132,6 +3132,8 @@ void printIclassDumpContents(uint8_t *iclass_dump, uint8_t startblock, uint8_t e
             } else {
                 if (i < 6) {
                     block_info = info_ks[i];
+                } else if (i > hdr->conf.app_limit) {
+                    block_info = info_ks[7];
                 } else {
                     block_info = info_ks[6];
                 }
@@ -3156,7 +3158,7 @@ void printIclassDumpContents(uint8_t *iclass_dump, uint8_t startblock, uint8_t e
 
             if (in_repeated_block == false) {
                 PrintAndLogEx(INFO,
-                              "%3d/0x%02X | %s | %s | %s ",
+                              "%3d/0x%02X | %s | %s | %s",
                               i,
                               i,
                               sprint_hex_ascii(blk, 8),


### PR DESCRIPTION
Fixes a couple of bugs, the first being that `block_cnt` was actually the last block read not the block count, but was being used as both depending on context. This meant dumping eg a 16k card with both debit and credit keys specified would only dump blocks 0-236 truncating the last 19 blocks when AA2 first block was 19 (236+19=255). The new code now dumps all 256 blocks (0-255) for a 16k card.

While dumping full 16k blocks a bunch of times to test  this, I noticed if coupling wasn't perfect it would fail on a few of the blocks which seemed strange as the code should have retried any failed reads. Looking closer at the trace I noticed the retry logic seemed to immediately retry so all 3 attempts failed - even though it read the block before and after perfectly fine. I realised this was because it was retrying almost immediately, when in reality the card may have head the command and started replying but we missed the reply - as such our logic should be to wait the time it would have taken the card to reply first before retrying. In reality when testing I found waiting 2x as long made it much more reliable so that's what the code does now.

I also did a little cleanup replacing some magic numbers with PICOPASS_BLOCK_SIZE in the memcpys I was touching.