### PR TITLE
add gdm flag to hf mf c* commands

### DIFF
--- a/armsrc/Standalone/hf_young.c
+++ b/armsrc/Standalone/hf_young.c
@@ -55,7 +55,7 @@ void RunMod(void) {
 
     card_clone_t uids[OPTS];
     iso14a_card_select_t card[OPTS];
-    uint8_t params = (MAGIC_SINGLE | MAGIC_DATAIN);
+    uint8_t params = (MAGIC_SINGLE | MAGIC_WUPC | MAGIC_DATAIN);
 
     LED(selected + 1, 0);
 
@@ -184,7 +184,7 @@ void RunMod(void) {
                             // Mifare UID BCC
                             block0[4] = block0[0]^block0[1]^block0[2]^block0[3]; // BCC on byte 5
                             Bytes 5-7 are reserved SAK and ATQA for mifare classic
-                    -Use mfCSetBlock(0, block0, oldUID, wantWipe, MAGIC_SINGLE) to write it
+                    -Use mfCSetBlock(0, block0, oldUID, wantWipe, MAGIC_SINGLE | MAGIC_WUPC) to write it
             */
             uint8_t oldBlock0[16] = {0}, newBlock0[16] = {0};
             // arg0 = Flags, arg1=blockNo

--- a/client/src/mifare/mifarehost.c
+++ b/client/src/mifare/mifarehost.c
@@ -1058,9 +1058,9 @@ int mfEmlSetMem_xt(uint8_t *data, int blockNum, int blocksCount, int blockBtWidt
 }
 
 // "MAGIC" CARD
-int mfCSetUID(uint8_t *uid, uint8_t uidlen, const uint8_t *atqa, const uint8_t *sak, uint8_t *old_uid, uint8_t *verifed_uid, uint8_t wipecard) {
+int mfCSetUID(uint8_t *uid, uint8_t uidlen, const uint8_t *atqa, const uint8_t *sak, uint8_t *old_uid, uint8_t *verifed_uid, uint8_t wipecard, uint8_t gdm) {
 
-    uint8_t params = MAGIC_SINGLE;
+    uint8_t params = MAGIC_SINGLE | (gdm ? MAGIC_GDM_ALT_WUPC : MAGIC_WUPC);
     uint8_t block0[MFBLOCK_SIZE];
     memset(block0, 0x00, sizeof(block0));
 
@@ -1111,7 +1111,7 @@ int mfCSetUID(uint8_t *uid, uint8_t uidlen, const uint8_t *atqa, const uint8_t *
 
     res = mfCSetBlock(0, block0, NULL, params);
     if (res == PM3_SUCCESS) {
-        params = MAGIC_SINGLE;
+        params = MAGIC_SINGLE | MAGIC_WUPC;
         memset(block0, 0, sizeof(block0));
         res = mfCGetBlock(0, block0, params);
         if (res == 0) {
@@ -1123,13 +1123,13 @@ int mfCSetUID(uint8_t *uid, uint8_t uidlen, const uint8_t *atqa, const uint8_t *
     return res;
 }
 
-int mfCWipe(uint8_t *uid, const uint8_t *atqa, const uint8_t *sak) {
+int mfCWipe(uint8_t *uid, const uint8_t *atqa, const uint8_t *sak, uint8_t gdm) {
     uint8_t block0[MFBLOCK_SIZE] = {0x00, 0x56, 0x78, 0xBB, 0x95, 0x08, 0x04, 0x00, 0x02, 0xB2, 0x1E, 0x24, 0x23, 0x27, 0x1E, 0x1D};
     // uint8_t block0[MFBLOCK_SIZE] = {0x04, 0x03, 0x02, 0x01, 0x04, 0x08, 0x04, 0x00, 0x64, 0xB9, 0x95, 0x11, 0x4D, 0x20, 0x42, 0x09};
     uint8_t blockD[MFBLOCK_SIZE] = {0x00};
     // default transport ACL
     uint8_t blockK[MFBLOCK_SIZE] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x07, 0x80, 0x69, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    uint8_t params = MAGIC_SINGLE;
+    uint8_t params = MAGIC_SINGLE | (gdm ? MAGIC_GDM_ALT_WUPC : MAGIC_WUPC);
 
     if (uid != NULL) {
         memcpy(block0, uid, 4);

--- a/client/src/mifare/mifarehost.h
+++ b/client/src/mifare/mifarehost.h
@@ -92,8 +92,8 @@ int mfEmlGetMem(uint8_t *data, int blockNum, int blocksCount);
 int mfEmlSetMem(uint8_t *data, int blockNum, int blocksCount);
 int mfEmlSetMem_xt(uint8_t *data, int blockNum, int blocksCount, int blockBtWidth);
 
-int mfCSetUID(uint8_t *uid, uint8_t uidlen, const uint8_t *atqa, const uint8_t *sak, uint8_t *old_uid, uint8_t *verifed_uid, uint8_t wipecard);
-int mfCWipe(uint8_t *uid, const uint8_t *atqa, const uint8_t *sak);
+int mfCSetUID(uint8_t *uid, uint8_t uidlen, const uint8_t *atqa, const uint8_t *sak, uint8_t *old_uid, uint8_t *verifed_uid, uint8_t wipecard, uint8_t gdm);
+int mfCWipe(uint8_t *uid, const uint8_t *atqa, const uint8_t *sak, uint8_t gdm);
 int mfCSetBlock(uint8_t blockNo, uint8_t *data, uint8_t *uid, uint8_t params);
 int mfCGetBlock(uint8_t blockNo, uint8_t *data, uint8_t params);
 

--- a/include/protocols.h
+++ b/include/protocols.h
@@ -250,6 +250,8 @@ ISO 7816-4 Basic interindustry commands. For command APDU's.
 // bit 3 - turn on FPGA
 // bit 4 - turn off FPGA
 // bit 5 - set datain instead of issuing USB reply (called via ARM for StandAloneMode14a)
+// bit 6 - wipe tag.
+// bit 7 - use USCUID/GDM (20/23) magic wakeup
 #define MAGIC_UID                   0x01
 #define MAGIC_WUPC                  0x02
 #define MAGIC_HALT                  0x04
@@ -257,7 +259,8 @@ ISO 7816-4 Basic interindustry commands. For command APDU's.
 #define MAGIC_OFF                   0x10
 #define MAGIC_DATAIN                0x20
 #define MAGIC_WIPE                  0x40
-#define MAGIC_SINGLE                (MAGIC_WUPC | MAGIC_HALT | MAGIC_INIT | MAGIC_OFF) //0x1E
+#define MAGIC_GDM_ALT_WUPC          0x80
+#define MAGIC_SINGLE                (MAGIC_HALT | MAGIC_INIT | MAGIC_OFF) //0x1E
 
 // by CMD_HF_MIFARE_CIDENT / Flags
 #define MAGIC_FLAG_NONE          0x0000


### PR DESCRIPTION
this enables the use of hf mf c* commands with gdm/uscuid cards when the alt wake up mode 20(7)/23 is enabled rather than gen1 wake up