### PR TITLE
Fix for issue #2244 (hf15 raw -k command)

### DIFF
--- a/armsrc/iso15693.c
+++ b/armsrc/iso15693.c
@@ -2434,9 +2434,12 @@ void BruteforceIso15693Afi(uint32_t speed) {
 
 // Allows to directly send commands to the tag via the client
 // OBS:  doesn't turn off rf field afterwards.
-void DirectTag15693Command(uint32_t datalen, uint32_t speed, uint32_t recv, uint8_t *data) {
+void DirectTag15693Command(uint32_t datalen, uint32_t speed, uint32_t flags, uint8_t *data) {
 
     LED_A_ON();
+	
+    bool recv = flags & 1 ? true : false;
+    bool field_already_on = flags & 2 ? true : false;
 
     uint8_t recvbuf[ISO15693_MAX_RESPONSE_LENGTH];
     uint16_t timeout;
@@ -2462,7 +2465,7 @@ void DirectTag15693Command(uint32_t datalen, uint32_t speed, uint32_t recv, uint
 
     uint32_t start_time = 0;
     uint16_t recvlen = 0;
-    int res = SendDataTag(data, datalen, true, speed, (recv ? recvbuf : NULL), sizeof(recvbuf), start_time, timeout, &eof_time, &recvlen);
+    int res = SendDataTag(data, datalen, !field_already_on, speed, (recv ? recvbuf : NULL), sizeof(recvbuf), start_time, timeout, &eof_time, &recvlen);
     if (res == PM3_ETEAROFF) { // tearoff occurred
         reply_ng(CMD_HF_ISO15693_COMMAND, res, NULL, 0);
     } else {
@@ -2487,8 +2490,8 @@ void DirectTag15693Command(uint32_t datalen, uint32_t speed, uint32_t recv, uint
 
     // note: this prevents using hf 15 cmd with s option - which isn't implemented yet anyway
     // also prevents hf 15 raw -k  keep_field on ...
-    FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
-    LED_D_OFF();
+    //FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
+    //LED_D_OFF();
 }
 
 /*

--- a/armsrc/iso15693.c
+++ b/armsrc/iso15693.c
@@ -2447,6 +2447,8 @@ void DirectTag15693Command(uint32_t datalen, uint32_t speed, uint32_t flags, uin
     bool request_answer = false;
 
     switch (data[1]) {
+        case ISO15693_SET_PASSWORD:
+        case ISO15693_ENABLE_PRIVACY:
         case ISO15693_WRITEBLOCK:
         case ISO15693_LOCKBLOCK:
         case ISO15693_WRITE_MULTI_BLOCK:

--- a/client/src/cmdhf15.c
+++ b/client/src/cmdhf15.c
@@ -1753,10 +1753,12 @@ static int CmdHF15Raw(const char *Cmd) {
     // arg: len, speed, recv?
     // arg0 (datalen,  cmd len?  .arg0 == crc?)
     // arg1 (speed == 0 == 1 of 256,  == 1 == 1 of 4 )
-    // arg2 (recv == 1 == expect a response)
+    // arg2 (recv == 1 == expect a response) |
+    //      (2 == field is already on, 0 == field is off)
     PacketResponseNG resp;
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO15693_COMMAND, datalen, fast, read_respone, data, datalen);
+    SendCommandMIX(CMD_HF_ISO15693_COMMAND, datalen, fast, (read_respone? 1 : 0) | (g_field_on ? 2 : 0), data, datalen);
+    g_field_on = true;
 
     if (read_respone) {
         if (WaitForResponseTimeout(CMD_HF_ISO15693_COMMAND, &resp, 2000)) {

--- a/client/src/comms.h
+++ b/client/src/comms.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 #ifndef DropField
-#define DropField() { clearCommandBuffer(); SetISODEPState(ISODEP_INACTIVE); SendCommandNG(CMD_HF_DROPFIELD, NULL, 0); }
+#define DropField() { clearCommandBuffer(); SetISODEPState(ISODEP_INACTIVE); SendCommandNG(CMD_HF_DROPFIELD, NULL, 0); g_field_on = false; }
 #endif
 
 #ifndef DropFieldEx

--- a/client/src/util.c
+++ b/client/src/util.c
@@ -40,6 +40,9 @@ uint8_t g_debugMode = 0;
 uint8_t g_printAndLog = PRINTANDLOG_PRINT | PRINTANDLOG_LOG;
 // global client tell if a pending prompt is present
 bool g_pendingPrompt = false;
+// global client: set to false by DropField()
+bool g_field_on = false;
+
 // global CPU core count override
 int g_numCPUs = 0;
 

--- a/client/src/util.h
+++ b/client/src/util.h
@@ -32,6 +32,8 @@
 extern uint8_t g_debugMode;
 extern uint8_t g_printAndLog;
 extern bool g_pendingPrompt;
+extern bool g_field_on;
+
 extern int g_numCPUs;
 
 #define PRINTANDLOG_PRINT 1


### PR DESCRIPTION
***Description***
This PR is submitted to address issue #2244 (hf 15 raw -k option (keep field on) is broken/removed)

Currently, the -k option for hf 15 raw command does not keep the RF field turned on.
The option is parsed, but the DirectTag15693Command in iso15693.c explicitly turns off the field at the end of the command. It also unconditionally resets the field at the start of the command.

***Why is this important?***
This is important for tags that have non standard Iso15693 commands that require the tag to remain powered between commands. An example is the NXP ICODE SLIX-L which requires that the tag remains powered during the privacy disable sequence (get random number followed by set password command). We already have instruction support for SLIX privacy enable/disable, but we should also be able to achieve the same thing using raw commands as Proxmark is meant to be a learning and investigative tool.

***Solution***
This PR updates the code provided in PR #1636 to be compatible with the new code base.
This PR also includes a minor modification to enable "write alike" timing for two ICODE SLIX-L commands (set password / enable privacy". Without this, the timeout is too short and the tag response is missed resulting in the client returning a "command failed" response.

