### PR TITLE
Added hf iclass unhash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Added `hf iclass unhash` command to reverse an iclass diversified key to hash0 pre-images (@antiklesys)
 - Added crypto1 support to `hf 14a raw` (@doegox)
 - Changed `hw version` command to print LUA and Python versions (@jmichelp)
 - Updated LUA to v5.4.7 which adds utf-8 support (@jmichelp)

--- a/client/src/loclass/ikeys.h
+++ b/client/src/loclass/ikeys.h
@@ -49,6 +49,7 @@
  * @return
  */
 void hash0(uint64_t c, uint8_t k[8]);
+void invert_hash0(uint8_t k[8]);
 int doKeyTests(void);
 /**
  * @brief Performs Elite-class key diversification


### PR DESCRIPTION
Added hf iclass unhash based on the document "Exposing iClass Key Diversification" The command works but only handles the "main" scenarios, retrieving only the main 8 of 512 potential hash0 pre-images.
Handling the generation of the additional pre-images is still work in progress.