### PR TITLE
Properly handle "hf mf dump" errors

### DIFF
--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -573,13 +573,13 @@ static int mfc_read_tag(iso14a_card_select_t *card, uint8_t *carddata, uint8_t n
     SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 1500) == false) {
-        PrintAndLogEx(FAILED, "iso14443a card select timeout");
+        PrintAndLogEx(DEBUG, "iso14443a card select timeout");
         return PM3_ETIMEOUT;
     }
 
     uint64_t select_status = resp.oldarg[0];
     if (select_status == 0) {
-        PrintAndLogEx(FAILED, "iso14443a card select failed");
+        PrintAndLogEx(DEBUG, "iso14443a card select failed");
         return PM3_ESOFT;
     }
 

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -573,14 +573,14 @@ static int mfc_read_tag(iso14a_card_select_t *card, uint8_t *carddata, uint8_t n
     SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 1500) == false) {
-        PrintAndLogEx(DEBUG, "iso14443a card select timeout");
+        PrintAndLogEx(FAILED, "iso14443a card select timeout");
         return PM3_ETIMEOUT;
     }
 
     uint64_t select_status = resp.oldarg[0];
     if (select_status == 0) {
-        PrintAndLogEx(DEBUG, "iso14443a card select failed");
-        return PM3_SUCCESS;
+        PrintAndLogEx(FAILED, "iso14443a card select failed");
+        return PM3_ESOFT;
     }
 
     // store card info


### PR DESCRIPTION
I was confused why `hf mf dump` wasn't showing any errors but the dump file was all zeros:
```
[usb|script] pm3 --> hf mf dump
[+] time: 0 seconds

[+] saved 1024 bytes to binary file `/Users/gsgx/hf-mf-D6E6ACDF-dump-001.bin`
[+] saved to json file `/Users/gsgx/hf-mf-D6E6ACDF-dump-001.json`
```

For some reason `PM3_SUCCESS` was being returned from this error path, and the log message was using the `DEBUG` log level. After this PR, it's more clear an error occured:

```
[usb|script] pm3 --> hf mf dump
[-]  iso14443a card select failed
```