### PR TITLE
feat: detect march and mcpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Added an Makefile variable `DONT_BUILD_NATIVE` in mfd_aes_brute Makefile to easify downstream package
+- Auto detect whether compile option `march=native` is supported for mfd_aes_brute Makefile
 - Changed `hf mf sim` - support data-first and nested reader attacks (@doegox)
 - Fixed em4x50_read() - `lf search` and `lf em 4x50 rdbl -b <blk>` does not coredump reading EM4450 tag (@ANTodorov)
 - Fixed flashing - client doesnt fail every other flash attempt (@iceman1001)

--- a/tools/mfd_aes_brute/Makefile
+++ b/tools/mfd_aes_brute/Makefile
@@ -5,15 +5,15 @@ MYCFLAGS = -Ofast
 MYDEFS =
 MYLDLIBS = -lcrypto
 
-# A better way would be to just try compiling with march and seeing if we succeed
-cpu_arch = $(shell uname -m)
-ifneq ($(findstring arm64, $(cpu_arch)), )
-    MYCFLAGS += -mcpu=native
-# iOS 'fun'
-else ifneq ($(findstring iP, $(cpu_arch)), )
-    MYCFLAGS += -mcpu=native
-else
+SUPPORT_MARCH := $(shell $(CC) -xc /dev/null -c -o /dev/null -march=native > /dev/null 2>/dev/null && echo y)
+SUPPORT_MCPU := $(shell $(CC) -xc /dev/null -c -o /dev/null -mcpu=native > /dev/null 2>/dev/null && echo y)
+
+ifeq ($(DONT_BUILD_NATIVE),y)
+    # do nothing
+else ifeq ($(SUPPORT_MARCH),y)
     MYCFLAGS += -march=native
+else ifeq ($(SUPPORT_MCPU),y)
+    MYCFLAGS += -mcpu=native
 endif
 
 ifneq ($(SKIPPTHREAD),1)
@@ -42,6 +42,8 @@ ifeq ($(USE_MACPORTS),1)
     MYCFLAGS += -I$(MACPORTS_PREFIX)/include/openssl-3 -I$(MACPORTS_PREFIX)/include/openssl-1.1
     MYLDFLAGS += -L$(MACPORTS_PREFIX)/lib/openssl-3 -L$(MACPORTS_PREFIX)/lib/openssl-1.1
 endif
+
+showinfo: $(info c flags: $(MYCFLAGS))
 
 brute_key : $(OBJDIR)/brute_key.o $(MYOBJS)
 


### PR DESCRIPTION
The compiler don't support `march=native` / `mcpu=native` on risvc64, either. This fix the compile failure on riscv64.

Reported-by: https://archriscv.felixc.at/.status/log.htm?url=logs/proxmark3/proxmark3-4.18589-1.log

Refactor the way that detect whether `march=native` / `mcpu=native` are supported on the platform, following the comment.

Add an option `DONT_BUILD_NATIVE` to suppress building with `march=native` / `mcpu=native`. For building it someone-self, it is helpful to generate the fastest binary, but for Linux or some other operating system distribution package maintainer, it is over optimized. We may build and package this software on a machine that is `x86_64-v3` but distribute it to a user that using an old hardware like `Intel Atom`, and result in a `SIGILL`.

Already tested it on `x86_64` and `riscv64`