### PR TITLE
cmdtrace.c: fix segfault in 'trace list' after failed load

### DIFF
--- a/client/src/cmdtrace.c
+++ b/client/src/cmdtrace.c
@@ -1293,7 +1293,7 @@ int CmdTraceList(const char *Cmd) {
 
     if (use_buffer == false) {
         download_trace();
-    } else if (gs_traceLen == 0) {
+    } else if (gs_traceLen == 0 || gs_trace ==NULL) {
         PrintAndLogEx(FAILED, "You requested a trace list in offline mode but there is no trace.");
         PrintAndLogEx(FAILED, "Consider using " _YELLOW_("`trace load`") " or removing parameter " _YELLOW_("`-1`"));
         return PM3_EINVARG;

--- a/client/src/cmdtrace.c
+++ b/client/src/cmdtrace.c
@@ -1094,8 +1094,9 @@ static int CmdTraceLoad(const char *Cmd) {
     CLIParserFree(ctx);
 
     if (gs_trace) {
-        free(gs_trace);
+        free(gs_trace);	// maybe better to not clobber this until we have successful load?
         gs_trace = NULL;
+	gs_traceLen = 0;
     }
 
     size_t len = 0;


### PR DESCRIPTION
When a trace is loaded, then a subsequent load fails, 'trace list' segfaults because CmdTraceLoad frees gs_trace but doesn't zero the length, and CmdTraceList doesn't check for NULL.  Fixed.