### PR TITLE
Fix ISO 14443-B tag simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Changed `intertic.py` - updated and code clean up (@gentilkiwi)
 - Added `pm3_tears_for_fears.py` - a ISO14443b tear off script by Pierre Granier
 - Added new t55xx password (002BCFCF) sniffed from cheap cloner (@davidbeauchamp)
+- Fixed 'hf 14b sim' - now works (@michi-jung)
 
 ## [Aurora.4.18589][2024-05-28]
 - Fixed the pm3 regressiontests for Hitag2Crack (@iceman1001)

--- a/armsrc/iso14443b.h
+++ b/armsrc/iso14443b.h
@@ -49,12 +49,10 @@ void SniffIso14443b(void);
 void SendRawCommand14443B(iso14b_raw_cmd_t *p);
 
 // States for 14B SIM command
-#define SIM_NOFIELD     0
+#define SIM_POWER_OFF   0
 #define SIM_IDLE        1
-#define SIM_HALTED      2
-#define SIM_SELECTING   3
-#define SIM_HALTING     4
-#define SIM_ACKNOWLEDGE 5
-#define SIM_WORK        6
+#define SIM_READY       2
+#define SIM_HALT        3
+#define SIM_ACTIVE      4
 
 #endif /* __ISO14443B_H */


### PR DESCRIPTION
See https://github.com/RfidResearchGroup/proxmark3/issues/1652

- Fix Bit Coding PICC -> PCD:  Encoding for 0 and 1 bits were reversed.
- Add a frontend delay for TR0 (No subcarrier) in TransmitFor14443b_AsTag.
- Remove unconditionally prefixing the encoded data with two '1' bits.
- Improve the Type B PICC State Machine implementation.

With these improvements my PCD can read the ISO 14443-B tag emulated by a Proxmark3 Easy.