### PR TITLE
Rename CMD_READ_MEM_DOWNLOAD flag.

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -2374,7 +2374,7 @@ static void PacketReceived(PacketCommandNG *packet) {
             bool isok = true;
             uint8_t *base = NULL;
 
-            bool raw_address_mode = (flags & READ_MEM_DOWNLOAD_FLAG_RAW) != 0;
+            bool raw_address_mode = (flags & READ_MEM_DOWNLOAD_FLAG_RAW) == READ_MEM_DOWNLOAD_FLAG_RAW;
             if (!raw_address_mode) {
 
                 base = (uint8_t *) _flash_start;

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -2374,7 +2374,7 @@ static void PacketReceived(PacketCommandNG *packet) {
             bool isok = true;
             uint8_t *base = NULL;
 
-            bool raw_address_mode = (flags & CMD_READ_MEM_DOWNLOAD_RAW) != 0;
+            bool raw_address_mode = (flags & READ_MEM_DOWNLOAD_FLAG_RAW) != 0;
             if (!raw_address_mode) {
 
                 base = (uint8_t *) _flash_start;

--- a/bootrom/bootrom.c
+++ b/bootrom/bootrom.c
@@ -169,7 +169,7 @@ static void UsbPacketReceived(uint8_t *packet) {
             bool isok = true;
             uint8_t *base = NULL;
 
-            bool raw_address_mode = (flags & READ_MEM_DOWNLOAD_FLAG_RAW) != 0;
+            bool raw_address_mode = (flags & READ_MEM_DOWNLOAD_FLAG_RAW) == READ_MEM_DOWNLOAD_FLAG_RAW;
             if (!raw_address_mode) {
 
                 base = (uint8_t *) _flash_start;

--- a/bootrom/bootrom.c
+++ b/bootrom/bootrom.c
@@ -169,7 +169,7 @@ static void UsbPacketReceived(uint8_t *packet) {
             bool isok = true;
             uint8_t *base = NULL;
 
-            bool raw_address_mode = (flags & CMD_READ_MEM_DOWNLOAD_RAW) != 0;
+            bool raw_address_mode = (flags & READ_MEM_DOWNLOAD_FLAG_RAW) != 0;
             if (!raw_address_mode) {
 
                 base = (uint8_t *) _flash_start;

--- a/client/src/comms.c
+++ b/client/src/comms.c
@@ -1136,7 +1136,7 @@ bool GetFromDevice(DeviceMemType_t memtype, uint8_t *dest, uint32_t bytes, uint3
         }
         case MCU_FLASH:
         case MCU_MEM: {
-            uint32_t flags = memtype == MCU_MEM ? CMD_READ_MEM_DOWNLOAD_RAW : 0;
+            uint32_t flags = memtype == MCU_MEM ? READ_MEM_DOWNLOAD_FLAG_RAW : 0;
             SendCommandBL(CMD_READ_MEM_DOWNLOAD, start_index, bytes, flags, NULL, 0);
             return dl_it(dest, bytes, response, ms_timeout, show_warning, CMD_READ_MEM_DOWNLOADED);
         }

--- a/client/src/comms.c
+++ b/client/src/comms.c
@@ -1136,7 +1136,7 @@ bool GetFromDevice(DeviceMemType_t memtype, uint8_t *dest, uint32_t bytes, uint3
         }
         case MCU_FLASH:
         case MCU_MEM: {
-            uint32_t flags = memtype == MCU_MEM ? READ_MEM_DOWNLOAD_FLAG_RAW : 0;
+            uint32_t flags = (memtype == MCU_MEM) ? READ_MEM_DOWNLOAD_FLAG_RAW : 0;
             SendCommandBL(CMD_READ_MEM_DOWNLOAD, start_index, bytes, flags, NULL, 0);
             return dl_it(dest, bytes, response, ms_timeout, show_warning, CMD_READ_MEM_DOWNLOADED);
         }

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -897,7 +897,7 @@ typedef struct {
 #define BL_VERSION_1_0_0    BL_MAKE_VERSION(1, 0, 0)
 
 /* CMD_READ_MEM_DOWNLOAD flags */
-#define CMD_READ_MEM_DOWNLOAD_RAW                    (1<<0)
+#define READ_MEM_DOWNLOAD_FLAG_RAW                   (1<<0)
 
 /* CMD_START_FLASH may have three arguments: start of area to flash,
    end of area to flash, optional magic.


### PR DESCRIPTION
CMD_READ_MEM_DOWNLOAD_RAW got automatically included in pm3_cmd.lua.  It then broke lua scripting because some versions of lua don't like the bit shift in the value.

Renaming it from CMD_READ_MEM_DOWNLOAD_RAW to READ_MEM_DOWNLOAD_FLAG_RAW so it's not included anymore.
