### PR TITLE
Readmem small fixes

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -2393,6 +2393,9 @@ static void PacketReceived(PacketCommandNG *packet) {
             } else {
                 // Allow reading from any memory address and length in special 'raw' mode.
                 base = NULL;
+                // Boundary check against end of addressable space.
+                if (offset > 0)
+                    count=MIN(count, -offset);
             }
 
             if (isok) {

--- a/bootrom/bootrom.c
+++ b/bootrom/bootrom.c
@@ -186,6 +186,9 @@ static void UsbPacketReceived(uint8_t *packet) {
             } else {
                 // Allow reading from any memory address and length in special 'raw' mode.
                 base = NULL;
+                // Boundary check against end of addressable space.
+                if (offset > 0)
+                    count=MIN(count, -offset);
             }
 
             if (isok) {

--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -682,7 +682,6 @@ static int CmdReadmem(const char *Cmd) {
     }
 
     if (save_to_file) {
-        PrintAndLogEx(INFO, "saving to "_YELLOW_("%s"), filename);
         saveFile(filename, ".bin", buffer, len);
     } else {
         PrintAndLogEx(INFO, "---- " _CYAN_("processor%s memory") " ----", flash_str);

--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -640,10 +640,10 @@ static int CmdReadmem(const char *Cmd) {
 
     void *argtable[] = {
         arg_param_begin,
-        arg_int0("a", "adr", "<dec>", "flash address to start reading from"),
-        arg_int0("l", "len", "<dec>", "length (default 32 or 512KB)"),
+        arg_u64_0("a", "adr", "<dec>", "flash address to start reading from"),
+        arg_u64_0("l", "len", "<dec>", "length (default 32 or 512KB)"),
         arg_str0("f", "file", "<fn>", "save to file"),
-        arg_int0("c", "cols", "<dec>", "column breaks"),
+        arg_u64_0("c", "cols", "<dec>", "column breaks"),
         arg_lit0("r", "raw", "use raw address mode: read from anywhere, not just flash"),
         arg_param_end
     };

--- a/client/src/proxmark3.c
+++ b/client/src/proxmark3.c
@@ -1139,7 +1139,7 @@ int main(int argc, char *argv[]) {
                 show_help(false, exec_name);
                 return 1;
             }
-            uint32_t tmpaddr = strtol(argv[i + 1], NULL, 10);
+            uint32_t tmpaddr = strtoul(argv[i + 1], NULL, 0);
             dumpmem_addr = tmpaddr;
             i++;
             continue;
@@ -1150,7 +1150,7 @@ int main(int argc, char *argv[]) {
                 show_help(false, exec_name);
                 return 1;
             }
-            uint32_t tmplen = strtol(argv[i + 1], NULL, 10);
+            uint32_t tmplen = strtoul(argv[i + 1], NULL, 0);
             dumpmem_len = tmplen;
             i++;
             continue;

--- a/client/src/proxmark3.c
+++ b/client/src/proxmark3.c
@@ -683,7 +683,6 @@ static int dumpmem_to_file(const char *filename, uint32_t addr, uint32_t len, bo
     }
 
     if (res == PM3_SUCCESS) {
-        PrintAndLogEx(INFO, "saving to "_YELLOW_("%s"), filename);
         if (saveFile(filename, ".bin", buffer, read) != 0) {
             PrintAndLogEx(ERR, "error writing to file "_YELLOW_("%s"), filename);
             res = PM3_EFILE;


### PR DESCRIPTION
Some minor cleanup in the new readmem functions.
- number entry should be unsigned and allow hexadecimal
- printing filename to the console twice
- corner case at the end of adressable memory
