### PR TITLE
Fix SimulateIso14443aInit usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added detection of a magic NTAG 215 (@iceman1001)
 - Fixed hardnested on AVX512F #2410 (@xianglin1998)
 - Added `hf 14a aidsim` - simulates a PICC (like `14a sim`), and allows you to respond to specific AIDs and getData responses (@evildaemond)
-- Fixed incorrect argument count for `SimulateIso14443aTag` in `hf_young.c`, `hf_aveful.c` and `hf_craftbyte.c`.
+- Fixed arguments for `SimulateIso14443aTag` and `SimulateIso14443aInit` in `hf_young.c`, `hf_aveful.c`, `hf_msdsal.c`, `hf_cardhopper.c`, `hf_reblay.c`, `hf_tcprst.c` and `hf_craftbyte.c` (@archi)
 
 ## [Backdoor.4.18994][2024-09-10]
 - Changed flashing messages to be less scary (@iceman1001)

--- a/armsrc/Standalone/hf_cardhopper.c
+++ b/armsrc/Standalone/hf_cardhopper.c
@@ -216,7 +216,7 @@ static void become_card(void) {
     uint32_t counters[3] = { 0 };
     uint8_t tearings[3] = { 0xbd, 0xbd, 0xbd };
     uint8_t pages;
-    SimulateIso14443aInit(tagType, flags, data, &canned, &cuid, counters, tearings, &pages);
+    SimulateIso14443aInit(tagType, flags, data, NULL, &canned, &cuid, counters, tearings, &pages);
 
     DbpString(_CYAN_("[@]") " Setup done - entering emulation loop");
     int fromReaderLen;

--- a/armsrc/Standalone/hf_msdsal.c
+++ b/armsrc/Standalone/hf_msdsal.c
@@ -378,7 +378,7 @@ void RunMod(void) {
             BigBuf_free_keep_EM();
 
             // tag type: 11 = ISO/IEC 14443-4 - javacard (JCOP)
-            if (SimulateIso14443aInit(11, flags, data, &responses, &cuid, NULL, NULL, NULL) == false) {
+            if (SimulateIso14443aInit(11, flags, data, NULL, &responses, &cuid, NULL, NULL, NULL) == false) {
                 BigBuf_free_keep_EM();
                 reply_ng(CMD_HF_MIFARE_SIMULATE, PM3_EINIT, NULL, 0);
                 DbpString(_RED_("Error initializing the emulation process!"));

--- a/armsrc/Standalone/hf_reblay.c
+++ b/armsrc/Standalone/hf_reblay.c
@@ -267,7 +267,7 @@ void RunMod() {
             BigBuf_free_keep_EM();
 
             // 4 = ISO/IEC 14443-4 - javacard (JCOP)
-            if (SimulateIso14443aInit(4, flags, data, &responses, &cuid, NULL, NULL, NULL) == false) {
+            if (SimulateIso14443aInit(4, flags, data, NULL, &responses, &cuid, NULL, NULL, NULL) == false) {
                 BigBuf_free_keep_EM();
                 reply_ng(CMD_HF_MIFARE_SIMULATE, PM3_EINIT, NULL, 0);
                 DbpString(_RED_("Error initializing the emulation process!"));

--- a/armsrc/Standalone/hf_tcprst.c
+++ b/armsrc/Standalone/hf_tcprst.c
@@ -192,7 +192,7 @@ void RunMod(void) {
 
             memcpy(data, stuid, sizeof(stuid));
 
-            if (SimulateIso14443aInit(tagType, flags, data, &responses, &cuid, counters, tearings, &pages) == false) {
+            if (SimulateIso14443aInit(tagType, flags, data, NULL, &responses, &cuid, counters, tearings, &pages) == false) {
                 BigBuf_free_keep_EM();
                 reply_ng(CMD_HF_MIFARE_SIMULATE, PM3_EINIT, NULL, 0);
                 DbpString(_YELLOW_("!!") "Error initializing the simulation process!");
@@ -370,7 +370,7 @@ void RunMod(void) {
 
             memcpy(data, stuid, sizeof(stuid));
 
-            if (SimulateIso14443aInit(tagType, flags, data, &responses, &cuid, counters, tearings, &pages) == false) {
+            if (SimulateIso14443aInit(tagType, flags, data, NULL, &responses, &cuid, counters, tearings, &pages) == false) {
                 BigBuf_free_keep_EM();
                 reply_ng(CMD_HF_MIFARE_SIMULATE, PM3_EINIT, NULL, 0);
                 DbpString(_YELLOW_("!!") "Error initializing the simulation process!");


### PR DESCRIPTION
Added NULL as `uint8_t *iRats` to all invokations in armsrc/Standalone.

Not sure if that is the right thing to do: The actual code checks for the presence of a special flag, but does not contain a check for NULL. IMHO adding a NULL check in `iso14443a.c` line 1259 wouldn't hurt, and could catch programming errors (flag set by accident, but NULL passed).

Maybe @evildaemond wants to verify whether my fix does the right thing or if I missed something (they added the iRATs to `iso14443a.h` with 56324b16b2).