### PR TITLE
Add JAKCOM R5 smart ring t55x default passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added `hf 14a aidsim` - simulates a PICC (like `14a sim`), and allows you to respond to specific AIDs and getData responses (@evildaemond)
 - Fixed arguments for `SimulateIso14443aTag` and `SimulateIso14443aInit` in `hf_young.c`, `hf_aveful.c`, `hf_msdsal.c`, `hf_cardhopper.c`, `hf_reblay.c`, `hf_tcprst.c` and `hf_craftbyte.c` (@archi)
 - Added `mf_backdoor_dump.py` script that dumps FM11RF08S and similar (Mifare Classic 1k) tag data that can be directly read by known backdoor keys. (@Aptimex)
+- Add JAKCOM R5 Smart Ring default t55x passwords to dictionary (@shellster)
 
 ## [Backdoor.4.18994][2024-09-10]
 - Changed flashing messages to be less scary (@iceman1001)

--- a/client/dictionaries/t55xx_default_pwds.dic
+++ b/client/dictionaries/t55xx_default_pwds.dic
@@ -170,4 +170,3 @@ F1EA5EED
 #JAKCOM R5 smart ring default credentials http://www.jakcom.com/ins/r5/r5en.html
 5469616e
 51243648
-

--- a/client/dictionaries/t55xx_default_pwds.dic
+++ b/client/dictionaries/t55xx_default_pwds.dic
@@ -168,5 +168,5 @@ F1EA5EED
 # natural log
 27182818
 #JAKCOM R5 smart ring default credentials http://www.jakcom.com/ins/r5/r5en.html
-5469616e
+5469616E
 51243648

--- a/client/dictionaries/t55xx_default_pwds.dic
+++ b/client/dictionaries/t55xx_default_pwds.dic
@@ -167,3 +167,7 @@ F1EA5EED
 93C467E3
 # natural log
 27182818
+#JAKCOM R5 smart ring default credentials http://www.jakcom.com/ins/r5/r5en.html
+5469616e
+51243648
+


### PR DESCRIPTION
Bought one of these cool little rings.  It has two integrated t55x clone chips (among others), however they come pre-password protected and the tradition test mode wipes didn't seem to unlock them.  I was able to unlock them with passwords in their manual (http://www.jakcom.com/ins/r5/r5en.html) and so I thought they would be good to add to the dictionary.