### PR TITLE
fis MF3ICD40 (D40) secure channel crypto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed DESFire D40 secure channel crypto (@nvx)
 - Fixed `hf mfp info` fix signature check on 4b UID cards (@doegox)
 - Automatically set maximum read/write block when using predefined types in `hf_mf_ultimatecard` script (@piotrva)
 - Changed SPI flash detection to calculate the size instead of table lookup, updated spi_flash_decode.py script with more ICs (@ANTodorov)

--- a/client/src/mifare/desfirecore.c
+++ b/client/src/mifare/desfirecore.c
@@ -1222,14 +1222,17 @@ static int DesfireAuthenticateEV1(DesfireContext_t *dctx, DesfireSecureChannel s
 
     // - Encrypt our response
     if (secureChannel == DACd40) {
+        // Original DESFire (MF3ICD40) silicon can only do encryption operations, so all PCD
+        // side operations must be decrypt, even when encrypting when doing D40 compatible
+        // secure channel operations
         memset(IV, 0, DESFIRE_MAX_CRYPTO_BLOCK_SIZE);
-        DesfireCryptoEncDecEx(dctx, DCOMainKey, RndA, rndlen, encRndA, true, true, IV);
+        DesfireCryptoEncDecEx(dctx, DCOMainKey, RndA, rndlen, encRndA, true, false, IV);
 
         memcpy(both, encRndA, rndlen);
         bin_xor(rotRndB, encRndA, rndlen);
 
         memset(IV, 0, DESFIRE_MAX_CRYPTO_BLOCK_SIZE);
-        DesfireCryptoEncDecEx(dctx, DCOMainKey, rotRndB, rndlen, encRndB, true, true, IV);
+        DesfireCryptoEncDecEx(dctx, DCOMainKey, rotRndB, rndlen, encRndB, true, false, IV);
 
         memcpy(both + rndlen, encRndB, rndlen);
     } else if (secureChannel == DACEV1) {

--- a/client/src/mifare/desfiresecurechan.c
+++ b/client/src/mifare/desfiresecurechan.c
@@ -313,6 +313,10 @@ static void DesfireSecureChannelEncodeD40(DesfireContext_t *ctx, uint8_t cmd, ui
         size_t srcmaclen = padded_data_length(srcdatalen - hdrlen, desfire_get_key_block_length(ctx->keyType));
 
         uint8_t mac[32] = {0};
+        PrintAndLogEx(DEBUG, "MACing");
+        // Even though original DESFire (MF3ICD40) silicon can only encrypt which means normally
+        // every PCD operation must be decrypt, verifying a MAC involves the same operation on both
+        // sides so this is still encrypt here
         DesfireCryptoEncDecEx(ctx, DCOSessionKeyMac, data, srcmaclen, NULL, true, true, mac);
 
         if (DesfireEV1D40TransmitMAC(ctx, cmd)) {
@@ -889,4 +893,3 @@ bool PrintChannelModeWarning(uint8_t cmd, DesfireSecureChannel secureChannel, De
 
     return found;
 }
-


### PR DESCRIPTION
I noticed D40 secure channel auth was broken. The original D40 silicon can only perform encryption operations so any data encryption PCD side must be done with the DES decrypt primitive. MAC calculation still needs to be done with the DES encrypt primitive though.

I added a couple of comments which should help the next person touching the code too.

Due to a weird quirk of DES that I only learnt just now, DES encryption with a key of all zeros is identical to DES decryption with  key of all zeros so the issue doesn't exhibit if you're testing with a factory defaulted card using zero'd keys, but it's easy enough to change the keys to test.

Previous broken behaviour shown below, note this is against a DESFire EV2 card, so can use EV1 auth to verify the keys are correct, while the D40 secure channel fails. With this patch both commands succeed. I also tested PCD MAC'd packets and they were already correct (eg doing a `hf mfd write` with the communication mode set to MAC) and indeed swapping the encryption primitive there breaks it (I did add a helpful comment there though)
```
[usb] pm3 --> hf mfd createapp --aid 123456 -t 2tdea
[usb] pm3 --> hf mfd changekey --aid 123456 -t 2tdea --newkey 11223344556677889900112233445566 --key 00000000000000000000000000000000
[usb] pm3 --> hf mfd auth -t 2tdea -k 11223344556677889900112233445566 --aid 123456 --schann d40
[!!] Desfire authenticate error. Result: [7] Sending auth command failed
[-] Select or authentication AID 123456 failed. Result [7] Sending auth command failed
[usb] pm3 --> hf mfd auth -t 2tdea -k 11223344556677889900112233445566 --aid 123456
[+] Application AID 123456 selected and authenticated succesfully
[+] Context:
[=] Key num: 0 Key algo: 2tdea Key[16]: 11 22 33 44 55 66 77 88 99 00 11 22 33 44 55 66
[=] Secure channel: ev1 Command set: niso Communication mode: plain
[=] Session key [16]: 01 02 03 04 16 A4 0D 02 05 06 07 08 18 EB D9 AF
[=]     IV [8]: 00 00 00 00 00 00 00 00
[usb] pm3 -->
```