### PR TITLE
Delete a duplicate header file fpga.h in armsrc/appmain.c

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -26,7 +26,6 @@
 #include "dbprint.h"
 #include "pmflash.h"
 #include "fpga.h"
-#include "fpga.h"
 #include "fpgaloader.h"
 #include "string.h"
 #include "printf.h"


### PR DESCRIPTION
In this patch a duplicate header file ``fpga.h`` is removed from ``armsrc/appmain.c``.