### PR TITLE
Update ext_flash_notes.md - update old backup command

### DIFF
--- a/doc/ext_flash_notes.md
+++ b/doc/ext_flash_notes.md
@@ -125,5 +125,5 @@ Here below is a sample output of a RDV4 device.
 
 To make a backup of the signature to file:
 
-`mem dump p f flash_signature_dump o 262015 l 128`
+`mem dump -f flash_signature_dump -o 262015 -l 128`
 


### PR DESCRIPTION
I think the last advice to backup is important, but the command does not work. "mem dump p f flash_signature_dump o 262015 l 128" is now "mem dump -f flash_signature_dump -o 262015 -l 128". (OS: Iceman/master/v4.18218)