### PR TITLE
Updated clone and sim handling for 48-Bit HID (C1k48s)

### DIFF
--- a/client/src/wiegand_formatutils.c
+++ b/client/src/wiegand_formatutils.c
@@ -196,6 +196,10 @@ bool add_HID_header(wiegand_message_t *data) {
     if (data->Length > 84 || data->Length == 0)
         return false;
 
+    if (data->Length == 48) {
+        data->Mid |= 1U << (data->Length - 32); // Example leading 1: start bit
+        return true;
+    }
     if (data->Length >= 64) {
         data->Top |= 0x09e00000; // Extended-length header
         data->Top |= 1U << (data->Length - 64); // leading 1: start bit


### PR DESCRIPTION
Added an if statement specifically for the handling of C1k48s (48-bit HID) to ensure that the clone and sim functions work as intended. Adjustment does not impact the handling of other card types.  