### PR TITLE
Fix compile error from variable type declaration

### DIFF
--- a/client/src/proxguiqt.cpp
+++ b/client/src/proxguiqt.cpp
@@ -863,7 +863,7 @@ void Plot::paintEvent(QPaintEvent *event) {
             snprintf(scalestr, sizeof(scalestr), "[%2.2f %s] ", ((int32_t)(CursorBPos - CursorAPos)) / g_CursorScaleFactor, g_CursorScaleFactorUnit);
         }
     }
-    snprintf(str, sizeof(str), "@%u..%u  dt=%zi %szoom=%2.3f  CursorAPos=%zu  CursorBPos=%zu  GridX=%lf  GridY=%lf (%s) GridXoffset=%lf",
+    snprintf(str, sizeof(str), "@%u..%u  dt=%i %szoom=%2.3f  CursorAPos=%u  CursorBPos=%u  GridX=%lf  GridY=%lf (%s) GridXoffset=%lf",
              g_GraphStart,
              g_GraphStop,
              CursorBPos - CursorAPos,


### PR DESCRIPTION
Compiling current code shows this error on macOS & Linux Mint. Reverting the one style line change fixes on both.

`src/proxguiqt.cpp: In member function ‘virtual void Plot::paintEvent(QPaintEvent*)’:
src/proxguiqt.cpp:866:47: error: format ‘%zi’ expects argument of type ‘signed size_t’, but argument 6 has type ‘uint32_t’ {aka ‘unsigned int’} [-Werror=format=]
  866 |     snprintf(str, sizeof(str), "@%u..%u  dt=%zi %szoom=%2.3f  CursorAPos=%zu  CursorBPos=%zu  GridX=%lf  

... 

make[1]: *** [Makefile:1002: obj/proxguiqt.o] Error 1
make: *** [Makefile:177: client/all] Error 2`