### PR TITLE
Add a note on building in a docker image instead

### DIFF
--- a/doc/fpga_arm_notes.md
+++ b/doc/fpga_arm_notes.md
@@ -69,7 +69,7 @@ There is very rarely changes to the images so there is no need to setup a fpga t
 Since the FPGA is very old,  the Xilinx WebPack ISE 10.1  is the last working tool chain.  You can download this legacy development on Xilinx and register for a free product installation id.
 Or use mine  `11LTAJ5ZJK3PXTUBMF0C0J6C4`    The package to download is about 7Gb and linux based.   Though I recently managed to install it on WSL for Windows 10.
 
-There is a docker image with webpack built in which has been built which you can use to easily compile the images:
+There is a docker image with webpack installed which has been built which you can use to easily compile the images:
 
 ```
 docker pull nhutton/prox-container:webp_image_complete

--- a/doc/fpga_arm_notes.md
+++ b/doc/fpga_arm_notes.md
@@ -69,6 +69,15 @@ There is very rarely changes to the images so there is no need to setup a fpga t
 Since the FPGA is very old,  the Xilinx WebPack ISE 10.1  is the last working tool chain.  You can download this legacy development on Xilinx and register for a free product installation id.
 Or use mine  `11LTAJ5ZJK3PXTUBMF0C0J6C4`    The package to download is about 7Gb and linux based.   Though I recently managed to install it on WSL for Windows 10.
 
+There is a docker image with webpack built in which has been built which you can use to easily compile the images:
+
+```
+docker pull nhutton/prox-container:webp_image_complete
+docker run -v <LOCAL_PATH>/proxmark3:/tmp --rm -it nhutton/prox-container:webp_image_complete bash
+$ cd /tmp/proxmark/fpga
+$ make all
+```
+
 In order to save space,  these fpga images are LZ4 compressed and included in the fullimage.elf file when compiling the ARM SRC.  `make armsrc`
 This means we save some precious space on the ARM but its a bit more complex when flashing to fpga since it has to decompress on the fly.  
 


### PR DESCRIPTION
The note should be pretty self-explanatory.

It should be simple for the reviewer to test this works. Delete a bit file and follow this method to recreate it. I don't know if there is a proxmark docker repo, but if there is, it should be a simple matter to retag it and push it to there, instead.

Tested on M1 mac and x86 ubuntu.

==========================================================

Perhaps there was an easier way, but...

For future reference to anyone reading this PR, to install Xilinx WebPack ISE 10.1 it was downloaded as a zip, mounted into a linux container and then during the install the gui installation popups were forwarded back to the host (ubuntu 22.04.1) with the following command:

`docker run -v <LOCAL_PATH>:/tmp --rm -it -v $XAUTHORITY:/tmp/.XAuthority -e XAUTHORITY=/tmp/.XAuthority  --net=host -e DISPLAY=:0 i686/ubuntu bash`

Inside the container, the `linux32` command was needed to trick the install process into being happy about the running architecture. This was only required for the install.

The docker image after the install can be 'frozen' using `docker commit` which allows you to restart it as it was (minus environment variables which have to be added to the .bashrc).