### PR TITLE
Extended documentation for magic tags

### DIFF
--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -34,6 +34,7 @@ Useful docs:
      * [FUID](#fuid)
      * [UFUID](#ufuid)
      * [ZUID](#zuid)
+     * [GDM](#gdm)
   * [MIFARE Classic, other versions](#mifare-classic-other-versions)
   * [MIFARE Classic Super](#mifare-classic-super)
 - [MIFARE Ultralight](#mifare-ultralight)
@@ -878,7 +879,7 @@ No implemented commands today
 ^[Top](#top)
 | Factory configuration | Name |
 | --- | --- |
-| 850000000000000000005A5A00000008 | GDMIC |
+| 850000000000000000005A5A00000008 | GDM |
 | 850000000000005A0000005A5A5A0008 | UCUID |
 | 8500000000005A00005A005A005A0008 | "7 byte hard" |
 | 7AFF850102015A00005A005A005A0008 | M1-7B |
@@ -900,7 +901,7 @@ Known as "write only once", which is only partially true.
 
 Allows direct write to block 0 only when UID is default `AA55C396`. But always could be rewritten multiple times with backdoors commands.
 
-Backdoor commands are available even after the personalization and makes that card detectable.
+Backdoor commands are available even after the personalization and makes that tag detectable.
 
 That's a key difference from [OTP](#mifare-classic-direct-write-otp)/[OTP 2.0](#mifare-classic-otp-2.0) tags.
 
@@ -933,7 +934,7 @@ More correct detection should be based on a backdoor commands and configuration 
 [usb] pm3 --> hf 14a raw -c -k -a E000
 [+] 7A FF 85 00 00 00 00 00 00 FF 00 00 00 00 00 08 [ 66 92 ]
 ```
-### Proxmark3 commands
+### Commands
 ^[Top](#top)
 
 * Commands described under the corresponding section of USCUID chip
@@ -958,9 +959,9 @@ More correct detection should be based on a backdoor commands and configuration 
 ## UFUID
 ^[Top](#top)
 
-The card is positioned as "sealable UID", so that means you could use the same commands, as you could use for UID chip in a default state. But after the sealing (changing the configuration) card will not answer to the backdoor commands and will behave as a normal Mifare Classic card. 
+The tag is positioned as "sealable UID", so that means you could use the same commands, as you could use for UID chip in a default state. But after the sealing (changing the configuration) tag will not answer to the backdoor commands and will behave as a normal Mifare Classic tag. 
 
-*But at the same time there is some unidentified behavior, which doesn't fully corresponds the protocol and original Mifare Classic cards. So the card could be filtered out with a protocol-based filters (i.e. Iron Logic OTP2 filter).* 
+*But at the same time there is some unidentified behavior, which doesn't fully corresponds the protocol and original Mifare Classic tags. So the tag could be filtered out with a protocol-based filters (i.e. Iron Logic OTP2 filter).* 
 
 ### Characteristics
 ^[Top](#top)
@@ -980,7 +981,7 @@ hf 14a info
 
 ```
 
-Currently Proxmark3 doesn't identify it as a sepatate card. 
+Currently Proxmark3 doesn't identify it as a separate tag. 
 Before the sealing could be detected from the config block value:
 
 ```
@@ -992,7 +993,7 @@ Before the sealing could be detected from the config block value:
 [+] 7A FF 00 00 00 00 00 00 BA FA 00 00 00 00 00 08 [ F1 69 ]
 ```
 
-### Proxmark3 commands
+### Commands
 ^[Top](#top)
 
 All commands are available before sealing.
@@ -1012,7 +1013,7 @@ hf 14a raw       -c   85000000000000000000000000000008
 ## ZUID
 ^[Top](#top)
 
-That card is a UID card, built on USCUID chip. It doesn't sold separately, but could be found on marketplaces under the guise of a UID card.
+That tag is a UID tag, built on USCUID chip. It doesn't sold separately, but could be found on marketplaces under the guise of a UID tag.
 
 ### Characteristics
 ^[Top](#top)
@@ -1032,7 +1033,7 @@ hf 14a info
 
 ```
 
-Currently Proxmark3 doesn't identify it as a sepatate card. 
+Currently Proxmark3 doesn't identify it as a separate tag. 
 Could be detected from the config block value:
 
 ```
@@ -1044,12 +1045,55 @@ Could be detected from the config block value:
 [+] 7A FF 00 00 00 00 00 00 00 00 00 00 00 00 00 08 [ 4E 17 ]
 ```
 
-### Proxmark3 commands
+### Commands
 ^[Top](#top)
 
 * Proxmark3 magic Gen1 commands
 * Read configuration: `E000+crc`
 * Write configuration: `E100+crc`
+
+## GDM
+^[Top](#top)
+
+The tag has a shadow mode, which means that every change to normal MFC memory would be restored back from the persistent memory after being off RFID field.
+
+### Characteristics
+^[Top](#top)
+
+* Configuration block value: `850000000000000000005A5A00000008`
+* No direct write to block 0
+* Responds to magic authentication: select, `8000+crc`, `[Crypto1 Auth: 000000000000]`
+
+### Identify
+^[Top](#top)
+
+```
+hf 14a info
+...
+[+] Magic capabilities : Gen 4 GDM
+
+```
+
+Could be manually validated with the configuration block value:
+
+```
+[usb] pm3 --> hf mf gdmcfg
+[+] config... 85 00 00 00 00 00 00 5A 00 FF 00 5A 00 00 00 08
+```
+
+### Commands
+^[Top](#top)
+
+* Magic authentication: select, `8000+crc`, `[Crypto1 Auth: 000000000000]`
+  * Backdoor read: `38xx+crc`
+  * Backdoor write: `A8xx+crc`, `[16 bytes data]+crc`
+  * Read configuration: `E000+crc`
+  * Write configuration: `E100+crc`; `[16 bytes data]+crc`
+* Proxmark3 commands (does auth and executes the corresponding command)
+  * Backdoor write: `gdmsetcfg`
+  * Read configuration: `gdmcfg`
+  * Write configuration: `gdmsetcfg`
+
 
 ## MIFARE Classic, other versions
 ^[Top](#top)

--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -35,6 +35,7 @@ Useful docs:
      * [UFUID](#ufuid)
      * [ZUID](#zuid)
      * [GDM](#gdm)
+     * [GDCUID](#gdcuid)
   * [MIFARE Classic, other versions](#mifare-classic-other-versions)
   * [MIFARE Classic Super](#mifare-classic-super)
 - [MIFARE Ultralight](#mifare-ultralight)
@@ -880,6 +881,7 @@ No implemented commands today
 | Factory configuration | Name |
 | --- | --- |
 | 850000000000000000005A5A00000008 | GDM |
+| 850000000000005A00FF005A00000008 | GDCUID |
 | 850000000000005A0000005A5A5A0008 | UCUID |
 | 8500000000005A00005A005A005A0008 | "7 byte hard" |
 | 7AFF850102015A00005A005A005A0008 | M1-7B |
@@ -1078,7 +1080,7 @@ Could be manually validated with the configuration block value:
 
 ```
 [usb] pm3 --> hf mf gdmcfg
-[+] config... 85 00 00 00 00 00 00 5A 00 FF 00 5A 00 00 00 08
+[+] config... 85 00 00 00 00 00 00 00 00 00 5A 5A 00 00 00 08
 ```
 
 ### Commands
@@ -1094,6 +1096,44 @@ Could be manually validated with the configuration block value:
   * Read configuration: `gdmcfg`
   * Write configuration: `gdmsetcfg`
 
+## GDCUID
+^[Top](#top)
+
+That tag is a CUID tag, built on USCUID chip. It doesn't sold separately, but could be found on marketplaces under the guise of a CUID tag.
+
+### Characteristics
+^[Top](#top)
+
+* Configuration block value: `850000000000005A00FF005A00000008`
+* Allows direct write to the block 0, so is Android compatible
+* Responds to magic authentication: select, `8000+crc`, `[Crypto1 Auth: 000000000000]`
+
+### Identify
+^[Top](#top)
+
+```
+hf 14a info
+...
+[+] Magic capabilities : Gen 4 GDM
+
+```
+Currently Proxmark3 doesn't identify it as a separate tag. 
+Could be manually validated with the configuration block value:
+
+```
+[usb] pm3 --> hf mf gdmcfg
+[+] config... 85 00 00 00 00 00 00 5A 00 FF 00 5A 00 00 00 08
+```
+
+### Commands
+^[Top](#top)
+
+* Magic authentication: select, `8000+crc`, `[Crypto1 Auth: 000000000000]`
+  * Read configuration: `E000+crc`
+  * Write configuration: `E100+crc`; `[16 bytes data]+crc`
+* Proxmark3 commands (does auth and executes the corresponding command)
+  * Read configuration: `gdmcfg`
+  * Write configuration: `gdmsetcfg`
 
 ## MIFARE Classic, other versions
 ^[Top](#top)

--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -33,6 +33,7 @@ Useful docs:
   * [MIFARE Classic USCUID](#mifare-classic-uscuid)
      * [FUID](#fuid)
      * [UFUID](#ufuid)
+     * [ZUID](#zuid)
   * [MIFARE Classic, other versions](#mifare-classic-other-versions)
   * [MIFARE Classic Super](#mifare-classic-super)
 - [MIFARE Ultralight](#mifare-ultralight)
@@ -884,8 +885,9 @@ No implemented commands today
 | 7AFF85000000000000FF000000000008 | FUID |
 | 7AFF000000000000BAFA358500000008 | PFUID |
 | 7AFF000000000000BAFA000000000008 | UFUID |
+| 7AFF0000000000000000000000000008 | ZUID |
 
-*Not all tags are the same!* UFUID and PFUID* are not full implementations of Magic85 - they only acknowledge the first 8 (except wakeup command) and last config byte(s).
+*Not all tags are the same!* UFUID, ZUID and PFUID* are not full implementations of Magic85 - they only acknowledge the first 8 (except wakeup command) and last config byte(s).
 
 *Read and write config commands are flipped
 
@@ -971,6 +973,13 @@ The card is positioned as "sealable UID", so that means you could use the same c
 ### Identify
 ^[Top](#top)
 
+```
+hf 14a info
+...
+[+] Magic capabilities : Gen 1a
+
+```
+
 Currently Proxmark3 doesn't identify it as a sepatate card. 
 Before the sealing could be detected from the config block value:
 
@@ -999,6 +1008,48 @@ hf 14a raw    -k      43
 hf 14a raw    -k -c   e100
 hf 14a raw       -c   85000000000000000000000000000008
 ```
+
+## ZUID
+^[Top](#top)
+
+That card is a UID card, built on USCUID chip. It doesn't sold separately, but could be found on marketplaces under the guise of a UID card.
+
+### Characteristics
+^[Top](#top)
+
+* Configuration block value: `7AFF0000000000000000000000000008`
+* No direct write to block 0
+* Responds to magic wakeup `40(7)`, `43` commands
+* Acknowledge only the first (except wakeup command) and last config byte(s), so doesn't have the hidden block
+
+### Identify
+^[Top](#top)
+
+```
+hf 14a info
+...
+[+] Magic capabilities : Gen 1a
+
+```
+
+Currently Proxmark3 doesn't identify it as a sepatate card. 
+Could be detected from the config block value:
+
+```
+[usb] pm3 --> hf 14a raw -k -a -b 7 40
+[+] 0A
+[usb] pm3 --> hf 14a raw -k -a 43
+[+] 0A
+[usb] pm3 --> hf 14a raw -c -k -a E000
+[+] 7A FF 00 00 00 00 00 00 00 00 00 00 00 00 00 08 [ 4E 17 ]
+```
+
+### Proxmark3 commands
+^[Top](#top)
+
+* Proxmark3 magic Gen1 commands
+* Read configuration: `E000+crc`
+* Write configuration: `E100+crc`
 
 ## MIFARE Classic, other versions
 ^[Top](#top)

--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -469,7 +469,34 @@ hf 14a info
 ## Mifare Classic Direct Write OTP
 ^[Top](#top)
 
-TODO
+Chip manufactured by iKey LLC as a bypass for Gen1 filters.
+Support Direct Write as CUID, but block0 can be written only once.
+
+The chip had an issue in the protocol implementation.
+
+The reader could interrupt radiofield for 2-3 microseconds (standard pause in the bit period of ISO14443-2).
+After the response to first `26 (7)` command, but before the following `93 70` command. In that case original M1 card will stop the flow, but OTP will continue it.
+
+That issue led to the development of the filters against that card and discontinuation of the production. 
+
+As a successor, [OTP 2.0](#mifare-classic-otp-2.0) was created.
+
+### Characteristics
+^[Top](#top)
+
+* Initial UID is AA55C396
+* Android compatible
+
+### Identify
+^[Top](#top)
+
+Only possible before personalization.
+
+```
+hf 14a info
+...
+[+] Magic capabilities : Write Once / FUID
+```
 
 ## MIFARE Classic OTP 2.0
 ^[Top](#top)

--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -1562,7 +1562,7 @@ script run hf_mfu_magicwrite -h
 ## UL series (RU)
 ^[Top](#top)
 
-Custom chips, manufactured by iKey LLC for cloning Ultralight tags.
+Custom chips, manufactured by iKey LLC for cloning Ultralight tags used in Visit intercoms. That leads to the non-standard for Ultralight chips tag version.
 
 ### UL-Y
 ^[Top](#top)
@@ -1597,16 +1597,44 @@ hf mfu info
 [=] TAG IC Signature: 0000000000000000000000000000000000000000000000000000000000000000
 [=] --- Tag Version
 [=]        Raw bytes: 00 34 21 01 01 00 0E 03
+[=]        Vendor ID: 34, Mikron JSC Russia
+[=]     Product type: 21, unknown
 ```
 
-Remember that this is not a reliable method of identification, as it interferes with locked [UL-5](#mifare-ul-5).
+#### ULtra flavour 1
+^[Top](#top)
+
+Could be identified by indirect evidence before writing
+
+* Initial UID: `34 D7 08 11 AD D7 D0`
+* `hf mfu dump --ns`
+  ```
+  [=]   3/0x03 | CF 39 A1 C8 | 1 | .9..
+  [=]   4/0x04 | B6 69 26 0D | 1 | .i&.
+  [=]   5/0x05 | EC A1 73 C4 | 1 | ..s.
+  [=]   6/0x06 | 81 3D 29 B8 | 1 | .=).
+  [=]  16/0x10 | 6A F0 2D FF | 0 | j.-.
+  [=]  20/0x14 | 6A F0 2D FF | 0 | j.-.
+  [=]  24/0x18 | 6A F0 2D FF | 0 | j.-.
+  [=]  38/0x26 | 00 E2 00 00 | 0 | .... <- E2, Virtual Card Type Identifier is not default
+
+  ```
+
+#### ULtra flavour 2
+^[Top](#top)
+
+Could be identified by indirect evidence before writing
+
+* Initial UID: `04 15 4A 23 36 2F 81`
+* Values in pages `3, 4, 5, 6, 16, 20, 24, 38` are default for that tag flavour
 
 ### UL-5
 ^[Top](#top)
 
-Ultralight EV1 magic; 41 page. Recommended for Vizit RF3.1 with 41 page and if [ULtra](#mifare-ultra) has failed.
+Ultralight EV1 magic; 41 page. Recommended for Vizit RF3.1 with 41 page.
+Created as a response to filters that try to overwrite page 0 (as a detection for [ULtra](#mifare-ultra) tags).
 
-Behavior: similar to Ultra, but after editing page 0, tag becomes original Mifare Ultralight EV1.
+Behavior: similar to Ultra, but after editing page 0 become locked and tag becomes the original Mifare Ultralight EV1 (except the tag version, which remains specific).
 
 **WARNING!** When using UL-5 to clone, write UID pages in inverse (from 2 to 0) and do NOT make mistakes! This tag does not allow reversing one-way actions (OTP page, lock bits).
 
@@ -1619,11 +1647,14 @@ hf mfu info
 TAG IC Signature: 0000000000000000000000000000000000000000000000000000000000000000
 [=] --- Tag Version
 [=]        Raw bytes: 00 34 21 01 01 00 0E 03
+[=]        Vendor ID: 34, Mikron JSC Russia
 ```
 
 After personalization it is not possible to identify UL-5. 
 
-Some chips have UID of `AA 55 C3 A4 30 61 80`.
+Usually chips have initial UIDs: 
+  * `AA 55 C3 A4 30 61 80`
+  * `AA 55 C3 A4 30 61 80`
 
 ### UL, other chips
 

--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -32,6 +32,7 @@ Useful docs:
   * [MIFARE Classic Gen3 aka APDU](#mifare-classic-gen3-aka-apdu)
   * [MIFARE Classic USCUID](#mifare-classic-uscuid)
      * [FUID](#fuid)
+     * [UFUID](#ufuid)
   * [MIFARE Classic, other versions](#mifare-classic-other-versions)
   * [MIFARE Classic Super](#mifare-classic-super)
 - [MIFARE Ultralight](#mifare-ultralight)
@@ -950,6 +951,53 @@ More correct detection should be based on a backdoor commands and configuration 
 [=]   # | sector 00 / 0x00                                | ascii
 [=] ----+-------------------------------------------------+-----------------
 [=]   0 | B5 02 45 4E BC 08 04 00 01 68 AA 89 47 CE 4D 1D | ..EN.....h..G.M.
+```
+
+## UFUID
+^[Top](#top)
+
+The card is positioned as "sealable UID", so that means you could use the same commands, as you could use for UID chip in a default state. But after the sealing (changing the configuration) card will not answer to the backdoor commands and will behave as a normal Mifare Classic card. 
+
+*But at the same time there is some unidentified behavior, which doesn't fully corresponds the protocol and original Mifare Classic cards. So the card could be filtered out with a protocol-based filters (i.e. Iron Logic OTP2 filter).* 
+
+### Characteristics
+^[Top](#top)
+
+* Configuration block value: `7AFF000000000000BAFA000000000008`
+* No direct write to block 0
+* Responds to magic wakeup `40(7)`, `43` commands before the sealing
+* Acknowledge only the first (except wakeup command) and last config byte(s), so doesn't have the hidden block
+
+### Identify
+^[Top](#top)
+
+Currently Proxmark3 doesn't identify it as a sepatate card. 
+Before the sealing could be detected from the config block value:
+
+```
+[usb] pm3 --> hf 14a raw -k -a -b 7 40
+[+] 0A
+[usb] pm3 --> hf 14a raw -k -a 43
+[+] 0A
+[usb] pm3 --> hf 14a raw -c -k -a E000
+[+] 7A FF 00 00 00 00 00 00 BA FA 00 00 00 00 00 08 [ F1 69 ]
+```
+
+### Proxmark3 commands
+^[Top](#top)
+
+All commands are available before sealing.
+* Proxmark3 magic Gen1 commands
+* Read configuration: `E000+crc`
+* Write configuration: `E100+crc`
+
+Example of the sealing, performed by Chinese copiers in raw commands:
+
+```
+hf 14a raw -a -k -b 7 40
+hf 14a raw    -k      43
+hf 14a raw    -k -c   e100
+hf 14a raw       -c   85000000000000000000000000000008
 ```
 
 ## MIFARE Classic, other versions

--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -25,7 +25,8 @@ Useful docs:
   * [MIFARE Classic block0](#mifare-classic-block0)
   * [MIFARE Classic Gen1A aka UID](#mifare-classic-gen1a-aka-uid)
   * [MIFARE Classic Gen1B](#mifare-classic-gen1b)
-  * [MIFARE Classic OTP2](#mifare-classic-otp2)
+  * [Mifare Classic Direct Write OTP](#mifare-classic-direct-write-otp)
+  * [MIFARE Classic OTP 2.0](#mifare-classic-otp-2.0)
   * [MIFARE Classic DirectWrite aka Gen2 aka CUID](#mifare-classic-directwrite-aka-gen2-aka-cuid)
   * [MIFARE Classic DirectWrite, FUID version aka 1-write](#mifare-classic-directwrite-fuid-version-aka-1-write)
   * [MIFARE Classic Gen3 aka APDU](#mifare-classic-gen3-aka-apdu)
@@ -465,10 +466,16 @@ hf 14a info
 * Read: `40(7)`, `30xx`
 * Write: `40(7)`, `A0xx`+crc, `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`+crc
 
-## MIFARE Classic OTP2
+## Mifare Classic Direct Write OTP
+^[Top](#top)
+
+TODO
+
+## MIFARE Classic OTP 2.0
 ^[Top](#top)
 
 Similar to Gen1A, but after first block 0 edit, tag no longer replies to 0x40 command.
+Were manufactured by iKey LLC as a replacement for [OTP](#mifare-classic-direct-write-otp)
 
 ### Characteristics
 


### PR DESCRIPTION
Decided to share some summary of personal investigations related to Mifare tags.

1. Separated **OTP** tag from **FUID** (those tags seems similar but are different from the chip + behavior PoV)
2. Described **OTP** tag and it's issues, lead to discontinuation
3. Added well-known subcategories of **USCUID** chip with accent focus on their core feature: **FUID**, **UFUID**, **ZUID**, **GDM**, **GDCUID**
4. Classified **ULtras** that exist on the market during those years and specified why their version is not a default one
5. Added a bit default `UL-5` info

Hope it will make the doc more detailed. 
And will wait for your feedback.