### PR TITLE
Add hint for iClass in `hf search`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Added hint for iClass to `hf search` (@bettse)
  - Changed `hf 14a apdu` - It now uses the FWI and SGFI values from the ATS to determine an appropriate timeout (@nvx)
  - Added a thread to check when device comes online again. It will connect and update prompt (@iceman1001)
  - Changed CLI offline prompt - replaces the old prompt when offline is detected (@iceman100)

--- a/client/src/cmdhf.c
+++ b/client/src/cmdhf.c
@@ -175,6 +175,7 @@ int CmdHFSearch(const char *Cmd) {
     if (IfPm3Iclass()) {
         if (read_iclass_csn(false, false, false) == PM3_SUCCESS) {
             PrintAndLogEx(SUCCESS, "\nValid " _GREEN_("iCLASS tag / PicoPass tag") " found\n");
+            PrintAndLogEx(HINT, "Hint: try " _YELLOW_("`hf iclass`") " commands\n");
             res = PM3_SUCCESS;
         }
     }


### PR DESCRIPTION
It was:

```
[usb] pm3 --> hf search
 🕙  Searching for iCLASS / PicoPass tag...   
[+] iCLASS / Picopass CSN: CE F0 43 01 F7 FF 12 E0 

[+] Valid iCLASS tag / PicoPass tag found
```

And now it is 

```
[usb] pm3 --> hf search
 🕗  Searching for iCLASS / PicoPass tag...   
[+] iCLASS / Picopass CSN: CE F0 43 01 F7 FF 12 E0 

[+] Valid iCLASS tag / PicoPass tag found

[?] Hint: try `hf iclass` commands
```
