### PR TITLE
Fix style error in `udev` rules.

### DIFF
--- a/driver/77-pm3-usb-device-blacklist-dialout.rules
+++ b/driver/77-pm3-usb-device-blacklist-dialout.rules
@@ -10,13 +10,13 @@
 ACTION!="add|change", GOTO="pm3_usb_device_blacklist_end"
 SUBSYSTEM!="tty", GOTO="pm3_ignore"
 
-ATTRS{idVendor}=="2d2d" ATTRS{idProduct}=="504d", ENV{ID_MM_DEVICE_IGNORE}="1" SYMLINK+="pm3-%n" MODE="660" GROUP="dialout"
-ATTRS{idVendor}=="9ac4" ATTRS{idProduct}=="4b8f", ENV{ID_MM_DEVICE_IGNORE}="1" SYMLINK+="pm3-%n" MODE="660" GROUP="dialout"
-ATTRS{idVendor}=="502d" ATTRS{idProduct}=="502d", ENV{ID_MM_DEVICE_IGNORE}="1" SYMLINK+="pm3-%n" MODE="660" GROUP="dialout"
+ATTRS{idVendor}=="2d2d", ATTRS{idProduct}=="504d", ENV{ID_MM_DEVICE_IGNORE}="1", SYMLINK+="pm3-%n", MODE="660", GROUP="dialout"
+ATTRS{idVendor}=="9ac4", ATTRS{idProduct}=="4b8f", ENV{ID_MM_DEVICE_IGNORE}="1", SYMLINK+="pm3-%n", MODE="660", GROUP="dialout"
+ATTRS{idVendor}=="502d", ATTRS{idProduct}=="502d", ENV{ID_MM_DEVICE_IGNORE}="1", SYMLINK+="pm3-%n", MODE="660", GROUP="dialout"
 
 LABEL="pm3_ignore"
-ATTRS{idVendor}=="2d2d" ATTRS{idProduct}=="504d", ENV{ID_MM_DEVICE_IGNORE}="1"
-ATTRS{idVendor}=="9ac4" ATTRS{idProduct}=="4b8f", ENV{ID_MM_DEVICE_IGNORE}="1"
-ATTRS{idVendor}=="502d" ATTRS{idProduct}=="502d", ENV{ID_MM_DEVICE_IGNORE}="1"
+ATTRS{idVendor}=="2d2d", ATTRS{idProduct}=="504d", ENV{ID_MM_DEVICE_IGNORE}="1"
+ATTRS{idVendor}=="9ac4", ATTRS{idProduct}=="4b8f", ENV{ID_MM_DEVICE_IGNORE}="1"
+ATTRS{idVendor}=="502d", ATTRS{idProduct}=="502d", ENV{ID_MM_DEVICE_IGNORE}="1"
 
 LABEL="pm3_usb_device_blacklist_end"


### PR DESCRIPTION
As called out by running `udevadm verify`,
the existing rules violate the requirement
that sections are separated by commas,
(not whitespace).