### PR TITLE
improve cardhopper to improve reliability when parts of the packet are buffered

### DIFF
--- a/armsrc/Standalone/hf_cardhopper.c
+++ b/armsrc/Standalone/hf_cardhopper.c
@@ -33,7 +33,10 @@
 #ifdef CARDHOPPER_USB
 #define cardhopper_write usb_write
 #define cardhopper_read usb_read_ng
-#define cardhopper_data_available usb_poll_validate_length
+bool cardhopper_data_available(void);
+bool cardhopper_data_available(void) {
+    return usb_read_ng_has_buffered_data() || usb_poll_validate_length();
+}
 #else
 #define cardhopper_write usart_writebuffer_sync
 #define cardhopper_read usart_read_ng
@@ -107,14 +110,22 @@ void RunMod(void) {
             break;
         }
 
-        if (memcmp(magicREAD, modeRx.dat, sizeof(magicREAD)) == 0) {
+        if (modeRx.len == 0) {
+            DbpString(_CYAN_("[@]") " Zero length message");
+            continue;
+        }
+
+        if (modeRx.len == sizeof(magicREAD) && memcmp(magicREAD, modeRx.dat, sizeof(magicREAD)) == 0) {
             DbpString(_CYAN_("[@]") " I am a READER. I talk to a CARD.");
             become_reader();
-        } else if (memcmp(magicCARD, modeRx.dat, sizeof(magicCARD)) == 0) {
+        } else if (modeRx.len == sizeof(magicCARD) && memcmp(magicCARD, modeRx.dat, sizeof(magicCARD)) == 0) {
             DbpString(_CYAN_("[@]") " I am a CARD. I talk to a READER.");
             become_card();
-        } else if (memcmp(magicEND, modeRx.dat, sizeof(magicEND)) == 0) {
+        } else if (modeRx.len == sizeof(magicEND) && memcmp(magicEND, modeRx.dat, sizeof(magicEND)) == 0) {
             break;
+        } else if (modeRx.len == sizeof(magicRSRT) && memcmp(magicRSRT, modeRx.dat, sizeof(magicRSRT)) == 0) {
+            DbpString(_CYAN_("[@]") " Got RESET but already reset.");
+            continue;
         } else {
             DbpString(_YELLOW_("[!]") " unknown mode!");
             Dbhexdump(modeRx.len, modeRx.dat, true);
@@ -142,7 +153,12 @@ static void become_reader(void) {
         WDT_HIT();
 
         read_packet(rx);
-        if (memcmp(magicRSRT, rx->dat, sizeof(magicRSRT)) == 0) break;
+        if (rx->len == sizeof(magicRSRT) && memcmp(magicRSRT, rx->dat, sizeof(magicRSRT)) == 0) break;
+
+        if (BUTTON_PRESS()) {
+            DbpString(_CYAN_("[@]") " Button pressed - Breaking from reader loop");
+            break;
+        }
 
         if (rx->dat[0] == ISO14443A_CMD_RATS && rx->len == 4) {
             // got RATS from reader, reset the card
@@ -206,7 +222,7 @@ static void become_card(void) {
     iso14443a_setup(FPGA_HF_ISO14443A_TAGSIM_LISTEN);
 
     uint8_t tagType;
-    uint16_t flags;
+    uint16_t flags = 0;
     uint8_t data[PM3_CMD_DATA_SIZE] = { 0 };
     packet_t ats = { 0 };
     prepare_emulation(&tagType, &flags, data, &ats);

--- a/common_arm/usb_cdc.c
+++ b/common_arm/usb_cdc.c
@@ -718,6 +718,10 @@ static uint8_t usb_read_ng_buffer[64] = {0};
 static uint8_t usb_read_ng_bufoffset = 0;
 static uint8_t usb_read_ng_buflen = 0;
 
+bool usb_read_ng_has_buffered_data(void) {
+    return usb_read_ng_buflen > 0;
+}
+
 uint32_t usb_read_ng(uint8_t *data, size_t len) {
 
     if (len == 0) {

--- a/common_arm/usb_cdc.h
+++ b/common_arm/usb_cdc.h
@@ -39,6 +39,7 @@ int async_usb_write_start(void);
 void async_usb_write_pushByte(uint8_t data);
 bool async_usb_write_requestWrite(void);
 int async_usb_write_stop(void);
+bool usb_read_ng_has_buffered_data(void);
 uint32_t usb_read_ng(uint8_t *data, size_t len);
 void usb_update_serial(uint64_t newSerialNumber);
 


### PR DESCRIPTION
if packets arrive in quick succession part of the next packet can sit in the buffer which isn't checked by cardhopper resulting in the standalone hanging. this makes it check for data in the internal buffer too preventing that condition.

I expect the same benefit may occur in `recieve_ng` (sic) by changing the `usb_poll_validate_length()` check to be `usb_read_ng_has_buffered_data() || usb_poll_validate_length()` as this does in the cardhopper standalone but it'd need more testing. I've been testing this change with cardhopper for a few months now and I'm confident it's good but haven't tested the same change in `recieve_ng` yet