### PR TITLE
Fix typo from envelop to envelope

### DIFF
--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -3384,9 +3384,9 @@ static int envelope_square(const int *in, int *out, size_t len) {
 
 static int CmdEnvelope(const char *Cmd) {
     CLIParserContext *ctx;
-    CLIParserInit(&ctx, "data envelop",
-                  "Create an square envelop of the samples",
-                  "data envelop"
+    CLIParserInit(&ctx, "data envelope",
+                  "Create an square envelope of the samples",
+                  "data envelope"
                  );
     void *argtable[] = {
         arg_param_begin,


### PR DESCRIPTION
The examples shown in the help output were referencing "envelop" instead of "envelope"