### PR TITLE
fix em4x50_read function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed em4x50_read() - `lf search` and `lf em 4x50 rdbl -b <blk>` does not coredump reading EM4450 tag (@ANTodorov)
 - Fixed flashing - client doesnt fail every other flash attempt (@iceman1001)
 - Changed `pref show` - add option to dump as JSON (@doegox)
 - Changed `mf_backdoor_dump.py`- use faster ecfill/eview (@doegox)

--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -639,10 +639,8 @@ int em4x50_read(em4x50_data_t *etd, em4x50_word_t *out) {
         return PM3_ESOFT;
     }
 
-    em4x50_read_data_response_t *o = (em4x50_read_data_response_t *)resp.data.asBytes;
-
     em4x50_word_t words[EM4X50_NO_WORDS] = {0};
-    em4x50_prepare_result((uint8_t *)o->words, etd->addresses & 0xFF, (etd->addresses >> 8) & 0xFF, words);
+    em4x50_prepare_result(resp.data.asBytes, etd->addresses & 0xFF, (etd->addresses >> 8) & 0xFF, words);
 
     if (out != NULL) {
         memcpy(out, &words, sizeof(em4x50_word_t) * EM4X50_NO_WORDS);


### PR DESCRIPTION
affected `lf search` and `lf em 4x50 rdbl -b <blk>`


```
[usb] pm3 --> lf em 4x50 rdbl -b 3

Thread 10 "WorkerThread" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffdefff700 (LWP 2592)]
em4x50_prepare_result (words=0x7fffdeffe310, lwr=3, fwr=<optimized out>, data=<optimized out>)
```

```
[usb] pm3 --> lf search

Thread 10 "WorkerThread" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffdefff700 (LWP 3091)]
em4x50_prepare_result (words=0x7fffdeffe340, lwr=32, fwr=<optimized out>, data=<optimized out>)
    at /home/ant/src/RF/Proxmark3/pm3/client/src/cmdlfem4x50.c:40
40	            words[i].byte[j] = data[i * 4 + (3 - j)];
```