### PR TITLE
Added led order parameter (for Proxmark3 Easy board)

### DIFF
--- a/Makefile.platform.sample
+++ b/Makefile.platform.sample
@@ -10,6 +10,10 @@ PLATFORM=PM3RDV4
 #PLATFORM_EXTRAS=BTADDON FLASH
 #STANDALONE=LF_SAMYRUN
 
+# Uncomment the line below to set the correct LED order on board Proxmark3 Easy
+# Only available with PLATFORM=PM3GENERIC
+#LED_ORDER=PM3EASY
+
 # Uncomment the lines below in order to make a 256KB image
 # and comment out the lines above
 

--- a/armsrc/util.h
+++ b/armsrc/util.h
@@ -41,17 +41,26 @@
 #define BYTEx(x, n) (((x) >> (n * 8)) & 0xff )
 #endif
 
-// Proxmark3 RDV4.0 LEDs
+// Proxmark3 RDV4.0 and Proxmark Easy LEDs
 #define LED_A 1
 #define LED_B 2
 #define LED_C 4
 #define LED_D 8
 
+
+#ifndef LED_ORDER_PM3EASY
 // Proxmark3 historical LEDs
 #define LED_ORANGE LED_A
 #define LED_GREEN  LED_B
 #define LED_RED    LED_C
 #define LED_RED2   LED_D
+#else
+// Proxmark3 Easy LEDs
+#define LED_GREEN  LED_A
+#define LED_RED    LED_B
+#define LED_ORANGE LED_C
+#define LED_RED2   LED_D
+#endif
 
 #define BUTTON_HOLD 1
 #define BUTTON_NO_CLICK 0

--- a/common_arm/Makefile.hal
+++ b/common_arm/Makefile.hal
@@ -108,11 +108,17 @@ else ifeq ($(PLATFORM),PM3OTHER)
     FPGA_BITSTREAMS = fpga_pm3_lf.bit fpga_pm3_hf.bit fpga_pm3_felica.bit fpga_pm3_hf_15.bit
     PLTNAME = Proxmark3 generic target
     PLATFORM_FPGA = xc2s30
+    ifeq ($(LED_ORDER),PM3EASY)
+        PLATFORM_DEFS = -DLED_ORDER_PM3EASY
+    endif
 else ifeq ($(PLATFORM),PM3GENERIC)
     # FPGA bitstream files, the order matters!
     FPGA_BITSTREAMS = fpga_pm3_lf.bit fpga_pm3_hf.bit fpga_pm3_felica.bit fpga_pm3_hf_15.bit
     PLTNAME = Proxmark3 generic target
     PLATFORM_FPGA = xc2s30
+    ifeq ($(LED_ORDER),PM3EASY)
+        PLATFORM_DEFS = -DLED_ORDER_PM3EASY
+    endif
 else ifeq ($(PLATFORM),PM3ICOPYX)
     # FPGA bitstream files, the order matters - only hf has a bitstream, the other 3 files are 0 bytes
     FPGA_BITSTREAMS = fpga_icopyx_lf.bit fpga_icopyx_hf.bit fpga_icopyx_felica.bit fpga_icopyx_hf_15.bit

--- a/include/config_gpio.h
+++ b/include/config_gpio.h
@@ -21,13 +21,21 @@
 
 #define GPIO_LED_A          AT91C_PIO_PA0
 #define GPIO_PA1            AT91C_PIO_PA1
+#ifndef LED_ORDER_PM3EASY
 #define GPIO_LED_D          AT91C_PIO_PA2
+#else
+#define GPIO_LED_B          AT91C_PIO_PA2
+#endif
 #define GPIO_NVDD_ON        AT91C_PIO_PA3
 #define GPIO_FPGA_NINIT     AT91C_PIO_PA4
 #define GPIO_PA5            AT91C_PIO_PA5
 #define GPIO_PCK0           AT91C_PA6_PCK0
 #define GPIO_LRST           AT91C_PIO_PA7
+#ifndef LED_ORDER_PM3EASY
 #define GPIO_LED_B          AT91C_PIO_PA8
+#else
+#define GPIO_LED_D          AT91C_PIO_PA8
+#endif
 #define GPIO_LED_C          AT91C_PIO_PA9
 
 // defines for flash mem,  or rdv40 ?


### PR DESCRIPTION
Added parameter `LED_ORDER` in Makefile.platform to correct led GPIO on Proxmark3 Easy board.

When setting `LED_ORDER=PM3EASY`, the LEDs get configured in the right order for this board, allowing correct binary counting of standalone modes and nice animations (SpinUp and SpinDown).