### PR TITLE
cmdhf15: fix sanity checks (uidlen alone is > 1 when -u is set)

### DIFF
--- a/client/src/cmdhf15.c
+++ b/client/src/cmdhf15.c
@@ -936,7 +936,7 @@ static int CmdHF15Info(const char *Cmd) {
     CLIParserFree(ctx);
 
     // sanity checks
-    if ((scan + unaddressed + uidlen) > 1) {
+    if ((scan + unaddressed + (uidlen > 0)) > 1) {
         PrintAndLogEx(WARNING, "Select only one option /scan/unaddress/uid");
         return PM3_EINVARG;
     }
@@ -1639,7 +1639,7 @@ static int CmdHF15WriteDsfid(const char *Cmd) {
     CLIParserFree(ctx);
 
     // sanity checks
-    if ((scan + unaddressed + uidlen) > 1) {
+    if ((scan + unaddressed + (uidlen > 0)) > 1) {
         PrintAndLogEx(WARNING, "Select only one option /scan/unaddress/uid");
         return PM3_EINVARG;
     }
@@ -2588,7 +2588,7 @@ static int CmdHF15Restore(const char *Cmd) {
     CLIParserFree(ctx);
 
     // sanity checks
-    if ((scan + unaddressed + uidlen) > 1) {
+    if ((scan + unaddressed + (uidlen > 0)) > 1) {
         PrintAndLogEx(WARNING, "Select only one option /scan/unaddress/uid");
         return PM3_EINVARG;
     }


### PR DESCRIPTION
Fix "hf 15 info", "hf 15 writedsfid" and "hf 15 restore" supports for "-u UID" option.