### PR TITLE
Set max write blocks to 251 in `hf_mf_ultimatecard` before writing version/signature in NTAG 21X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+ - Set max write blocks to 251 in hf_mf_ultimatecard before writing version/signature in NTAG 21X (@antgamdia)
  - Changed HF_UNISNIFF standalone mode, output and also sniffs iclass too (@iceman1001)
  - Changed `hw standalone` - added `-b` param to control HF_UNISNIFF from client (@iceman1001)
  - Changed `mem spiffs dump` - now if `-t` and `-d` it will also save to file (@iceman1001)
@@ -91,7 +92,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
  - Changed `hf waveshare` - image is automatically scaled and cropped to match panel size (@socram8888)
  - Changed `hf waveshare` - image loading and processing is now done using [GDlib](https://github.com/libgd/libgd) (@socram8888)
  - Added trace of sniffed SEOS traffic between reader and card (@iceman1001)
- - Change `hf seos list` - print crc and annotate better (@iceman1001) 
+ - Change `hf seos list` - print crc and annotate better (@iceman1001)
  - Added troubleshooting entry - ARM architecture error (@francis2054)
  - Fixed `lf pyramid sim` - wrong parameter handling (@iceman1001)
  - Fixed bootloader - Ignore jitters when pressing the button (@wh201906)

--- a/client/luascripts/hf_mf_ultimatecard.lua
+++ b/client/luascripts/hf_mf_ultimatecard.lua
@@ -21,7 +21,7 @@ example = [[
     ]]..ansicolors.yellow..[[script run hf_mf_ultimatecard -c  ]]..ansicolors.reset..[[
 
     -- set uid
-    ]]..ansicolors.yellow..[[script run hf_mf_ultimatecard -u 04112233445566 ]]..ansicolors.reset..[[
+    ]]..ansicolors.yellow..[[script run hf_mf_ultimatecard -u 04E10CDA993C80 ]]..ansicolors.reset..[[
 
     -- set NTAG pwd / pack
     ]]..ansicolors.yellow..[[script run hf_mf_ultimatecard -p 11223344 -a 8080 ]]..ansicolors.reset..[[
@@ -39,7 +39,7 @@ example = [[
     ]]..ansicolors.yellow..[[script run hf_mf_ultimatecard -k ffffffff -w 1]]..ansicolors.reset..[[
 
     -- Wipe tag, turn into NTAG215, set sig, version, NTAG pwd/pak, and OTP.
-    ]]..ansicolors.yellow..[[script run hf_mf_ultimatecard -w 1 -t 18 -u 04112233445566 -s 112233445566778899001122334455667788990011223344556677 -p FFFFFFFF -a 8080 -o 11111111]]..ansicolors.reset..[[
+    ]]..ansicolors.yellow..[[script run hf_mf_ultimatecard -w 1 -t 18 -u 04E10CDA993C80 -s 8B76052EE42F5567BEB53238B3E3F9950707C0DCC956B5C5EFCFDB709B2D82B3 -p FFFFFFFF -a 8080 -o 11111111]]..ansicolors.reset..[[
 
 ]]
 usage = [[
@@ -762,7 +762,7 @@ local function set_type(tagtype)
         send('a210000000FF')
         send('a21100050000')
     lib14a.disconnect()
-    write_uid('04112233445566')
+    write_uid('04E10CDA993C80')
         write_version('0004040101000b03')   -- NTAG210 00 04 04 01 01 00 0b 03
     elseif tagtype == 16 then
         print('Setting: Ultimate Magic card to NTAG 212')
@@ -776,7 +776,7 @@ local function set_type(tagtype)
         send('a225000000FF')
         send('a22600050000')
     lib14a.disconnect()
-    write_uid('04112233445566')
+    write_uid('04E10CDA993C80')
         write_version('0004040101000E03')   -- NTAG212 00 04 04 01 01 00 0E 03
     elseif tagtype == 17 then
         print('Setting: Ultimate Magic card to NTAG 213')
@@ -790,7 +790,7 @@ local function set_type(tagtype)
         send('a229000000ff')
         send('a22a00050000')
     lib14a.disconnect()
-    write_uid('04112233445566')
+    write_uid('04E10CDA993C80')
         write_version('0004040201000F03')       -- NTAG213 00 04 04 02 01 00 0f 03
     elseif tagtype == 18 then
         print('Setting: Ultimate Magic card to NTAG 215')
@@ -804,7 +804,7 @@ local function set_type(tagtype)
         send('a283000000ff')
         send('a28400050000')
     lib14a.disconnect()
-    write_uid('04112233445566')
+    write_uid('04E10CDA993C80')
         write_version('0004040201001103')       -- NTAG215 00 04 04 02 01 00 11 03
     elseif tagtype == 19 then
         print('Setting: Ultimate Magic card to NTAG 216')
@@ -818,7 +818,7 @@ local function set_type(tagtype)
         send('a2e3000000ff')
         send('a2e400050000')
     lib14a.disconnect()
-    write_uid('04112233445566')
+    write_uid('04E10CDA993C80')
         write_version('0004040201001303')       -- NTAG216 00 04 04 02 01 00 13 03
     elseif tagtype == 20 then
         print('Setting: Ultimate Magic card to NTAG I2C 1K')
@@ -829,7 +829,7 @@ local function set_type(tagtype)
         send('a2040300fe00')
         send('a20500000000')
     lib14a.disconnect()
-    write_uid('04112233445566')
+    write_uid('04E10CDA993C80')
         write_version('0004040502011303')       -- NTAG_I2C_1K 00 04 04 05 02 01 13 03
     elseif tagtype == 21 then
         print('Setting: Ultimate Magic card to NTAG I2C 2K')
@@ -840,7 +840,7 @@ local function set_type(tagtype)
         send('a2040300fe00')
         send('a20500000000')
     lib14a.disconnect()
-    write_uid('04112233445566')
+    write_uid('04E10CDA993C80')
         write_version('0004040502011503')       -- NTAG_I2C_2K 00 04 04 05 02 01 15 03
     elseif tagtype == 22 then
         print('Setting: Ultimate Magic card to NTAG I2C plus 1K')
@@ -851,7 +851,7 @@ local function set_type(tagtype)
         send('a2040300fe00')
         send('a20500000000')
     lib14a.disconnect()
-    write_uid('04112233445566')
+    write_uid('04E10CDA993C80')
         write_version('0004040502021303')       -- NTAG_I2C_1K 00 04 04 05 02 02 13 03
     elseif tagtype == 23 then
         print('Setting: Ultimate Magic card to NTAG I2C plus 2K')
@@ -861,7 +861,7 @@ local function set_type(tagtype)
         send('a203e1106D00')
         send('a2040300fe00')
         send('a20500000000')
-    write_uid('04112233445566')
+    write_uid('04E10CDA993C80')
         write_version('0004040502021503')       -- NTAG_I2C_2K 00 04 04 05 02 02 15 03
     elseif tagtype == 24 then
         print('Setting: Ultimate Magic card to  NTAG 213F')
@@ -875,7 +875,7 @@ local function set_type(tagtype)
         send('a229000000ff')
         send('a22a00050000')
     lib14a.disconnect()
-    write_uid('04112233445566')
+    write_uid('04E10CDA993C80')
         write_version('0004040401000F03')       -- NTAG213F 00 04 04 04 01 00 0f 03
     elseif tagtype == 25 then
         print('Setting: Ultimate Magic card to  NTAG 216F')
@@ -889,7 +889,7 @@ local function set_type(tagtype)
         send('a2e3000000ff')
         send('a2e400050000')
     lib14a.disconnect()
-    write_uid('04112233445566')
+    write_uid('04E10CDA993C80')
         write_version('0004040401001303')       -- NTAG216F 00 04 04 04 01 00 13 03
     else
     oops('No matching tag types')
@@ -987,7 +987,7 @@ local function wipe(wtype)
         err, msg = set_type(17)
         if err == nil then return err, msg end
         --set UID
-        err, msg = write_uid('04112233445566')
+        err, msg = write_uid('04E10CDA993C80')
         if err == nil then return err, msg end
         --set NTAG pwd
         err, msg = write_ntagpwd('FFFFFFFF')

--- a/client/luascripts/hf_mf_ultimatecard.lua
+++ b/client/luascripts/hf_mf_ultimatecard.lua
@@ -995,6 +995,9 @@ local function wipe(wtype)
         --set pack
         err, msg = write_pack('0000')
         if err == nil then return err, msg end
+        --set signature
+        err, msg = write_signature('8B76052EE42F5567BEB53238B3E3F9950707C0DCC956B5C5EFCFDB709B2D82B3')
+        if err == nil then return err, msg end
         lib14a.disconnect()
         return true, 'Ok'
     else oops('Use 0 for Mifare wipe or 1 for Ultralight wipe')

--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -432,7 +432,7 @@ hf mf cwipe
 hf mf csetblk
 hf mf cgetblk
 hf mf cgetsc
-hf mf cload 
+hf mf cload
 hf mf csave
 hf mf cview
 ```
@@ -870,7 +870,7 @@ Possible tag wakeup mechanisms are:
   * Write hidden block: `A8xx+crc`, `[16 bytes data]+crc`
   * Read configuration: `E000+crc`
   * Write configuration: `E100+crc`
-  
+
 * **DANGER**
   * Set main memory and config to 00 `F000+crc`
   * Set main memory and config to FF `F100+crc`
@@ -933,7 +933,7 @@ Sector 0
 ^^ ^^ ^^ ^^                                     - UID0
             ^^                                  - BCC0
                ^^                               - SAK0
-                  ^^ ^^ ^^ ^^ ^^ ^^ ^^ ^^ ^^ ^^ - Unused 
+                  ^^ ^^ ^^ ^^ ^^ ^^ ^^ ^^ ^^ ^^ - Unused
 Block 2: unused
 Block 3: ignored (custom keys, acl; broken acl ignored - anticollision will still work)
 Sector 1
@@ -1657,7 +1657,7 @@ hf mfu setuid -h
 Equivalent: don't use `hf mfu wrbl` as you need to write three blocks in a row, but do, with proper BCCx:
 
 ```
-hf 14a raw -s -c -k a2 00 041122bf 
+hf 14a raw -s -c -k a2 00 041122bf
 hf 14a raw    -c -k a2 01 33445566
 hf 14a raw    -c    a2 02 44480000
 ```
@@ -2088,7 +2088,7 @@ The same effect (with better ATQA!) can be obtained with a MFC Gen1A that uses S
 ```
 hf mf csetblk --blk 0 -d 1122334444204403A1A2A3A4A5A6A7A8
 hf 14a info
-[+]  UID: 11 22 33 44 
+[+]  UID: 11 22 33 44
 [+] ATQA: 03 44
 [+]  SAK: 20 [1]
 [+] Possible types:
@@ -2157,7 +2157,7 @@ hf 15 csetuid E011223344556677
 or (ignore errors):
 
 ```
-script run hf_15_magic -u E004013344556677  
+script run hf_15_magic -u E004013344556677
 ```
 
 <a id="g4top"></a>
@@ -2241,20 +2241,20 @@ Arguments
     -c      read magic configuration
     -u      UID (8-20 hexsymbols), set UID on tag
     -t      tag type to impersonate
-                 1 = Mifare Mini S20 4-byte 
+                 1 = Mifare Mini S20 4-byte
                  2 = Mifare Mini S20 7-byte 15 = NTAG 210
                  3 = Mifare Mini S20 10-byte 16 = NTAG 212
                  4 = Mifare 1k S50 4-byte   17 = NTAG 213
                  5 = Mifare 1k S50 7-byte   18 = NTAG 215
-                 6 = Mifare 1k S50 10-byte  19 = NTAG 216 
+                 6 = Mifare 1k S50 10-byte  19 = NTAG 216
                  7 = Mifare 4k S70 4-byte   20 = NTAG I2C 1K
                  8 = Mifare 4k S70 7-byte   21 = NTAG I2C 2K
                  9 = Mifare 4k S70 10-byte  22 = NTAG I2C 1K PLUS
             ***  10 = UL -   NOT WORKING FULLY   23 = NTAG I2C 2K PLUS
             ***  11 = UL-C - NOT WORKING FULLY   24 = NTAG 213F
                  12 = UL EV1 48b                25 = NTAG 216F
-                 13 = UL EV1 128b        
-            ***  14 = UL Plus - NOT WORKING YET  
+                 13 = UL EV1 128b
+            ***  14 = UL Plus - NOT WORKING YET
 
     -p      NTAG password (8 hexsymbols),  set NTAG password on tag.
     -a      NTAG pack ( 4 hexsymbols), set NTAG pack on tag.
@@ -2330,11 +2330,11 @@ Default `<passwd>`: `00000000`
 # view contents of tag memory:
 hf mf gview
 # Read a specific block via backdoor command:
-hf mf ggetblk 
+hf mf ggetblk
 # Write a specific block via backdoor command:
-hf mf gsetblk 
+hf mf gsetblk
 # Load dump to tag:
-hf mf gload 
+hf mf gload
 # Save dump from tag:
 hf mf gsave
 ```
@@ -2435,13 +2435,13 @@ hf 14a raw -s -c -t 1000 CF00000000CD01101112131415161718191A1B1C1D1E1F
 hf 14a reader
 ```
 
-MFC mode 4b UID  
+MFC mode 4b UID
 
 => UID `00010203`
 
 `script run hf_mf_ultimatecard -t 4 -u 00010203`
 
-MFC mode 7b UID  
+MFC mode 7b UID
 
 => UID `00010203040506`
 
@@ -2457,9 +2457,9 @@ Ultralight mode, 4b UID
 
 => UID `00010203`
 
-Ultralight mode, 7b UID  
+Ultralight mode, 7b UID
 
-=> UID `00010210111213`  
+=> UID `00010210111213`
 
 👉 the UID is composed of first two blocks as in regular Ultralights
 
@@ -2468,8 +2468,8 @@ Ultralight mode, 7b UID
   * UL EV1 128b = `script run hf_mf_ultimatecard -t 13 -u 00010203040506`
   * NTAG 215 = `script run hf_mf_ultimatecard -t 18 -u 00010203040506`
 
-Ultralight mode, 10b UID  
-=> UID `00010203040506070809`  
+Ultralight mode, 10b UID
+=> UID `00010203040506070809`
 👉 the UID is composed only from block0
 
 ### Set 14443B UID and ATQB
@@ -2487,7 +2487,7 @@ hf 14a raw -s -c -t 1000 CF00000000CD00000102030405060708090A0B0C0D0E0F
 hf 14b reader
 ```
 
-=> UID 00010203  
+=> UID 00010203
 => ATQB 0405060708090A
 
 ### (De)Activate Ultralight mode
@@ -2812,7 +2812,7 @@ hf 14a raw -s -c -t 1000 CF00000000F001010000000003000978009102DABC1910101112131
 
 ^[Top](#top) ^^[Gen4](#g4top)
 
-Don`t forget configure maximum read/write blocks. It`s can be adjusted directly in config (see *Dump configuration*) or by command 6B:
+Don't forget configure maximum read/write blocks. It's can be adjusted directly in config (see *Dump configuration*) or by command 6B:
 
 ```
 hf 14a raw -s -c -t 1000 CF000000006BFB


### PR DESCRIPTION
This PR mainly sets the max write blocks to 251 before attempting to write either the version or signature in NTAG chips (see 90e9a0da39bed2ba6cb7d686338abafee208520d).

Besides, it changes the UID and signature used in the CLI example so that they match. Currently, using the example signature returns an error, since the format is invalid.

Finally, a trivial typo (`` ` ``instead of `'`) has been fixed.

_This is a purely personal contribution, not related to my current employer whatsoever._

Fixes #2325
