### PR TITLE
Improve reliability of `lf em 4x70 writekey`

### DIFF
--- a/armsrc/em4x70.c
+++ b/armsrc/em4x70.c
@@ -581,6 +581,11 @@ static bool send_command_and_read(uint8_t command, uint8_t *bytes, size_t length
                 Dbprintf("Invalid data received length: %d, expected %d", len, out_length_bits);
                 return false;
             }
+            // TODO: Figure out why getting an extra bit (quite often) here
+            // e.g., write block and info commands both reach here and output:
+            // [#] Should have a multiple of 8 bits, was sent 33
+            // [#] Should have a multiple of 8 bits, was sent 65
+            // Extra bits are currently just dropped, with no ill effect noticed.
             bits2bytes(bits, len, bytes);
             return true;
         }
@@ -903,10 +908,12 @@ void em4x70_write_key(const em4x70_data_t *etd, bool ledcontrol) {
                     break;
                 }
             }
-            // TODO: Ideally here we would perform a test authentication
-            //       to ensure the new key was written correctly. This is
-            //       what the datasheet suggests. We can't do that until
-            //       we have the crypto algorithm implemented.
+            // The client now has support for test authentication after
+            // writing a new key, thus allowing to verify that the new
+            // key was written correctly.  This is what the datasheet
+            // suggests.   Not currently implemented in the firmware,
+            // although ID48LIB has no dependencies that would prevent
+            // use within the firmware layer.
         }
     }
 

--- a/client/src/cmdlfem4x70.c
+++ b/client/src/cmdlfem4x70.c
@@ -712,7 +712,10 @@ int CmdEM4x70WriteKey(const char *Cmd) {
         if (PM3_SUCCESS != result) {
             PrintAndLogEx(FAILED, "Authenticating with new key: " _RED_("failed"));
         } else if (memcmp(&grn, &tag_grn, sizeof(ID48LIB_GRN)) != 0) {
-            PrintAndLogEx(FAILED, "Authenticating with new key returned : " _RED_("failed"));
+            PrintAndLogEx(FAILED, "Authenticating with new key returned %02x %02x %02x, expected %02x %02x %02x (torn write): " _RED_("failed"),
+                tag_grn.grn[0], tag_grn.grn[1], tag_grn.grn[2],
+                grn.grn[0], grn.grn[1], grn.grn[2]
+                );
         } else {
             PrintAndLogEx(INFO, "Authenticating with new key: " _GREEN_("ok"));
         }

--- a/client/src/cmdlfem4x70.c
+++ b/client/src/cmdlfem4x70.c
@@ -716,6 +716,7 @@ int CmdEM4x70WriteKey(const char *Cmd) {
                 tag_grn.grn[0], tag_grn.grn[1], tag_grn.grn[2],
                 grn.grn[0], grn.grn[1], grn.grn[2]
                 );
+            result = PM3_EWRONGANSWER;
         } else {
             PrintAndLogEx(INFO, "Authenticating with new key: " _GREEN_("ok"));
         }

--- a/include/em4x70.h
+++ b/include/em4x70.h
@@ -39,6 +39,7 @@ typedef struct {
 
     // Used for writing address
     uint8_t address;
+    // ISSUE: Presumes target is little-endian
     uint16_t word;
 
     // PIN to unlock
@@ -53,6 +54,7 @@ typedef struct {
     uint8_t crypt_key[12];
 
     // used for bruteforce the partial key
+    // ISSUE: Presumes target is little-endian
     uint16_t start_key;
 
 } em4x70_data_t;


### PR DESCRIPTION
After key is written, authentication is attempted using the new key.  This is particularly important for glass modules, where the coupling can be quite weak, to ensure the key is properly written.

Split parameter parsing from client/firmware interaction by adding helper functions.  This enables re-use and building more complex commands easily.

Firmware: Partially-tracked at least one of the places where the notice of extra bits was coming from.  Add a TODO comment to remind where to look for further review.

No changelog entry needed for this, it's primarily internal, and a continuation of the last PR.