### PR TITLE
Update to fix some small USCUID-UL errors and add new developments

### DIFF
--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -2114,7 +2114,7 @@ Possible tag wakeup mechanisms are:
     ^^                              >> Magic wakeup command (00 for 40-43; 85 for 20-23)
       ^^                            >> Config available using regular mode (ON: A0)
          ^^                         >> Auth type (00 = PWD mode, 0A = 2TDEA mode for UL-C)
-             ^^                     >> CUID mode, allows writing to blocks 0-3 (ON: A0)
+             ^^                     >> CUID mode, allows writing to blocks 0-3 (ON: 0A)
                ^^                   >> Maximum memory configuration, please see below *
                   ^^^^^^^^ ^^^^^^^^ >> Version info
 


### PR DESCRIPTION
Update which includes new developments with USCUID-ULs and amended language for clarity.

- Added new discovery by @Eltrick which specifies tearing counters in hidden blocks F2-F4
- Cleared up some language regarding turning on CUID mode, including fixing incorrect A0 to turn it on instead of the correct 0A.
- Added anticoll settings for hidden block F6, thanks to @AnnPlusPlus