### PR TITLE
Ability to force MAD decode

### DIFF
--- a/client/pyscripts/fm11rf08_full.py
+++ b/client/pyscripts/fm11rf08_full.py
@@ -166,7 +166,7 @@ globals:
     # Currently dumpAcl is hardcoded for RF08S
     dumpAcl(data)
 
-    if mad is True:
+    if (mad is True) or (args.mad is True):
         dumpMad(dump18)
 
     if (args.bambu is True) or (detectBambu(data) is True):
@@ -207,6 +207,7 @@ def parseCli():
     parser.add_argument('-r', '--recover',  action='store_true', help='run key recovery script if required')
     parser.add_argument('-f', '--force',    action='store_true', help='force recovery of keys')
     parser.add_argument('-b', '--bambu',    action='store_true', help='force Bambu tag decode')
+    parser.add_argument('-m', '--mad',      action='store_true', help='force M.A.D. decode')
     parser.add_argument('-v', '--validate', action='store_true', help='check Fudan signature (requires internet)')
     parser.add_argument('--fast', action='store_true', help='use ecfill for faster card transactions')
 

--- a/client/pyscripts/fm11rf08_full.py
+++ b/client/pyscripts/fm11rf08_full.py
@@ -978,7 +978,7 @@ globals:
     lprint("====================================")
     lprint()
 
-    cmd = f"hf mf mad --verbose --file {dump18}"
+    cmd = f"hf mf mad --force --verbose --file {dump18}"
     lprint(f"`{cmd}`", log=False)
 
     lprint('\n`-._,-\'"`-._,-"`-._,-\'"`-._,-\'"`-._,-\'"`-._,-\'"`-._,-\'"`-._,-\'"`-._,\n')

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -6171,7 +6171,8 @@ static int CmdHF14AMfMAD(const char *Cmd) {
         arg_lit0("b",  "keyb",     "use key B for access printing sectors (by default: key A)"),
         arg_lit0(NULL, "be",       "(optional, BigEndian)"),
         arg_lit0(NULL, "dch",      "decode Card Holder information"),
-        arg_str0("f", "file",      "<fn>", "load dump file and decode MAD"),
+        arg_str0("f",  "file",     "<fn>", "load dump file and decode MAD"),
+        arg_lit0(NULL, "force",    "force decode (skip key check)"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
@@ -6185,6 +6186,7 @@ static int CmdHF14AMfMAD(const char *Cmd) {
     bool keyB = arg_get_lit(ctx, 4);
     bool swapmad = arg_get_lit(ctx, 5);
     bool decodeholder = arg_get_lit(ctx, 6);
+    bool force = arg_get_lit(ctx, 8);
 
     int fnlen = 0;
     char filename[FILE_PATH_SIZE] = {0};
@@ -6214,7 +6216,7 @@ static int CmdHF14AMfMAD(const char *Cmd) {
         }
 
         // MAD detection
-        if (HasMADKey(dump) == false) {
+        if ((HasMADKey(dump) == false) && (force == false)) {
             PrintAndLogEx(FAILED, "No MAD key was detected in the dump file");
             free(dump);
             return PM3_ESOFT;


### PR DESCRIPTION
MAD data is not autodetected unless keys are recovered.
With the FM11RF08S (and siblings) it is possible to retrieve the data and never know the keys.
If the data is MAD, but the keys are missing `hf mf mad` refuses to decode the data.
This patch adds the `--force` switch to the core functionality, and `--mad` to fm11rf08s_full.py so the user can decode MAD data even when the keys are not known.
