### PR TITLE
Add option to set and get maximum read/write block number using hf_mf_ultimatecard script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Add option to set and get maximum read/write block number using `hf_mf_ultimatecard` script (@piotrva)
 - Added special iclass legacy config cards in `hf iclass configcard` (@antiklesys)
 - Added simulation function to `hf iclass legrec` (@antiklesys)
 

--- a/client/luascripts/hf_mf_ultimatecard.lua
+++ b/client/luascripts/hf_mf_ultimatecard.lua
@@ -51,17 +51,17 @@ arguments = [[
     -u      UID (8-20 hexsymbols), set UID on tag
     -t      tag type to impersonate
                  1 = Mifare Mini S20 4-byte
-                 2 = Mifare Mini S20 7-byte 15 = NTAG 210
-                 3 = Mifare Mini S20 10-byte 16 = NTAG 212
-                 4 = Mifare 1k S50 4-byte   17 = NTAG 213
-                 5 = Mifare 1k S50 7-byte   18 = NTAG 215
-                 6 = Mifare 1k S50 10-byte  19 = NTAG 216
-                 7 = Mifare 4k S70 4-byte   20 = NTAG I2C 1K
-                 8 = Mifare 4k S70 7-byte   21 = NTAG I2C 2K
-                 9 = Mifare 4k S70 10-byte  22 = NTAG I2C 1K PLUS
-            ***  10 = UL -   NOT WORKING FULLY   23 = NTAG I2C 2K PLUS
-            ***  11 = UL-C - NOT WORKING FULLY   24 = NTAG 213F
-                 12 = UL EV1 48b                25 = NTAG 216F
+                 2 = Mifare Mini S20 7-byte     |  15 = NTAG 210
+                 3 = Mifare Mini S20 10-byte    |  16 = NTAG 212
+                 4 = Mifare 1k S50 4-byte       |  17 = NTAG 213
+                 5 = Mifare 1k S50 7-byte       |  18 = NTAG 215
+                 6 = Mifare 1k S50 10-byte      |  19 = NTAG 216
+                 7 = Mifare 4k S70 4-byte       |  20 = NTAG I2C 1K
+                 8 = Mifare 4k S70 7-byte       |  21 = NTAG I2C 2K
+                 9 = Mifare 4k S70 10-byte      |  22 = NTAG I2C 1K PLUS
+            ***  10 = UL -   NOT WORKING FULLY  |  23 = NTAG I2C 2K PLUS
+            ***  11 = UL-C - NOT WORKING FULLY  |  24 = NTAG 213F
+                 12 = UL EV1 48b                |  25 = NTAG 216F
                  13 = UL EV1 128b
             ***  14 = UL Plus - NOT WORKING YET
 

--- a/client/luascripts/hf_mf_ultimatecard.lua
+++ b/client/luascripts/hf_mf_ultimatecard.lua
@@ -186,6 +186,7 @@ local function read_config()
     end
     -- extract data from CONFIG - based on CONFIG in https://github.com/RfidResearchGroup/proxmark3/blob/master/doc/magic_cards_notes.md#gen-4-gtu
     ulprotocol, uidlength, readpass, gtumode, ats, atqa1, atqa2, sak, ulmode = magicconfig:sub(1,2), magicconfig:sub(3,4), magicconfig:sub(5,12), magicconfig:sub(13,14), magicconfig:sub(15,48), magicconfig:sub(51,52), magicconfig:sub(49,50), magicconfig:sub(53,54), magicconfig:sub(55,56)
+    maxRWblk = magicconfig:sub(57, 58)
     atqaf = atqa1..' '..atqa2
     cardtype, cardprotocol, gtustr, atsstr = 'unknown', 'unknown', 'unknown', 'unknown'
     if magicconfig == nil then lib14a.disconnect(); return nil, "can't read configuration, "..err_lock end
@@ -291,6 +292,7 @@ local function read_config()
         print(' - Version      ', cversion)
         print(' - Signature    ', signature1..signature2)
     end
+    print(' - Max R/W Block  ', maxRWblk)
     end
 lib14a.disconnect()
 return true, 'Ok'


### PR DESCRIPTION
As this was not covered before in the script mentioned I made few changes:

1. Added display of maximum read/write block to read magic configuration option
2. Added `-b` argument to set maximum read/write block
3. Needed to split argument string because reached lua maximum string length
4. Refactored help for `-t` option to increase readability, because already reached the limit explained above

Tested with two exactly same unbranded UMC's I own.