### PR TITLE
Fixed argument count for SimulateIso14443aTag() in hf_young.c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added detection of a magic NTAG 215 (@iceman1001)
 - Fixed hardnested on AVX512F #2410 (@xianglin1998)
 - Added `hf 14a aidsim` - simulates a PICC (like `14a sim`), and allows you to respond to specific AIDs and getData responses (@evildaemond)
+- Fixed incorrect argument count for `SimulateIso14443aTag` in `hf_young.c`.
 
 ## [Backdoor.4.18994][2024-09-10]
 - Changed flashing messages to be less scary (@iceman1001)

--- a/armsrc/Standalone/hf_young.c
+++ b/armsrc/Standalone/hf_young.c
@@ -252,25 +252,25 @@ void RunMod(void) {
 
                     if (uids[selected].sak == 0x08 && uids[selected].atqa[0] == 0x04 && uids[selected].atqa[1] == 0) {
                         DbpString("Mifare Classic 1k");
-                        SimulateIso14443aTag(1, flags, data, 0);
+                        SimulateIso14443aTag(1, flags, data, 0, NULL);
                     } else if (uids[selected].sak == 0x18 && uids[selected].atqa[0] == 0x02 && uids[selected].atqa[1] == 0) {
                         DbpString("Mifare Classic 4k (4b uid)");
-                        SimulateIso14443aTag(8, flags, data, 0);
+                        SimulateIso14443aTag(8, flags, data, 0, NULL);
                     } else if (uids[selected].sak == 0x08 && uids[selected].atqa[0] == 0x44 && uids[selected].atqa[1] == 0) {
                         DbpString("Mifare Classic 4k (7b uid)");
-                        SimulateIso14443aTag(8, flags, data, 0);
+                        SimulateIso14443aTag(8, flags, data, 0, NULL);
                     } else if (uids[selected].sak == 0x00 && uids[selected].atqa[0] == 0x44 && uids[selected].atqa[1] == 0) {
                         DbpString("Mifare Ultralight");
-                        SimulateIso14443aTag(2, flags, data, 0);
+                        SimulateIso14443aTag(2, flags, data, 0, NULL);
                     } else if (uids[selected].sak == 0x20 && uids[selected].atqa[0] == 0x04 && uids[selected].atqa[1] == 0x03) {
                         DbpString("Mifare DESFire");
-                        SimulateIso14443aTag(3, flags, data, 0);
+                        SimulateIso14443aTag(3, flags, data, 0, NULL);
                     } else if (uids[selected].sak == 0x20 && uids[selected].atqa[0] == 0x44 && uids[selected].atqa[1] == 0x03) {
                         DbpString("Mifare DESFire Ev1/Plus/JCOP");
-                        SimulateIso14443aTag(3, flags, data, 0);
+                        SimulateIso14443aTag(3, flags, data, 0, NULL);
                     } else {
                         Dbprintf("Unrecognized tag type -- defaulting to Mifare Classic emulation");
-                        SimulateIso14443aTag(1, flags, data, 0);
+                        SimulateIso14443aTag(1, flags, data, 0, NULL);
                     }
 
                 } else if (button_pressed == BUTTON_SINGLE_CLICK) {


### PR DESCRIPTION
 SimulateIso14443aTag() now requires five arguments, added NULL to all calls in hf_young.c