### PR TITLE
hf mf dump print by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,15 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Changed `hf mf dump --np` - now prints dump by default and supports noprint flag (@francesco-scar)
  - Fixed `hf 14a info` - magic detection works again and better hint detection (@iceman1001)
+ - Changed `14b wrbl` - now uses SRIX 4k as default tag (@Sonic803)
+ - Changed `14b reader` - now shows data plot (@Sonic803)
  - Added `hf 14b restore` - new command to restore dump files to a SR512/4k card (@Sonic803)
  - Changed led show / leds detection for PM3 Easy devices (@francesco-scar)
 
 ## [DEFCON is Cancelled.4.18218][2024-02-18]
+ - Fixed `hf mf autopwn` - now correctly attempts static nested attack (@Sonic803 and @francesco-scar)
  - Changed `hf fudan dump --ns` - now supports nosave flag (@iceman1001)
  - Added `lf em 410x --electra` - adds two extra blocks. Thanks jareckib (@iceman1001)
  - Changed `hf mfu info` - now identifies UL-AES correct (@iceman1001)

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -347,7 +347,9 @@ static void mf_print_blocks(uint16_t n, uint8_t *d, bool verbose) {
         mf_print_block(i, d + (i * MFBLOCK_SIZE), verbose);
     }
     PrintAndLogEx(INFO, "-----+-----+-------------------------------------------------+-----------------");
-    PrintAndLogEx(HINT, _CYAN_("cyan") " = value block with decoded value");
+    if (verbose) {
+        PrintAndLogEx(HINT, _CYAN_("cyan") " = value block with decoded value");
+    }
 
     // MAD detection
     if (HasMADKey(d)) {

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -1224,6 +1224,8 @@ static int CmdHF14AMfDump(const char *Cmd) {
         arg_lit0(NULL, "2k", "MIFARE Classic/Plus 2k"),
         arg_lit0(NULL, "4k", "MIFARE Classic 4k / S70"),
         arg_lit0(NULL, "ns", "no save to file"),
+        arg_lit0(NULL, "np", "no print dump to screen"),
+        arg_lit0("v", "verbose", "decode value blocks"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
@@ -1241,6 +1243,8 @@ static int CmdHF14AMfDump(const char *Cmd) {
     bool m2 = arg_get_lit(ctx, 5);
     bool m4 = arg_get_lit(ctx, 6);
     bool nosave = arg_get_lit(ctx, 7);
+    bool noprint = arg_get_lit(ctx, 8);
+    bool verbose = arg_get_lit(ctx, 9);
     CLIParserFree(ctx);
 
     uint64_t t1 = msclock();
@@ -1287,6 +1291,14 @@ static int CmdHF14AMfDump(const char *Cmd) {
     }
 
     PrintAndLogEx(SUCCESS, "time: %" PRIu64 " seconds\n", (msclock() - t1) / 1000);
+
+    // Skip printing dump to screen
+    if (noprint) {
+        PrintAndLogEx(INFO, "Called with no print option");
+    } else {
+        PrintAndLogEx(INFO, "Verbose %d", verbose);
+        mf_print_blocks(bytes/MFBLOCK_SIZE, mem, verbose);
+    }
 
     // Skip saving card data to file
     if (nosave) {

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -4411,9 +4411,11 @@
                 "--1k MIFARE Classic 1k / S50 (def)",
                 "--2k MIFARE Classic/Plus 2k",
                 "--4k MIFARE Classic 4k / S70",
-                "--ns no save to file"
+                "--ns no save to file",
+                "--np no print dump to screen",
+                "-v, --verbose decode value blocks"
             ],
-            "usage": "hf mf dump [-h] [-f <fn>] [-k <fn>] [--mini] [--1k] [--2k] [--4k] [--ns]"
+            "usage": "hf mf dump [-hv] [-f <fn>] [-k <fn>] [--mini] [--1k] [--2k] [--4k] [--ns] [--np]"
         },
         "hf mf ecfill": {
             "command": "hf mf ecfill",


### PR DESCRIPTION
Added dump print by default in `hf mf dump` and now supports the noprint flag to allow the same behavior as before.
Also updated the changelog for past commits.