### PR TITLE
revert opensuse-leap docker to default Python 3.6

### DIFF
--- a/docker/opensuse-leap/Dockerfile
+++ b/docker/opensuse-leap/Dockerfile
@@ -2,14 +2,14 @@ FROM opensuse/leap
 
 ENV LANG=C
 # libqt5-qtbase-devel skipped
-RUN zypper --non-interactive install --no-recommends shadow sudo git patterns-devel-base-devel_basis gcc-c++ readline-devel libbz2-devel liblz4-devel bluez-devel python311-devel libopenssl-devel gd-devel
+RUN zypper --non-interactive install --no-recommends shadow sudo git patterns-devel-base-devel_basis gcc-c++ readline-devel libbz2-devel liblz4-devel bluez-devel python3-devel libopenssl-devel gd-devel
 
 RUN zypper addrepo https://download.opensuse.org/repositories/home:wkazubski/15.6/home:wkazubski.repo && \
     zypper --gpg-auto-import-keys refresh && \
     zypper --non-interactive install cross-arm-none-eabi-gcc13 cross-arm-none-eabi-newlib
 
-RUN zypper --non-interactive install cmake python311 python311-pip && \
-    python3.11 -m pip install ansicolors sslcrypto
+RUN zypper --non-interactive install cmake python3 python3-pip && \
+    python3 -m pip install ansicolors sslcrypto
 
 RUN zypper --non-interactive install ocl-icd-devel
 


### PR DESCRIPTION
@doegox  forgot to restore the opensuse-leap/Dockerfile changes when reworking commit https://github.com/RfidResearchGroup/proxmark3/commit/39c846ada4832a874a1744bc45851b385857f6cb