### PR TITLE
Improve `hw detectreader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Changed `hw detectreader` - Detect both LF and HF at the same time (@wh201906)
  - Changed `hf mfu info` - should not try pwd against a UL-AES (@iceman1001)
  - Fixed `hf mfu info` - tag type identification now properly handles 64bits (@iceman1001)
  - Changed `hf st info` - reworked the output (@iceman1001)


### PR DESCRIPTION
Bring back support for detecting both HF and LF reader in mode 1
Add support for switching modes by keyboard