### PR TITLE
Marker code cleanup

### DIFF
--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -1085,8 +1085,8 @@ static int CmdTune(const char *Cmd) {
                       , LF_DIV2FREQ(LF_DIVISOR_134)
                      );
         g_GraphTraceLen = 256;
-        g_CursorCPos = LF_DIVISOR_125;
-        g_CursorDPos = LF_DIVISOR_134;
+        g_MarkerCPos = LF_DIVISOR_125;
+        g_MarkerDPos = LF_DIVISOR_134;
         ShowGraphWindow();
         RepaintGraphWindow();
     } else {

--- a/client/src/proxgui.h
+++ b/client/src/proxgui.h
@@ -43,8 +43,9 @@ void ExitGraphics(void);
 
 extern double g_CursorScaleFactor;
 extern char g_CursorScaleFactorUnit[11];
-extern double g_PlotGridX, g_PlotGridY, g_PlotGridXdefault, g_PlotGridYdefault, g_GridOffset;
-extern uint32_t g_CursorCPos, g_CursorDPos, g_GraphStart, g_GraphStart_old, g_GraphStop;
+extern double g_PlotGridX, g_PlotGridY, g_DefaultGridX, g_DefaultGridY, g_GridOffset;
+extern uint32_t g_MarkerAPos, g_MarkerBPos, g_MarkerCPos, g_MarkerDPos;
+extern uint32_t g_GraphStart, g_GraphStart_old, g_GraphStop;
 extern int CommandFinished;
 extern int offline;
 extern bool g_GridLocked;

--- a/client/src/proxguiqt.h
+++ b/client/src/proxguiqt.h
@@ -43,13 +43,12 @@ class Plot: public QWidget {
   private:
     QWidget *master;
     double g_GraphPixelsPerPoint; // How many visual pixels are between each sample point (x axis)
-    uint32_t CursorAPos;
-    uint32_t CursorBPos;
     void PlotGraph(int *buffer, size_t len, QRect plotRect, QRect annotationRect, QPainter *painter, int graphNum);
     void PlotDemod(uint8_t *buffer, size_t len, QRect plotRect, QRect annotationRect, QPainter *painter, int graphNum, uint32_t plotOffset);
     void plotGridLines(QPainter *painter, QRect r);
     void plotOperations(int *buffer, size_t len, QPainter *painter, QRect rect);
     void drawAnnotations(QRect annotationRect, QPainter *painter);
+    void draw_marker(uint32_t cursor, QRect plotRect, QColor color, QPainter *painter);
     int xCoordOf(int i, QRect r);
     int yCoordOf(int v, QRect r, int maxVal);
     int valueOf_yCoord(int y, QRect r, int maxVal);

--- a/client/src/ui.c
+++ b/client/src/ui.c
@@ -49,9 +49,11 @@ session_arg_t g_session;
 
 double g_CursorScaleFactor = 1;
 char g_CursorScaleFactorUnit[11] = {0};
-double g_PlotGridX = 0, g_PlotGridY = 0, g_PlotGridXdefault = 64, g_PlotGridYdefault = 64;
-uint32_t g_CursorCPos = 0, g_CursorDPos = 0, g_GraphStop = 0;
+double g_PlotGridX = 0, g_PlotGridY = 0;
+double g_DefaultGridX = 64, g_DefaultGridY = 64;
+uint32_t g_MarkerAPos = 0, g_MarkerBPos = 0, g_MarkerCPos = 0, g_MarkerDPos = 0;
 uint32_t g_GraphStart = 0; // Starting point/offset for the left side of the graph
+uint32_t g_GraphStop = 0;
 uint32_t g_GraphStart_old = 0;
 double g_GraphPixelsPerPoint = 1.f; // How many visual pixels are between each sample point (x axis)
 static bool flushAfterWrite = false;


### PR DESCRIPTION
Cleaned up and unified the marker code I've been combing through.

- Renamed `CursorXPos` to `g_MarkerXPos` and moved all of them under `ui.h/ui.c` for consistency. It also is a better name for the variables due to them actually being markers and not cursors.
- Made the Marker drawing a bit more flexible by throwing it into its own function. It is now easier to add markers in the future. Note: I need to do that to the Annotation drawing code as well, but I'm not sure if the function should go in `proxguiqt.cpp` or `ui.c` or what. I honestly think it might be better to move the utility functions I've been creating into another file that's suited for that instead of gumming up the `proxguiqt.cpp` file more.
- Extended `data setgraphmarkers` to be able to modify Marker A and B as well as C and D. Also added `--keep` as a flag to prevent nuking other values not being set in a command if you don't want them to be.
- Renamed `g_PlotGridXdefault/g_PlotGridYdefault` to `g_DefaultXGrid/g_DefaultYGrid`. Frivolous change, but easier to read.