### PR TITLE
Changed hf_cardhopper standalone mode to allow running over the internal PM3 USB-CDC serial port.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Changed `hf_cardhopper` standalone mode to allow running over the internal Proxmark3 USB-CDC serial port (@nvx)
  - Fixed CLI prompt - Update connection type prompt after running `hw connect` (@wh201906)
  - Changed `uart_receive()` - Check if TCP connection is lost (@wh201906)
  - Change `data detectclock` - now tries all clocks if called w/o any params (@iceman1001)


### PR DESCRIPTION
This functionality can be enabled by adding the following to your Makefile.platform:

`STANDALONE_PLATFORM_DEFS+=-DCARDHOPPER_USB`