### PR TITLE
add new exes to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ tools/mfd_aes_brute/mfd_aes_brute
 tools/mfd_aes_brute/mfd_multi_brute
 tools/mfd_aes_brute/brute_key
 !tools/lena.bmp
+tools/mf_nonce_brute/
+tools/mfkey/
+tools/nonce2key/
 
 fpga/__build*
 


### PR DESCRIPTION
make is creating exes which are being caught by `git add -A` (and other commands)

```
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        tools/mf_nonce_brute/
        tools/mfkey/
        tools/nonce2key/
```