### PR TITLE
fm11rf08s_recovery: Specify the encoding as UTF-8 when opening the MFC dictionary file.

### DIFF
--- a/client/pyscripts/fm11rf08s_recovery.py
+++ b/client/pyscripts/fm11rf08s_recovery.py
@@ -142,7 +142,7 @@ for sec in range(NUM_SECTORS):
 
 if os.path.isfile(DICT_DEF_PATH):
     print(f"Loading {DICT_DEF}")
-    with open(DICT_DEF_PATH, 'r') as file:
+    with open(DICT_DEF_PATH, 'r', encoding='utf-8') as file:
         for line in file:
             if line[0] != '#' and len(line) >= 12:
                 DEFAULT_KEYS.add(line[:12])


### PR DESCRIPTION
In Proxspace or some other specific environments, if the encoding is not specified, an error will occur:
[+] args ''
UID: 23A6D2A0
Getting nonces...
Processing traces...
Loading mfc_default_keys.dic
Traceback (most recent call last):
  File "fm11rf08s_recovery.py", line 146, in <module>
    for line in file:
UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 in position 506: illegal multibyte sequence

[!] finished fm11rf08s_recovery.py with exception