### PR TITLE
Add alt Disney AID for desfire

### DIFF
--- a/client/resources/aid_desfire.json
+++ b/client/resources/aid_desfire.json
@@ -377,6 +377,14 @@
         "Type": "payment system"
     },
     {
+        "AID": "78E127",
+        "Vendor": "Disney",
+        "Country": "US",
+        "Name": "Disney MagicBand",
+        "Description": "",
+        "Type": "payment system"
+    },
+    {
         "AID": "44434C",
         "Vendor": "Disney",
         "Country": "US",


### PR DESCRIPTION
Noticed the AID for the MagicBand didn't match on my "Key to the world" card from Disney Cruise Line.

Not sure if it is only used on DCL though