### PR TITLE
Corrected an incorrect Readline library URL in client CMakeLists.txt

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -125,7 +125,7 @@ if (NOT SKIPREADLINE EQUAL 1)
         ExternalProject_Add_StepTargets(ncurses configure build install)
 
         ExternalProject_Add(readline
-            URL                   http://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz
+            URL                   https://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz
             PREFIX                deps/readline
             DOWNLOAD_DIR          ${CMAKE_CURRENT_SOURCE_DIR}/deps/readline
             CONFIGURE_COMMAND     ./configure CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} LD=${CMAKE_C_COMPILER} AR=${CMAKE_AR} RANLIB=${CMAKE_RANLIB} ${CFLAGS_EXTERNAL_LIB} --host=arm --enable-static

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -125,7 +125,7 @@ if (NOT SKIPREADLINE EQUAL 1)
         ExternalProject_Add_StepTargets(ncurses configure build install)
 
         ExternalProject_Add(readline
-            URL                   ftp://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz
+            URL                   http://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz
             PREFIX                deps/readline
             DOWNLOAD_DIR          ${CMAKE_CURRENT_SOURCE_DIR}/deps/readline
             CONFIGURE_COMMAND     ./configure CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} LD=${CMAKE_C_COMPILER} AR=${CMAKE_AR} RANLIB=${CMAKE_RANLIB} ${CFLAGS_EXTERNAL_LIB} --host=arm --enable-static

--- a/client/experimental_lib/CMakeLists.txt
+++ b/client/experimental_lib/CMakeLists.txt
@@ -126,7 +126,7 @@ if (NOT SKIPREADLINE EQUAL 1)
         ExternalProject_Add_StepTargets(ncurses configure build install)
 
         ExternalProject_Add(readline
-            URL                   ftp://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz
+            URL                   http://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz
             PREFIX                deps/readline
             DOWNLOAD_DIR          ${CMAKE_CURRENT_SOURCE_DIR}/deps/readline
             CONFIGURE_COMMAND     ./configure CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} LD=${CMAKE_C_COMPILER} AR=${CMAKE_AR} RANLIB=${CMAKE_RANLIB} ${CFLAGS_EXTERNAL_LIB} --host=arm --enable-static

--- a/client/experimental_lib/CMakeLists.txt
+++ b/client/experimental_lib/CMakeLists.txt
@@ -126,7 +126,7 @@ if (NOT SKIPREADLINE EQUAL 1)
         ExternalProject_Add_StepTargets(ncurses configure build install)
 
         ExternalProject_Add(readline
-            URL                   http://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz
+            URL                   https://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz
             PREFIX                deps/readline
             DOWNLOAD_DIR          ${CMAKE_CURRENT_SOURCE_DIR}/deps/readline
             CONFIGURE_COMMAND     ./configure CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} LD=${CMAKE_C_COMPILER} AR=${CMAKE_AR} RANLIB=${CMAKE_RANLIB} ${CFLAGS_EXTERNAL_LIB} --host=arm --enable-static


### PR DESCRIPTION
Corrected an incorrect Readline library URL in client and client/experimental_lib CMakeLists.txt
from ftp://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz Change to https://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz