### PR TITLE
Fix MacOS building

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,9 +40,9 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install setuptools ansicolors sslcrypto
-          if [ -f requirements.txt ]; then python3 -m pip install -r requirements.txt; fi
+          python3 -m pip install --break-system-packages --user --upgrade pip
+          python3 -m pip install --break-system-packages --user setuptools ansicolors sslcrypto
+          if [ -f requirements.txt ]; then python3 -m pip install --break-system-packages --user -r requirements.txt; fi
 
       - name: make clean
         run: make clean
@@ -80,9 +80,9 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install setuptools ansicolors sslcrypto
-          if [ -f requirements.txt ]; then python3 -m pip install -r requirements.txt; fi
+          python3 -m pip install --break-system-packages --user --upgrade pip
+          python3 -m pip install --break-system-packages --user setuptools ansicolors sslcrypto
+          if [ -f requirements.txt ]; then python3 -m pip install --break-system-packages --user -r requirements.txt; fi
 
       - name: make clean
         run: make clean
@@ -121,9 +121,9 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install setuptools ansicolors sslcrypto
-          if [ -f requirements.txt ]; then python3 -m pip install -r requirements.txt; fi
+          python3 -m pip install --break-system-packages --user --upgrade pip
+          python3 -m pip install --break-system-packages --user setuptools ansicolors sslcrypto
+          if [ -f requirements.txt ]; then python3 -m pip install --break-system-packages --user -r requirements.txt; fi
 
       - name: Prepare Build Folders
         run: |


### PR DESCRIPTION
Pass `--break-system-packages --user` to the python commands to stop it complaining about breaking the externally managed dependencies of a non-virtual environment that's actually a virtual environment.

This **SHOULDN'T** be done locally because it could break things, but it's good enough for github actions