### PR TITLE
Fix 'invalid literal for int() with base16: 'xxxxxxxx(random)'

### DIFF
--- a/client/pyscripts/fm11rf08s_recovery.py
+++ b/client/pyscripts/fm11rf08s_recovery.py
@@ -67,7 +67,8 @@ uid = None
 if p.grabbed_output is not None:
     for line in p.grabbed_output.split('\n'):
         if "UID:" in line:
-            uid = int(line[10:].replace(' ', ''), 16)
+            uid_str = line[10:].split('(')[0].replace(' ', '')
+            uid = int(uid_str, 16)
 if uid is None:
     print("Card not found")
     exit()


### PR DESCRIPTION
Original code somehow not working on my machine, but somehow this fix fixed somehow error

```
[fpc] pm3 --> script run client/pyscripts/fm11rf08s_recovery.py 
[+] executing python client/pyscripts/fm11rf08s_recovery.py
[+] args ''
Traceback (most recent call last):
  File "client/pyscripts/fm11rf08s_recovery.py", line 70, in <module>
    uid = int(line[10:].replace(' ', ''), 16)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 16: '08637D03(random)'

[!] ⚠  finished client/pyscripts/fm11rf08s_recovery.py with exception

```