### PR TITLE
Add new t55xx password (002BCFCF) sniffed from cheap cloner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 
 ## [unreleased][unreleased]
 - Added `pm3_tears_for_fears.py` - a ISO14443b tear off script by Pierre Granier
+- Added new t55xx password (002BCFCF) sniffed from cheap cloner (@davidbeauchamp)
 
 ## [Aurora.4.18589][2024-05-28]
 - Fixed the pm3 regressiontests for Hitag2Crack (@iceman1001)

--- a/client/dictionaries/t55xx_default_pwds.dic
+++ b/client/dictionaries/t55xx_default_pwds.dic
@@ -5,6 +5,8 @@
 51243648
 000D8787
 19920427
+# White Chinese cloner, circa 2019, firmware v5.04.16.0727 (eBay)
+002BCFCF
 # ZX-copy3  T55xx / EM4305
 # ref. http://www.proxmark.org/forum/viewtopic.php?pid=40662#p40662
 # default PROX


### PR DESCRIPTION
I have a handheld white cloner and a handful of t5577 fobs that were supposedly re-writable but would not wipe. After some sniffing with the Proxmark3 I was able to uncover the password and to wipe the fobs, subsequently using the fobs with the PM3:

```
[usb] pm3 --> lf t55xx sniff

[=] T55xx command detection
[+] Downlink mode           |  password  |   Data   | blk | page |  0  |  1  | raw
[+] ------------------------+------------+----------+-----+------+-----+-----+-------------------------
[+] Default pwd write       |   44B44CAE | 002BCFCF |  7  |   0  |  19 |  46 | 1001000100101101000100110010101110000000000001010111100111111001111111
[+] ---------------------------------------------------------------------------------------------------
```

Picture of the cloner w/firmware version, was purchased some time in 2019 from eBay:
![cloner](https://github.com/RfidResearchGroup/proxmark3/assets/1675112/60bd2929-0f3e-45b5-a4e8-af71dab46e76)

~~I couldn't decide if this minor change was worth inclusion in the changelog or not so I left it out.~~ Thank you, bot.