### PR TITLE
When simulate a ISO15693 tag the pageCount could be zero 

### DIFF
--- a/armsrc/iso15693.c
+++ b/armsrc/iso15693.c
@@ -2173,7 +2173,6 @@ void SimTagIso15693(const uint8_t *uid, uint8_t block_size) {
 
     if ((tag->pagesCount > ISO15693_TAG_MAX_PAGES) ||
             ((tag->pagesCount * tag->bytesPerPage) > ISO15693_TAG_MAX_SIZE) ||
-            (tag->pagesCount == 0) ||
             (tag->bytesPerPage == 0)) {
         Dbprintf("Tag size error: pagesCount = %d, bytesPerPage=%d", tag->pagesCount, tag->bytesPerPage);
         reply_ng(CMD_HF_ISO15693_SIMULATE, PM3_EOPABORTED, NULL, 0);

--- a/client/src/cmdhf15.c
+++ b/client/src/cmdhf15.c
@@ -1246,7 +1246,6 @@ static int CmdHF15ELoad(const char *Cmd) {
 
     if ((tag->pagesCount > ISO15693_TAG_MAX_PAGES) ||
             ((tag->pagesCount * tag->bytesPerPage) > ISO15693_TAG_MAX_SIZE) ||
-            (tag->pagesCount == 0) ||
             (tag->bytesPerPage == 0)) {
         PrintAndLogEx(FAILED, "Tag size error: pagesCount=%d, bytesPerPage=%d",
                       tag->pagesCount, tag->bytesPerPage);
@@ -2708,7 +2707,6 @@ static int CmdHF15Restore(const char *Cmd) {
 
     if ((tag->pagesCount > ISO15693_TAG_MAX_PAGES) ||
             ((tag->pagesCount * tag->bytesPerPage) > ISO15693_TAG_MAX_SIZE) ||
-            (tag->pagesCount == 0) ||
             (tag->bytesPerPage == 0)) {
         PrintAndLogEx(FAILED, "Tag size error: pagesCount=%d, bytesPerPage=%d",
                       tag->pagesCount, tag->bytesPerPage);
@@ -3373,7 +3371,6 @@ static int CmdHF15View(const char *Cmd) {
 
     if ((tag->pagesCount > ISO15693_TAG_MAX_PAGES) ||
             ((tag->pagesCount * tag->bytesPerPage) > ISO15693_TAG_MAX_SIZE) ||
-            (tag->pagesCount == 0) ||
             (tag->bytesPerPage == 0)) {
         PrintAndLogEx(FAILED, "Tag size error: pagesCount=%d, bytesPerPage=%d",
                       tag->pagesCount, tag->bytesPerPage);


### PR DESCRIPTION
Recently I got a RFID card. Regarding the info below it is produced by EM Microelectronic-Marmin SA Switzerland. It supports three standards: 14a, 15 and Legic Prime.

```
[usb] pm3 --> hf search
[-] Searching for ISO14443-A tag...
[+]  UID: XX XX XX XX XX XX XX
[+] ATQA: 00 41
[+]  SAK: 20 [1]
[+] MANUFACTURER: EM Microelectronic-Marin SA Switzerland
[+]    JCOP 31/41
[=] -------------------------- ATS --------------------------
[+] ATS: 05 77 77 81 02 [ 91 00 ]
[=]      05...............  TL    length is 5 bytes
[=]         77............  T0    TA1 is present, TB1 is present, TC1 is present, FSCI is 7 (FSC = 128)
[=]            77.........  TA1   different divisors are supported, DR: [2, 4, 8], DS: [2, 4, 8]
[=]               81......  TB1   SFGI = 1 (SFGT = 8192/fc), FWI = 8 (FWT = 1048576/fc)
[=]                  02...  TC1   NAD is NOT supported, CID is supported

[?] Hint: try `hf mf` commands


[+] Valid ISO 14443-A tag found

[|] Searching for LEGIC tag...
[+]  MCD: XX
[+]  MSN: XX XX XX
[+] TYPE: MIM1024 card (1002 bytes)

[+] Valid LEGIC Prime tag found

[|] Searching for ISO15693 tag...
[+] UID.... XX XX XX XX XX XX XX XX
[+] TYPE... EM Microelectronic-Marin SA Switzerland (Skidata)

[+] Valid ISO 15693 tag found

[?] Hint: try `hf legic` commands

[?] Hint: try `hf 15` commands

```

I got a message "[=] Tag is empty!", when I dump the card using `hf 15 dump`. The value pageCount in the dump file is 0.
I got an error message "[-] Tag size error: pagesCount=0, bytesPerPage=4" when I tried to load the dump file into the memory.
But I think pagesCount=0 should be accepted since we have an empty ISO 15693 tag.

Using the attached patch I could load the dump into the memory and simulate the empty iso15693 tag properly.
