### PR TITLE
Fix missing line return when viewing dumps

### DIFF
--- a/client/src/util.c
+++ b/client/src/util.c
@@ -529,7 +529,7 @@ char *sprint_hex_ascii(const uint8_t *data, const size_t len) {
 
     while (i < max_len) {
         unsigned char c = (unsigned char)data[i];
-        tmp[pos + i]  = isprint(c) ? c : '.';
+        tmp[pos + i]  = (isprint(c) && c != 0xff) ? c : '.';
         ++i;
     }
 out:
@@ -546,7 +546,7 @@ char *sprint_ascii_ex(const uint8_t *data, const size_t len, const size_t min_st
 
     while (i < max_len) {
         unsigned char c = (unsigned char)data[i];
-        tmp[i]  = isprint(c) ? c : '.';
+        tmp[i]  = (isprint(c) && c != 0xff) ? c : '.';
         ++i;
     }
 


### PR DESCRIPTION
For some reason, `isprint()` claims that `0xff` is printable. But it's used by `PrintAndLog` functions as a marker value to suppress the line return.

So when viewing a dump where the last byte of a block/sector is `0xff`, it was suppressing the new line between blocks/sectors. This fixes it by excluding `0xff` from printable values.