### PR TITLE
Fix corrupted data caused by CMD_WTX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed the corrupted data in real-time sampling (@wh201906)
  - Added a slider in the plot window for navigation (@wh201906)
  - Fixed client build bug with Python 3.12 (@wh201906)
  - Fixed `ExchangeAPDUSC()` in `cmdsmartcard.c` to prevent client crash (@wh201906)

--- a/armsrc/fpgaloader.h
+++ b/armsrc/fpgaloader.h
@@ -24,12 +24,6 @@
 #define FpgaDisableSscDma(void) AT91C_BASE_PDC_SSC->PDC_PTCR = AT91C_PDC_RXTDIS;
 #define FpgaEnableSscDma(void) AT91C_BASE_PDC_SSC->PDC_PTCR = AT91C_PDC_RXTEN;
 
-// definitions for multiple FPGA config files support
-#define FPGA_BITSTREAM_LF 1
-#define FPGA_BITSTREAM_HF 2
-#define FPGA_BITSTREAM_HF_FELICA 3
-#define FPGA_BITSTREAM_HF_15 4
-
 /*
  Communication between ARM / FPGA is done inside armsrc/fpgaloader.c see: function FpgaSendCommand()
  Send 16 bit command / data pair to FPGA with the bit format:

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -4249,7 +4249,7 @@ int CmdHF14AMfELoad(const char *Cmd) {
 
     // ICEMAN:  bug.  if device has been using ICLASS commands,
     // the device needs to load the HF fpga image. It takes 1.5 second.
-    set_fpga_mode(2);
+    set_fpga_mode(FPGA_BITSTREAM_HF);
 
     // use RDV4 spiffs
     if (use_spiffs && IfPm3Flash() == false) {
@@ -8006,7 +8006,7 @@ static int CmdHF14AGen4Save(const char *Cmd) {
 
     // ICEMAN:  bug.  if device has been using ICLASS commands,
     // the device needs to load the HF fpga image. It takes 1.5 second.
-    set_fpga_mode(2);
+    set_fpga_mode(FPGA_BITSTREAM_HF);
 
     // validations
     if (pwd_len != 4 && pwd_len != 0) {

--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -1105,7 +1105,7 @@ static int CmdBreak(const char *Cmd) {
 }
 
 int set_fpga_mode(uint8_t mode) {
-    if (mode < 1 || mode > 4) {
+    if (mode < FPGA_BITSTREAM_LF || mode > FPGA_BITSTREAM_HF_15) {
         return PM3_EINVARG;
     }
     uint8_t d[] = {mode};

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -847,6 +847,11 @@ typedef struct {
 # define UART_TCP_LOCAL_CLIENT_RX_TIMEOUT_MS  40
 # define UART_UDP_LOCAL_CLIENT_RX_TIMEOUT_MS  20
 
+// definitions for multiple FPGA config files support
+#define FPGA_BITSTREAM_LF 1
+#define FPGA_BITSTREAM_HF 2
+#define FPGA_BITSTREAM_HF_FELICA 3
+#define FPGA_BITSTREAM_HF_15 4
 
 // CMD_DEVICE_INFO response packet has flags in arg[0], flag definitions:
 /* Whether a bootloader that understands the g_common_area is present */


### PR DESCRIPTION
1. Make sure the LF bitstream is loaded before real-time sampling so the response of CMD_WTX won't appear.
2. Decrease the wait time from 2.5s (1s + FPGA_LOAD_WAIT_TIME) to 1s if the real-time sampling stops. 
