### PR TITLE
Iclass Legacy Raw Key Recovery Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added MFC Key for swimming pool cards in Reykjavík Iceland (@dandri)
 - Added key for Orkan keyfobs (@dandri)
 - Added key for Atlantsolía keyfobs (@dandri)
+- Added `hf iclass legbrute` this function allows to bruteforce 40/64 k1 bits of an iclass card to recover the raw key used(@antiklesys).
+- Added `hf iclass legrec` this function allows to recover 24/64 k1 bits of an iclass card (@antiklesys).
 ## [Aurora.4.18589][2024-05-28]
 - Fixed the pm3 regressiontests for Hitag2Crack (@iceman1001)
 - Changed `mem spiffs tree` - adapted to bigbuff and show if empty (@iceman1001)

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -2061,6 +2061,10 @@ static void PacketReceived(PacketCommandNG *packet) {
             iClass_Restore((iclass_restore_req_t *)packet->data.asBytes);
             break;
         }
+        case CMD_HF_ICLASS_RECOVER: {
+            iClass_Recover((iclass_recover_req_t *)packet->data.asBytes);
+            break;
+        }
         case CMD_HF_ICLASS_CREDIT_EPURSE: {
             iclass_credit_epurse((iclass_credit_epurse_t *)packet->data.asBytes);
             break;

--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -2254,20 +2254,20 @@ Xorring the index of iterations against those decimal numbers allows us to retri
     while (bits_found == -1){
 
     //Step3 Calculate New Key
-    uint8_t GenKeyBlock[PICOPASS_BLOCK_SIZE];
-    uint8_t GenKeyBlock_old[PICOPASS_BLOCK_SIZE];
+    uint8_t genkeyblock[PICOPASS_BLOCK_SIZE];
+    uint8_t genkeyblock_old[PICOPASS_BLOCK_SIZE];
     uint8_t xorkeyblock[PICOPASS_BLOCK_SIZE];
-    generate_single_key_block_inverted(zero_key, index, GenKeyBlock);
+    generate_single_key_block_inverted(zero_key, index, genkeyblock);
 
     //NOTE BEFORE UPDATING THE KEY WE NEED TO KEEP IN MIND KEYS ARE XORRED
     //xor the new key against the previously generated key so that we only update the difference
     if(index != 0){
-        generate_single_key_block_inverted(zero_key, index - 1, GenKeyBlock_old);
+        generate_single_key_block_inverted(zero_key, index - 1, genkeyblock_old);
         for (int i = 0; i < 8 ; i++) {
-            xorkeyblock[i] = GenKeyBlock[i] ^ GenKeyBlock_old[i];
+            xorkeyblock[i] = genkeyblock[i] ^ genkeyblock_old[i];
         }
     }else{
-            memcpy(xorkeyblock, GenKeyBlock, PICOPASS_BLOCK_SIZE);
+            memcpy(xorkeyblock, genkeyblock, PICOPASS_BLOCK_SIZE);
     }
 
     //Step4 Calculate New Mac

--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -2293,7 +2293,7 @@ Xorring the index of iterations against those decimal numbers allows us to retri
     for (int i = 0; i < 8 ; ++i) {
         //need to craft the authentication payload accordingly
         memcpy(msg->req.key, iclass_mac_table[i], 8);
-        res = authenticate_iclass_tag(&msg->req, &hdr, &start_time, &eof_time, mac1); //the mac here needs to be changed, mac 2 is a compiling placeholder
+        res = authenticate_iclass_tag(&msg->req, &hdr, &start_time, &eof_time, mac1); //mac1 here shouldn't matter
         if (res == true) {
             bits_found = iclass_mac_table_bit_values[i] ^ index;
             Dbprintf("Found Card Bits Index: " _GREEN_("[%3d]"), index);

--- a/armsrc/iclass.h
+++ b/armsrc/iclass.h
@@ -71,9 +71,6 @@ bool authenticate_iclass_tag(iclass_auth_req_t *payload, picopass_hdr_t *hdr, ui
 uint8_t get_pagemap(const picopass_hdr_t *hdr);
 void iclass_send_as_reader(uint8_t *frame, int len, uint32_t *start_time, uint32_t *end_time, bool shallow_mod);
 
-void generate_single_key_block_inverted(const uint8_t startingKey[PICOPASS_BLOCK_SIZE], uint32_t index, uint8_t keyBlock[PICOPASS_BLOCK_SIZE]);
-void intToBinary(unsigned int num, char *binaryStr, int size);
-uint8_t binaryToHex(char *binaryStr);
-void convertToHexArray(unsigned int num, uint8_t *partialKey);
+void generate_single_key_block_inverted(const uint8_t *startingKey, uint32_t index, uint8_t *keyBlock);
 void iClass_Recover(iclass_recover_req_t *msg);
 #endif

--- a/armsrc/iclass.h
+++ b/armsrc/iclass.h
@@ -70,4 +70,10 @@ bool authenticate_iclass_tag(iclass_auth_req_t *payload, picopass_hdr_t *hdr, ui
 
 uint8_t get_pagemap(const picopass_hdr_t *hdr);
 void iclass_send_as_reader(uint8_t *frame, int len, uint32_t *start_time, uint32_t *end_time, bool shallow_mod);
+
+void generate_single_key_block_inverted(const uint8_t startingKey[PICOPASS_BLOCK_SIZE], uint32_t index, uint8_t keyBlock[PICOPASS_BLOCK_SIZE]);
+void intToBinary(unsigned int num, char *binaryStr, int size);
+uint8_t binaryToHex(char *binaryStr);
+void convertToHexArray(unsigned int num, uint8_t *partialKey);
+void iClass_Recover(iclass_recover_req_t *msg);
 #endif

--- a/armsrc/util.c
+++ b/armsrc/util.c
@@ -395,3 +395,33 @@ uint32_t flash_size_from_cidr(uint32_t cidr) {
 uint32_t get_flash_size(void) {
     return flash_size_from_cidr(*AT91C_DBGU_CIDR);
 }
+
+// Function to convert an unsigned int to binary string
+void intToBinary(uint8_t num, char *binaryStr, int size) {
+    binaryStr[size] = '\0';  // Null-terminate the string
+    for (int i = size - 1; i >= 0; i--) {
+        binaryStr[i] = (num % 2) ? '1' : '0';
+        num /= 2;
+    }
+}
+
+// Function to convert a binary string to hexadecimal
+uint8_t binaryToHex(char *binaryStr) {
+    return (uint8_t)strtoul(binaryStr, NULL, 2);
+}
+
+// Function to convert an unsigned int to an array of hex values
+void convertToHexArray(uint8_t num, uint8_t *partialkey) {
+    char binaryStr[25];  // 24 bits for binary representation + 1 for null terminator
+
+    // Convert the number to binary string
+    intToBinary(num, binaryStr, 24);
+
+    // Split the binary string into groups of 3 and convert to hex
+    for (int i = 0; i < PICOPASS_BLOCK_SIZE; i++) {
+        char group[4];
+        strncpy(group, binaryStr + i * 3, 3);
+        group[3] = '\0';  // Null-terminate the group string
+        partialkey[i] = binaryToHex(group);
+    }
+}

--- a/armsrc/util.c
+++ b/armsrc/util.c
@@ -410,8 +410,6 @@ uint8_t binaryToHex(char *binaryStr) {
     return (uint8_t)strtoul(binaryStr, NULL, 2);
 }
 
-#define PICOPASS_BLOCK_SIZE 8
-
 // Function to convert an unsigned int to an array of hex values
 void convertToHexArray(uint8_t num, uint8_t *partialkey) {
     char binaryStr[25];  // 24 bits for binary representation + 1 for null terminator
@@ -420,7 +418,7 @@ void convertToHexArray(uint8_t num, uint8_t *partialkey) {
     intToBinary(num, binaryStr, 24);
 
     // Split the binary string into groups of 3 and convert to hex
-    for (int i = 0; i < PICOPASS_BLOCK_SIZE; i++) {
+    for (int i = 0; i < 8 ; i++) {
         char group[4];
         strncpy(group, binaryStr + i * 3, 3);
         group[3] = '\0';  // Null-terminate the group string

--- a/armsrc/util.c
+++ b/armsrc/util.c
@@ -410,6 +410,8 @@ uint8_t binaryToHex(char *binaryStr) {
     return (uint8_t)strtoul(binaryStr, NULL, 2);
 }
 
+#define PICOPASS_BLOCK_SIZE 8
+
 // Function to convert an unsigned int to an array of hex values
 void convertToHexArray(uint8_t num, uint8_t *partialkey) {
     char binaryStr[25];  // 24 bits for binary representation + 1 for null terminator

--- a/armsrc/util.h
+++ b/armsrc/util.h
@@ -88,6 +88,10 @@ int hex2binarray(char *target, char *source);
 int hex2binarray_n(char *target, const char *source, int sourcelen);
 int binarray2hex(const uint8_t *bs, int bs_len, uint8_t *hex);
 
+void intToBinary(uint8_t num, char *binaryStr, int size);
+uint8_t binaryToHex(char *binaryStr);
+void convertToHexArray(uint8_t num, uint8_t *partialKey);
+
 void LED(int led, int ms);
 void LEDsoff(void);
 void SpinOff(uint32_t pause);

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -3871,13 +3871,6 @@ static int CmdHFiClassRecover(uint8_t key[8]) {
     clearCommandBuffer();
     SendCommandNG(CMD_HF_ICLASS_RECOVER, (uint8_t *)payload, payload_size);
 
-    if (WaitForResponseTimeout(CMD_HF_ICLASS_RECOVER, &resp, 2500) == 0) {
-        PrintAndLogEx(WARNING, "command execute timeout");
-        DropField();
-        free(payload);
-        return PM3_ETIMEOUT;
-    }
-
     if (resp.status == PM3_SUCCESS) {
         PrintAndLogEx(SUCCESS, "iCLASS Recover " _GREEN_("successful"));
     } else {

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -3845,7 +3845,8 @@ void picopass_elite_nextKey(uint8_t* key) {
 static int CmdHFiClassRecover(uint8_t key[8]) {
 
     uint32_t payload_size = sizeof(iclass_recover_req_t);
-    uint8_t aa2_standard_key[PICOPASS_BLOCK_SIZE] = {0xFD, 0xCB, 0x5A, 0x52, 0xEA, 0x8F, 0x30, 0x90};
+    uint8_t aa2_standard_key[PICOPASS_BLOCK_SIZE] = {0};
+    memcpy(aa2_standard_key, iClass_Key_Table[1], PICOPASS_BLOCK_SIZE);
     iclass_recover_req_t *payload = calloc(1, payload_size);
     payload->req.use_raw = true;
     payload->req.use_elite = false;
@@ -3918,22 +3919,6 @@ void *generate_key_blocks(void *arg) {
     }
 
     return NULL;
-}
-
-void generate_single_key_block_inverted(const uint8_t startingKey[PICOPASS_BLOCK_SIZE], uint32_t index, uint8_t keyBlock[PICOPASS_BLOCK_SIZE]) {
-    uint32_t carry = index;
-    memcpy(keyBlock, startingKey, PICOPASS_BLOCK_SIZE);
-
-    for (int j = PICOPASS_BLOCK_SIZE - 1; j >= 0; j--) {
-        uint8_t increment_value = carry & 0x07;  // Use only the last 3 bits of carry
-        keyBlock[j] = increment_value;  // Set the last 3 bits, assuming first 5 bits are always 0
-
-        carry >>= 3;  // Shift right by 3 bits for the next byte
-        if (carry == 0) {
-            // If no more carry, break early to avoid unnecessary loops
-            break;
-        }
-    }
 }
 
 static int CmdHFiClassLegRecLookUp(const char *Cmd) {

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -3871,6 +3871,8 @@ static int CmdHFiClassRecover(uint8_t key[8]) {
     clearCommandBuffer();
     SendCommandNG(CMD_HF_ICLASS_RECOVER, (uint8_t *)payload, payload_size);
 
+    WaitForResponse(CMD_HF_ICLASS_RECOVER, &resp);
+
     if (resp.status == PM3_SUCCESS) {
         PrintAndLogEx(SUCCESS, "iCLASS Recover " _GREEN_("successful"));
     } else {

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -4027,7 +4027,7 @@ static int CmdHFiClassLegRecLookUp(const char *Cmd) {
             thread_data[t].keyBlock = calloc(keys_per_thread, PICOPASS_BLOCK_SIZE);
 
             if (thread_data[t].keyBlock == NULL) {
-                PrintAndLogEx(ERROR, "Memory allocation failed for keyBlock in thread %d.", t);
+                PrintAndLogEx(ERR, "Memory allocation failed for keyBlock in thread %d.", t);
                 for (uint32_t i = 0; i < t; i++) {
                     free(thread_data[i].keyBlock);
                 }
@@ -4048,7 +4048,7 @@ static int CmdHFiClassLegRecLookUp(const char *Cmd) {
         }
 
         if (prekey == NULL) {
-            PrintAndLogEx(ERROR, "Memory allocation failed for prekey.");
+            PrintAndLogEx(ERR, "Memory allocation failed for prekey.");
             for (uint32_t t = 0; t < num_threads; t++) {
                 free(thread_data[t].keyBlock);
             }

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -3842,6 +3842,304 @@ void picopass_elite_nextKey(uint8_t* key) {
     memcpy(key, key_state, 8);
 }
 
+static int CmdHFiClassRecover(uint8_t key[8]) {
+
+    uint32_t payload_size = sizeof(iclass_recover_req_t);
+    uint8_t aa2_standard_key[PICOPASS_BLOCK_SIZE] = {0xFD, 0xCB, 0x5A, 0x52, 0xEA, 0x8F, 0x30, 0x90};
+    iclass_recover_req_t *payload = calloc(1, payload_size);
+    payload->req.use_raw = true;
+    payload->req.use_elite = false;
+    payload->req.use_credit_key = false;
+    payload->req.use_replay = true;
+    payload->req.send_reply = true;
+    payload->req.do_auth = true;
+    payload->req.shallow_mod = false;
+    payload->req2.use_raw = false;
+    payload->req2.use_elite = false;
+    payload->req2.use_credit_key = true;
+    payload->req2.use_replay = false;
+    payload->req2.send_reply = true;
+    payload->req2.do_auth = true;
+    payload->req2.shallow_mod = false;
+    memcpy(payload->req.key, key, 8);
+    memcpy(payload->req2.key, aa2_standard_key, 8);
+
+    PrintAndLogEx(INFO, "Recover started...");
+
+    PacketResponseNG resp;
+    clearCommandBuffer();
+    SendCommandNG(CMD_HF_ICLASS_RECOVER, (uint8_t *)payload, payload_size);
+
+    if (WaitForResponseTimeout(CMD_HF_ICLASS_RECOVER, &resp, 2500) == 0) {
+        PrintAndLogEx(WARNING, "command execute timeout");
+        DropField();
+        free(payload);
+        return PM3_ETIMEOUT;
+    }
+
+    if (resp.status == PM3_SUCCESS) {
+        PrintAndLogEx(SUCCESS, "iCLASS Recover " _GREEN_("successful"));
+    } else {
+        PrintAndLogEx(WARNING, "iCLASS Recover " _RED_("failed"));
+    }
+
+    free(payload);
+    return resp.status;
+}
+
+typedef struct {
+    uint32_t start_index;
+    uint32_t keycount;
+    const uint8_t *startingKey;
+    uint8_t (*keyBlock)[PICOPASS_BLOCK_SIZE];
+} ThreadData;
+
+void *generate_key_blocks(void *arg) {
+    ThreadData *data = (ThreadData *)arg;
+    uint32_t start_index = data->start_index;
+    uint32_t keycount = data->keycount;
+    const uint8_t *startingKey = data->startingKey;
+    uint8_t (*keyBlock)[PICOPASS_BLOCK_SIZE] = data->keyBlock;
+
+    for (uint32_t i = 0; i < keycount; i++) {
+        uint32_t carry = start_index + i;
+        memcpy(keyBlock[i], startingKey, PICOPASS_BLOCK_SIZE);
+
+        for (int j = PICOPASS_BLOCK_SIZE - 1; j >= 0; j--) {
+            uint8_t increment_value = (carry & 0x1F) << 3;  // Use only the first 5 bits of carry
+            keyBlock[i][j] = (keyBlock[i][j] & 0x07) | increment_value;  // Preserve the last three bits
+
+            carry >>= 5;  // Shift right by 5 bits for the next byte
+            if (carry == 0) {
+                // If no more carry, break early to avoid unnecessary loops
+                break;
+            }
+        }
+    }
+
+    return NULL;
+}
+
+void generate_single_key_block_inverted(const uint8_t startingKey[PICOPASS_BLOCK_SIZE], uint32_t index, uint8_t keyBlock[PICOPASS_BLOCK_SIZE]) {
+    uint32_t carry = index;
+    memcpy(keyBlock, startingKey, PICOPASS_BLOCK_SIZE);
+
+    for (int j = PICOPASS_BLOCK_SIZE - 1; j >= 0; j--) {
+        uint8_t increment_value = carry & 0x07;  // Use only the last 3 bits of carry
+        keyBlock[j] = increment_value;  // Set the last 3 bits, assuming first 5 bits are always 0
+
+        carry >>= 3;  // Shift right by 3 bits for the next byte
+        if (carry == 0) {
+            // If no more carry, break early to avoid unnecessary loops
+            break;
+        }
+    }
+}
+
+static int CmdHFiClassLegRecLookUp(const char *Cmd) {
+
+    //Standalone Command Start
+    CLIParserContext *ctx;
+    CLIParserInit(&ctx, "hf iclass legbrute",
+                  "This command take sniffed trace data and partial raw key and bruteforces the remaining 40 bits of the raw key.",
+                  "hf iclass legbrute --csn 8D7BD711FEFF12E0 --epurse feffffffffffffff --macs 00000000BD478F76 --pk B4F12AADC5301225"
+                 );
+
+    void *argtable[] = {
+        arg_param_begin,
+        arg_str1(NULL, "csn", "<hex>", "Specify CSN as 8 hex bytes"),
+        arg_str1(NULL, "epurse", "<hex>", "Specify ePurse as 8 hex bytes"),
+        arg_str1(NULL, "macs", "<hex>", "MACs"),
+        arg_str1(NULL, "pk", "<hex>", "Partial Key"),
+        arg_param_end
+    };
+    CLIExecWithReturn(ctx, Cmd, argtable, false);
+
+    int csn_len = 0;
+    uint8_t csn[8] = {0};
+    CLIGetHexWithReturn(ctx, 1, csn, &csn_len);
+
+    if (csn_len > 0) {
+        if (csn_len != 8) {
+            PrintAndLogEx(ERR, "CSN is incorrect length");
+            CLIParserFree(ctx);
+            return PM3_EINVARG;
+        }
+    }
+
+    int epurse_len = 0;
+    uint8_t epurse[8] = {0};
+    CLIGetHexWithReturn(ctx, 2, epurse, &epurse_len);
+
+    if (epurse_len > 0) {
+        if (epurse_len != 8) {
+            PrintAndLogEx(ERR, "ePurse is incorrect length");
+            CLIParserFree(ctx);
+            return PM3_EINVARG;
+        }
+    }
+
+    int macs_len = 0;
+    uint8_t macs[8] = {0};
+    CLIGetHexWithReturn(ctx, 3, macs, &macs_len);
+
+    if (macs_len > 0) {
+        if (macs_len != 8) {
+            PrintAndLogEx(ERR, "MAC is incorrect length");
+            CLIParserFree(ctx);
+            return PM3_EINVARG;
+        }
+    }
+
+    int startingkey_len = 0;
+    uint8_t startingKey[8] = {0};
+    CLIGetHexWithReturn(ctx, 4, startingKey, &startingkey_len);
+
+    if (startingkey_len > 0) {
+        if (startingkey_len != 8) {
+            PrintAndLogEx(ERR, "Partial Key is incorrect length");
+            CLIParserFree(ctx);
+            return PM3_EINVARG;
+        }
+    }
+
+    CLIParserFree(ctx);
+    //Standalone Command End
+
+    uint8_t CCNR[12];
+    uint8_t MAC_TAG[4] = {0, 0, 0, 0};
+
+    // Copy CCNR and MAC_TAG
+    memcpy(CCNR, epurse, 8);
+    memcpy(CCNR + 8, macs, 4);
+    memcpy(MAC_TAG, macs + 4, 4);
+
+    PrintAndLogEx(SUCCESS, "    CSN: " _GREEN_("%s"), sprint_hex(csn, 8));
+    PrintAndLogEx(SUCCESS, " Epurse: %s", sprint_hex(epurse, 8));
+    PrintAndLogEx(SUCCESS, "   MACS: %s", sprint_hex(macs, 8));
+    PrintAndLogEx(SUCCESS, "   CCNR: " _GREEN_("%s"), sprint_hex(CCNR, sizeof(CCNR)));
+    PrintAndLogEx(SUCCESS, "TAG MAC: %s", sprint_hex(MAC_TAG, sizeof(MAC_TAG)));
+    PrintAndLogEx(SUCCESS, "Starting Key: %s", sprint_hex(startingKey, 8));
+
+    uint32_t keycount = 1000000;
+    uint32_t keys_per_thread = 200000;
+    uint32_t num_threads = keycount / keys_per_thread;
+    pthread_t threads[num_threads];
+    ThreadData thread_data[num_threads];
+    iclass_prekey_t *prekey = NULL;
+    iclass_prekey_t lookup;
+    iclass_prekey_t *item = NULL;
+
+    memcpy(lookup.mac, MAC_TAG, 4);
+
+    uint32_t block_index = 0;
+
+    while (item == NULL) {
+        for (uint32_t t = 0; t < num_threads; t++) {
+            thread_data[t].start_index = block_index * keycount + t * keys_per_thread;
+            thread_data[t].keycount = keys_per_thread;
+            thread_data[t].startingKey = startingKey;
+            thread_data[t].keyBlock = calloc(keys_per_thread, PICOPASS_BLOCK_SIZE);
+
+            if (thread_data[t].keyBlock == NULL) {
+                PrintAndLogEx(ERROR, "Memory allocation failed for keyBlock in thread %d.", t);
+                for (uint32_t i = 0; i < t; i++) {
+                    free(thread_data[i].keyBlock);
+                }
+                return PM3_EINVARG;
+            }
+
+            pthread_create(&threads[t], NULL, generate_key_blocks, (void *)&thread_data[t]);
+        }
+
+        for (uint32_t t = 0; t < num_threads; t++) {
+            pthread_join(threads[t], NULL);
+        }
+
+        if (prekey == NULL) {
+            prekey = calloc(keycount, sizeof(iclass_prekey_t));
+        } else {
+            prekey = realloc(prekey, (block_index + 1) * keycount * sizeof(iclass_prekey_t));
+        }
+
+        if (prekey == NULL) {
+            PrintAndLogEx(ERROR, "Memory allocation failed for prekey.");
+            for (uint32_t t = 0; t < num_threads; t++) {
+                free(thread_data[t].keyBlock);
+            }
+            return PM3_EINVARG;
+        }
+
+        PrintAndLogEx(INFO, "Generating diversified keys...");
+        for (uint32_t t = 0; t < num_threads; t++) {
+            GenerateMacKeyFrom(csn, CCNR, true, false, (uint8_t *)thread_data[t].keyBlock, keys_per_thread, prekey + (block_index * keycount) + (t * keys_per_thread));
+        }
+
+        PrintAndLogEx(INFO, "Sorting...");
+
+        // Sort mac list
+        qsort(prekey, (block_index + 1) * keycount, sizeof(iclass_prekey_t), cmp_uint32);
+
+        PrintAndLogEx(SUCCESS, "Searching for " _YELLOW_("%s") " key...", "DEBIT");
+
+        // Binary search
+        item = (iclass_prekey_t *)bsearch(&lookup, prekey, (block_index + 1) * keycount, sizeof(iclass_prekey_t), cmp_uint32);
+
+        for (uint32_t t = 0; t < num_threads; t++) {
+            free(thread_data[t].keyBlock);
+        }
+
+        block_index++;
+    }
+
+    if (item != NULL) {
+        PrintAndLogEx(SUCCESS, "Found valid RAW key " _GREEN_("%s"), sprint_hex(item->key, 8));
+    }
+
+    free(prekey);
+    PrintAndLogEx(NORMAL, "");
+    return PM3_SUCCESS;
+}
+
+
+static int CmdHFiClassLegacyRecover(const char *Cmd) {
+
+    CLIParserContext *ctx;
+    CLIParserInit(&ctx, "hf iclass legrec",
+        "Attempts to recover the diversified key of a specific iClass card. This may take a long time. The Card must remain be on the PM3 antenna during the whole process! This process may brick the card!",
+        "hf iclass legrec --macs 0000000089cb984b"
+        );
+
+    void *argtable[] = {
+    arg_param_begin,
+    arg_str1(NULL, "macs", "<hex>", "MACs"),
+    arg_param_end
+    };
+    CLIExecWithReturn(ctx, Cmd, argtable, false);
+
+    int macs_len = 0;
+    uint8_t macs[8] = {0};
+    CLIGetHexWithReturn(ctx, 1, macs, &macs_len);
+
+    if (macs_len > 0) {
+        if (macs_len != 8) {
+            PrintAndLogEx(ERR, "MAC is incorrect length");
+            CLIParserFree(ctx);
+            return PM3_EINVARG;
+        }
+    }
+
+    CLIParserFree(ctx);
+
+    CmdHFiClassRecover(macs);
+
+    PrintAndLogEx(WARNING, _YELLOW_("If the process completed, you can now run 'hf iclass legrecbrute' with the partial key found."));
+
+    PrintAndLogEx(NORMAL, "");
+    return PM3_SUCCESS;
+
+}
+
 static int CmdHFiClassLookUp(const char *Cmd) {
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "hf iclass lookup",
@@ -4738,6 +5036,8 @@ static command_t CommandTable[] = {
     {"chk",         CmdHFiClassCheckKeys,       IfPm3Iclass,     "Check keys"},
     {"loclass",     CmdHFiClass_loclass,        AlwaysAvailable, "Use loclass to perform bruteforce reader attack"},
     {"lookup",      CmdHFiClassLookUp,          AlwaysAvailable, "Uses authentication trace to check for key in dictionary file"},
+    {"legrec",      CmdHFiClassLegacyRecover,   IfPm3Iclass,     "Attempts to recover the standard key of a legacy card"},
+    {"legbrute",    CmdHFiClassLegRecLookUp,    AlwaysAvailable, "Bruteforces 40 bits of a partial raw key"},
     {"-----------", CmdHelp,                    IfPm3Iclass,     "-------------------- " _CYAN_("Simulation") " -------------------"},
     {"sim",         CmdHFiClassSim,             IfPm3Iclass,     "Simulate iCLASS tag"},
     {"eload",       CmdHFiClassELoad,           IfPm3Iclass,     "Upload file into emulator memory"},

--- a/client/src/cmdhficlass.h
+++ b/client/src/cmdhficlass.h
@@ -42,7 +42,5 @@ void picopass_elite_reset(void);
 uint32_t picopass_elite_rng(void);
 uint32_t picopass_elite_lcg(void);
 uint8_t picopass_elite_nextByte(void);
-
 void *generate_key_blocks(void *arg);
-void generate_single_key_block_inverted(const uint8_t startingKey[PICOPASS_BLOCK_SIZE], uint32_t index, uint8_t keyBlock[PICOPASS_BLOCK_SIZE]);
 #endif

--- a/client/src/cmdhficlass.h
+++ b/client/src/cmdhficlass.h
@@ -42,4 +42,7 @@ void picopass_elite_reset(void);
 uint32_t picopass_elite_rng(void);
 uint32_t picopass_elite_lcg(void);
 uint8_t picopass_elite_nextByte(void);
+
+void *generate_key_blocks(void *arg);
+void generate_single_key_block_inverted(const uint8_t startingKey[PICOPASS_BLOCK_SIZE], uint32_t index, uint8_t keyBlock[PICOPASS_BLOCK_SIZE]);
 #endif

--- a/include/iclass_cmd.h
+++ b/include/iclass_cmd.h
@@ -105,6 +105,11 @@ typedef struct {
     iclass_restore_item_t blocks[];
 } PACKED iclass_restore_req_t;
 
+typedef struct {
+    iclass_auth_req_t req;
+    iclass_auth_req_t req2;
+} PACKED iclass_recover_req_t;
+
 typedef struct iclass_premac {
     uint8_t mac[4];
 } PACKED iclass_premac_t;

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -630,6 +630,7 @@ typedef struct {
 #define CMD_HF_ICLASS_CHKKEYS                                             0x039A
 #define CMD_HF_ICLASS_RESTORE                                             0x039B
 #define CMD_HF_ICLASS_CREDIT_EPURSE                                       0x039C
+#define CMD_HF_ICLASS_RECOVER                                             0x039D
 
 
 // For ISO1092 / FeliCa


### PR DESCRIPTION
Based on the work described in Dismantling iClass whitepaper. 

- `hf iclass legbrute` is tested working on sample data generated accordingly to the hash0 logic.

- `hf iclass legrec ` is partially working: 
1. Logic of operations and sequence are in order 
2. Individual functionalities have been tested on sample/simulated data and was found to be effective and correct.
3. The privilege escalation operation is still NOT working during my tests (may be a silicon issue tho), but the logic in place should be correct.