### PR TITLE
Fixed keygen bug in legrec

### DIFF
--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -2314,9 +2314,9 @@ void iClass_Recover(iclass_recover_req_t *msg) {
             }
         }
 
-        if (msg->test) {
         //Step3 Calculate New Key (Optimised Algo V2)
         generate_single_key_block_inverted_opt(zero_key, index, genkeyblock);
+        if (msg->test) {
             memcpy(genkeyblock, zero_key, PICOPASS_BLOCK_SIZE);
         }
 


### PR DESCRIPTION
Fixed legrec bug that was generating blank keys after one line of code misalignment in commit: 110dfab668307ba2ed5f320bf6ea6200f9a91a97