### PR TITLE
Refactored Plot Annotations and some cleanup

### DIFF
--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -447,7 +447,7 @@ int ASKDemod_ext(int clk, int invert, int maxErr, size_t maxlen, bool amplify, b
         return PM3_EMALLOC;
     }
 
-    size_t bitlen = getFromGraphBuf(bits);
+    size_t bitlen = getFromGraphBuffer(bits);
 
     PrintAndLogEx(DEBUG, "DEBUG: (ASKDemod_ext) #samples from graphbuff: %zu", bitlen);
 
@@ -760,7 +760,7 @@ int ASKbiphaseDemod(int offset, int clk, int invert, int maxErr, bool verbose) {
         return PM3_EMALLOC;
     }
 
-    size_t size = getFromGraphBufEx(bs, MAX_DEMOD_BUF_LEN);
+    size_t size = getFromGraphBufferEx(bs, MAX_DEMOD_BUF_LEN);
     if (size == 0) {
         PrintAndLogEx(DEBUG, "DEBUG: no data in graphbuf");
         free(bs);
@@ -1298,7 +1298,7 @@ int FSKrawDemod(uint8_t rfLen, uint8_t invert, uint8_t fchigh, uint8_t fclow, bo
         return PM3_EMALLOC;
     }
 
-    size_t bitlen = getFromGraphBuf(bits);
+    size_t bitlen = getFromGraphBuffer(bits);
     if (bitlen == 0) {
         PrintAndLogEx(DEBUG, "DEBUG: no data in graphbuf");
         free(bits);
@@ -1400,7 +1400,7 @@ int PSKDemod(int clk, int invert, int maxErr, bool verbose) {
         PrintAndLogEx(FAILED, "failed to allocate memory");
         return PM3_EMALLOC;
     }
-    size_t bitlen = getFromGraphBuf(bits);
+    size_t bitlen = getFromGraphBuffer(bits);
     if (bitlen == 0) {
         free(bits);
         return PM3_ESOFT;
@@ -1451,7 +1451,7 @@ int NRZrawDemod(int clk, int invert, int maxErr, bool verbose) {
         return PM3_EMALLOC;
     }
 
-    size_t bitlen = getFromGraphBuf(bits);
+    size_t bitlen = getFromGraphBuffer(bits);
 
     if (bitlen == 0) {
         free(bits);
@@ -1821,10 +1821,10 @@ int CmdHpf(const char *Cmd) {
         PrintAndLogEx(FAILED, "failed to allocate memory");
         return PM3_EMALLOC;
     }
-    size_t size = getFromGraphBuf(bits);
+    size_t size = getFromGraphBuffer(bits);
     removeSignalOffset(bits, size);
     // push it back to graph
-    setGraphBuf(bits, size);
+    setGraphBuffer(bits, size);
     // set signal properties low/high/mean/amplitude and is_noise detection
     computeSignalProperties(bits, size);
 
@@ -1929,7 +1929,7 @@ int getSamplesFromBufEx(uint8_t *data, size_t sample_num, uint8_t bits_per_sampl
         PrintAndLogEx(FAILED, "failed to allocate memory");
         return PM3_EMALLOC;
     }
-    size_t size = getFromGraphBuf(bits);
+    size_t size = getFromGraphBuffer(bits);
     // set signal properties low/high/mean/amplitude and is_noise detection
     computeSignalProperties(bits, size);
     free(bits);
@@ -2039,10 +2039,10 @@ static int CmdLoad(const char *Cmd) {
             PrintAndLogEx(FAILED, "failed to allocate memory");
             return PM3_EMALLOC;
         }
-        size_t size = getFromGraphBuf(bits);
+        size_t size = getFromGraphBuffer(bits);
 
         removeSignalOffset(bits, size);
-        setGraphBuf(bits, size);
+        setGraphBuffer(bits, size);
         computeSignalProperties(bits, size);
         free(bits);
     }
@@ -2186,7 +2186,7 @@ int CmdNorm(const char *Cmd) {
         PrintAndLogEx(FAILED, "failed to allocate memory");
         return PM3_EMALLOC;
     }
-    size_t size = getFromGraphBuf(bits);
+    size_t size = getFromGraphBuffer(bits);
     // set signal properties low/high/mean/amplitude and is_noise detection
     computeSignalProperties(bits, size);
 
@@ -2337,7 +2337,7 @@ static int CmdDirectionalThreshold(const char *Cmd) {
         PrintAndLogEx(FAILED, "failed to allocate memory");
         return PM3_EMALLOC;
     }
-    size_t size = getFromGraphBuf(bits);
+    size_t size = getFromGraphBuffer(bits);
     // set signal properties low/high/mean/amplitude and is_noice detection
     computeSignalProperties(bits, size);
 
@@ -2385,7 +2385,7 @@ static int CmdZerocrossings(const char *Cmd) {
         PrintAndLogEx(FAILED, "failed to allocate memory");
         return PM3_EMALLOC;
     }
-    size_t size = getFromGraphBuf(bits);
+    size_t size = getFromGraphBuffer(bits);
     // set signal properties low/high/mean/amplitude and is_noise detection
     computeSignalProperties(bits, size);
     RepaintGraphWindow();
@@ -2600,7 +2600,7 @@ static int CmdDataIIR(const char *Cmd) {
         PrintAndLogEx(FAILED, "failed to allocate memory");
         return PM3_EMALLOC;
     }
-    size_t size = getFromGraphBuf(bits);
+    size_t size = getFromGraphBuffer(bits);
     // set signal properties low/high/mean/amplitude and is_noise detection
     computeSignalProperties(bits, size);
     RepaintGraphWindow();
@@ -3336,7 +3336,7 @@ static int CmdCenterThreshold(const char *Cmd) {
         PrintAndLogEx(FAILED, "failed to allocate memory");
         return PM3_EMALLOC;
     }
-    size_t size = getFromGraphBuf(bits);
+    size_t size = getFromGraphBuffer(bits);
     // set signal properties low/high/mean/amplitude and is_noice detection
     computeSignalProperties(bits, size);
     RepaintGraphWindow();
@@ -3386,7 +3386,7 @@ static int CmdEnvelope(const char *Cmd) {
         PrintAndLogEx(FAILED, "failed to allocate memory");
         return PM3_EMALLOC;
     }
-    size_t size = getFromGraphBuf(bits);
+    size_t size = getFromGraphBuffer(bits);
     // set signal properties low/high/mean/amplitude and is_noice detection
     computeSignalProperties(bits, size);
     RepaintGraphWindow();

--- a/client/src/cmdlfawid.c
+++ b/client/src/cmdlfawid.c
@@ -149,7 +149,7 @@ int demodAWID(bool verbose) {
         return PM3_EMALLOC;
     }
 
-    size_t size = getFromGraphBuf(bits);
+    size_t size = getFromGraphBuffer(bits);
     if (size == 0) {
         PrintAndLogEx(DEBUG, "DEBUG: Error - AWID not enough samples");
         free(bits);

--- a/client/src/cmdlfem4x05.c
+++ b/client/src/cmdlfem4x05.c
@@ -175,7 +175,7 @@ static bool em4x05_download_samples(void) {
         return false;
     }
 
-    setGraphBuf(got, sizeof(got));
+    setGraphBuffer(got, sizeof(got));
     // set signal properties low/high/mean/amplitude and is_noise detection
     computeSignalProperties(got, sizeof(got));
     RepaintGraphWindow();

--- a/client/src/cmdlfhid.c
+++ b/client/src/cmdlfhid.c
@@ -122,7 +122,7 @@ int demodHID(bool verbose) {
         PrintAndLogEx(FAILED, "failed to allocate memory");
         return PM3_EMALLOC;
     }
-    size_t size = getFromGraphBuf(bits);
+    size_t size = getFromGraphBuffer(bits);
     if (size == 0) {
         PrintAndLogEx(DEBUG, "DEBUG: Error - " _RED_("HID not enough samples"));
         free(bits);

--- a/client/src/cmdlfindala.c
+++ b/client/src/cmdlfindala.c
@@ -408,7 +408,7 @@ static int CmdIndalaDemodAlt(const char *Cmd) {
         PrintAndLogEx(FAILED, "failed to allocate memory");
         return PM3_EMALLOC;
     }
-    size_t datasize = getFromGraphBuf(data);
+    size_t datasize = getFromGraphBuffer(data);
 
     uint8_t rawbits[4096] = {0};
     int rawbit = 0;

--- a/client/src/cmdlfio.c
+++ b/client/src/cmdlfio.c
@@ -71,7 +71,7 @@ int demodIOProx(bool verbose) {
         PrintAndLogEx(FAILED, "failed to allocate memory");
         return PM3_EMALLOC;
     }
-    size_t size = getFromGraphBuf(bits);
+    size_t size = getFromGraphBuffer(bits);
     if (size < 65) {
         PrintAndLogEx(DEBUG, "DEBUG: Error - IO prox not enough samples in GraphBuffer");
         free(bits);

--- a/client/src/cmdlfparadox.c
+++ b/client/src/cmdlfparadox.c
@@ -108,7 +108,7 @@ int demodParadox(bool verbose, bool oldChksum) {
         PrintAndLogEx(FAILED, "failed to allocate memory");
         return PM3_EMALLOC;
     }
-    size_t size = getFromGraphBuf(bits);
+    size_t size = getFromGraphBuffer(bits);
     if (size == 0) {
         PrintAndLogEx(DEBUG, "DEBUG: Error - Paradox not enough samples");
         free(bits);

--- a/client/src/cmdlfpyramid.c
+++ b/client/src/cmdlfpyramid.c
@@ -48,7 +48,7 @@ int demodPyramid(bool verbose) {
         PrintAndLogEx(FAILED, "failed to allocate memory");
         return PM3_EMALLOC;
     }
-    size_t size = getFromGraphBuf(bits);
+    size_t size = getFromGraphBuffer(bits);
     if (size == 0) {
         PrintAndLogEx(DEBUG, "DEBUG: Error - Pyramid not enough samples");
         free(bits);

--- a/client/src/cmdlft55xx.c
+++ b/client/src/cmdlft55xx.c
@@ -2900,7 +2900,7 @@ static int CmdResetRead(const char *Cmd) {
             free(got);
             return PM3_ETIMEOUT;
         }
-        setGraphBuf(got, gotsize);
+        setGraphBuffer(got, gotsize);
         free(got);
     }
 

--- a/client/src/graph.h
+++ b/client/src/graph.h
@@ -28,10 +28,11 @@ extern "C" {
 void AppendGraph(bool redraw, uint16_t clock, int bit);
 size_t ClearGraph(bool redraw);
 bool HasGraphData(void);
-void setGraphBuf(const uint8_t *src, size_t size);
+void setGraphBuffer(const uint8_t *src, size_t size);
 void save_restoreGB(uint8_t saveOpt);
-size_t getFromGraphBuf(uint8_t *dest);
-size_t getFromGraphBufEx(uint8_t *dest, size_t maxLen);
+size_t getFromGraphBuffer(uint8_t *dest);
+size_t getFromGraphBufferEx(uint8_t *dest, size_t maxLen);
+size_t getGraphBufferChunk(uint8_t *dest, size_t start, size_t end);
 void convertGraphFromBitstream(void);
 void convertGraphFromBitstreamEx(int hi, int low);
 bool isGraphBitstream(void);
@@ -47,8 +48,10 @@ bool fskClocks(uint8_t *fc1, uint8_t *fc2, uint8_t *rf1, int *firstClockEdge);
 #define GRAPH_SAVE 1
 #define GRAPH_RESTORE 0
 
-extern int g_GraphBuffer[MAX_GRAPH_TRACE_LEN];
-extern int g_OperationBuffer[MAX_GRAPH_TRACE_LEN];
+extern int32_t g_GraphBuffer[MAX_GRAPH_TRACE_LEN];
+extern int32_t g_OperationBuffer[MAX_GRAPH_TRACE_LEN];
+extern int32_t g_OverlayBuffer[MAX_GRAPH_TRACE_LEN];
+extern bool    g_useOverlays;
 extern size_t g_GraphTraceLen;
 
 #ifdef __cplusplus

--- a/client/src/proxguiqt.h
+++ b/client/src/proxguiqt.h
@@ -49,10 +49,12 @@ class Plot: public QWidget {
     void PlotDemod(uint8_t *buffer, size_t len, QRect plotRect, QRect annotationRect, QPainter *painter, int graphNum, uint32_t plotOffset);
     void plotGridLines(QPainter *painter, QRect r);
     void plotOperations(int *buffer, size_t len, QPainter *painter, QRect rect);
+    void drawAnnotations(QRect annotationRect, QPainter *painter);
     int xCoordOf(int i, QRect r);
     int yCoordOf(int v, QRect r, int maxVal);
     int valueOf_yCoord(int y, QRect r, int maxVal);
     void setMaxAndStart(int *buffer, size_t len, QRect plotRect);
+    void appendMax(int *buffer, size_t len, QRect plotRect);
     QColor getColor(int graphNum);
 
   public:


### PR DESCRIPTION
Not the refactor I _wanted_ to do, but the one I did.

I cleaned up and rewrote how annotations are displayed on the plot window. They are now a lot more flexible and should be easier to add to in the future, since 90% of them are set up and rendered in `Plot::drawAnnotations()`. The only other annotations that are rendered is in the `Plot::PlotGraph()` function, because I really didn't want to redo all the min/max/mean calculations again.

This now has the ability to show up to 4 graphs of min/max/mean numbers, all 4 cursors info (including Operation Buffer changes with CursorA), and has enough space to add future info. Oh, and a lot of the annotations are tied to the state of the objects they track, so if the cursors aren't on screen, those annotations won't show up. Same with the grid, and the three other graphs that can be rendered.

I also moved the overlay buffer (`g_OverlayBuffer`) from `proxguiqt.cpp` to `graph.c` to keep all the graphs together. Once I understand more about how the Demod buffer works, I'll probably move that over as well, but for right now those three are there.

There's also some random cleanup for `graph.c` that touched a _lot_ of files in this PR, since I forgot to remove them before pushing. sorry 😅

![image](https://github.com/RfidResearchGroup/proxmark3/assets/522065/44e02443-2b1a-4892-9738-e39dd1afe579)
