### PR TITLE
mkversion: Fix readme location

### DIFF
--- a/tools/mkversion.sh
+++ b/tools/mkversion.sh
@@ -71,7 +71,7 @@ if [ "$commandGIT" != "" ]; then
     fi
 else
     fullgitinfo="${fullgitinfo}/master/release (no_git)"
-    dl_time=$(stat --printf="%y" ../README.md)
+    dl_time=$(stat --printf="%y" README.md)
     # POSIX way...
     ctime=${dl_time%.*}
 fi


### PR DESCRIPTION
While building proxmark3 in an environment without `git` installed, I noticed the following errors on stderr:

```
mkversion create test                   env: 'git': No such file or directory
stat: cannot statx '../README.md': No such file or directory
```

The first line "env: 'git': No such file or directory" is expected, as git is not installed.

However, the second line "stat: cannot statx '../README.md': No such file or directory" is a real error: we're running from top-level directory, so the correct path for README.md is just "README.md".