### PR TITLE
Show correct example for `data num --hex`

### DIFF
--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -3069,7 +3069,7 @@ static int CmdNumCon(const char *Cmd) {
                   "Function takes a decimal or hexdecimal number and print it in decimal/hex/binary\n"
                   "Will print message if number is a prime number\n",
                   "data num --dec 2023\n"
-                  "data num --hex 0x1000\n"
+                  "data num --hex 2A\n"
                  );
 
     void *argtable[] = {


### PR DESCRIPTION
The example shows a formatting that the command actually does not support, `0x` in front of the value returns an error. This was true since the inception of the command, and it seems easier to keep the functionality the same instead of changing the logic. At the same time, changing the logic would ideally also mean converting from binary should follow the same type of formatting (prepending with `0b`).

Changed the value in the example a bit at the same time to make sure the distinction is still visible between a hex and decimal value, just for the fun of it.