### PR TITLE
Fix Mifare Classic sim with interactive and reader attack mode never returning console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Fixed `hf iclass dump` truncating AA2 blocks and improve reliability (@nvx)
  - Added some info about UMC in "doc/magic_cards_notes.md" (@temskiy)
  - Added standalone mode `hf_unisniff` combining 14a/14b/15 sniffing with extra flash save options (@hazardousvoltage)
+ - Fixed `hf mf sim -ix` never returning console (@datatags)
 
 ## [Faraday.4.17511][2023-11-13]
  - Fixed Python support of `experimental_client_with_swig` (@doegox)

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -3890,6 +3890,7 @@ static int CmdHF14AMfSim(const char *Cmd) {
             nonces_t data[1];
             memcpy(data, resp.data.asBytes, sizeof(data));
             readerAttack(k_sector, k_sectors_cnt, data[0], setEmulatorMem, verbose);
+            break;
         }
         //iceman:  readerAttack call frees k_sector.  this call below is useless.
         showSectorTable(k_sector, k_sectors_cnt);


### PR DESCRIPTION
The help for `hf mf sim` says that if `-i` is passed, "Console will not be returned until simulation finishes or is aborted." However, when using interactive with the reader attack option (`hf mf sim -ix`), the console does not return when the simulation is finished or when the button is pressed.

This seems to be because in `cmdhfmf.c`, it continues waiting for more `CMD_ACK`s after processing the information from the device, while the device only sends `CMD_ACK` once (after the simulation is finished or the button is pressed.) Adding `break` after the `readerAttack` line seems to fix this, and doesn't seem to cause any other issues.