### PR TITLE
Fix hf sniff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Fixed `hf sniff` broken since 17ab86c52 (@nvx)
  - Added `--dumpmem` to proxmark3 client for memory dumping to file (@martian01010)
  - Changed `hw readmem` to allow larger reads, write to file and better hex viewer (@martian01010)
  - Added `CMD_READ_MEM_DOWNLOAD` and `CMD_READ_MEM_DOWNLOADED` to osimage and bootloader (@martian01010)

--- a/armsrc/hfsnoop.c
+++ b/armsrc/hfsnoop.c
@@ -106,7 +106,7 @@ int HfSniff(uint32_t samplesToSkip, uint32_t triggersToSkip, uint16_t *len, uint
     FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_SNIFF);
     SpinDelay(100);
 
-    *len = (BigBuf_max_traceLen() & 0xFFFE);
+    *len = BigBuf_max_traceLen();
     uint8_t *mem = BigBuf_malloc(*len);
 
     uint32_t trigger_cnt = 0;


### PR DESCRIPTION
This was broken in commit 17ab86c52 as the forced rounding up of the size to 4-byte alignment in BigBuf_malloc made the size check possibly larger than the buffer size as the check was always +3 on the requested size rather than the rounded size. This was made worse by BigBuf_max_traceLen not taking into account alignment either and the alignmentn check in hfsnoop.c checking to 2 byte alignment instead of 4 byte alignment.

The alignment size check now checks the size after alignment rounding, and BigBuf_max_traceLen takes into account alignment losses too reducing the need for BigBuf consumers to have to care about alignment.