### PR TITLE
Decoder must not write more bit than requested

### DIFF
--- a/armsrc/em4x70.c
+++ b/armsrc/em4x70.c
@@ -687,11 +687,15 @@ static int em4x70_receive(uint8_t *bits, size_t length) {
             // pulse length 1.5 -> 2 bits + flip edge detection
             if (edge == FALLING_EDGE) {
                 bits[bit_pos++] = 0;
-                bits[bit_pos++] = 0;
+                if (bit_pos < length) {
+                    bits[bit_pos++] = 0;
+                }
                 edge = RISING_EDGE;
             } else {
                 bits[bit_pos++] = 1;
-                bits[bit_pos++] = 1;
+                if (bit_pos < length) {
+                    bits[bit_pos++] = 1;
+                }
                 edge = FALLING_EDGE;
             }
 
@@ -700,10 +704,14 @@ static int em4x70_receive(uint8_t *bits, size_t length) {
             // pulse length of 2 -> two bits
             if (edge == FALLING_EDGE) {
                 bits[bit_pos++] = 0;
-                bits[bit_pos++] = 1;
+                if (bit_pos < length) {
+                    bits[bit_pos++] = 1;
+                }
             } else {
                 bits[bit_pos++] = 1;
-                bits[bit_pos++] = 0;
+                if (bit_pos < length) {
+                    bits[bit_pos++] = 0;
+                }
             }
 
         } else {


### PR DESCRIPTION
Fixes the following error messages when using em4x70 tags:

```
[#] Should have a multiple of 8 bits, was sent 65
[#] Should have a multiple of 8 bits, was sent 33
```

The underlying issue is that the manchester decoder was writing one extra bit of data when reading certain tag data.  (_the buffer happened to always be larger than necessary, so did not happen to corrupt data_)

To repro the problem behavior:
`lf em 4x70 --block 12 --data 0xAAAA`
`lf em 4x70 --block 0 --data 8765`

