### PR TITLE
Add new AID & ECP definitions

### DIFF
--- a/client/resources/aidlist.json
+++ b/client/resources/aidlist.json
@@ -2284,7 +2284,7 @@
         "Vendor": "Apple",
         "Country": "",
         "Name": "Apple Home Key Framework",
-        "Description": "Home Key configuration applet. Selected after a first transaction on a newely-invited device (allegedly for mailbox sync/attestation exchange)",
+        "Description": "Home Key configuration applet. Used for attestation exchange",
         "Type": ""
     },
     {
@@ -2292,7 +2292,39 @@
         "Vendor": "Apple",
         "Country": "",
         "Name": "Apple Home Key",
-        "Description": "NFC Home Key for select HomeKit-compatible locks",
+        "Description": "NFC Home Key for select HomeKit-compatible locks based on Apple UnifiedAccess protocol",
+        "Type": "access"
+    },
+    {
+        "AID": "A0000008580202",
+        "Vendor": "Apple",
+        "Country": "",
+        "Name": "Apple Access Key Framework",
+        "Description": "Access Key configuration applet. Used for attestation exchange",
+        "Type": ""
+    },
+    {
+        "AID": "A0000008580201",
+        "Vendor": "Apple",
+        "Country": "",
+        "Name": "Apple Access Key",
+        "Description": "NFC Access Key for commercial properties based on Apple UnifiedAccess protocol",
+        "Type": "access"
+    },
+    {
+        "AID": "A000000909ACCE5502",
+        "Vendor": "Connectivity Standards Alliance (CSA)",
+        "Country": "",
+        "Name": "Aliro Framework",
+        "Description": "Used during key provisioning, configuration, attestation exchange",
+        "Type": ""
+    },
+    {
+        "AID": "A000000909ACCE5501",
+        "Vendor": "Connectivity Standards Alliance (CSA)",
+        "Country": "",
+        "Name": "Aliro",
+        "Description": "",
         "Type": "access"
     },
     {
@@ -2429,6 +2461,14 @@
         "Country": "Singapore",
         "Name": "CEPAS",
         "Description": "Transit and e-money card used in Singapore",
+        "Type": "transport"
+    },
+    {
+        "AID": "A0000004040125",
+        "Vendor": "Ile-de-France Mobilites",
+        "Country": "France",
+        "Name": "Navigo",
+        "Description": "CALYPSO-based transit card",
         "Type": "transport"
     }
 ]

--- a/client/resources/ecp_taxonomy.json
+++ b/client/resources/ecp_taxonomy.json
@@ -1,0 +1,126 @@
+{
+    "versions": {
+        "01": {
+            "tci": {
+                "000000": {
+                    "id": "tci-vas-or-pay",
+                    "name": "VAS or payment",
+                    "description": "Used when a reader needs a pass or a payment card. Sometimes called VAS over Payment"
+                }, 
+                "000001": {
+                    "id": "tci-vas-and-pay",
+                    "name": "VAS and payment",
+                    "description": "Also called single tap mode. Allows reading multiple passes with different ids in one tap"
+                },
+                "000002": {
+                    "id": "tci-vas-only",
+                    "name": "VAS only",
+                    "description": "Used when a reader requests passes only"
+                },
+                "000003": {
+                    "id": "tci-pay-only",
+                    "name": "VAS only",
+                    "description": "Used when a reader requests payment cards only. Also disables express mode for chinese transit cards"
+                },
+                "cf0000": {
+                    "id": "tci-ignore",
+                    "name": "Ignore",
+                    "description": "iPhones before IOS17 emit this frame so that other apple devices don't react to the field"
+                }
+            }
+        },
+    
+        "02": {
+            "types": {
+                "01": {
+                    "id": "terminal-type-transit",
+                    "name": "Transit",
+                    "description": "Used by express-mode enabled transit terminals",
+                    
+                    "subtypes": {
+                        "00": {
+                            "id": "terminal-subtype-default",
+                            "name": "Default subtype",
+                            "description": "",
+
+                            "tci": {
+                                "030400": {
+                                    "id": "tci-hop-fastpass",
+                                    "name": "HOP Fastpass",
+                                    "description": ""
+                                },
+                                "030002": {
+                                    "id": "tci-transit-for-london",
+                                    "name": "TFL",
+                                    "description": "First publically known TCI, found by Proxmark community member"
+                                },
+                                "030001": {
+                                    "id": "tci-wmata",
+                                    "name": "SmartTrip",
+                                    "description": ""
+                                },
+                                "030005": {
+                                    "id": "tci-la-tapp",
+                                    "name": "LA Tap",
+                                    "description": ""
+                                },
+                                "030007": {
+                                    "id": "tci-clipper",
+                                    "name": "Clipper",
+                                    "description": ""
+                                },
+                                "03095a": {
+                                    "id": "tci-navigo",
+                                    "name": "Navigo",
+                                    "description": ""
+                                }
+                            },
+
+                            "data": {
+                                "length": 5,
+                                "name": "Fallback EMV payment networks",
+                                "description": "Bit mask of allowed EMV open loop payment cards. First byte is responsible for most popular payment networks"
+                            }
+                        }
+                    }
+                },
+                "02": {
+                    "id": "terminal-type-access",
+                    "name": "Access",
+                    "description": "Used by express-mode enabled access and key readers",
+
+                    "subtypes": {
+                        "00": {
+                            "id": "terminal-subtype-venue",
+                            "name": "Venue",
+                            "description": "Used by following venues: Offices, Parks, Universities",
+                            "tci": {
+                                "no-info-add-if-found": ""
+                            }
+                        },
+                        "06": {
+                            "id": "terminal-subtype-home-key",
+                            "name": "Home Key",
+                            "description": "Used by home key",
+                            "tci": {
+                                "021100": {
+                                    "id": "tci-homekey",
+                                    "name": "Home Key",
+                                    "description": ""
+                                }
+                            }
+                        },
+                        "09": {
+                            "id": "terminal-subtype-automotive-pairing",
+                            "name": "Automotive",
+                            "description": "Used by cars for access and setup",
+                            "tci": {
+                                "no-info-add-if-found": ""
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/client/resources/ecplist.json
+++ b/client/resources/ecplist.json
@@ -55,6 +55,11 @@
         "name": "Transit: Clipper",
         "description": ""
     },
+    {
+        "value": "6a02c8010003095a0000000000",
+        "name": "Transit: Navigo",
+        "description": ""
+    },
 
     {
         "value": "6a02c3020002ffff",


### PR DESCRIPTION
Added the following:
* AID:
  - Apple Access Key;
  - Aliro;
  - Navigo.
* ECP:
  - Navigo.

* Added ECP taxonomy file, which was missing (I intended to add it when creating ecplist.json initially).