### PR TITLE
Update connection type in CLI prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed CLI prompt - Update connection type prompt after running `hw connect` (@wh201906)
  - Changed `uart_receive()` - Check if TCP connection is lost (@wh201906)
  - Change `data detectclock` - now tries all clocks if called w/o any params (@iceman1001)
  - Changed `lf search -1u` - improved the autocorrelation detection for unknown signals (@iceman1001)

--- a/client/src/proxmark3.c
+++ b/client/src/proxmark3.c
@@ -281,6 +281,8 @@ main_loop(char *script_cmds_file, char *script_cmd, bool stayInCommandLoop) {
                     prompt_net = PROXPROMPT_NET_UDPV6;
                     break;
                 case PM3_NONE:
+                    prompt_net = PROXPROMPT_NET_NONE;
+                    break;
                 default:
                     break;
             }

--- a/client/src/proxmark3.h
+++ b/client/src/proxmark3.h
@@ -39,6 +39,7 @@
 #define PROXPROMPT_NET_UDPV4   "|" _RL_BOLD_GREEN_("udp")
 #define PROXPROMPT_NET_TCPV6   "|" _RL_BOLD_GREEN_("tcp v6")
 #define PROXPROMPT_NET_UDPV6   "|" _RL_BOLD_GREEN_("udp v6")
+#define PROXPROMPT_NET_NONE    ""
 
 
 #define PROXHISTORY "history.txt"

--- a/client/src/uart/uart_posix.c
+++ b/client/src/uart/uart_posix.c
@@ -90,6 +90,7 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
     }
 
     sp->udpBuffer = NULL;
+    rx_empty_counter = 0;
     // init timeouts
     timeout.tv_usec = UART_FPC_CLIENT_RX_TIMEOUT_MS * 1000;
     g_conn.send_via_local_ip = false;
@@ -157,10 +158,12 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
             }
 
             // for bind option, it's possible to only specify address or port
-            if (strlen(bindAddrStr) == 0)
+            if (strlen(bindAddrStr) == 0) {
                 bindAddrStr = NULL;
-            if (bindPortStr != NULL && strlen(bindPortStr) == 0)
+            }
+            if (bindPortStr != NULL && strlen(bindPortStr) == 0) {
                 bindPortStr = NULL;
+            }
         }
 
         const char *addrStr = NULL;
@@ -208,8 +211,9 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
         for (rp = addr; rp != NULL; rp = rp->ai_next) {
             sfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
 
-            if (sfd == -1)
+            if (sfd == -1) {
                 continue;
+            }
 
             if (!uart_bind(&sfd, bindAddrStr, bindPortStr, isBindingIPv6)) {
                 PrintAndLogEx(ERR, "error: Could not bind. errno: %d", errno);
@@ -220,8 +224,9 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
                 return INVALID_SERIAL_PORT;
             }
 
-            if (connect(sfd, rp->ai_addr, rp->ai_addrlen) != -1)
+            if (connect(sfd, rp->ai_addr, rp->ai_addrlen) != -1) {
                 break;
+            }
 
             close(sfd);
         }

--- a/client/src/uart/uart_win32.c
+++ b/client/src/uart/uart_win32.c
@@ -93,6 +93,7 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
     }
 
     sp->udpBuffer = NULL;
+    rx_empty_counter = 0;
     g_conn.send_via_local_ip = false;
     g_conn.send_via_ip = PM3_NONE;
 
@@ -149,10 +150,12 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
             }
 
             // for bind option, it's possible to only specify address or port
-            if (strlen(bindAddrStr) == 0)
+            if (strlen(bindAddrStr) == 0) {
                 bindAddrStr = NULL;
-            if (bindPortStr != NULL && strlen(bindPortStr) == 0)
+            }
+            if (bindPortStr != NULL && strlen(bindPortStr) == 0) {
                 bindPortStr = NULL;
+            }
         }
 
         const char *addrStr = NULL;
@@ -211,8 +214,9 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
         for (rp = addr; rp != NULL; rp = rp->ai_next) {
             hSocket = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
 
-            if (hSocket == INVALID_SOCKET)
+            if (hSocket == INVALID_SOCKET) {
                 continue;
+            }
 
             if (!uart_bind(&hSocket, bindAddrStr, bindPortStr, isBindingIPv6)) {
                 PrintAndLogEx(ERR, "error: Could not bind. error: %u", WSAGetLastError());
@@ -225,8 +229,9 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
                 return INVALID_SERIAL_PORT;
             }
 
-            if (connect(hSocket, rp->ai_addr, (int)rp->ai_addrlen) != INVALID_SOCKET)
+            if (connect(hSocket, rp->ai_addr, (int)rp->ai_addrlen) != INVALID_SOCKET) {
                 break;
+            }
 
             closesocket(hSocket);
             hSocket = INVALID_SOCKET;


### PR DESCRIPTION
The connection type prompt wouldn't change if I connect to hardware via TCP then run `hw connect -p /dev/ttyACM0`. The old `prompt_net` is not cleared.
I also cleaned up some code in commit e5dd9952d78e6b9a7a6e18cb4da8dd71352a1ba1