### PR TITLE
R&Y: Updated DEN MyRide AID in aid_desfire.json

### DIFF
--- a/client/resources/aid_desfire.json
+++ b/client/resources/aid_desfire.json
@@ -1065,10 +1065,10 @@
     },
     {
         "AID": "DD00DD",
-        "Vendor": "Regional Transporation District (RTD) via masabi justride",
+        "Vendor": "Regional Transporation District (RTD) via Masabi Ltd",
         "Country": "US",
         "Name": "MyRide Card (DEN)",
-        "Description": "DEN MyRide Card",
+        "Description": "DEN MyRide Card; Masabi Justride Tap and Ride DESFire Smartcard",
         "Type": "transport"
     },
     {


### PR DESCRIPTION
- Updated Vendor to its legal name (Masabi Ltd).
- Added a standardised description to identify the AID as being issued by Masabi Ltd for its Justride platform.

Thank you.

-R&Y.