### PR TITLE
Add `--emu` and `--issue` support to `hf iclass encode` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Added --issue to hf iclass encode command (@micsen)
 - Added custom CTF Wiegand format from Defcon32 with comments (@micsen)
 - Added native output grabbing for Python and Lua: less hacky than `output_grabber.py`, should work on ProxSpace as well (@doegox)
 - Changed `hf mf chk/fchk`: added option `--no-default` to skip loading the usual ~61 hardcoded keys (@doegox)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Added custom CTF Wiegand format from Defcon32 with comments (@micsen)
 - Added native output grabbing for Python and Lua: less hacky than `output_grabber.py`, should work on ProxSpace as well (@doegox)
 - Changed `hf mf chk/fchk`: added option `--no-default` to skip loading the usual ~61 hardcoded keys (@doegox)
 - Fixed `hf mf wipe` to detect properly write errors (@doegox)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
-- Added --issue to hf iclass encode command (@micsen)
+- Added --issue and (--emu)lator support to `hf iclass encode` command (@micsen)
 - Added custom CTF Wiegand format from Defcon32 with comments (@micsen)
 - Added native output grabbing for Python and Lua: less hacky than `output_grabber.py`, should work on ProxSpace as well (@doegox)
 - Changed `hf mf chk/fchk`: added option `--no-default` to skip loading the usual ~61 hardcoded keys (@doegox)

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -4592,10 +4592,10 @@ static int CmdHFiClassEncode(const char *Cmd) {
         arg_str0(NULL, "enckey", "<hex>", "3DES transport key, 16 hex bytes"),
         arg_u64_0(NULL, "fc", "<dec>", "facility code"),
         arg_u64_0(NULL, "cn", "<dec>", "card number"),
+        arg_u64_0(NULL, "issue", "<dec>", "issue level"),
         arg_str0("w",   "wiegand", "<format>", "see " _YELLOW_("`wiegand list`") " for available formats"),
         arg_lit0(NULL, "shallow", "use shallow (ASK) reader modulation instead of OOK"),
         arg_lit0("v", NULL, "verbose (print encoded blocks)"),
-        arg_u64_0(NULL, "issue", "<dec>", "issue level"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, false);
@@ -4636,14 +4636,14 @@ static int CmdHFiClassEncode(const char *Cmd) {
     memset(&card, 0, sizeof(wiegand_card_t));
     card.FacilityCode = arg_get_u32_def(ctx, 7, 0);
     card.CardNumber = arg_get_u32_def(ctx, 8, 0);
-    card.IssueLevel = arg_get_u32_def(ctx, 12, 0);
+    card.IssueLevel = arg_get_u32_def(ctx, 9, 0);
 
     char format[16] = {0};
     int format_len = 0;
-    CLIParamStrToBuf(arg_get_str(ctx, 9), (uint8_t *)format, sizeof(format), &format_len);
+    CLIParamStrToBuf(arg_get_str(ctx, 10), (uint8_t *)format, sizeof(format), &format_len);
 
-    bool shallow_mod = arg_get_lit(ctx, 10);
-    bool verbose = arg_get_lit(ctx, 11);
+    bool shallow_mod = arg_get_lit(ctx, 11);
+    bool verbose = arg_get_lit(ctx, 12);
 
     CLIParserFree(ctx);
 

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -4595,6 +4595,7 @@ static int CmdHFiClassEncode(const char *Cmd) {
         arg_str0("w",   "wiegand", "<format>", "see " _YELLOW_("`wiegand list`") " for available formats"),
         arg_lit0(NULL, "shallow", "use shallow (ASK) reader modulation instead of OOK"),
         arg_lit0("v", NULL, "verbose (print encoded blocks)"),
+        arg_u64_0(NULL, "issue", "<dec>", "issue level"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, false);
@@ -4635,6 +4636,7 @@ static int CmdHFiClassEncode(const char *Cmd) {
     memset(&card, 0, sizeof(wiegand_card_t));
     card.FacilityCode = arg_get_u32_def(ctx, 7, 0);
     card.CardNumber = arg_get_u32_def(ctx, 8, 0);
+    card.IssueLevel = arg_get_u32_def(ctx, 12, 0);
 
     char format[16] = {0};
     int format_len = 0;


### PR DESCRIPTION
Added the ability to update emulator memory instead of only writing to card as well as encoding issuance level directly from the encode command. 