### PR TITLE
add option to build against non-default python3 package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Added option to build against non-default python3 (@ANTodorov)
 - Changed `hf 14a info` `hf mf info` - now detects FM1216-137 CPU cards (@iceman1001)
 - Changed `hf iclass configcard` expanding the list of available options and functionalities (@antiklesys)
 - Fixed `intertic.py` - missing comma in array (@iceman1001)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -53,7 +53,7 @@ USERMOD = usermod -aG
 ADDUSER = adduser
 GETENT_BL = getent group bluetooth
 
-
+PYTHON3_PKGCONFIG ?=   python3
 
 PATHSEP=/
 PREFIX ?=              /usr/local

--- a/client/Makefile
+++ b/client/Makefile
@@ -282,15 +282,15 @@ endif
 ## Python3 (optional)
 ifneq ($(SKIPPYTHON),1)
 # since python3.8, applications willing to embed python must use -embed:
-    PYTHONINCLUDES = $(shell $(PKG_CONFIG_ENV) pkg-config --cflags python3-embed 2>/dev/null)
-    PYTHONLDLIBS = $(shell $(PKG_CONFIG_ENV) pkg-config --libs python3-embed 2>/dev/null)
+    PYTHONINCLUDES = $(shell $(PKG_CONFIG_ENV) pkg-config --cflags $(PYTHON3_PKGCONFIG)-embed 2>/dev/null)
+    PYTHONLDLIBS = $(shell $(PKG_CONFIG_ENV) pkg-config --libs $(PYTHON3_PKGCONFIG)-embed 2>/dev/null)
     ifneq ($(PYTHONLDLIBS),)
         PYTHONLIBLD = $(PYTHONLDLIBS)
         PYTHONLIBINC = $(subst -I,-isystem ,$(PYTHONINCLUDES))
         PYTHON_FOUND = 1
     else
-        PYTHONINCLUDES = $(shell $(PKG_CONFIG_ENV) pkg-config --cflags python3 2>/dev/null)
-        PYTHONLDLIBS = $(shell $(PKG_CONFIG_ENV) pkg-config --libs python3 2>/dev/null)
+        PYTHONINCLUDES = $(shell $(PKG_CONFIG_ENV) pkg-config --cflags $(PYTHON3_PKGCONFIG) 2>/dev/null)
+        PYTHONLDLIBS = $(shell $(PKG_CONFIG_ENV) pkg-config --libs $(PYTHON3_PKGCONFIG) 2>/dev/null)
         ifneq ($(PYTHONLDLIBS),)
             PYTHONLIBLD = $(PYTHONLDLIBS)
             PYTHONLIBINC = $(subst -I,-isystem ,$(PYTHONINCLUDES))
@@ -531,7 +531,7 @@ ifeq ($(SKIPPYTHON),1)
         $(info Python3 library:   skipped)
 else
     ifeq ($(PYTHON_FOUND),1)
-        $(info Python3 library:   Python3 v$(shell $(PKG_CONFIG_ENV) pkg-config --modversion python3) found, enabled)
+        $(info Python3 library:   Python3 v$(shell $(PKG_CONFIG_ENV) pkg-config --modversion $(PYTHON3_PKGCONFIG)) found, enabled)
     else
         $(info Python3 library:   Python3 not found, disabled)
     endif

--- a/doc/md/Use_of_Proxmark/0_Compilation-Instructions.md
+++ b/doc/md/Use_of_Proxmark/0_Compilation-Instructions.md
@@ -10,6 +10,7 @@
     - [Compile for generic Proxmark3 platforms](#compile-for-generic-proxmark3-platforms)
   - [Get the latest commits](#get-the-latest-commits)
   - [Clean and compile everything](#clean-and-compile-everything)
+    - [if there are different python3 packages installed](#if-there-are-different-python3-packages-installed)
     - [if you got an error](#if-you-got-an-error)
   - [Install](#install)
   - [Flash the BOOTROM & FULLIMAGE](#flash-the-bootrom--fullimage)
@@ -54,6 +55,15 @@ git pull
 
 ```sh
 make clean && make -j
+```
+
+### if there are different python3 packages installed
+^[Top](#top)
+
+It is possible to point to a different python3 package. For example, to build against Python3.11:
+
+```sh
+make clean && make -j PYTHON3_PKGCONFIG=python-3.11
 ```
 
 ### if you got an error

--- a/docker/opensuse-leap/Dockerfile
+++ b/docker/opensuse-leap/Dockerfile
@@ -2,14 +2,14 @@ FROM opensuse/leap
 
 ENV LANG=C
 # libqt5-qtbase-devel skipped
-RUN zypper --non-interactive install --no-recommends shadow sudo git patterns-devel-base-devel_basis gcc-c++ readline-devel libbz2-devel liblz4-devel bluez-devel python3-devel libopenssl-devel gd-devel
+RUN zypper --non-interactive install --no-recommends shadow sudo git patterns-devel-base-devel_basis gcc-c++ readline-devel libbz2-devel liblz4-devel bluez-devel python311-devel libopenssl-devel gd-devel
 
 RUN zypper addrepo https://download.opensuse.org/repositories/home:wkazubski/15.6/home:wkazubski.repo && \
     zypper --gpg-auto-import-keys refresh && \
     zypper --non-interactive install cross-arm-none-eabi-gcc13 cross-arm-none-eabi-newlib
 
-RUN zypper --non-interactive install cmake python3 python3-pip && \
-    python3 -m pip install ansicolors sslcrypto
+RUN zypper --non-interactive install cmake python311 python311-pip && \
+    python3.11 -m pip install ansicolors sslcrypto
 
 RUN zypper --non-interactive install ocl-icd-devel
 


### PR DESCRIPTION
Tested in the following docker containers
* opensuse-leap - just `make` is failing, `make PYTHON3_PKGCONFIG=python-3.11` succeed
* opensuse-tumbleweed - just `make` succeed, as expected
* debian-13-trixie - just `make` succeed, as expected

So, the patch is properly activated only when the make variable is defined
