### PR TITLE
fix: lf cmdread. skip WaitMS(100) when keep signal field ON.

### DIFF
--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -426,7 +426,10 @@ void ModThenAcquireRawAdcSamples125k(uint32_t delay_off, uint16_t period_0, uint
     // start timer
     StartTicks();
 
-    WaitMS(100);
+    if (!prev_keep) {
+        WaitMS(100);
+    }
+
     // clear read buffer
     BigBuf_Clear_keep_EM();
 


### PR DESCRIPTION
4 extra symbol.
avoid include SOF in crc-hitag

split of #2456