### PR TITLE
Fixed elite configcard generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `hf iclass configcard` when generating elite or keyroll elite configcards for Rev.C legacy readers (@antiklesys)
 - Changed `hf mf c*` - now accepts a --gdm flag to write using uscuid/gdm 20/23 alt magic wakeup (@nvx)
 - Changed `pm3_console()` - Python/Lua/C: replace `passthru` by `capture` and `quiet` (@doegox)
 - Fixed `hf iclass list` - annotation crc handled better (@iceman1001)

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -500,10 +500,14 @@ static int generate_config_card(const iclass_config_card_item_t *o,  uint8_t *ke
             memcpy(data + (0x0D * 8), lkey, sizeof(enckey1));
         }
         // encrypted 0xFF
-        for (uint8_t i = 0x0E; i < 0x14; i++) {
+        for (uint8_t i = 0x0E; i < 0x13; i++) {
             memcpy(data + (i * 8), ffs, sizeof(ffs));
         }
         PrintAndLogEx(NORMAL, "( " _GREEN_("ok") " )");
+
+        //Block 13 (This is needed for Rev.C readers!)
+        uint8_t block_0x13[PICOPASS_BLOCK_SIZE] = {0x03,0x00,0x00,0x00,0x00,0x00,0x00,0x1C};
+        memcpy(data + (0x13 * 8), block_0x13, sizeof(block_0x13));
 
         // encrypted partial keyroll key 14
         PrintAndLogEx(INFO, "Setting encrypted partial key14... " NOLF);


### PR DESCRIPTION
Fixed elite configcard generation. From nfc-iclass and other resources block 13 generation was completely missing. This resulted in configcards for legacy readers to be working on Rev.A readers but not Rev.C readers when it came to setting elite keys or enabling keyrolling.