### PR TITLE
fix hf mfu pwdgen for 7 byte uid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `hf mfu pwdgen` for the 7 byte UID (@ANTodorov)
 - Added `hf iclass unhash` command to reverse an iclass diversified key to hash0 pre-images (@antiklesys)
 - Added crypto1 support to `hf 14a raw` (@doegox)
 - Changed `hw version` command to print LUA and Python versions (@jmichelp)

--- a/client/src/cmdhfmfu.c
+++ b/client/src/cmdhfmfu.c
@@ -4392,6 +4392,10 @@ static int CmdHF14AMfUPwdGen(const char *Cmd) {
         if (u_len != 7 && u_len != 4) {
             PrintAndLogEx(WARNING, "Key must be 7 hex bytes");
             return PM3_EINVARG;
+        } else if (u_len == 4) {
+            // adapt to 7 bytes :)
+            memset(uid + 4, 0x00, 3);
+            u_len = 7;
         }
     }
 

--- a/client/src/cmdhfmfu.c
+++ b/client/src/cmdhfmfu.c
@@ -4392,10 +4392,6 @@ static int CmdHF14AMfUPwdGen(const char *Cmd) {
         if (u_len != 7 && u_len != 4) {
             PrintAndLogEx(WARNING, "Key must be 7 hex bytes");
             return PM3_EINVARG;
-        } else {
-            // adapt to 7 bytes :)
-            memset(uid + 4, 0x00, 3);
-            u_len = 7;
         }
     }
 


### PR DESCRIPTION
The last 3 bytes of the 7 byte uid are zeroed out
Tested with the example from the forum http://www.proxmark.org/forum/viewtopic.php?pid=44238#p44238