### PR TITLE
Update aid_desfire.json

### DIFF
--- a/client/resources/aid_desfire.json
+++ b/client/resources/aid_desfire.json
@@ -88,6 +88,14 @@
         "Type": "pacs"
     },
     {
+        "AID": "F51BC0",
+        "Vendor": "",
+        "Country": "",
+        "Name": "",
+        "Description": "Unknown MF3DH42 [MFDES EV2]",
+        "Type": "pacs"
+    },
+    {
         "AID": "F52310",
         "Vendor": "Integrated Control Technology Limited [ICT]",
         "Country": "NZ",
@@ -530,7 +538,7 @@
     {
         "AID": "F21150",
         "Vendor": "Prague Public Transit Company via Haguess a.s.",
-		"Country": "CZ",
+        "Country": "CZ",
         "Name": "Lítačka Opencard [PRG]",
         "Description": "PRG Lítačka Opencard",
         "Type": "transport"

--- a/client/resources/aid_desfire.json
+++ b/client/resources/aid_desfire.json
@@ -89,10 +89,10 @@
     },
     {
         "AID": "F51BC0",
-        "Vendor": "",
-        "Country": "",
-        "Name": "",
-        "Description": "Unknown MF3DH42 [MFDES EV2]",
+        "Vendor": "STid Group",
+        "Country": "FR",
+        "Name": "CCT Card / DTA Tag / PCG Fob",
+        "Description": "STid Easyline / Architect Access Credetials",
         "Type": "pacs"
     },
     {


### PR DESCRIPTION
**Added a new PACS AID** which was obtained from a NXP TagInfo scan; *however, the person that sent me the screenshot did not show me a photo of the credential in question, leading me to classify it as an unknown MF3DH42*.

*I will follow up with NVX to try and change a blank MFDES card to the above AID to then extract the information from NXP TagInfo on my end and then submit another PR.*

**Corrected minor formatting typo for AID F21150** *to make sure the Country field uses eight [8] spaces; I missed this when submitting my last PR, so apologies for that*.