### PR TITLE
Clear bss on bootloader start.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed bootloader to correctly clear bss segment on start. Fixes USB serial number sometimes not working in the bootloader (@nvx)
  - Change `notes on downgrade attacks` - reworked the original text follow repo style (@iceman1001)
  - Added `hf mf info` command and static encrypted nonce detection (@merlokk)
  - Added Saflok KDF - generate MFC keys (@h1kari)

--- a/bootrom/bootrom.c
+++ b/bootrom/bootrom.c
@@ -30,7 +30,7 @@
 common_area_t g_common_area __attribute__((section(".commonarea")));
 uint32_t start_addr, end_addr;
 bool bootrom_unlocked;
-extern uint32_t _bootrom_start[], _bootrom_end[], _flash_start[], _flash_end[], _osimage_entry[];
+extern uint32_t _bootrom_start[], _bootrom_end[], _flash_start[], _flash_end[], _osimage_entry[], __bss_start__[], __bss_end__[];
 
 static int reply_old(uint64_t cmd, uint64_t arg0, uint64_t arg1, uint64_t arg2, void *data, size_t len) {
     PacketResponseOLD txcmd;
@@ -268,6 +268,10 @@ static void flash_mode(void) {
 
 void BootROM(void);
 void BootROM(void) {
+    /* Set up (that is: clear) BSS. */
+    uint32_t *bss_dst = __bss_start__;
+    while (bss_dst < __bss_end__) *bss_dst++ = 0;
+
     //------------
     // First set up all the I/O pins; GPIOs configured directly, other ones
     // just need to be assigned to the appropriate peripheral.


### PR DESCRIPTION
This fixes a bug with the USB device serial number sometimes not working in bootloader mode.