### PR TITLE
Bugfixes and code improvements for hf iclass legrec

### DIFF
--- a/armsrc/util.c
+++ b/armsrc/util.c
@@ -396,32 +396,22 @@ uint32_t get_flash_size(void) {
     return flash_size_from_cidr(*AT91C_DBGU_CIDR);
 }
 
-// Function to convert an unsigned int to binary string
-void intToBinary(uint8_t num, char *binaryStr, int size) {
-    binaryStr[size] = '\0';  // Null-terminate the string
-    for (int i = size - 1; i >= 0; i--) {
+// Combined function to convert an unsigned int to an array of hex values corresponding to the last three bits of k1
+void convertToHexArray(uint8_t num, uint8_t *partialkey) {
+    char binaryStr[25];  // 24 bits for binary representation + 1 for null terminator
+    binaryStr[24] = '\0';  // Null-terminate the string
+
+    // Convert the number to binary string
+    for (int i = 23; i >= 0; i--) {
         binaryStr[i] = (num % 2) ? '1' : '0';
         num /= 2;
     }
-}
-
-// Function to convert a binary string to hexadecimal
-uint8_t binaryToHex(char *binaryStr) {
-    return (uint8_t)strtoul(binaryStr, NULL, 2);
-}
-
-// Function to convert an unsigned int to an array of hex values
-void convertToHexArray(uint8_t num, uint8_t *partialkey) {
-    char binaryStr[25];  // 24 bits for binary representation + 1 for null terminator
-
-    // Convert the number to binary string
-    intToBinary(num, binaryStr, 24);
 
     // Split the binary string into groups of 3 and convert to hex
     for (int i = 0; i < 8 ; i++) {
         char group[4];
         strncpy(group, binaryStr + i * 3, 3);
         group[3] = '\0';  // Null-terminate the group string
-        partialkey[i] = binaryToHex(group);
+        partialkey[i] = (uint8_t)strtoul(group, NULL, 2);
     }
 }

--- a/armsrc/util.h
+++ b/armsrc/util.h
@@ -88,8 +88,6 @@ int hex2binarray(char *target, char *source);
 int hex2binarray_n(char *target, const char *source, int sourcelen);
 int binarray2hex(const uint8_t *bs, int bs_len, uint8_t *hex);
 
-void intToBinary(uint8_t num, char *binaryStr, int size);
-uint8_t binaryToHex(char *binaryStr);
 void convertToHexArray(uint8_t num, uint8_t *partialKey);
 
 void LED(int led, int ms);

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -3874,9 +3874,9 @@ static int CmdHFiClassRecover(uint8_t key[8]) {
     WaitForResponse(CMD_HF_ICLASS_RECOVER, &resp);
 
     if (resp.status == PM3_SUCCESS) {
-        PrintAndLogEx(SUCCESS, "iCLASS Recover " _GREEN_("successful"));
+        PrintAndLogEx(SUCCESS, "iCLASS Key Bits Recovery " _GREEN_("successful"));
     } else {
-        PrintAndLogEx(WARNING, "iCLASS Recover " _RED_("failed"));
+        PrintAndLogEx(WARNING, "iCLASS Key Bits Recovery " _RED_("failed"));
     }
 
     free(payload);


### PR DESCRIPTION
1- Inlined functions related to hf iclass legrec within util.c for marginal performance gains.
2- Fixed bug preventing errors to be displayed properly and the process from interrupting on an error or on completion.
3- Fixed code indentation of the while loop in iclass.c
4- Fixed bug in the while cycle (was missing index++)
5- Improved printing of k1 hex bytes results by using dbhexdump