### PR TITLE
fixed symlink name in mem spiffs tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- fixed symlink name in `mem spiffs tree` (@ANTodorov)
 - Updated atrs list (@iceman1001)
 - Added support for a new KDF (@iceman1001)
 - Added Inner range aid and mad entries (@iceman1001)

--- a/armsrc/spiffs.c
+++ b/armsrc/spiffs.c
@@ -651,8 +651,11 @@ void rdv40_spiffs_safe_print_tree(void) {
 
             read_from_spiffs((char *)pe->name, (uint8_t *)linkdest, SPIFFS_OBJ_NAME_LEN);
             sprintf(resolvedlink, "(.lnk) --> %s", linkdest);
-            // Kind of stripping the .lnk extension
-            strtok((char *)pe->name, ".");
+            char *linkname = (char *)pe->name;
+            int len = strlen(linkname);
+            if (len >= 4 && strcmp(&linkname[len - 4], ".lnk") == 0) {
+                linkname[len - 4] = '\0';
+            }
         }
 
         Dbprintf("[%04x] " _YELLOW_("%5i") " B |-- %s%s", pe->obj_id, pe->size, pe->name, resolvedlink);


### PR DESCRIPTION
the used strtok(...,".")` is cutting the name to the first dot linkname.txt.lnk -> linkname

![Screenshot from 2024-11-21 14-13-39](https://github.com/user-attachments/assets/57e2fa90-f2e6-4e43-95f6-09591675d587)

with the fix it is
linkname.txt.lnk -> linkname.txt

![Screenshot from 2024-11-21 14-14-55](https://github.com/user-attachments/assets/c3db0dac-c715-40f5-837e-5c5dee75affa)
