### PR TITLE
Ignore button jitters in bootloader mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed bootloader - Ignore jitters when pressing the button (@wh201906)
 
 ## [Steamboat Willie.4.17768][2024-01-03]
  - Changed `mem spiffs dump -t` - now supports downloading direct into trace buffer (@hazardousvoltage)

--- a/bootrom/bootrom.c
+++ b/bootrom/bootrom.c
@@ -252,10 +252,17 @@ static void flash_mode(void) {
             }
         }
 
-        if (g_common_area.flags.button_pressed && BUTTON_PRESS() == false) {
+        bool button_state = BUTTON_PRESS();
+        // ~10ms, prevent jitter
+        delay_loop(3333);
+        if (button_state != BUTTON_PRESS()) {
+            // in jitter state, ignore
+            continue;
+        }
+        if (g_common_area.flags.button_pressed && button_state == false) {
             g_common_area.flags.button_pressed = 0;
         }
-        if (!g_common_area.flags.button_pressed && BUTTON_PRESS()) {
+        if (!g_common_area.flags.button_pressed && button_state) {
             /* Perform a reset to leave flash mode */
             g_common_area.flags.button_pressed = 1;
             usb_disable();


### PR DESCRIPTION
Commit 51e4df533e79399fef1672325d2ec57fdcc27986 changed the button behavior, but it doesn't work on my Proxmark3 Easy. I think it's caused by the jitter (bounce) when pressing/releasing the button.