### PR TITLE
Some fixes for the reconnect feature

### DIFF
--- a/client/src/comms.c
+++ b/client/src/comms.c
@@ -699,7 +699,7 @@ size_t GetCommunicationRawReceiveNum(void) {
 
 bool OpenProxmarkSilent(pm3_device_t **dev, const char *port, uint32_t speed) {
 
-    sp = uart_open(port, speed);
+    sp = uart_open(port, speed, true);
 
     // check result of uart opening
     if (sp == INVALID_SERIAL_PORT) {
@@ -742,14 +742,14 @@ bool OpenProxmark(pm3_device_t **dev, const char *port, bool wait_for_port, int 
 
     if (!wait_for_port) {
         PrintAndLogEx(INFO, "Using UART port " _YELLOW_("%s"), port);
-        sp = uart_open(port, speed);
+        sp = uart_open(port, speed, false);
     } else {
         PrintAndLogEx(SUCCESS, "Waiting for Proxmark3 to appear on " _YELLOW_("%s"), port);
         fflush(stdout);
         int openCount = 0;
         PrintAndLogEx(INPLACE, "% 3i", timeout);
         do {
-            sp = uart_open(port, speed);
+            sp = uart_open(port, speed, false);
             msleep(500);
             PrintAndLogEx(INPLACE, "% 3i", timeout - openCount - 1);
 

--- a/client/src/comms.c
+++ b/client/src/comms.c
@@ -355,6 +355,8 @@ void *uart_reconnect(void *targ) {
     }
 
     while (1) {
+        // throttle
+        msleep(200);
         if (OpenProxmarkSilent(&g_session.current_device, connection->serial_port_name, speed) == false) {
             continue;
         }

--- a/client/src/uart/uart.h
+++ b/client/src/uart/uart.h
@@ -40,8 +40,10 @@ typedef void *serial_port;
  * used for future references to that port.
  *
  * On errors, this method returns INVALID_SERIAL_PORT or CLAIMED_SERIAL_PORT.
+ * If slient is set to false, this function will print the error information
+ * when error occurs.
  */
-serial_port uart_open(const char *pcPortName, uint32_t speed);
+serial_port uart_open(const char *pcPortName, uint32_t speed, bool slient);
 
 /* Closes the given port.
  */

--- a/client/src/uart/uart_posix.c
+++ b/client/src/uart/uart_posix.c
@@ -81,7 +81,7 @@ uint32_t uart_get_timeouts(void) {
     return newtimeout_value;
 }
 
-serial_port uart_open(const char *pcPortName, uint32_t speed) {
+serial_port uart_open(const char *pcPortName, uint32_t speed, bool slient) {
     serial_port_unix_t_t *sp = calloc(sizeof(serial_port_unix_t_t), sizeof(uint8_t));
 
     if (sp == 0) {
@@ -98,7 +98,7 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
 
     char *prefix = str_dup(pcPortName);
     if (prefix == NULL) {
-        PrintAndLogEx(ERR, "error:  string duplication");
+        PrintAndLogEx(ERR, "error: string duplication");
         free(sp);
         return INVALID_SERIAL_PORT;
     }
@@ -235,7 +235,9 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
         free(addrPortStr);
 
         if (rp == NULL) {               /* No address succeeded */
-            PrintAndLogEx(ERR, "error: Could not connect");
+            if (slient == false) {
+                PrintAndLogEx(ERR, "error: Could not connect");
+            }
             free(sp);
             return INVALID_SERIAL_PORT;
         }
@@ -292,7 +294,9 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
         }
 
         if (connect(sfd, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
-            PrintAndLogEx(ERR, "Error: cannot connect device " _YELLOW_("%s") " over Bluetooth", addrstr);
+            if (slient == false) {
+                PrintAndLogEx(ERR, "Error: cannot connect device " _YELLOW_("%s") " over Bluetooth", addrstr);
+            }
             close(sfd);
             free(addrstr);
             free(sp);

--- a/client/src/uart/uart_win32.c
+++ b/client/src/uart/uart_win32.c
@@ -82,7 +82,7 @@ static int uart_reconfigure_timeouts_polling(serial_port sp) {
     return PM3_SUCCESS;
 }
 
-serial_port uart_open(const char *pcPortName, uint32_t speed) {
+serial_port uart_open(const char *pcPortName, uint32_t speed, bool slient) {
     char acPortName[255] = {0};
     serial_port_windows_t *sp = calloc(sizeof(serial_port_windows_t), sizeof(uint8_t));
     sp->hSocket = INVALID_SOCKET; // default: serial port
@@ -99,7 +99,7 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
 
     char *prefix = str_dup(pcPortName);
     if (prefix == NULL) {
-        PrintAndLogEx(ERR, "error:  string duplication");
+        PrintAndLogEx(ERR, "error: string duplication");
         free(sp);
         return INVALID_SERIAL_PORT;
     }
@@ -241,7 +241,9 @@ serial_port uart_open(const char *pcPortName, uint32_t speed) {
         free(addrPortStr);
 
         if (rp == NULL) {               /* No address succeeded */
-            PrintAndLogEx(ERR, "error: Could not connect");
+            if (slient == false) {
+                PrintAndLogEx(ERR, "error: Could not connect");
+            }
             WSACleanup();
             free(sp);
             return INVALID_SERIAL_PORT;


### PR DESCRIPTION
1. Add `msleep()` to reduce the CPU usage
2. Disable printing error information when calling `uart_open()` in `OpenProxmarkSilent()`

I'm still finding the reason of crash when running `hw connect` to a different port in the offline mode, so I created this as a draft.