### PR TITLE
Felica raw command select key fix

### DIFF
--- a/client/src/cmdhffelica.c
+++ b/client/src/cmdhffelica.c
@@ -336,7 +336,13 @@ int read_felica_uid(bool loop, bool verbose) {
             }
 
             felica_card_select_t card;
-            memcpy(&card, (felica_card_select_t *)resp.data.asBytes, sizeof(felica_card_select_t));
+            memcpy(card.IDm, resp.data.asBytes + 4,     8);
+            memcpy(card.PMm, resp.data.asBytes + 4 + 8, 8);
+            // memcpy(card->servicecode, FelicaFrame.framebytes + 4 + 8 + 8, 2);
+            memcpy(card.code,   card.IDm,     2);
+            memcpy(card.uid,    card.IDm + 2, 6);
+            memcpy(card.iccode, card.PMm,     2);
+            memcpy(card.mrt,    card.PMm + 2, 6);
             if (loop == false) {
                 PrintAndLogEx(NORMAL, "");
             }


### PR DESCRIPTION
### Problem:
Currently when using `hf felica raw` command with flag `-s` it fails because of the CRC check during command reception.
![image](https://github.com/RfidResearchGroup/proxmark3/assets/138568282/54a6c651-0374-420d-80c5-1892647bd1d0)
But if then we take a look into `hf felica list`, we can see that in fact it receives correct data:
![image](https://github.com/RfidResearchGroup/proxmark3/assets/138568282/007d48e0-4a32-4dfc-bed8-ef65a080e083)
The reason of that, is that when `-s` flag is used firmware side calls `felica_select_card` which selects a card and copies all the data to `felica_card_select_t` which then is transmitted to client. 
And then when client tries to check CRC it fails, because it expects raw frame for that check.
### Solution:
This fix changes the logic so `felica_select_card` on the firmware side returns a raw frame to client, which then is able to check CRC correctly. Also it required to change 'read_felica_uid' on the client side, now it copies required data from raw bytes to `felica_card_select_t`.