### PR TITLE
Safer buffers

### DIFF
--- a/armsrc/felica.c
+++ b/armsrc/felica.c
@@ -847,6 +847,9 @@ void felica_dump_lite_s(void) {
             // for (c=0; c < 8; c++)
             // ndef[c] = FelicaFrame.framebytes[c+4];
 
+            // This is an unwritten assumption.  Seems safe for now, but when moving to C11,
+            // should add the static_assert() to validate at compilation this hidden assumption.
+            // static_assert(BigBuf_get_size() >= 560); // 20 bytes written per loop, and liteblks has 28 elements
             for (blknum = 0; blknum < ARRAYLEN(liteblks);) {
                 // block to read.
                 BuildFliteRdblk(ndef, 1, &liteblks[blknum]);

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -628,7 +628,9 @@ void doT55x7Acquisition(size_t sample_size, bool ledcontrol) {
                     startFound = true;
                 }
                 // collect samples
-                dest[i++] = sample;
+                if (i < bufsize) {
+                    dest[i++] = sample;
+                }
             }
         }
     }
@@ -698,13 +700,15 @@ void doCotagAcquisition(void) {
                 firstlow = true;
             }
 
-            ++i;
             if (sample > COTAG_ONE_THRESHOLD) {
                 dest[i] = 255;
+                ++i;
             } else if (sample < COTAG_ZERO_THRESHOLD) {
                 dest[i] = 0;
-            } else {
+                ++i;
+            } else if (i != 0) {
                 dest[i] = dest[i - 1];
+                ++i;
             }
         }
     }

--- a/common/array_size2.h
+++ b/common/array_size2.h
@@ -1,0 +1,157 @@
+/**
+
+The MIT License (MIT)
+
+Copyright (c) SimpleHacks, Henry Gabryjelski
+https://github.com/SimpleHacks/UtilHeaders
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#ifndef ARRAYSIZE2_H
+#define ARRAYSIZE2_H
+
+/**
+    The following, if defined prior to inclusion of this header file,
+    will modify its behavior as noted:
+
+        ARRAYSIZE2_SHOW_VERSION_MESSAGE
+        -- if defined, will show which version of ARRAY_SIZE2 macro is selected
+ */
+
+
+/**
+    see example source at:
+    https://godbolt.org/z/zzYoeK6Mf
+*/
+
+#ifndef __has_feature
+    #define __has_feature(x) 0 /* Compatibility with non-clang compilers. */
+#endif
+
+#if (defined(__cplusplus) && __cplusplus >= 201103L) ||    /* any compiler claiming C++11 support */ \
+    (defined(__cplusplus) && _MSC_VER >= 1900 && __cplusplus != 199711L) ||    /* Visual C++ 2015 or higher           */ \
+    __has_feature(cxx_constexpr) /* CLang versions supporting constexp  */
+
+    #include <stddef.h> /* required for size_t */
+    #if defined(ARRAYSIZE2_SHOW_VERSION_MESSAGE)
+        #pragma message( "ARRAY_SIZE2 -- Using C++11 version" )
+    #endif
+
+    namespace detail
+    {
+        template <typename T, size_t N>
+        constexpr size_t ARRAY_SIZE2_ARGUMENT_CANNOT_BE_POINTER(T const (&)[N]) noexcept
+        {
+            return N;
+        }
+    } /* namespace detail */
+    #define ARRAY_SIZE2(arr) detail::ARRAY_SIZE2_ARGUMENT_CANNOT_BE_POINTER(arr)
+
+#elif defined(__cplusplus) && __cplusplus >= 199711L && ( /* C++ 98 trick */   \
+      defined(__INTEL_COMPILER) ||                     \
+      defined(__clang__) ||                            \
+      (defined(__GNUC__) && (                          \
+          (__GNUC__ > 4) ||                            \
+          (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)       \
+      )))
+
+    #include <stddef.h> /* required for size_t */
+    #if defined(ARRAYSIZE2_SHOW_VERSION_MESSAGE)
+        #pragma message "ARRAY_SIZE2 -- Using C++98 version"
+    #endif
+    template <typename T, size_t N>
+    char(&_ArraySizeHelperRequiresArray(T(&)[N]))[N];
+    #define ARRAY_SIZE2(x) sizeof(_ArraySizeHelperRequiresArray(x))
+
+#elif defined(__cplusplus) /* && ((__cplusplus >= 199711L) || defined(__INTEL_COMPILER) || defined(__clang__)) */
+    
+    #if defined(ARRAYSIZE2_SHOW_VERSION_MESSAGE)
+        #pragma message( "ARRAY_SIZE2 -- Using Ivan J. Johnson's C++ version" )
+    #endif
+    /*
+        Works on older compilers, even Visual C++ 6....
+        Created by Ivan J. Johnson, March 06, 2007
+        See http://drdobbs.com/cpp/197800525?pgno=1
+
+        Full description is in markdown file array_size2.md
+    */
+    #define ARRAY_SIZE2(arr) ( \
+       0 * sizeof(reinterpret_cast<const ::Bad_arg_to_ARRAY_SIZE2*>(arr)) + /*check1*/ \
+       0 * sizeof(::Bad_arg_to_ARRAY_SIZE2::check_type((arr), &(arr)))    + /*check2*/ \
+       sizeof(arr) / sizeof((arr)[0])                                       /* eval */ \
+       )
+
+    struct Bad_arg_to_ARRAY_SIZE2 {
+       class Is_pointer; /* incomplete */
+       class Is_array {};
+       template <typename T>
+       static Is_pointer check_type(T const *, T const * const *);
+       static Is_array check_type(void const *, void const *);
+    };
+
+#elif !defined(__cplusplus) && defined(__GNUC__)
+
+    #include <stdint.h>
+
+    /**
+        Even C can have type-safety for equivalent of ARRAY_SIZE() macro,
+        when using the following two GCC extensions:
+           typeof()
+           __builtin_types_compatible_p()
+    */
+
+    #if defined(ARRAYSIZE2_SHOW_VERSION_MESSAGE)
+        #pragma message( "ARRAY_SIZE2 -- Using GNUC version" )
+    #endif
+
+    /**
+        validated using:
+          MSP430  gcc   4.5.3
+          x86-64  icc  16.0.3
+          x86-64  gcc   4.1.2
+          x86-64 clang  3.0.0
+          AVR     gcc   4.5.4
+          ARM     gcc   4.5.4
+    */
+
+    #define __SIMPLEHACKS_COMPATIBLE_TYPES__(a,b)   __builtin_types_compatible_p(__typeof__(a), __typeof__(b)) /* GCC extensions */
+    #define __SIMPLEHACKS_BUILD_ERROR_ON_NONZERO__(x)  (sizeof(struct { uint8_t q: (-!!(x)*0x1ee7)+1u;})-1u) /* if x is zero, reports "error: negative width in bit-field '<anonymous>'" */
+    #define __SIMPLEHACKS_MUST_BE_ARRAY__(x)        __SIMPLEHACKS_BUILD_ERROR_ON_NONZERO__(__SIMPLEHACKS_COMPATIBLE_TYPES__((x), &(*x)))
+    #define ARRAY_SIZE2(_arr)       ( (sizeof(_arr) / sizeof((_arr)[0])) + __SIMPLEHACKS_MUST_BE_ARRAY__(_arr) ) /* compile-time error if not an array */
+
+#else
+
+    /**
+        The good news is that all compilers (as of 20202-05-08)
+        on godbolt.org are fully supported.  Therefore, if some
+        other compiler does not support any of the above method,
+        it's important to force a compile-time error, to avoid
+        any suggestion that this provides a safe macro.
+    */
+   
+    #error "Unable to provide type-safe ARRAY_SIZE2 macro"
+
+
+#endif
+
+#endif  // ARRAYSIZE2_H

--- a/common/commonutil.h
+++ b/common/commonutil.h
@@ -19,6 +19,7 @@
 #ifndef __COMMONUTIL_H
 #define __COMMONUTIL_H
 
+#include "array_size2.h" // safer compile-time array size determination
 #include "common.h"
 
 // endian change for 16bit
@@ -42,7 +43,7 @@
 # define BITMASK(X) (1 << (X))
 #endif
 #ifndef ARRAYLEN
-# define ARRAYLEN(x) (sizeof(x)/sizeof((x)[0]))
+# define ARRAYLEN(x) ARRAY_SIZE2(x) // use safer version of compile-time array size ... rejects pointers, must be array
 #endif
 
 #ifndef NTIME


### PR DESCRIPTION
1. Hitag2 -- complex decoder was left alone, and instead the fix is a hack ... allocate one extra byte to allow the one-byte buffer overrun to occur safely.
2. HitagS -- fix potential one-byte overrun
3. lfsampling -- fix potential one-byte overrun
4. Add safer array size calculation macro (from [SimpleHacks](https://github.com/SimpleHacks/UtilHeaders/blob/e098233cfec34674eee7dbe4318d81900d818cec/src/array_size2.h)) ... which has zero net binary effect, but avoids accidental errors, such as refactoring resulting in accidentally taking the length of a pointer (rather than the length of an array).