### PR TITLE
Updated aidlist to include CEPAS AID

### DIFF
--- a/client/resources/aidlist.json
+++ b/client/resources/aidlist.json
@@ -2422,5 +2422,13 @@
         "Name": "SEOS Mobile",
         "Description": "Declared by some SEOS-compatible applications for HCE",
         "Type": "access"
+    },
+    {
+        "AID": "A000000341000101",
+        "Vendor": "TransitLink Pte Ltd",
+        "Country": "Singapore",
+        "Name": "CEPAS",
+        "Description": "Transit and e-money card used in Singapore",
+        "Type": "transport"
     }
 ]


### PR DESCRIPTION
CEPAS is a (Singaporean) standard for e-money smart cards; it's mainly used for transit, road tolls, and parking payments, but it also sees some use for retail payments and access control.