### PR TITLE
Added Jett's 24 Hour Fitness

### DIFF
--- a/client/dictionaries/mfc_default_keys.dic
+++ b/client/dictionaries/mfc_default_keys.dic
@@ -307,7 +307,7 @@ E3429281EFC1
 # EPI Envisionte
 AAFB06045877
 #
-# gym
+# Gyms / Fitness Clubs / Health Clubs / Wellness Centres
 #
 # Fysiken A
 3E65E4FB65B3
@@ -318,8 +318,8 @@ AAFB06045877
 #
 # https://mattionline.de/fitnessstudio-armband-reverse-engineering/
 # https://mattionline.de/milazycracker/
-# gym wistband A, same as Fysiken A
-# gym wistband B
+# Gym Wristband A - Same as Fysiken A
+# Gym Wristband B
 81CC25EBBB6A
 195DC63DB3A3
 #
@@ -330,9 +330,13 @@ A05DBD98E0FC
 AA4DDA458EBB
 EAB8066C7479
 #
-# Nordic Wellness A, same as Fysiken A
+# Nordic Wellness A - Same as Fysiken A
 # Nordic Wellness B
 E5519E1CC92B
+# 
+# Jett's 24 Hour Fitness S0 KA/B
+# 049979614077
+# 829338771705
 #
 # Hotel KeyCard
 D3B595E9DD63


### PR DESCRIPTION
Updated gym list; made some minor spelling corrections.

Added Jett's 24 Hour Fitness Sector 0 Keys A/B to the MFC Default Keys dictionary; these keys are static based on testing using inactive credentials purchased on second-hand marketplaces.

Jett's 24 Hour Fitness might also share access keys with Zap Fitness gym tags; however, I am currently unable to test that theory.

Thank you for your time.