### PR TITLE
Fix homebrew Qt5 detection on MacOS

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -37,7 +37,7 @@ OBJDIR = obj
 ifeq ($(USE_BREW),1)
 	INCLUDES += -I$(BREW_PREFIX)/include
 	LDLIBS += -L$(BREW_PREFIX)/lib
-	PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(BREW_PREFIX)/lib/pkgconfig:$(BREW_PREFIX)/opt/qt/lib/pkgconfig:$(BREW_PREFIX)/opt/qt5/lib/pkgconfig
+	PKG_CONFIG_ENV := PKG_CONFIG_PATH=$(BREW_PREFIX)/lib/pkgconfig:$(BREW_PREFIX)/opt/qt@5/lib/pkgconfig:$(BREW_PREFIX)/opt/qt@5/lib/pkgconfig
 endif
 
 ifeq ($(USE_MACPORTS),1)


### PR DESCRIPTION
After install of `brew install qt5` compilation with `make clean && make -j` didnt find Qt5 lib. 

I found [this old PR](https://github.com/RfidResearchGroup/proxmark3/pull/1737) that once fixed same issue but by now homebrew changed the lib path, so here is a fix again

> GUI support:       QT5 found, enabled (Qt version 5.15.13 in /opt/homebrew/Cellar/qt@5/5.15.13/lib)