### PR TITLE
Fix typo in cmake for qt5 detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,9 +44,14 @@ Makefile.platform.*
 .Makefile.options.cache
 
 # cmake
+CMakeFiles/
+deps/
+client/CMakeFiles/
+client/deps/
 client/build/
 client/android/build/
-client/deps/bzip2/
+CMakeCache.txt
+*.cmake
 
 # Coverity
 cov-int/

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -64,7 +64,7 @@ if (NOT SKIPQT EQUAL 1)
         # QT_FIND_PACKAGE_OPTIONS should be passed to find_package,
         # e.g. find_package(Qt5Core ${QT_FIND_PACKAGE_OPTIONS})
         list(APPEND QT_FIND_PACKAGE_OPTIONS PATHS /opt/homebrew/opt/qt@5)
-    endif(APPLE AND EXISTS /opt/homebrew/opt/qt5)
+    endif(APPLE AND EXISTS /opt/homebrew/opt/qt@5)
     set(QT_PACKAGELIST
         Qt5Core
         Qt5Widgets


### PR DESCRIPTION
this was missed in #2351 and produces a build warning

I also updated the gitignore with generated artifacts of CMake but could also bring that to a separate PR