### PR TITLE
Indala 26 parity

### DIFF
--- a/client/src/cmdlfindala.c
+++ b/client/src/cmdlfindala.c
@@ -1175,7 +1175,7 @@ int getIndalaBits(uint8_t fc, uint16_t cn, uint8_t *bits) {
     bits[38] = 0; // parity for even bits
     uint8_t p1 = 1;
     uint8_t p2 = 1;
-    
+
     for (int i=33; i < 64; i++) {
         if (i%2) 
             p1 ^= bits[i];

--- a/client/src/cmdlfindala.c
+++ b/client/src/cmdlfindala.c
@@ -1136,7 +1136,6 @@ int getIndalaBits(uint8_t fc, uint16_t cn, uint8_t *bits) {
     bits[51] = ((cn >> 8) & 1);  // b9  - c
     bits[46] = ((cn >> 7) & 1);  // b8
     bits[33] = ((cn >> 6) & 1);  // b7  - c
-  //  bits[61] = ((cn >> 6) & 1);  // b7  - c
     bits[37] = ((cn >> 5) & 1);  // b6  - c
     bits[54] = ((cn >> 4) & 1);  // b5
     bits[56] = ((cn >> 3) & 1);  // b4
@@ -1182,6 +1181,7 @@ int getIndalaBits(uint8_t fc, uint16_t cn, uint8_t *bits) {
         else
             p2 ^= bits[i];
     }
+
     bits[34] = p1; // parity for odd bits
     bits[38] = p2; // parity for even bits
 

--- a/client/src/cmdlfindala.c
+++ b/client/src/cmdlfindala.c
@@ -1136,6 +1136,7 @@ int getIndalaBits(uint8_t fc, uint16_t cn, uint8_t *bits) {
     bits[51] = ((cn >> 8) & 1);  // b9  - c
     bits[46] = ((cn >> 7) & 1);  // b8
     bits[33] = ((cn >> 6) & 1);  // b7  - c
+  //  bits[61] = ((cn >> 6) & 1);  // b7  - c
     bits[37] = ((cn >> 5) & 1);  // b6  - c
     bits[54] = ((cn >> 4) & 1);  // b5
     bits[56] = ((cn >> 3) & 1);  // b4
@@ -1164,11 +1165,25 @@ int getIndalaBits(uint8_t fc, uint16_t cn, uint8_t *bits) {
     }
 
     // add parity
-    bits[34] = 1; // p1  64 - 30 = 34
-    bits[38] = 1; // p2  68 - 30 = 38
+    // bits[34] = 1; // p1  64 - 30 = 34
+    // bits[38] = 1; // p2  68 - 30 = 38
 
     // 92 = 62
     // 93 = 63
+    
+    bits[34] = 0; // parity for odd bits
+    bits[38] = 0; // parity for even bits
+    uint8_t p1 = 1;
+    uint8_t p2 = 1;
+    
+    for (int i=33; i < 64; i++) {
+        if (i%2) 
+            p1 ^= bits[i];
+        else
+            p2 ^= bits[i];
+    }
+    bits[34] = p1; // parity for odd bits
+    bits[38] = p2; // parity for even bits
 
     return PM3_SUCCESS;
 }


### PR DESCRIPTION
Updated the party from fixed "11" parity to even/odd calculation.
Has worked for every test on both an omnikey and signo reader.
I have tested all single bit FC with CN 1 and all single bit CN with FC 1
Also random range checks with a fixed FC and sequential CN over a range of 10-15 CNs.

