### PR TITLE
Fixed syntax error in flags declaration in hf_young.c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed 'hf_young.c' - flags declaration was missing a semicolon (@jakkpotts)
 - Changed `hf mf sim` - add option to allow key b to be used even if readable (@doegox)
 - Changed `data num` - outputed binary strings are now properly zero padded (@iceman1001)
 - Changed `hf iclass info` - now tries default keys and decode if legacy (@iceman1001)

--- a/armsrc/Standalone/hf_young.c
+++ b/armsrc/Standalone/hf_young.c
@@ -236,7 +236,7 @@ void RunMod(void) {
                 int button_pressed = BUTTON_HELD(1000);
                 if (button_pressed == BUTTON_NO_CLICK) {  // No button action, proceed with sim
 
-                    uint16_t flags = 0
+                    uint16_t flags = 0;
                     FLAG_SET_UID_IN_DATA(flags, 4);
                     uint8_t data[PM3_CMD_DATA_SIZE] = {0}; // in case there is a read command received we shouldn't break
 


### PR DESCRIPTION
Missing a semicolon, prevented compiling if hf_young was set as Standalone mode