### PR TITLE
Fix hf_aveful.c: too few arguments to function 'SimulateIso14443aTag'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added detection of a magic NTAG 215 (@iceman1001)
 - Fixed hardnested on AVX512F #2410 (@xianglin1998)
 - Added `hf 14a aidsim` - simulates a PICC (like `14a sim`), and allows you to respond to specific AIDs and getData responses (@evildaemond)
-- Fixed incorrect argument count for `SimulateIso14443aTag` in `hf_young.c`.
+- Fixed incorrect argument count for `SimulateIso14443aTag` in `hf_young.c` and `hf_aveful.c`.
 
 ## [Backdoor.4.18994][2024-09-10]
 - Changed flashing messages to be less scary (@iceman1001)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added detection of a magic NTAG 215 (@iceman1001)
 - Fixed hardnested on AVX512F #2410 (@xianglin1998)
 - Added `hf 14a aidsim` - simulates a PICC (like `14a sim`), and allows you to respond to specific AIDs and getData responses (@evildaemond)
-- Fixed incorrect argument count for `SimulateIso14443aTag` in `hf_young.c` and `hf_aveful.c`.
+- Fixed incorrect argument count for `SimulateIso14443aTag` in `hf_young.c`, `hf_aveful.c` and `hf_craftbyte.c`.
 
 ## [Backdoor.4.18994][2024-09-10]
 - Changed flashing messages to be less scary (@iceman1001)

--- a/armsrc/Standalone/hf_aveful.c
+++ b/armsrc/Standalone/hf_aveful.c
@@ -251,7 +251,7 @@ void RunMod(void) {
                 uint16_t flags = FLAG_7B_UID_IN_DATA;
 
                 Dbprintf("Starting simulation, press " _GREEN_("pm3 button") " to stop and go back to search state.");
-                SimulateIso14443aTag(7, flags, card.uid, 0);
+                SimulateIso14443aTag(7, flags, card.uid, 0, NULL);
 
                 // Go back to search state if user presses pm3-button
                 state = STATE_SEARCH;

--- a/armsrc/Standalone/hf_craftbyte.c
+++ b/armsrc/Standalone/hf_craftbyte.c
@@ -94,22 +94,22 @@ void RunMod(void) {
                 Dbprintf("Starting simulation, press " _GREEN_("pm3 button") " to stop and go back to search state.");
                 if (card.sak == 0x08 && card.atqa[0] == 0x04 && card.atqa[1] == 0) {
                     DbpString("Mifare Classic 1k");
-                    SimulateIso14443aTag(1, flags, card.uid, 0);
+                    SimulateIso14443aTag(1, flags, card.uid, 0, NULL);
                 } else if (card.sak == 0x08 && card.atqa[0] == 0x44 && card.atqa[1] == 0) {
                     DbpString("Mifare Classic 4k ");
-                    SimulateIso14443aTag(8, flags, card.uid, 0);
+                    SimulateIso14443aTag(8, flags, card.uid, 0, NULL);
                 } else if (card.sak == 0x00 && card.atqa[0] == 0x44 && card.atqa[1] == 0) {
                     DbpString("Mifare Ultralight");
-                    SimulateIso14443aTag(2, flags, card.uid, 0);
+                    SimulateIso14443aTag(2, flags, card.uid, 0, NULL);
                 } else if (card.sak == 0x20 && card.atqa[0] == 0x04 && card.atqa[1] == 0x03) {
                     DbpString("Mifare DESFire");
-                    SimulateIso14443aTag(3, flags, card.uid, 0);
+                    SimulateIso14443aTag(3, flags, card.uid, 0, NULL);
                 } else if (card.sak == 0x20 && card.atqa[0] == 0x44 && card.atqa[1] == 0x03) {
                     DbpString("Mifare DESFire Ev1/Plus/JCOP");
-                    SimulateIso14443aTag(3, flags, card.uid, 0);
+                    SimulateIso14443aTag(3, flags, card.uid, 0, NULL);
                 } else {
                     Dbprintf("Unrecognized tag type -- defaulting to Mifare Classic emulation");
-                    SimulateIso14443aTag(1, flags, card.uid, 0);
+                    SimulateIso14443aTag(1, flags, card.uid, 0, NULL);
                 }
 
                 // Go back to search state if user presses pm3-button


### PR DESCRIPTION
Just a quick fix to the build (+ CHANGELOG). I adapted the change from `hf_young.c` (just added a NULL pointer), but didn't dive into the code to figure out if this is the best approach or not.

btw, thanks for the tool + code!

Original error:

```
[-] CC ../armsrc/Standalone/hf_aveful.c
../armsrc/Standalone/hf_aveful.c: In function 'RunMod':
../armsrc/Standalone/hf_aveful.c:254:17: error: too few arguments to function 'SimulateIso14443aTag'
  254 |                 SimulateIso14443aTag(7, flags, card.uid, 0);
      |                 ^~~~~~~~~~~~~~~~~~~~
In file included from ../armsrc/Standalone/hf_aveful.c:44:
./iso14443a.h:143:6: note: declared here
  143 | void SimulateIso14443aTag(uint8_t tagType, uint16_t flags, uint8_t *data, uint8_t exitAfterNReads, uint8_t *iRATs);
      |      ^~~~~~~~~~~~~~~~~~~~
make[1]: *** [../common_arm/Makefile.common:119: obj/hf_aveful.o] Error 1
make: *** [Makefile:168: armsrc/install] Error 2
==> ERROR: A failure occurred in build().
    Aborting...
makepkg  484.97s user 21.77s system 95% cpu 8:52.73 total
```