### PR TITLE
Graph Markers, Version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Updated Graph Markers implementation to include temporary markers and marker labels (@HACKhalo2)
 - Updated to SWIG 4.2.1 (@iceman1001)
 - Removed `data bin2hex` - replaced by `data num`  (@iceman1001)
 - Removed `data hex2bin` - replaced by `data num`  (@iceman1001)

--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -478,8 +478,8 @@ int ASKDemod_ext(int clk, int invert, int maxErr, size_t maxlen, bool amplify, b
 
     if (st) {
         *stCheck = st;
-        g_MarkerCPos = ststart;
-        g_MarkerDPos = stend;
+        g_MarkerC.pos = ststart;
+        g_MarkerD.pos = stend;
         if (verbose)
             PrintAndLogEx(DEBUG, "Found Sequence Terminator - First one is shown by orange / blue graph markers");
     }
@@ -1738,16 +1738,16 @@ static int CmdSetGraphMarkers(const char *Cmd) {
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
     bool keep    = arg_get_lit(ctx, 1);
-    g_MarkerAPos = arg_get_u32_def(ctx, 2, (keep ? g_MarkerAPos : 0));
-    g_MarkerBPos = arg_get_u32_def(ctx, 3, (keep ? g_MarkerBPos : 0));
-    g_MarkerCPos = arg_get_u32_def(ctx, 4, (keep ? g_MarkerCPos : 0));
-    g_MarkerDPos = arg_get_u32_def(ctx, 5, (keep ? g_MarkerDPos : 0));
+    g_MarkerA.pos = arg_get_u32_def(ctx, 2, (keep ? g_MarkerA.pos : 0));
+    g_MarkerB.pos = arg_get_u32_def(ctx, 3, (keep ? g_MarkerB.pos : 0));
+    g_MarkerC.pos = arg_get_u32_def(ctx, 4, (keep ? g_MarkerC.pos : 0));
+    g_MarkerD.pos = arg_get_u32_def(ctx, 5, (keep ? g_MarkerD.pos : 0));
     CLIParserFree(ctx);
     PrintAndLogEx(INFO, "Setting markers " _BRIGHT_YELLOW_("A") "=%u, "_BRIGHT_MAGENTA_("B") "=%u, "_RED_("C") "=%u, "_BLUE_("D") "=%u", 
-        g_MarkerAPos,
-        g_MarkerBPos,
-        g_MarkerCPos,
-        g_MarkerDPos
+        g_MarkerA.pos,
+        g_MarkerB.pos,
+        g_MarkerC.pos,
+        g_MarkerD.pos
     );
     RepaintGraphWindow();
     return PM3_SUCCESS;

--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -1085,8 +1085,8 @@ static int CmdTune(const char *Cmd) {
                       , LF_DIV2FREQ(LF_DIVISOR_134)
                      );
         g_GraphTraceLen = 256;
-        g_MarkerCPos = LF_DIVISOR_125;
-        g_MarkerDPos = LF_DIVISOR_134;
+        g_MarkerC.pos = LF_DIVISOR_125;
+        g_MarkerD.pos = LF_DIVISOR_134;
         ShowGraphWindow();
         RepaintGraphWindow();
     } else {

--- a/client/src/cmdlfti.c
+++ b/client/src/cmdlfti.c
@@ -19,6 +19,7 @@
 #include "cmdlfti.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>       // strncpy
 #include <inttypes.h>
 #include "cmdparser.h"    // command_t
 #include "commonutil.h"
@@ -168,8 +169,8 @@ int demodTI(bool verbose) {
 
     // place a marker in the buffer to visually aid location
     // of the start of sync
-    g_GraphBuffer[maxPos] = 800;
-    g_GraphBuffer[maxPos + 1] = -800;
+    g_MarkerC.pos = maxPos;
+    strcpy(g_MarkerC.label, "Sync Start");
 
     // advance pointer to start of actual data stream (after 16 pre and 8 start bits)
     maxPos += 17 * lowLen;
@@ -177,8 +178,8 @@ int demodTI(bool verbose) {
 
     // place a marker in the buffer to visually aid location
     // of the end of sync
-    g_GraphBuffer[maxPos] = 800;
-    g_GraphBuffer[maxPos + 1] = -800;
+    g_MarkerD.pos = maxPos;
+    strcpy(g_MarkerD.label, "Sync End");
 
     PrintAndLogEx(DEBUG, "actual data bits start at sample %d", maxPos);
     PrintAndLogEx(DEBUG, "length %d/%d", highLen, lowLen);
@@ -214,8 +215,7 @@ int demodTI(bool verbose) {
         shift3 >>= 1;
 
         // place a marker in the buffer between bits to visually aid location
-        g_GraphBuffer[maxPos] = 800;
-        g_GraphBuffer[maxPos + 1] = -800;
+        add_temporary_marker(maxPos, "");
     }
 
     RepaintGraphWindow();

--- a/client/src/graph.c
+++ b/client/src/graph.c
@@ -81,6 +81,12 @@ size_t ClearGraph(bool redraw) {
     g_DemodBufferLen = 0;
     g_useOverlays = false;
 
+    remove_temporary_markers();
+    g_MarkerA.pos = 0;
+    g_MarkerB.pos = 0;
+    g_MarkerC.pos = 0;
+    g_MarkerD.pos = 0;
+
     if (redraw) {
         RepaintGraphWindow();
     }
@@ -123,6 +129,7 @@ void setGraphBuffer(const uint8_t *src, size_t size) {
         g_OperationBuffer[i] = src[i] - 128;
     }
 
+    remove_temporary_markers();
     g_GraphTraceLen = size;
     RepaintGraphWindow();
 }

--- a/client/src/proxgui.cpp
+++ b/client/src/proxgui.cpp
@@ -139,7 +139,7 @@ extern "C" void InitGraphics(int argc, char **argv, char *script_cmds_file, char
 
 void add_temporary_marker(uint32_t position, const char *label) {
     if(g_TempMarkerSize == 0) { //Initialize the marker array
-        g_TempMarkers = (marker_t*)malloc(sizeof(marker_t));
+        g_TempMarkers = (marker_t*)calloc(1, sizeof(marker_t));
     } else { //add more space to the marker array using realloc()
         marker_t *temp = (marker_t*)realloc(g_TempMarkers, ((g_TempMarkerSize + 1) * sizeof(marker_t)));
 
@@ -155,12 +155,12 @@ void add_temporary_marker(uint32_t position, const char *label) {
 
     g_TempMarkers[g_TempMarkerSize].pos = position;
 
-    char *markerLabel = (char*)malloc(strlen(label));
+    char *markerLabel = (char*)calloc(1, strlen(label) + 1);
     strcpy(markerLabel, label);
 
-    if(strlen(markerLabel) > 29) {
+    if(strlen(markerLabel) > 30) {
         PrintAndLogEx(WARNING, "Label for temporary marker too long! Trunicating...");
-        markerLabel[29] = '\0';
+        markerLabel[30] = '\0';
     }
 
     strncpy(g_TempMarkers[g_TempMarkerSize].label, markerLabel, 30);

--- a/client/src/proxgui.cpp
+++ b/client/src/proxgui.cpp
@@ -24,6 +24,9 @@
 #include "ui.h"  // for prints
 
 static ProxGuiQT *gui = NULL;
+marker_t g_MarkerA, g_MarkerB, g_MarkerC, g_MarkerD;
+marker_t *g_TempMarkers;
+uint8_t g_TempMarkerSize = 0;
 static WorkerThread *main_loop_thread = NULL;
 
 WorkerThread::WorkerThread(char *script_cmds_file, char *script_cmd, bool stayInCommandLoop) : script_cmds_file(script_cmds_file), script_cmd(script_cmd), stayInCommandLoop(stayInCommandLoop) {
@@ -132,6 +135,47 @@ extern "C" void InitGraphics(int argc, char **argv, char *script_cmds_file, char
 #endif
     main_loop_thread = new WorkerThread(script_cmds_file, script_cmd, stayInCommandLoop);
     gui = new ProxGuiQT(argc, argv, main_loop_thread);
+}
+
+void add_temporary_marker(uint32_t position, const char *label) {
+    if(g_TempMarkerSize == 0) { //Initialize the marker array
+        g_TempMarkers = (marker_t*)malloc(sizeof(marker_t));
+    } else { //add more space to the marker array using realloc()
+        marker_t *temp = (marker_t*)realloc(g_TempMarkers, ((g_TempMarkerSize + 1) * sizeof(marker_t)));
+
+        if(temp == NULL) { //Unable to reallocate memory for a new marker
+            PrintAndLogEx(FAILED, "Unable to allocate memory for a new temporary marker!");
+            free(temp);
+            return;
+        } else {
+            //Set g_TempMarkers to the new pointer
+            g_TempMarkers = temp;
+        }
+    }
+
+    g_TempMarkers[g_TempMarkerSize].pos = position;
+
+    char *markerLabel = (char*)malloc(strlen(label));
+    strcpy(markerLabel, label);
+
+    if(strlen(markerLabel) > 29) {
+        PrintAndLogEx(WARNING, "Label for temporary marker too long! Trunicating...");
+        markerLabel[29] = '\0';
+    }
+
+    strncpy(g_TempMarkers[g_TempMarkerSize].label, markerLabel, 30);
+    g_TempMarkerSize++;
+
+    memset(markerLabel, 0x00, strlen(label));
+    free(markerLabel);
+}
+
+void remove_temporary_markers(void) {
+    if(g_TempMarkerSize == 0) return;
+
+    memset(g_TempMarkers, 0x00, (g_TempMarkerSize * sizeof(marker_t)));
+    free(g_TempMarkers);
+    g_TempMarkerSize = 0;
 }
 
 extern "C" void ExitGraphics(void) {

--- a/client/src/proxgui.h
+++ b/client/src/proxgui.h
@@ -27,6 +27,11 @@ extern "C" {
 #include <stddef.h>
 #include <stdbool.h>
 
+typedef struct {
+    uint32_t pos;
+    char label[30];
+} marker_t;
+
 void ShowGraphWindow(void);
 void HideGraphWindow(void);
 void RepaintGraphWindow(void);
@@ -41,10 +46,16 @@ void MainGraphics(void);
 void InitGraphics(int argc, char **argv, char *script_cmds_file, char *script_cmd, bool stayInCommandLoop);
 void ExitGraphics(void);
 
+//Temporary Marker Functions
+extern void add_temporary_marker(uint32_t position, const char *label);
+extern void remove_temporary_markers(void);
+
 extern double g_CursorScaleFactor;
 extern char g_CursorScaleFactorUnit[11];
 extern double g_PlotGridX, g_PlotGridY, g_DefaultGridX, g_DefaultGridY, g_GridOffset;
-extern uint32_t g_MarkerAPos, g_MarkerBPos, g_MarkerCPos, g_MarkerDPos;
+extern marker_t g_MarkerA, g_MarkerB, g_MarkerC, g_MarkerD;
+extern marker_t *g_TempMarkers;
+extern uint8_t g_TempMarkerSize;
 extern uint32_t g_GraphStart, g_GraphStart_old, g_GraphStop;
 extern int CommandFinished;
 extern int offline;

--- a/client/src/proxguiqt.cpp
+++ b/client/src/proxguiqt.cpp
@@ -783,8 +783,7 @@ void Plot::drawAnnotations(QRect annotationRect, QPainter *painter) {
     char graphText[] = "@%u..%u  dt=%i %s zoom=%2.3f";
     length = ((sizeof(graphText))+(sizeof(uint32_t)*3)+sizeof(scalestr)+sizeof(float_t));
 
-    annotation = (char*)malloc(length);
-    memset(annotation, 0x00, length);
+    annotation = (char*)calloc(1, length);
 
     snprintf(annotation, length, graphText,
         g_GraphStart,
@@ -805,8 +804,7 @@ void Plot::drawAnnotations(QRect annotationRect, QPainter *painter) {
         char gridText[] = "GridX=%lf  GridY=%lf (%s) GridXoffset=%lf";
         length = (sizeof(gridText) + (sizeof(double)*3) + sizeof(gridLocked));
 
-        annotation = (char*)malloc(length);
-        memset(annotation, 0x00, length);
+        annotation = (char*)calloc(1, length);
 
         snprintf(annotation, length, gridText,
             g_DefaultGridX,
@@ -832,11 +830,8 @@ void Plot::drawAnnotations(QRect annotationRect, QPainter *painter) {
         bool flag = false;
         size_t value;
 
-        annotation = (char*)malloc(length);
-        char *textA = (char*)malloc(length);
-
-        memset(annotation, 0x00, length);
-        memset(textA, 0x00, length);
+        annotation = (char*)calloc(1, length);
+        char *textA = (char*)calloc(1, length);
 
         strcat(textA, markerText);
         strcat(textA, " (%s%u)");
@@ -867,8 +862,7 @@ void Plot::drawAnnotations(QRect annotationRect, QPainter *painter) {
         length = ((sizeof(markerText))+(sizeof(uint32_t)*2)+1);
         pos = g_MarkerB.pos;
 
-        annotation = (char*)malloc(length);
-        memset(annotation, 0x00, length);
+        annotation = (char*)calloc(1, length);
 
         snprintf(annotation, length, markerText,
             "B",
@@ -885,8 +879,7 @@ void Plot::drawAnnotations(QRect annotationRect, QPainter *painter) {
         length = ((sizeof(markerText))+(sizeof(uint32_t)*2)+1);
         pos = g_MarkerC.pos;
 
-        annotation = (char*)malloc(length);
-        memset(annotation, 0x00, length);
+        annotation = (char*)calloc(1, length);
 
         snprintf(annotation, length, markerText,
             "C",
@@ -903,8 +896,7 @@ void Plot::drawAnnotations(QRect annotationRect, QPainter *painter) {
         length = ((sizeof(markerText))+(sizeof(uint32_t)*2)+1);
         pos = g_MarkerD.pos;
 
-        annotation = (char*)malloc(length);
-        memset(annotation, 0x00, length);
+        annotation = (char*)calloc(1, length);
 
         snprintf(annotation, length, markerText,
             "D",

--- a/client/src/proxguiqt.h
+++ b/client/src/proxguiqt.h
@@ -29,6 +29,7 @@
 #include <QPainter>
 #include <QtGui>
 
+#include "proxgui.h"
 #include "ui/ui_overlays.h"
 #include "ui/ui_image.h"
 
@@ -48,7 +49,7 @@ class Plot: public QWidget {
     void plotGridLines(QPainter *painter, QRect r);
     void plotOperations(int *buffer, size_t len, QPainter *painter, QRect rect);
     void drawAnnotations(QRect annotationRect, QPainter *painter);
-    void draw_marker(uint32_t cursor, QRect plotRect, QColor color, QPainter *painter);
+    void draw_marker(marker_t marker, QRect plotRect, QColor color, QPainter *painter);
     int xCoordOf(int i, QRect r);
     int yCoordOf(int v, QRect r, int maxVal);
     int valueOf_yCoord(int y, QRect r, int maxVal);

--- a/client/src/ui.c
+++ b/client/src/ui.c
@@ -51,7 +51,6 @@ double g_CursorScaleFactor = 1;
 char g_CursorScaleFactorUnit[11] = {0};
 double g_PlotGridX = 0, g_PlotGridY = 0;
 double g_DefaultGridX = 64, g_DefaultGridY = 64;
-uint32_t g_MarkerAPos = 0, g_MarkerBPos = 0, g_MarkerCPos = 0, g_MarkerDPos = 0;
 uint32_t g_GraphStart = 0; // Starting point/offset for the left side of the graph
 uint32_t g_GraphStop = 0;
 uint32_t g_GraphStart_old = 0;

--- a/client/src/ui.h
+++ b/client/src/ui.h
@@ -66,6 +66,7 @@ typedef struct {
 } session_arg_t;
 
 extern session_arg_t g_session;
+
 #ifndef M_PI
 #define M_PI 3.14159265358979323846264338327
 #endif


### PR DESCRIPTION
Did a decent overhaul of the Graph Markers (again, but this time with more features!)

- Moved things around again. The four main markers (A through D) now live in proxgui instead of ui
- Implemented the `marker_t` struct, which currently holds a marker's position and it's label
- Added the ability to set Temporary Markers
  - These Markers are only set in code (for now), and are for things like marking noteworthy positions on the graph (like the start of a bit)

Oh, I also fixed a few memory leaks I accidentally introduced 😅

If you want to see what a full implementation of this updated marker system can do, load `lf_TI` and `demod` it.

![image](https://github.com/RfidResearchGroup/proxmark3/assets/522065/5f0d0431-b66c-4727-b23d-24a9671ad26c)
