### PR TITLE
Updated hf iclass legbrute

### DIFF
--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -3890,32 +3890,6 @@ static int CmdHFiClassRecover(uint8_t key[8]) {
     return resp.status;
 }
 
-typedef struct {
-    uint32_t start_index;
-    uint32_t keycount;
-    const uint8_t *startingKey;
-    uint8_t (*keyBlock)[PICOPASS_BLOCK_SIZE];
-} ThreadData;
-
-void *generate_key_blocks(void *arg) {
-    ThreadData *data = (ThreadData *)arg;
-    uint32_t start_index = data->start_index;
-    uint32_t keycount = data->keycount;
-    const uint8_t *startingKey = data->startingKey;
-    uint8_t (*keyBlock)[PICOPASS_BLOCK_SIZE] = data->keyBlock;
-
-    for (uint32_t i = 0; i < keycount; i++) {
-        uint32_t carry = start_index + i;
-        memcpy(keyBlock[i], startingKey, PICOPASS_BLOCK_SIZE);
-
-        for (int j = PICOPASS_BLOCK_SIZE - 1; j >= 0; j--) {
-            uint8_t increment_value = (carry & 0x1F) << 3;  // Use only the first 5 bits of carry
-            keyBlock[i][j] = (keyBlock[i][j] & 0x07) | increment_value;  // Preserve the last three bits
-
-            carry >>= 5;  // Shift right by 5 bits for the next byte
-            if (carry == 0) {
-                // If no more carry, break early to avoid unnecessary loops
-                break;
             }
         }
     }
@@ -3923,8 +3897,8 @@ void *generate_key_blocks(void *arg) {
     return NULL;
 }
 
-void generate_key_block_inverted(const uint8_t *startingKey, uint32_t index, uint8_t *keyBlock) {
-    uint32_t carry = index;
+void generate_key_block_inverted(const uint8_t *startingKey, uint64_t index, uint8_t *keyBlock) {
+    uint64_t carry = index;
     memcpy(keyBlock, startingKey, PICOPASS_BLOCK_SIZE);
 
     for (int j = PICOPASS_BLOCK_SIZE - 1; j >= 0; j--) {

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -3890,13 +3890,6 @@ static int CmdHFiClassRecover(uint8_t key[8]) {
     return resp.status;
 }
 
-            }
-        }
-    }
-
-    return NULL;
-}
-
 void generate_key_block_inverted(const uint8_t *startingKey, uint64_t index, uint8_t *keyBlock) {
     uint64_t carry = index;
     memcpy(keyBlock, startingKey, PICOPASS_BLOCK_SIZE);
@@ -4059,7 +4052,7 @@ static int CmdHFiClassLegRecLookUp(const char *Cmd) {
                 PrintAndLogEx(SUCCESS, _GREEN_("CONFIRMED VALID RAW key ") _RED_("%s"), sprint_hex(div_key, 8));
                 verified = true;
             }else{
-                PrintAndLogEx(INFO, _YELLOW_("Found potentially valid RAW key ") _GREEN_("%s")_YELLOW_(" verifying it..."), sprint_hex(div_key, 8));
+                PrintAndLogEx(INFO, _YELLOW_("Raw Key Invalid"));
             }
 
         }

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -4057,7 +4057,7 @@ static int CmdHFiClassLegRecLookUp(const char *Cmd) {
 
         }
         if(index % 1000000 == 0){
-            PrintAndLogEx(INFO, "Tested: " _YELLOW_("%d")" keys", index);
+            PrintAndLogEx(INFO, "Tested: " _YELLOW_("%" PRIu64 )" million keys", index/1000000);
             PrintAndLogEx(INFO, "Last Generated Key Value: " _YELLOW_("%s"), sprint_hex(div_key, 8));
         }
         index++;

--- a/client/src/cmdhficlass.h
+++ b/client/src/cmdhficlass.h
@@ -43,5 +43,5 @@ uint32_t picopass_elite_rng(void);
 uint32_t picopass_elite_lcg(void);
 uint8_t picopass_elite_nextByte(void);
 void *generate_key_blocks(void *arg);
-void generate_key_block_inverted(const uint8_t *startingKey, uint32_t index, uint8_t *keyBlock);
+void generate_key_block_inverted(const uint8_t *startingKey, uint64_t index, uint8_t *keyBlock);
 #endif

--- a/client/src/cmdhficlass.h
+++ b/client/src/cmdhficlass.h
@@ -43,4 +43,5 @@ uint32_t picopass_elite_rng(void);
 uint32_t picopass_elite_lcg(void);
 uint8_t picopass_elite_nextByte(void);
 void *generate_key_blocks(void *arg);
+void generate_key_block_inverted(const uint8_t *startingKey, uint32_t index, uint8_t *keyBlock);
 #endif

--- a/client/src/cmdhficlass.h
+++ b/client/src/cmdhficlass.h
@@ -42,6 +42,5 @@ void picopass_elite_reset(void);
 uint32_t picopass_elite_rng(void);
 uint32_t picopass_elite_lcg(void);
 uint8_t picopass_elite_nextByte(void);
-void *generate_key_blocks(void *arg);
 void generate_key_block_inverted(const uint8_t *startingKey, uint64_t index, uint8_t *keyBlock);
 #endif


### PR DESCRIPTION
Update legbrute to perform a double check when finding a potentially valid raw key, to ensure that is indeed the raw key and works against multiple macs (for the same epurse values).