### PR TITLE
add `lf em 4x70 calc` and self-tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Added `lf em 4x70 calc` - calculate `frn`/`grn` for a given `key` + `rnd`
 - Fixed `hf 15 dump` memory leaks (@jlitewski)
 - Changed `hf search` - topaz is detect before ISO14443a and commented out WIP ICT code path (@iceman1001)
 - Fixed `hf search` - where felica reader now doesnt timeout and give wrong response (@iceman1001)

--- a/armsrc/em4x70.c
+++ b/armsrc/em4x70.c
@@ -30,43 +30,50 @@ static em4x70_tag_t tag = { 0 };
 // EM4170 requires a parity bit on commands, other variants do not.
 static bool command_parity = true;
 
-// Conversion from Ticks to RF periods
-// 1 us = 1.5 ticks
-// 1RF Period = 8us = 12 Ticks
-#define TICKS_PER_FC                        12
 
-// Chip timing from datasheet
-// Converted into Ticks for timing functions
-#define EM4X70_T_TAG_QUARTER_PERIOD          (8 * TICKS_PER_FC)
-#define EM4X70_T_TAG_HALF_PERIOD            (16 * TICKS_PER_FC)
-#define EM4X70_T_TAG_THREE_QUARTER_PERIOD   (24 * TICKS_PER_FC)
-#define EM4X70_T_TAG_FULL_PERIOD            (32 * TICKS_PER_FC) // 1 Bit Period
-#define EM4X70_T_TAG_TWA                   (128 * TICKS_PER_FC) // Write Access Time
-#define EM4X70_T_TAG_DIV                   (224 * TICKS_PER_FC) // Divergency Time
-#define EM4X70_T_TAG_AUTH                 (4224 * TICKS_PER_FC) // Authentication Time
-#define EM4X70_T_TAG_WEE                  (3072 * TICKS_PER_FC) // EEPROM write Time
-#define EM4X70_T_TAG_TWALB                 (672 * TICKS_PER_FC) // Write Access Time of Lock Bits
-#define EM4X70_T_TAG_BITMOD                  (4 * TICKS_PER_FC) // Initial time to stop modulation when sending 0
-#define EM4X70_T_TAG_TOLERANCE               (8 * TICKS_PER_FC) // Tolerance in RF periods for receive/LIW
+#if 1 // Calculation of ticks for timing functions
+    // Conversion from Ticks to RF periods
+    // 1 us = 1.5 ticks
+    // 1RF Period = 8us = 12 Ticks
+    #define TICKS_PER_FC                        12
 
-#define EM4X70_T_TAG_TIMEOUT                 (4 * EM4X70_T_TAG_FULL_PERIOD) // Timeout if we ever get a pulse longer than this
-#define EM4X70_T_WAITING_FOR_LIW             50 // Pulses to wait for listen window
-#define EM4X70_T_READ_HEADER_LEN             16 // Read header length (16 bit periods)
+    // Chip timing from datasheet
+    // Converted into Ticks for timing functions
+    #define EM4X70_T_TAG_QUARTER_PERIOD          (8 * TICKS_PER_FC)
+    #define EM4X70_T_TAG_HALF_PERIOD            (16 * TICKS_PER_FC)
+    #define EM4X70_T_TAG_THREE_QUARTER_PERIOD   (24 * TICKS_PER_FC)
+    #define EM4X70_T_TAG_FULL_PERIOD            (32 * TICKS_PER_FC) // 1 Bit Period
+    #define EM4X70_T_TAG_TWA                   (128 * TICKS_PER_FC) // Write Access Time
+    #define EM4X70_T_TAG_DIV                   (224 * TICKS_PER_FC) // Divergency Time
+    #define EM4X70_T_TAG_AUTH                 (4224 * TICKS_PER_FC) // Authentication Time
+    #define EM4X70_T_TAG_WEE                  (3072 * TICKS_PER_FC) // EEPROM write Time
+    #define EM4X70_T_TAG_TWALB                 (672 * TICKS_PER_FC) // Write Access Time of Lock Bits
+    #define EM4X70_T_TAG_BITMOD                  (4 * TICKS_PER_FC) // Initial time to stop modulation when sending 0
+    #define EM4X70_T_TAG_TOLERANCE               (8 * TICKS_PER_FC) // Tolerance in RF periods for receive/LIW
 
-#define EM4X70_COMMAND_RETRIES               5 // Attempts to send/read command
-#define EM4X70_MAX_RECEIVE_LENGTH           96 // Maximum bits to expect from any command
+    #define EM4X70_T_TAG_TIMEOUT                 (4 * EM4X70_T_TAG_FULL_PERIOD) // Timeout if we ever get a pulse longer than this
+    #define EM4X70_T_WAITING_FOR_LIW             50 // Pulses to wait for listen window
+    #define EM4X70_T_READ_HEADER_LEN             16 // Read header length (16 bit periods)
 
-/**
- * These IDs are from the EM4170 datasheet
- * Some versions of the chip require a
- * (even) parity bit, others do not
- */
-#define EM4X70_COMMAND_ID                   0x01
-#define EM4X70_COMMAND_UM1                  0x02
-#define EM4X70_COMMAND_AUTH                 0x03
-#define EM4X70_COMMAND_PIN                  0x04
-#define EM4X70_COMMAND_WRITE                0x05
-#define EM4X70_COMMAND_UM2                  0x07
+    #define EM4X70_COMMAND_RETRIES               5 // Attempts to send/read command
+    #define EM4X70_MAX_RECEIVE_LENGTH           96 // Maximum bits to expect from any command
+#endif // Calculation of ticks for timing functions
+
+#if 1 // EM4x70 Command IDs
+    /**
+     * These IDs are from the EM4170 datasheet.
+     * Some versions of the chip require a
+     * (even) parity bit, others do not.
+     * The command is thus stored only in the
+     * three least significant bits (mask 0x07).
+     */
+    #define EM4X70_COMMAND_ID                   0x01
+    #define EM4X70_COMMAND_UM1                  0x02
+    #define EM4X70_COMMAND_AUTH                 0x03
+    #define EM4X70_COMMAND_PIN                  0x04
+    #define EM4X70_COMMAND_WRITE                0x05
+    #define EM4X70_COMMAND_UM2                  0x07
+#endif // EM4x70 Command IDs
 
 // Constants used to determine high/low state of signal
 #define EM4X70_NOISE_THRESHOLD  13  // May depend on noise in environment

--- a/client/src/cmdlfem4x70.c
+++ b/client/src/cmdlfem4x70.c
@@ -440,7 +440,7 @@ static int verify_auth_em4x70(const em4x70_cmd_input_verify_auth_t *opts) {
 }
 
 
-int CmdEM4x70Info(const char *Cmd) {
+static int CmdEM4x70Info(const char *Cmd) {
 
     // invoke reading of a EM4x70 tag which has to be on the antenna because
     // decoding is done by the device (not on client side)
@@ -480,7 +480,7 @@ int CmdEM4x70Info(const char *Cmd) {
     return result;
 }
 
-int CmdEM4x70Write(const char *Cmd) {
+static int CmdEM4x70Write(const char *Cmd) {
 
     // write one block/word (16 bits) to the tag at given block address (0-15)
     CLIParserContext *ctx;
@@ -532,7 +532,7 @@ int CmdEM4x70Write(const char *Cmd) {
     return result;
 }
 
-int CmdEM4x70Brute(const char *Cmd) {
+static int CmdEM4x70Brute(const char *Cmd) {
 
     // From paper "Dismantling Megamos Crypto", Roel Verdult, Flavio D. Garcia and Barıs¸ Ege.
     // Partial Key-Update Attack (optimized version)
@@ -618,7 +618,7 @@ int CmdEM4x70Brute(const char *Cmd) {
     return result;
 }
 
-int CmdEM4x70Unlock(const char *Cmd) {
+static int CmdEM4x70Unlock(const char *Cmd) {
 
     // send pin code to device, unlocking it for writing
     CLIParserContext *ctx;
@@ -666,7 +666,7 @@ int CmdEM4x70Unlock(const char *Cmd) {
     return result;
 }
 
-int CmdEM4x70Auth(const char *Cmd) {
+static int CmdEM4x70Auth(const char *Cmd) {
 
     // Authenticate transponder
     // Send 56-bit random number + pre-computed f(rnd, k) to transponder.
@@ -726,7 +726,7 @@ int CmdEM4x70Auth(const char *Cmd) {
     return result;
 }
 
-int CmdEM4x70SetPIN(const char *Cmd) {
+static int CmdEM4x70SetPIN(const char *Cmd) {
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "lf em 4x70 setpin",
                   "Write new PIN\n",
@@ -771,7 +771,7 @@ int CmdEM4x70SetPIN(const char *Cmd) {
     return result;
 }
 
-int CmdEM4x70SetKey(const char *Cmd) {
+static int CmdEM4x70SetKey(const char *Cmd) {
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "lf em 4x70 setkey",
                   "Write new 96-bit key to tag\n",
@@ -969,7 +969,7 @@ static int CmdEM4x70Recover_ParseArgs(const char *Cmd, em4x70_cmd_input_recover_
     return result;
 }
 
-int CmdEM4x70Recover(const char *Cmd) {
+static int CmdEM4x70Recover(const char *Cmd) {
     // From paper "Dismantling Megamos Crypto", Roel Verdult, Flavio D. Garcia and Barıs¸ Ege.
     // Partial Key-Update Attack -- final 48 bits (after optimized version gets k95..k48)
     em4x70_recovery_data_t recover_ctx = {0};
@@ -1552,6 +1552,7 @@ static int CmdHelp(const char *Cmd) {
     return PM3_SUCCESS;
 }
 
+///////////////////////////////////////////////////////////////////////////////
 // Only two functions need to be non-static:
 // * CmdLFEM4X70()
 // * detect_4x70_block()

--- a/client/src/cmdlfem4x70.c
+++ b/client/src/cmdlfem4x70.c
@@ -1522,8 +1522,7 @@ static int CmdEM4x70Calc(const char *Cmd) {
             data.grn.grn[0], data.grn.grn[1], data.grn.grn[2]
             );
     }
-
-    PrintAndLogEx(SUCCESS, "KEY: " _GREEN_("%s") "  RND: " _GREEN_("%s") "  FRN: " _GREEN_("%s") "  GRN: " _GREEN_("%s"), key_string, rnd_string, frn_string, grn_string);
+    PrintAndLogEx(SUCCESS, "KEY: %s  RND: %s  FRN: " _GREEN_("%s") "  GRN: " _GREEN_("%s"), key_string, rnd_string, frn_string, grn_string);
     return PM3_SUCCESS;
 }
 

--- a/client/src/cmdlfem4x70.h
+++ b/client/src/cmdlfem4x70.h
@@ -24,14 +24,6 @@
 #define TIMEOUT                     2000
 
 int CmdLFEM4X70(const char *Cmd);
-int CmdEM4x70Info(const char *Cmd);
-int CmdEM4x70Write(const char *Cmd);
-int CmdEM4x70Brute(const char *Cmd);
-int CmdEM4x70Unlock(const char *Cmd);
-int CmdEM4x70Auth(const char *Cmd);
-int CmdEM4x70SetPIN(const char *Cmd);
-int CmdEM4x70SetKey(const char *Cmd);
-int CmdEM4x70Recover(const char *Cmd);
 
 // for `lf search`:
 bool detect_4x70_block(void);

--- a/tools/pm3_tests.sh
+++ b/tools/pm3_tests.sh
@@ -414,26 +414,30 @@ while true; do
       if ! CheckExecute "nfc decode test - signature"    "$CLIENTBIN -c 'nfc decode -d 03FF010194113870696C65742E65653A656B616172743A3266195F26063132303832325904202020205F28033233335F2701316E1B5A13333038363439303039303030323636343030355304EBF2CE704103000000AC536967010200803A2448FCA7D354A654A81BD021150D1A152D1DF4D7A55D2B771F12F094EAB6E5E10F2617A2F8DAD4FD38AFF8EA39B71C19BD42618CDA86EE7E144636C8E0E7CFC4096E19C3680E09C78A0CDBC05DA2D698E551D5D709717655E56FE3676880B897D2C70DF5F06ECE07C71435255144F8EE41AF110E7B180DA0E6C22FB8FDEF61800025687474703A2F2F70696C65742E65652F6372742F33303836343930302D303030312E637274FE'" "30864900-0001.crt"; then break; fi
 
       echo -e "\n${C_BLUE}Testing LF:${C_NC}"
-      if ! CheckExecute "lf hitag2 test"        "$CLIENTBIN -c 'lf hitag test'" "Tests \( ok"; then break; fi
-      if ! CheckExecute "lf cotag demod test"   "$CLIENTBIN -c 'data load -f traces/lf_cotag_220_8331.pm3; data norm; data cthreshold -u 50 -d -20; data envelope; data raw --ar -c 272; lf cotag demod'" \
+      if ! CheckExecute "lf hitag2 test"             "$CLIENTBIN -c 'lf hitag test'" "Tests \( ok"; then break; fi
+      if ! CheckExecute "lf cotag demod test"        "$CLIENTBIN -c 'data load -f traces/lf_cotag_220_8331.pm3; data norm; data cthreshold -u 50 -d -20; data envelope; data raw --ar -c 272; lf cotag demod'" \
                                                                      "COTAG Found: FC 220, CN: 8331 Raw: FFB841170363FFFE00001E7F00000000"; then break; fi
-      if ! CheckExecute "lf AWID test"          "$CLIENTBIN -c 'data load -f traces/lf_AWID-15-259.pm3;lf search -1'" "AWID ID found"; then break; fi
-      if ! CheckExecute "lf EM410x test"        "$CLIENTBIN -c 'data load -f traces/lf_EM4102-1.pm3;lf search -1'" "EM410x ID found"; then break; fi
-      if ! CheckExecute "lf EM4x05 test"        "$CLIENTBIN -c 'data load -f traces/lf_EM4x05.pm3;lf search -1'" "FDX-B ID found"; then break; fi
-      if ! CheckExecute "lf FDX-A FECAVA test"  "$CLIENTBIN -c 'data load -f traces/lf_EM4305_fdxa_destron.pm3;lf search -1'" "FDX-A FECAVA Destron ID found"; then break; fi
-      if ! CheckExecute "lf FDX-B test"         "$CLIENTBIN -c 'data load -f traces/lf_HomeAgain1600.pm3;lf search -1'" "FDX-B ID found"; then break; fi
-      if ! CheckExecute "lf FDX/BioThermo test" "$CLIENTBIN -c 'data load -f traces/lf_FDXB_Bio-Thermo.pm3; lf fdxb demod'" "95.2 F / 35.1 C"; then break; fi
-      if ! CheckExecute "lf GPROXII test"       "$CLIENTBIN -c 'data load -f traces/lf_GProx_36_30_14489.pm3; lf search -1'" "Guardall G-Prox II ID found"; then break; fi
-      if ! CheckExecute "lf HID Prox test"      "$CLIENTBIN -c 'data load -f traces/lf_HID-proxCardII-05512-11432784-1.pm3;lf search -1'" "HID Prox ID found"; then break; fi
-      if ! CheckExecute "lf IDTECK test"        "$CLIENTBIN -c 'data load -f traces/lf_IDTECK_4944544BAC40E069.pm3; lf search -1'" "Idteck ID found"; then break; fi
-      if ! CheckExecute "lf INDALA test"        "$CLIENTBIN -c 'data load -f traces/lf_Indala-504278295.pm3;lf search -1'" "Indala ID found"; then break; fi
-      if ! CheckExecute "lf KERI test"          "$CLIENTBIN -c 'data load -f traces/lf_Keri.pm3;lf search -1'" "Pyramid ID found"; then break; fi
-      if ! CheckExecute "lf NEXWATCH test"      "$CLIENTBIN -c 'data load -f traces/lf_NEXWATCH_Quadrakey-521512301.pm3;lf search -1 '" "NexWatch ID found"; then break; fi
-      if ! CheckExecute "lf SECURAKEY test"     "$CLIENTBIN -c 'data load -f traces/lf_NEXWATCH_Securakey-64169.pm3;lf search -1 '" "Securakey ID found"; then break; fi
-      if ! CheckExecute "lf PAC test"           "$CLIENTBIN -c 'data load -f traces/lf_PAC-8E4C058E.pm3;lf search -1'" "PAC/Stanley ID found"; then break; fi
-      if ! CheckExecute "lf PARADOX test"       "$CLIENTBIN -c 'data load -f traces/lf_Paradox-96_40426-APJN08.pm3;lf search -1'" "Paradox ID found"; then break; fi
-      if ! CheckExecute "lf VIKING test"        "$CLIENTBIN -c 'data load -f traces/lf_Transit999-best.pm3;lf search -1'" "Viking ID found"; then break; fi
-      if ! CheckExecute "lf VISA2000 test"      "$CLIENTBIN -c 'data load -f traces/lf_VISA2000.pm3;lf search -1'" "Visa2000 ID found"; then break; fi
+      if ! CheckExecute "lf AWID test"               "$CLIENTBIN -c 'data load -f traces/lf_AWID-15-259.pm3;lf search -1'" "AWID ID found"; then break; fi
+      if ! CheckExecute "lf EM410x test"             "$CLIENTBIN -c 'data load -f traces/lf_EM4102-1.pm3;lf search -1'" "EM410x ID found"; then break; fi
+      if ! CheckExecute "lf EM4x05 test"             "$CLIENTBIN -c 'data load -f traces/lf_EM4x05.pm3;lf search -1'" "FDX-B ID found"; then break; fi
+      if ! CheckExecute "lf EM4x70 calc test"        "$CLIENTBIN -c 'lf em 4x70 calc --key F32AA98CF5BE4ADFA6D3480B --rnd 45F54ADA252AAC'" "FRN: 4866BB70  GRN: 9BD180"; then break; fi
+      if ! CheckExecute "lf EM4x70 recover test 1/3" "$CLIENTBIN -c 'lf em 4x70 recover --key 022A028C02BE --rnd 7D5167003571F8 --frn 982DBCC0 --grn 36C0E0'" "022a028c02be000102030405"; then break; fi
+      if ! CheckExecute "lf EM4x70 recover test 2/3" "$CLIENTBIN -c 'lf em 4x70 recover --key 022A028C02BE --rnd 7D5167003571F8 --frn 982DBCC0 --grn 36C0E0'" "022a028c02be366866191b60"; then break; fi
+      if ! CheckExecute "lf EM4x70 recover test 3/3" "$CLIENTBIN -c 'lf em 4x70 recover --key 022A028C02BE --rnd 7D5167003571F8 --frn 982DBCC0 --grn 36C0E0'" "022a028c02bef1e352c2718d"; then break; fi
+      if ! CheckExecute "lf FDX-A FECAVA test"       "$CLIENTBIN -c 'data load -f traces/lf_EM4305_fdxa_destron.pm3;lf search -1'" "FDX-A FECAVA Destron ID found"; then break; fi
+      if ! CheckExecute "lf FDX-B test"              "$CLIENTBIN -c 'data load -f traces/lf_HomeAgain1600.pm3;lf search -1'" "FDX-B ID found"; then break; fi
+      if ! CheckExecute "lf FDX/BioThermo test"      "$CLIENTBIN -c 'data load -f traces/lf_FDXB_Bio-Thermo.pm3; lf fdxb demod'" "95.2 F / 35.1 C"; then break; fi
+      if ! CheckExecute "lf GPROXII test"            "$CLIENTBIN -c 'data load -f traces/lf_GProx_36_30_14489.pm3; lf search -1'" "Guardall G-Prox II ID found"; then break; fi
+      if ! CheckExecute "lf HID Prox test"           "$CLIENTBIN -c 'data load -f traces/lf_HID-proxCardII-05512-11432784-1.pm3;lf search -1'" "HID Prox ID found"; then break; fi
+      if ! CheckExecute "lf IDTECK test"             "$CLIENTBIN -c 'data load -f traces/lf_IDTECK_4944544BAC40E069.pm3; lf search -1'" "Idteck ID found"; then break; fi
+      if ! CheckExecute "lf INDALA test"             "$CLIENTBIN -c 'data load -f traces/lf_Indala-504278295.pm3;lf search -1'" "Indala ID found"; then break; fi
+      if ! CheckExecute "lf KERI test"               "$CLIENTBIN -c 'data load -f traces/lf_Keri.pm3;lf search -1'" "Pyramid ID found"; then break; fi
+      if ! CheckExecute "lf NEXWATCH test"           "$CLIENTBIN -c 'data load -f traces/lf_NEXWATCH_Quadrakey-521512301.pm3;lf search -1 '" "NexWatch ID found"; then break; fi
+      if ! CheckExecute "lf SECURAKEY test"          "$CLIENTBIN -c 'data load -f traces/lf_NEXWATCH_Securakey-64169.pm3;lf search -1 '" "Securakey ID found"; then break; fi
+      if ! CheckExecute "lf PAC test"                "$CLIENTBIN -c 'data load -f traces/lf_PAC-8E4C058E.pm3;lf search -1'" "PAC/Stanley ID found"; then break; fi
+      if ! CheckExecute "lf PARADOX test"            "$CLIENTBIN -c 'data load -f traces/lf_Paradox-96_40426-APJN08.pm3;lf search -1'" "Paradox ID found"; then break; fi
+      if ! CheckExecute "lf VIKING test"             "$CLIENTBIN -c 'data load -f traces/lf_Transit999-best.pm3;lf search -1'" "Viking ID found"; then break; fi
+      if ! CheckExecute "lf VISA2000 test"           "$CLIENTBIN -c 'data load -f traces/lf_VISA2000.pm3;lf search -1'" "Visa2000 ID found"; then break; fi
 
       if ! CheckExecute slow "lf T55 awid 26 test"               "$CLIENTBIN -c 'data load -f traces/lf_ATA5577_awid_26.pm3; lf search -1'" "AWID ID found"; then break; fi
       if ! CheckExecute slow "lf T55 awid 26 test2"              "$CLIENTBIN -c 'data load -f traces/lf_ATA5577_awid_26.pm3; lf awid demod'" \


### PR DESCRIPTION

As requested in Issue #2376, adding unit tests for `lf em 4x70` commands.

Also added new `lf em 4x70 calc` command:  Given a key and 56-bit random value, it will generate the reader challenge (`frn`) and tag response (`grn`).