### PR TITLE
Do not respond to mifare simulation sectors out of bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `hf mf sim` not to respond to authentication attempts for sectors out of bound for selected Mifare type (@piotrva)
 - Added option to build against non-default python3 with CMake as well (@doegox)
 - Added option to build against non-default python3 with Makefile (@ANTodorov)
 - Changed `hf 14a info` `hf mf info` - now detects FM1216-137 CPU cards (@iceman1001)

--- a/armsrc/mifaresim.c
+++ b/armsrc/mifaresim.c
@@ -478,6 +478,7 @@ void Mifare1ksim(uint16_t flags, uint8_t exitAfterNReads, uint8_t *uid, uint16_t
 
     uint8_t cardWRBL = 0;
     uint8_t cardAUTHSC = 0;
+    uint8_t cardMaxSEC = MifareMaxSector(flags);
     uint8_t cardAUTHKEY = AUTHKEYNONE;  // no authentication
     uint32_t cardRr = 0;
     uint32_t ans = 0;
@@ -784,7 +785,7 @@ void Mifare1ksim(uint16_t flags, uint8_t exitAfterNReads, uint8_t *uid, uint16_t
                     if (g_dbglevel >= DBG_EXTENDED) Dbprintf("[MFEMUL_WORK] KEY %c: %012" PRIx64, (cardAUTHKEY == 0) ? 'A' : 'B', emlGetKey(cardAUTHSC, cardAUTHKEY));
 
                     // sector out of range - do not respond
-                    if (cardAUTHSC >= MifareMaxSector(flags)) {
+                    if (cardAUTHSC >= cardMaxSEC) {
                         cardAUTHKEY = AUTHKEYNONE; // not authenticated
                         cardSTATE_TO_IDLE();
                         if (g_dbglevel >= DBG_EXTENDED) Dbprintf("[MFEMUL_WORK] Out of range sector %d(0x%02x)", cardAUTHSC, cardAUTHSC);


### PR DESCRIPTION
This change causes `hf mf sim` not to respond for auth attempts for sectors that are out of range for a selected mifare type.
This prevents some readers to always identify simulated card as Mifare Classic 4k

Resolves #2635