### PR TITLE
Inside Wash Membership Card in Portugal

### DIFF
--- a/client/dictionaries/mfc_default_keys.dic
+++ b/client/dictionaries/mfc_default_keys.dic
@@ -2417,3 +2417,6 @@ EC2B9FD483CA
 # Hotel Intelier Orange - Benicasim, Spain
 # block 1 - key A
 04256CFE0425
+
+# InsideWash Membership Card - Portugal
+C18063858BB9


### PR DESCRIPTION
Just one key is used. The rest of the card is blank.

I tested on 3 different cards and got through a hardnested attack.