### PR TITLE
fix ssp_clk sometimes resetting to 0 shortly after being started or reset

### DIFF
--- a/common_arm/ticks.c
+++ b/common_arm/ticks.c
@@ -149,7 +149,8 @@ void StartCountSspClk(void) {
                              | AT91C_TC_WAVE                // Waveform Mode
                              | AT91C_TC_WAVESEL_UP          // just count
                              | AT91C_TC_ACPA_CLEAR          // Clear TIOA0 on RA Compare
-                             | AT91C_TC_ACPC_SET;           // Set TIOA0 on RC Compare
+                             | AT91C_TC_ACPC_SET            // Set TIOA0 on RC Compare
+                             | AT91C_TC_ASWTRG_SET;         // Set TIOA0 on software trigger to trigger instant reset of TC2
     AT91C_BASE_TC0->TC_RA = 1;                              // RA Compare value = 1; pulse width to TC2
     AT91C_BASE_TC0->TC_RC = 0;                              // RC Compare value = 0; increment TC2 on overflow
 
@@ -191,8 +192,8 @@ void StartCountSspClk(void) {
     // whenever the last three bits of our counter go 0, we can be sure to be in the middle of a frame transfer.
     // (just started with the transfer of the 4th Bit).
 
-    // The high word of the counter (TC2) will not reset until the low word (TC0) overflows.
-    // Therefore need to wait quite some time before we can use the counter.
+    // The high word of the counter (TC2) will not reset until the low word (TC0) clocks to process the external trigger.
+    // Therefore may need to wait a little bit before we can use the counter.
     while (AT91C_BASE_TC2->TC_CV > 0);
 }
 void ResetSspClk(void) {
@@ -336,4 +337,3 @@ void StopTicks(void) {
     AT91C_BASE_TC0->TC_CCR = AT91C_TC_CLKDIS;
     AT91C_BASE_TC1->TC_CCR = AT91C_TC_CLKDIS;
 }
-


### PR DESCRIPTION
this could happen if TC2 was already 0 when it was started or reset resulting in the initial reset not happening until TC0 had overflowed for the first time as the delay to ensure this didn't happen would be missed when TC2 was already 0

the new behaviour results in TIOA0 being toggled when a software trigger of TC0 happens which makes TC2 reset immediately without having to wait for TC0 to overflow

I tested this quite thoroughly with all the edge cases I could think of around calls to `StartCountSspClk` and `ResetSspClk` and it seems to be doing the right thing now in all cases (eg TC2 starts at 0 after either function returns and increments exactly once each time TC0 overflows regardless of the initial value of TC2 when when the functions are called).

This fixes #2611 - I suspect the GCC version was resulting in slightly different timings due to better or worse optimisations in the code.

As an aside it should make calls to `StartCountSspClk` very slightly faster now too as it doesn't have to wait for the initial overflow of TC0 anymore