### PR TITLE
Clean up the code for network connection

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -288,6 +288,7 @@ set (TARGET_SOURCES
         ${PM3_ROOT}/client/src/mifare/desfiretest.c
         ${PM3_ROOT}/client/src/mifare/gallaghercore.c
         ${PM3_ROOT}/client/src/uart/ringbuffer.c
+        ${PM3_ROOT}/client/src/uart/uart_common.c
         ${PM3_ROOT}/client/src/uart/uart_posix.c
         ${PM3_ROOT}/client/src/uart/uart_win32.c
         ${PM3_ROOT}/client/src/ui/overlays.ui

--- a/client/Makefile
+++ b/client/Makefile
@@ -713,6 +713,7 @@ SRCS =  mifare/aiddesfire.c \
 		proxmark3.c \
 		scandir.c \
 		uart/ringbuffer.c \
+		uart/uart_common.c \
 		uart/uart_posix.c \
 		uart/uart_win32.c \
 		scripting.c \

--- a/client/experimental_lib/CMakeLists.txt
+++ b/client/experimental_lib/CMakeLists.txt
@@ -289,6 +289,7 @@ set (TARGET_SOURCES
         ${PM3_ROOT}/client/src/mifare/desfiretest.c
         ${PM3_ROOT}/client/src/mifare/gallaghercore.c
         ${PM3_ROOT}/client/src/uart/ringbuffer.c
+        ${PM3_ROOT}/client/src/uart/uart_common.c
         ${PM3_ROOT}/client/src/uart/uart_posix.c
         ${PM3_ROOT}/client/src/uart/uart_win32.c
         ${PM3_ROOT}/client/src/ui/overlays.ui

--- a/client/src/uart/uart.h
+++ b/client/src/uart/uart.h
@@ -84,6 +84,11 @@ uint32_t uart_get_timeouts(void);
 
 /* Specify the outbound address and port for TCP/UDP connections
  */
-bool uart_bind(void *socket, char *bindAddrStr, char *bindPortStr, bool isBindingIPv6);
+bool uart_bind(void *socket, const char *bindAddrStr, const char *bindPortStr, bool isBindingIPv6);
+
+/* Parse address and port from string.
+   This could change the addrPortStr
+ */
+int uart_parse_address_port(char *addrPortStr, const char **addrStr, const char **portStr, bool *isIPv6);
 
 #endif // _UART_H_

--- a/client/src/uart/uart_common.c
+++ b/client/src/uart/uart_common.c
@@ -1,0 +1,74 @@
+//-----------------------------------------------------------------------------
+// Copyright (C) Proxmark3 contributors. See AUTHORS.md for details.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// See LICENSE.txt for the text of the license.
+//-----------------------------------------------------------------------------
+// Generic uart / rs232/ serial port library
+//-----------------------------------------------------------------------------
+
+#include "uart.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "comms.h"
+#include "ui.h"
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#endif
+
+bool uart_bind(void *socket, char *bindAddrStr, char *bindPortStr, bool isBindingIPv6) {
+    if (bindAddrStr == NULL && bindPortStr == NULL)
+        return true; // no need to bind
+
+    struct sockaddr_storage bindSockaddr;
+    memset(&bindSockaddr, 0, sizeof(bindSockaddr));
+    int bindPort = 0; // 0: port unspecified
+    if (bindPortStr != NULL)
+        bindPort = atoi(bindPortStr);
+
+    if (!isBindingIPv6) {
+        struct sockaddr_in *bindSockaddr4 = (struct sockaddr_in *)&bindSockaddr;
+        bindSockaddr4->sin_family = AF_INET;
+        bindSockaddr4->sin_port = htons(bindPort);
+        if (bindAddrStr == NULL)
+            bindSockaddr4->sin_addr.s_addr = INADDR_ANY;
+        else
+            bindSockaddr4->sin_addr.s_addr = inet_addr(bindAddrStr);
+    } else {
+        struct sockaddr_in6 *bindSockaddr6 = (struct sockaddr_in6 *)&bindSockaddr;
+        bindSockaddr6->sin6_family = AF_INET6;
+        bindSockaddr6->sin6_port = htons(bindPort);
+        if (bindAddrStr == NULL)
+            bindSockaddr6->sin6_addr = in6addr_any;
+        else
+            inet_pton(AF_INET6, bindAddrStr, &(bindSockaddr6->sin6_addr));
+    }
+#ifdef _WIN32
+    int res = bind(*(SOCKET *)socket, (struct sockaddr *)&bindSockaddr, sizeof(bindSockaddr));
+#else
+    int res = bind(*(int *)socket, (struct sockaddr *)&bindSockaddr, sizeof(bindSockaddr));
+#endif
+    return (res >= 0);
+}

--- a/client/src/uart/uart_posix.c
+++ b/client/src/uart/uart_posix.c
@@ -106,6 +106,7 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
         free(prefix);
 
         if (strlen(pcPortName) <= 4) {
+            PrintAndLogEx(ERR, "error: tcp port name length too short");
             free(sp);
             return INVALID_SERIAL_PORT;
         }
@@ -297,6 +298,7 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
         free(prefix);
 
         if (strlen(pcPortName) <= 4) {
+            PrintAndLogEx(ERR, "error: udp port name length too short");
             free(sp);
             return INVALID_SERIAL_PORT;
         }
@@ -994,38 +996,6 @@ uint32_t uart_get_speed(const serial_port sp) {
             return 0;
     };
     return uiPortSpeed;
-}
-
-bool uart_bind(void *socket, char *bindAddrStr, char *bindPortStr, bool isBindingIPv6) {
-    if (bindAddrStr == NULL && bindPortStr == NULL)
-        return true; // no need to bind
-
-    struct sockaddr_storage bindSockaddr;
-    memset(&bindSockaddr, 0, sizeof(bindSockaddr));
-    int bindPort = 0; // 0: port unspecified
-    if (bindPortStr != NULL)
-        bindPort = atoi(bindPortStr);
-
-    if (!isBindingIPv6) {
-        struct sockaddr_in *bindSockaddr4 = (struct sockaddr_in *)&bindSockaddr;
-        bindSockaddr4->sin_family = AF_INET;
-        bindSockaddr4->sin_port = htons(bindPort);
-        if (bindAddrStr == NULL)
-            bindSockaddr4->sin_addr.s_addr = INADDR_ANY;
-        else
-            bindSockaddr4->sin_addr.s_addr = inet_addr(bindAddrStr);
-    } else {
-        struct sockaddr_in6 *bindSockaddr6 = (struct sockaddr_in6 *)&bindSockaddr;
-        bindSockaddr6->sin6_family = AF_INET6;
-        bindSockaddr6->sin6_port = htons(bindPort);
-        if (bindAddrStr == NULL)
-            bindSockaddr6->sin6_addr = in6addr_any;
-        else
-            inet_pton(AF_INET6, bindAddrStr, &(bindSockaddr6->sin6_addr));
-    }
-
-    int res = bind(*(int *)socket, (struct sockaddr *)&bindSockaddr, sizeof(bindSockaddr));
-    return (res >= 0);
 }
 
 #endif

--- a/client/src/uart/uart_posix.c
+++ b/client/src/uart/uart_posix.c
@@ -114,8 +114,6 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
         struct addrinfo *addr = NULL, *rp;
 
         char *addrPortStr = str_dup(pcPortName + 4);
-        char *addrstr = addrPortStr;
-        const char *portstr;
         if (addrPortStr == NULL) {
             PrintAndLogEx(ERR, "error: string duplication");
             free(sp);
@@ -126,54 +124,24 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
 
         // find the "bind" option
         char *bindAddrPortStr = strstr(addrPortStr, ",bind=");
-        char *bindAddrStr = NULL;
-        char *bindPortStr = NULL;
-        bool isBindingIPv6 = false; // Assume v4
+        const char *bindAddrStr = NULL;
+        const char *bindPortStr = NULL;
+        bool isBindingIPv6 = false;
+
         if (bindAddrPortStr != NULL) {
             *bindAddrPortStr = '\0'; // as the end of target address (and port)
-            bindAddrPortStr += 6;
-            bindAddrStr = bindAddrPortStr;
+            bindAddrPortStr += 6; // strlen(",bind=")
 
-            // find the start of the bind address
-            char *endBracket = strrchr(bindAddrPortStr, ']');
-            if (bindAddrPortStr[0] == '[') {
-                bindAddrStr += 1;
-                if (endBracket == NULL) {
+            int result = uart_parse_address_port(bindAddrPortStr, &bindAddrStr, &bindPortStr, &isBindingIPv6);
+            if (result != PM3_SUCCESS) {
+                if (result == PM3_ESOFT) {
                     PrintAndLogEx(ERR, "error: wrong address: [] unmatched in bind option");
-                    free(addrPortStr);
-                    free(sp);
-                    return INVALID_SERIAL_PORT;
-                }
-            }
-
-            // find the bind port
-            char *lColon = strchr(bindAddrPortStr, ':');
-            char *rColon = strrchr(bindAddrPortStr, ':');
-            if (rColon == NULL) {
-                // no colon
-                // ",bind=<ipv4 address>", ",bind=[<ipv4 address>]"
-                bindPortStr = NULL;
-            } else if (lColon == rColon) {
-                // only one colon
-                // ",bind=<ipv4 address>:<port>", ",bind=[<ipv4 address>]:<port>"
-                bindPortStr = rColon + 1;
-            } else {
-                // two or more colon, IPv6 address
-                // ",bind=[<ipv6 address>]:<port>"
-                // ",bind=<ipv6 address>", ",bind=[<ipv6 address>]"
-                if (endBracket != NULL && rColon == endBracket + 1) {
-                    bindPortStr = rColon + 1;
                 } else {
-                    bindPortStr = NULL;
+                    PrintAndLogEx(ERR, "error: failed to parse address and port in bind option");
                 }
-                isBindingIPv6 = true;
-            }
-
-            // handle the end of the bind address
-            if (endBracket != NULL) {
-                *endBracket = '\0';
-            } else if (rColon != NULL && lColon == rColon) {
-                *rColon = '\0';
+                free(addrPortStr);
+                free(sp);
+                return INVALID_SERIAL_PORT;
             }
 
             // for bind option, it's possible to only specify address or port
@@ -183,51 +151,24 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
                 bindPortStr = NULL;
         }
 
-        // find the start of the address
-        char *endBracket = strrchr(addrPortStr, ']');
-        if (addrPortStr[0] == '[') {
-            addrstr += 1;
-            if (endBracket == NULL) {
+        const char *addrStr = NULL;
+        const char *portStr = NULL;
+        bool isIPv6 = false;
+
+        int result = uart_parse_address_port(addrPortStr, &addrStr, &portStr, &isIPv6);
+        if (result != PM3_SUCCESS) {
+            if (result == PM3_ESOFT) {
                 PrintAndLogEx(ERR, "error: wrong address: [] unmatched");
-                free(addrPortStr);
-                free(sp);
-                return INVALID_SERIAL_PORT;
-            }
-        }
-
-
-        // assume v4
-        g_conn.send_via_ip = PM3_TCPv4;
-
-        // find the port
-        char *lColon = strchr(addrPortStr, ':');
-        char *rColon = strrchr(addrPortStr, ':');
-        if (rColon == NULL) {
-            // no colon
-            // "tcp:<ipv4 address>", "tcp:[<ipv4 address>]"
-            portstr = "18888";
-        } else if (lColon == rColon) {
-            // only one colon
-            // "tcp:<ipv4 address>:<port>", "tcp:[<ipv4 address>]:<port>"
-            portstr = rColon + 1;
-        } else {
-            // two or more colon, IPv6 address
-            // "tcp:[<ipv6 address>]:<port>"
-            // "tcp:<ipv6 address>", "tcp:[<ipv6 address>]"
-            if (endBracket != NULL && rColon == endBracket + 1) {
-                portstr = rColon + 1;
             } else {
-                portstr = "18888";
+                PrintAndLogEx(ERR, "error: failed to parse address and port");
             }
-            g_conn.send_via_ip = PM3_TCPv6;
+            free(addrPortStr);
+            free(sp);
+            return INVALID_SERIAL_PORT;
         }
 
-        // handle the end of the address
-        if (endBracket != NULL) {
-            *endBracket = '\0';
-        } else if (rColon != NULL && lColon == rColon) {
-            *rColon = '\0';
-        }
+        g_conn.send_via_ip = isIPv6 ? PM3_TCPv6 : PM3_TCPv4;
+        portStr = (portStr == NULL) ? "18888" : portStr;
 
         struct addrinfo info;
 
@@ -236,13 +177,13 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
         info.ai_family = PF_UNSPEC;
         info.ai_socktype = SOCK_STREAM;
 
-        if ((strstr(addrstr, "localhost") != NULL) ||
-                (strstr(addrstr, "127.0.0.1") != NULL) ||
-                (strstr(addrstr, "::1") != NULL)) {
+        if ((strstr(addrStr, "localhost") != NULL) ||
+                (strstr(addrStr, "127.0.0.1") != NULL) ||
+                (strstr(addrStr, "::1") != NULL)) {
             g_conn.send_via_local_ip = true;
         }
 
-        int s = getaddrinfo(addrstr, portstr, &info, &addr);
+        int s = getaddrinfo(addrStr, portStr, &info, &addr);
         if (s != 0) {
             PrintAndLogEx(ERR, "error: getaddrinfo: %s", gai_strerror(s));
             freeaddrinfo(addr);
@@ -306,8 +247,6 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
         struct addrinfo *addr = NULL, *rp;
 
         char *addrPortStr = str_dup(pcPortName + 4);
-        char *addrstr = addrPortStr;
-        const char *portstr;
         if (addrPortStr == NULL) {
             PrintAndLogEx(ERR, "error: string duplication");
             free(sp);
@@ -318,54 +257,24 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
 
         // find the "bind" option
         char *bindAddrPortStr = strstr(addrPortStr, ",bind=");
-        char *bindAddrStr = NULL;
-        char *bindPortStr = NULL;
-        bool isBindingIPv6 = false; // Assume v4
+        const char *bindAddrStr = NULL;
+        const char *bindPortStr = NULL;
+        bool isBindingIPv6 = false;
+    
         if (bindAddrPortStr != NULL) {
             *bindAddrPortStr = '\0'; // as the end of target address (and port)
-            bindAddrPortStr += 6;
-            bindAddrStr = bindAddrPortStr;
+            bindAddrPortStr += 6; // strlen(",bind=")
 
-            // find the start of the bind address
-            char *endBracket = strrchr(bindAddrPortStr, ']');
-            if (bindAddrPortStr[0] == '[') {
-                bindAddrStr += 1;
-                if (endBracket == NULL) {
+            int result = uart_parse_address_port(bindAddrPortStr, &bindAddrStr, &bindPortStr, &isBindingIPv6);
+            if (result != PM3_SUCCESS) {
+                if (result == PM3_ESOFT) {
                     PrintAndLogEx(ERR, "error: wrong address: [] unmatched in bind option");
-                    free(addrPortStr);
-                    free(sp);
-                    return INVALID_SERIAL_PORT;
-                }
-            }
-
-            // find the bind port
-            char *lColon = strchr(bindAddrPortStr, ':');
-            char *rColon = strrchr(bindAddrPortStr, ':');
-            if (rColon == NULL) {
-                // no colon
-                // ",bind=<ipv4 address>", ",bind=[<ipv4 address>]"
-                bindPortStr = NULL;
-            } else if (lColon == rColon) {
-                // only one colon
-                // ",bind=<ipv4 address>:<port>", ",bind=[<ipv4 address>]:<port>"
-                bindPortStr = rColon + 1;
-            } else {
-                // two or more colon, IPv6 address
-                // ",bind=[<ipv6 address>]:<port>"
-                // ",bind=<ipv6 address>", ",bind=[<ipv6 address>]"
-                if (endBracket != NULL && rColon == endBracket + 1) {
-                    bindPortStr = rColon + 1;
                 } else {
-                    bindPortStr = NULL;
+                    PrintAndLogEx(ERR, "error: failed to parse address and port in bind option");
                 }
-                isBindingIPv6 = true;
-            }
-
-            // handle the end of the bind address
-            if (endBracket != NULL) {
-                *endBracket = '\0';
-            } else if (rColon != NULL && lColon == rColon) {
-                *rColon = '\0';
+                free(addrPortStr);
+                free(sp);
+                return INVALID_SERIAL_PORT;
             }
 
             // for bind option, it's possible to only specify address or port
@@ -375,50 +284,24 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
                 bindPortStr = NULL;
         }
 
-        // find the start of the address
-        char *endBracket = strrchr(addrPortStr, ']');
-        if (addrPortStr[0] == '[') {
-            addrstr += 1;
-            if (endBracket == NULL) {
+        const char *addrStr = NULL;
+        const char *portStr = NULL;
+        bool isIPv6 = false;
+
+        int result = uart_parse_address_port(addrPortStr, &addrStr, &portStr, &isIPv6);
+        if (result != PM3_SUCCESS) {
+            if (result == PM3_ESOFT) {
                 PrintAndLogEx(ERR, "error: wrong address: [] unmatched");
-                free(addrPortStr);
-                free(sp);
-                return INVALID_SERIAL_PORT;
-            }
-        }
-
-        // Assume v4
-        g_conn.send_via_ip = PM3_UDPv4;
-
-        // find the port
-        char *lColon = strchr(addrPortStr, ':');
-        char *rColon = strrchr(addrPortStr, ':');
-        if (rColon == NULL) {
-            // no colon
-            // "udp:<ipv4 address>", "udp:[<ipv4 address>]"
-            portstr = "18888";
-        } else if (lColon == rColon) {
-            // only one colon
-            // "udp:<ipv4 address>:<port>", "udp:[<ipv4 address>]:<port>"
-            portstr = rColon + 1;
-        } else {
-            // two or more colon, IPv6 address
-            // "udp:[<ipv6 address>]:<port>"
-            // "udp:<ipv6 address>", "udp:[<ipv6 address>]"
-            if (endBracket != NULL && rColon == endBracket + 1) {
-                portstr = rColon + 1;
             } else {
-                portstr = "18888";
+                PrintAndLogEx(ERR, "error: failed to parse address and port");
             }
-            g_conn.send_via_ip = PM3_UDPv6;
+            free(addrPortStr);
+            free(sp);
+            return INVALID_SERIAL_PORT;
         }
 
-        // handle the end of the address
-        if (endBracket != NULL) {
-            *endBracket = '\0';
-        } else if (rColon != NULL && lColon == rColon) {
-            *rColon = '\0';
-        }
+        g_conn.send_via_ip = isIPv6 ? PM3_UDPv6 : PM3_UDPv4;
+        portStr = (portStr == NULL) ? "18888" : portStr;
 
         struct addrinfo info;
 
@@ -427,13 +310,13 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
         info.ai_family = PF_UNSPEC;
         info.ai_socktype = SOCK_DGRAM;
 
-        if ((strstr(addrstr, "localhost") != NULL) ||
-                (strstr(addrstr, "127.0.0.1") != NULL) ||
-                (strstr(addrstr, "::1") != NULL)) {
+        if ((strstr(addrStr, "localhost") != NULL) ||
+                (strstr(addrStr, "127.0.0.1") != NULL) ||
+                (strstr(addrStr, "::1") != NULL)) {
             g_conn.send_via_local_ip = true;
         }
 
-        int s = getaddrinfo(addrstr, portstr, &info, &addr);
+        int s = getaddrinfo(addrStr, portStr, &info, &addr);
         if (s != 0) {
             PrintAndLogEx(ERR, "error: getaddrinfo: %s", gai_strerror(s));
             freeaddrinfo(addr);

--- a/client/src/uart/uart_win32.c
+++ b/client/src/uart/uart_win32.c
@@ -314,7 +314,7 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
         free(prefix);
 
         if (strlen(pcPortName) <= 4) {
-            PrintAndLogEx(ERR, "error: tcp port name length too short");
+            PrintAndLogEx(ERR, "error: udp port name length too short");
             free(sp);
             return INVALID_SERIAL_PORT;
         }
@@ -778,38 +778,6 @@ int uart_send(const serial_port sp, const uint8_t *p_tx, const uint32_t len) {
         return PM3_SUCCESS;
 
     }
-}
-
-bool uart_bind(void *socket, char *bindAddrStr, char *bindPortStr, bool isBindingIPv6) {
-    if (bindAddrStr == NULL && bindPortStr == NULL)
-        return true; // no need to bind
-
-    struct sockaddr_storage bindSockaddr;
-    memset(&bindSockaddr, 0, sizeof(bindSockaddr));
-    int bindPort = 0; // 0: port unspecified
-    if (bindPortStr != NULL)
-        bindPort = atoi(bindPortStr);
-
-    if (!isBindingIPv6) {
-        struct sockaddr_in *bindSockaddr4 = (struct sockaddr_in *)&bindSockaddr;
-        bindSockaddr4->sin_family = AF_INET;
-        bindSockaddr4->sin_port = htons(bindPort);
-        if (bindAddrStr == NULL)
-            bindSockaddr4->sin_addr.s_addr = INADDR_ANY;
-        else
-            bindSockaddr4->sin_addr.s_addr = inet_addr(bindAddrStr);
-    } else {
-        struct sockaddr_in6 *bindSockaddr6 = (struct sockaddr_in6 *)&bindSockaddr;
-        bindSockaddr6->sin6_family = AF_INET6;
-        bindSockaddr6->sin6_port = htons(bindPort);
-        if (bindAddrStr == NULL)
-            bindSockaddr6->sin6_addr = in6addr_any;
-        else
-            inet_pton(AF_INET6, bindAddrStr, &(bindSockaddr6->sin6_addr));
-    }
-
-    int res = bind(*(SOCKET *)socket, (struct sockaddr *)&bindSockaddr, sizeof(bindSockaddr));
-    return (res >= 0);
 }
 
 #endif

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -842,7 +842,7 @@ typedef struct {
 // all zero's configure: no timeout for read/write used.
 // took settings from libnfc/buses/uart.c
 
-// uart_windows.c & uart_posix.c
+// uart_win32.c & uart_posix.c
 # define UART_FPC_CLIENT_RX_TIMEOUT_MS        200
 # define UART_USB_CLIENT_RX_TIMEOUT_MS        20
 # define UART_NET_CLIENT_RX_TIMEOUT_MS        500


### PR DESCRIPTION
+ Move `uart_bind()` to `uart_common.c`, as most of the code in it is platform-independent.
+ Add const qualifier to some arguments of `uart_bind()`
+ Refactor the address/port parser into a separate function `uart_parse_address_port()`. This code block was repeated 8 times in the old implementation.
+ Merge the code of TCP and UDP connection in `uart_open()`
+ Add some code to check the prefix length before calling `memcmp()`