### PR TITLE
Move and Rename Static Mifare Classic Write Block Function

### DIFF
--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -6769,9 +6769,9 @@ skipfile:
             }
 
             // write to card,  try B key first
-            if (mfWriteBlock(keyB[i], MF_KEY_B, b, block) != PM3_SUCCESS) {
+            if (mfWriteBlock(b, MF_KEY_B, keyB[i], block) != PM3_SUCCESS) {
                 // try A key,
-                if (mfWriteBlock(keyA[i], MF_KEY_A, b, block) != PM3_SUCCESS) {
+                if (mfWriteBlock(b, MF_KEY_A, keyA[i], block) != PM3_SUCCESS) {
                     return PM3_EFAILED;
                 }
             }
@@ -7012,10 +7012,11 @@ int CmdHFMFNDEFWrite(const char *Cmd) {
         }
 
         // write to card,  try B key first
-        if (mfWriteBlock(g_mifare_default_key, MF_KEY_B, block_no, block) != PM3_SUCCESS) {
+        if (mfWriteBlock(block_no,  MF_KEY_B, g_mifare_default_key, block) != PM3_SUCCESS) {
 
             // try A key,
-            if (mfWriteBlock(g_mifare_ndef_key, MF_KEY_A, block_no, block) != PM3_SUCCESS) {
+    
+            if (mfWriteBlock(block_no, MF_KEY_A, g_mifare_ndef_key, block) != PM3_SUCCESS) {
                 return PM3_EFAILED;
             }
         }
@@ -9492,8 +9493,8 @@ static int CmdHFMFHidEncode(const char *Cmd) {
             PrintAndLogEx(INFO, "Writing %u - %s", (i + 1), sprint_hex_inrow(blocks + (i * MFBLOCK_SIZE), MFBLOCK_SIZE));
         }
 
-        if (mfWriteBlock(empty, MF_KEY_A, (i + 1), blocks + (i * MFBLOCK_SIZE)) == PM3_EFAILED) {
-            if (mfWriteBlock(empty, MF_KEY_B, (i + 1), blocks + (i * MFBLOCK_SIZE)) == PM3_EFAILED) {
+        if (mfWriteBlock((i + 1), MF_KEY_A, empty, blocks + (i * MFBLOCK_SIZE)) == PM3_EFAILED) {
+            if (mfWriteBlock((i + 1), MF_KEY_B, empty, blocks + (i * MFBLOCK_SIZE)) == PM3_EFAILED) {
                 PrintAndLogEx(WARNING, "failed writing block %d using default empty key", (i + 1));
                 res = false;
                 break;

--- a/client/src/mifare/mifarehost.c
+++ b/client/src/mifare/mifarehost.c
@@ -994,7 +994,7 @@ int mfReadBlock(uint8_t blockNo, uint8_t keyType, const uint8_t *key, uint8_t *d
     return PM3_SUCCESS;
 }
 
-int mfWriteBlock(const uint8_t *key, uint8_t keytype, uint8_t blockno, uint8_t *block) {
+int mfWriteBlock(uint8_t blockno, uint8_t keyType, const uint8_t *key, uint8_t *block) {
 
     uint8_t data[26];
     memcpy(data, key, MIFARE_KEY_SIZE);
@@ -1009,6 +1009,10 @@ int mfWriteBlock(const uint8_t *key, uint8_t keytype, uint8_t blockno, uint8_t *
     }
 
     return ((resp.oldarg[0] & 0xff) == 1)?PM3_SUCCESS:PM3_EFAILED;
+}
+
+int mfWriteSector(uint8_t sectorNo, uint8_t keyType, const uint8_t *key, uint8_t *sector){
+    
 }
 
 // EMULATOR

--- a/client/src/mifare/mifarehost.c
+++ b/client/src/mifare/mifarehost.c
@@ -994,6 +994,23 @@ int mfReadBlock(uint8_t blockNo, uint8_t keyType, const uint8_t *key, uint8_t *d
     return PM3_SUCCESS;
 }
 
+int mfWriteBlock(const uint8_t *key, uint8_t keytype, uint8_t blockno, uint8_t *block) {
+
+    uint8_t data[26];
+    memcpy(data, key, MIFARE_KEY_SIZE);
+    memcpy(data + 10, block, MFBLOCK_SIZE);
+
+    clearCommandBuffer();
+    SendCommandMIX(CMD_HF_MIFARE_WRITEBL, blockno, keytype, 0, data, sizeof(data));
+    PacketResponseNG resp;
+    if (WaitForResponseTimeout(CMD_ACK, &resp, 1500) == false) {
+        PrintAndLogEx(FAILED, "mfWriteBlock execution time out");
+        return PM3_ETIMEOUT;
+    }
+
+    return ((resp.oldarg[0] & 0xff) == 1)?PM3_SUCCESS:PM3_EFAILED;
+}
+
 // EMULATOR
 int mfEmlGetMem(uint8_t *data, int blockNum, int blocksCount) {
 

--- a/client/src/mifare/mifarehost.c
+++ b/client/src/mifare/mifarehost.c
@@ -1012,7 +1012,14 @@ int mfWriteBlock(uint8_t blockno, uint8_t keyType, const uint8_t *key, uint8_t *
 }
 
 int mfWriteSector(uint8_t sectorNo, uint8_t keyType, const uint8_t *key, uint8_t *sector){
-    
+    int res;
+    for (int i=0;i<4; i++){
+        res = mfWriteBlock((sectorNo*4)+i, keyType, key, sector+(i*MFBLOCK_SIZE));
+        if (res != PM3_SUCCESS){
+            return (i==0)?PM3_EFAILED:PM3_EPARTIAL;
+        }
+    }
+    return PM3_SUCCESS;
 }
 
 // EMULATOR

--- a/client/src/mifare/mifarehost.h
+++ b/client/src/mifare/mifarehost.h
@@ -88,8 +88,7 @@ int mfKeyBrute(uint8_t blockNo, uint8_t keyType, const uint8_t *key, uint64_t *r
 int mfReadSector(uint8_t sectorNo, uint8_t keyType, const uint8_t *key, uint8_t *data);
 int mfReadBlock(uint8_t blockNo, uint8_t keyType, const uint8_t *key, uint8_t *data);
 
-int mfWriteBlock(const uint8_t *key, uint8_t keytype, uint8_t blockno, uint8_t *block);
-
+int mfWriteBlock(uint8_t blockno, uint8_t keyType, const uint8_t *key, uint8_t *block);
 int mfEmlGetMem(uint8_t *data, int blockNum, int blocksCount);
 int mfEmlSetMem(uint8_t *data, int blockNum, int blocksCount);
 int mfEmlSetMem_xt(uint8_t *data, int blockNum, int blocksCount, int blockBtWidth);

--- a/client/src/mifare/mifarehost.h
+++ b/client/src/mifare/mifarehost.h
@@ -88,6 +88,8 @@ int mfKeyBrute(uint8_t blockNo, uint8_t keyType, const uint8_t *key, uint64_t *r
 int mfReadSector(uint8_t sectorNo, uint8_t keyType, const uint8_t *key, uint8_t *data);
 int mfReadBlock(uint8_t blockNo, uint8_t keyType, const uint8_t *key, uint8_t *data);
 
+int mfWriteBlock(const uint8_t *key, uint8_t keytype, uint8_t blockno, uint8_t *block);
+
 int mfEmlGetMem(uint8_t *data, int blockNum, int blocksCount);
 int mfEmlSetMem(uint8_t *data, int blockNum, int blocksCount);
 int mfEmlSetMem_xt(uint8_t *data, int blockNum, int blocksCount, int blockBtWidth);

--- a/client/src/mifare/mifarehost.h
+++ b/client/src/mifare/mifarehost.h
@@ -89,6 +89,8 @@ int mfReadSector(uint8_t sectorNo, uint8_t keyType, const uint8_t *key, uint8_t 
 int mfReadBlock(uint8_t blockNo, uint8_t keyType, const uint8_t *key, uint8_t *data);
 
 int mfWriteBlock(uint8_t blockno, uint8_t keyType, const uint8_t *key, uint8_t *block);
+int mfWriteSector(uint8_t sectorNo, uint8_t keyType, const uint8_t *key, uint8_t *sector);
+
 int mfEmlGetMem(uint8_t *data, int blockNum, int blocksCount);
 int mfEmlSetMem(uint8_t *data, int blockNum, int blocksCount);
 int mfEmlSetMem_xt(uint8_t *data, int blockNum, int blocksCount, int blockBtWidth);


### PR DESCRIPTION
`src/mifare/mifarehost.[c/h]` implements `mfReadBlock` and `mfReadSector` so I was expecting to also find `mfWriteBlock` and `mfWriteSector`, but they don't exist. Looking a little further and `cmdhfmf.c` used a static `function static bool mf_write_block` for this. 
As I want to use it in a hf gallagher extension I'd like it to not be static.

The other similar functions mentioned above return a PM3 status enum rather than bool's, so I also lightly refactored the uses of `mfWriteSector` to check for `PM3_SUCCESS` or similar.

I did read

> Function names should be separated_with_underscores(), except for standard functions (memcpy, etc.). It may make sense to break this rule for very common, generic functions that look like library functions (e.g. dprintf()). 

However the other functions within `src/mifare/mifarehost.[c/h]` don't follow this convention, and I didn't want this to turn into a major refactor.

