### PR TITLE
SPIFFS: implement dumping from SPIFFS to client trace buffer

### DIFF
--- a/client/src/cmdtrace.c
+++ b/client/src/cmdtrace.c
@@ -91,6 +91,25 @@ static uint8_t calc_pos(const uint8_t *d) {
     return pos;
 }
 
+// Copy an existing buffer into client trace buffer
+// I think this is cleaner than further globalizing gs_trace, and may lend itself to more modularity later?
+bool ImportTraceBuffer(uint8_t *trace_src, uint16_t trace_len)
+{
+    if (trace_len == 0 || trace_src == NULL) return(false);
+    if (gs_trace) {
+        free(gs_trace);
+        gs_traceLen = 0;
+    }
+    gs_trace = calloc(trace_len, sizeof(uint8_t));
+    if (gs_trace == NULL)
+    {
+        return(false);
+    }
+    memcpy(gs_trace, trace_src, trace_len);
+    gs_traceLen = trace_len;
+    return(true);
+}
+
 static uint8_t extract_uid[10] = {0};
 static uint8_t extract_uidlen = 0;
 static uint8_t extract_epurse[8] = {0};

--- a/client/src/cmdtrace.h
+++ b/client/src/cmdtrace.h
@@ -24,5 +24,6 @@
 int CmdTrace(const char *Cmd);
 int CmdTraceList(const char *Cmd);
 int CmdTraceListAlias(const char *Cmd, const char *alias, const char *protocol);
+bool ImportTraceBuffer(uint8_t *trace_src, uint16_t trace_len);
 
 #endif


### PR DESCRIPTION
Sometimes one has a bunch of traces in SPIFFS after a long day of standalone work, and wants to look at them and decide what to save.  Adds '-t' option to mem spiffs dump, to download the data into client trace buffer instead of creating a local file which one must then 'trace load'

Not sure I like how I implemented this, or whether it's useful to anyone else.