### PR TITLE
hitags sim: apply correct coding after select(uid)

### DIFF
--- a/armsrc/hitagS.c
+++ b/armsrc/hitagS.c
@@ -526,6 +526,20 @@ static void hts_handle_reader_command(uint8_t *rx, const size_t rxlen,
 
                     tx[4] = crc;
                 }
+                switch (tag.mode) {
+                    case HT_STANDARD:
+                    case HT_ADVANCED: {
+                        m = MC4K;
+                        break;
+                    }
+                    case HT_FAST_ADVANCED: {
+                        m = MC8K;
+                        break;
+                    }
+                    default: {
+                        break;
+                    }
+                }
             }
             break;
         }


### PR DESCRIPTION
in the current sim, the anticoll coding is still used after the tag has been selected. this patch ensures, that the corresponding mc coding is used after select(uid)