### PR TITLE
No code change: .gitignore user's custom Makefile.platform.xxx files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ originalitysig.csv
 
 # new build file for add-ons.
 Makefile.platform
+Makefile.platform.*
+!Makefile.platform.sample
+
 # Cache for detecting platform def changes
 .Makefile.options.cache
 


### PR DESCRIPTION
For example, I have my own makefiles named:

* `Makefile.platform.RDV4`
* `Makefile.platform.PM3Easy`

I can imagine similar options others might then be able to create, without having to remember to always remove those files from any commit / push / PR, such as:

* `Makefile.platform.PM3Easy_NoFlash`
* `Makefile.platform.PM3Easy_WithFlash`
* `Makefile.platform.PM3X`
* etc.
