### PR TITLE
Delete extra whitespace character in mf_backdoor_dump.py

### DIFF
--- a/client/pyscripts/mf_backdoor_dump.py
+++ b/client/pyscripts/mf_backdoor_dump.py
@@ -26,7 +26,7 @@ for bk, sz in BACKDOOR_KEYS:
         print("Error reading the tag:")
         print("\n".join(output))
         break
-    elif "[-]  Fill ( fail )" in output:
+    elif "[-] Fill ( fail )" in output:
         continue
     elif "[+] Fill ( ok )" not in output:
         print("Unexpected output, exiting:")


### PR DESCRIPTION
In this patch an extra whitespace character in mf_backdoor_dump.py will be deleted. 
This blank character prevents the for loop from trying the next backdoor key.