### PR TITLE
Add `data crypto` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Added `data crypto` to encrypt and decrypt data in the proxmark client using built-in methods (@team-orangeBlue)
  - Changed `hf tune` and `lf tune` - Added an option to show statistical data after tuning (@wh201906)
  - Changed `lf idteck demod --raw` - now supports raw hex string to decode (@iceman1001)
  - Changed `lf em 410x demod --bin` - now supports a raw binary string to demodulate. (@iceman1001)

--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -3742,8 +3742,8 @@ static int CmdCryptography(const char *Cmd) {
                         des_encrypt_cbc(dato, dati, datilen, key, iv);
                         char pad[250];
                         memset(pad, ' ', 4 + 8 + (datilen - 8) * 3);
-                        pad[4 + 8 + (datilen - 8) * 3] = 0; // Make a padding to insert FMCOS macing algorithm guide
-                        PrintAndLogEx(NONE, "%sVV VV VV VV FMCOS MAC", pad);
+                        pad[8 + (datilen - 8) * 3] = 0; // Make a padding to insert FMCOS macing algorithm guide
+                        PrintAndLogEx(INFO, "%sVV VV VV VV FMCOS MAC", pad);
                     }
                 }
             }

--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -39,6 +39,7 @@
 #include "mbedtls/entropy.h"     //
 #include "mbedtls/ctr_drbg.h"    // random generator
 #include "atrs.h"                // ATR lookup
+#include "crypto/libpcrypto.h"   // Cryptography
 
 uint8_t g_DemodBuffer[MAX_DEMOD_BUF_LEN] = { 0x00 };
 size_t g_DemodBufferLen = 0;

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -273,6 +273,27 @@
             ],
             "usage": "data clear [-h]"
         },
+        "data crypto": {
+            "command": "data crypto",
+            "description": "Encrypt and decrypt data",
+            "notes": [
+                "Supply data, key, IV (needed for des MAC or aes), and cryptography action.",
+                "To calculate a MAC for FMCOS, supply challenge as IV, data as data, and session/line protection key as key.",
+                "To calculate a MAC for FeliCa, supply first RC as IV, BLE+data as data and session key as key.",
+                "data crypto -d 04D6850E06AABB80 -k FFFFFFFFFFFFFFFF --iv 9EA0401A00000000 --des -> Calculate a MAC for FMCOS chip. The result should be ED3A0133"
+            ],
+            "offline": true,
+            "options": [
+                "-h, --help This help",
+                "-d, --data <hex> Data to process",
+                "-k, --key <hex> Key to use",
+                "-r, --rev Decrypt, not encrypt",
+                "--des Cipher with DES, not AES",
+                "--mac Calculate AES CMAC/FeliCa Lite MAC",
+                "--iv <hex> IV value if needed"
+            ],
+            "usage": "data crypto [-hr] -d <hex> -k <hex> [--des] [--mac] [--iv <hex>]"
+        },
         "data convertbitstream": {
             "command": "data convertbitstream",
             "description": "Convert GraphBuffer's 0|1 values to 127|-127",

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -128,6 +128,7 @@ Check column "offline" for their availability.
 |`data bitsamples        `|N       |`Get raw samples as bitstring`
 |`data bmap              `|Y       |`Convert hex value according a binary template`
 |`data clear             `|Y       |`Clears bigbuf on deviceside and graph window`
+|`data crypto            `|Y       |`Encrypt and decrypt data`
 |`data diff              `|Y       |`Diff of input files`
 |`data hexsamples        `|N       |`Dump big buffer as hex bytes`
 |`data hex2bin           `|Y       |`Converts hexadecimal to binary`


### PR DESCRIPTION
Implementation to quickly cipher data and not look for a tool online, with some proprietary algorithms.

Includes:
* DES ECB/CBC de/encryption
* 2/3 key TDEA ECB/CBC de/encryption
* AES 128 CBC de/encryption
* FMCOS DES MAC calculation (part of DES CBC encryption)
* AES CMAC

Tests were done on real chips. The outputs are equal.
A sample is provided.

*FeliCa Lite MAC is not implemented due to lack of testing material*