### PR TITLE
SPI flash area for Mifare keys extended from 2047 to 4095 keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Extended area for Mifare keys in SPI flash to hold 4095 keys (@piotrva)
 - Fixed DESFire D40 secure channel crypto (@nvx)
 - Fixed `hf mfp info` fix signature check on 4b UID cards (@doegox)
 - Automatically set maximum read/write block when using predefined types in `hf_mf_ultimatecard` script (@piotrva)

--- a/doc/ext_flash_notes.md
+++ b/doc/ext_flash_notes.md
@@ -36,22 +36,22 @@ Therefore a flash address can be interpreted as such:
 
 Page 0:
 * available for user data
-* to dump it: `mem dump f page0_dump o 0 l 65536`
+* to dump it: `mem dump -f page0_dump -o 0 -l 65536`
 * to erase it: `mem wipe p 0`
 
 Page 1:
 * available for user data
-* to dump it: `mem dump f page1_dump o 65536 l 65536`
+* to dump it: `mem dump -f page1_dump -o 65536 -l 65536`
 * to erase it: `mem wipe p 1`
 
 Page 2:
 * available for user data
-* to dump it: `mem dump f page2_dump o 131072 l 65536`
+* to dump it: `mem dump -f page2_dump -o 131072 -l 65536`
 * to erase it: `mem wipe p 2`
 
 Page 3:
 * used by Proxmark3 RDV4 specific functions: flash signature and keys dictionaries, see below for details
-* to dump it: `mem dump f page3_dump o 196608 l 65536`
+* to dump it: `mem dump -f page3_dump -o 196608 -l 65536`
 * to erase it:
   * **Beware** it will erase your flash signature so better to back it up first as you won't be able to regenerate it by yourself!
   * edit the source code to enable Page 3 as a valid input in the `mem wipe` command.

--- a/doc/ext_flash_notes.md
+++ b/doc/ext_flash_notes.md
@@ -63,8 +63,8 @@ Page 3:
 Page3 is used as follows by the Proxmark3 RDV4 firmware:
 
 * **MF_KEYS**
-  * offset: page 3 sector  9 (0x9) @ 3*0x10000+9*0x1000=0x39000
-  * length: 2 sectors
+  * offset: page 3 sector  5 (0x5) @ 3*0x10000+5*0x1000=0x35000
+  * length: 6 sectors
 
 * **ICLASS_KEYS**
   * offset: page 3 sector 11 (0xB) @ 3*0x10000+11*0x1000=0x3B000

--- a/doc/md/Use_of_Proxmark/0_Compilation-Instructions.md
+++ b/doc/md/Use_of_Proxmark/0_Compilation-Instructions.md
@@ -117,6 +117,17 @@ or
 proxmark3 /dev/ttyACM0 --flash --unlock-bootloader --image /tmp/my-bootrom.elf --image /tmp/my-fullimage.elf
 ```
 
+## Updating SPI flash structure and contents (RDV4.x, some PM3 Easy variants)
+^[Top](#top)
+
+For the devices equipped with external SPI flash memory chip in some cases it might be essential to update the memory structure as well as to upload new keys from the dictionaries. To do so execute following command inside the client:
+
+```
+[usb] pm3 --> script run init_rdv4
+```
+
+For more details prease refer to [this doc](./2_Configuration-and-Verification.md).
+
 ### The button trick
 ^[Top](#top)
 

--- a/include/pmflash.h
+++ b/include/pmflash.h
@@ -28,7 +28,7 @@
 // 0x3E000 - 1 4kb sector = settings
 // 0x3D000 - 1 4kb sector = default T55XX keys dictionary
 // 0x3B000 - 1 4kb sector = default ICLASS keys dictionary
-// 0x38000 - 3 4kb sectors = default MFC keys dictionary
+// 0x35000 - 6 4kb sectors = default MFC keys dictionary
 //
 #ifndef FLASH_MEM_BLOCK_SIZE
 # define FLASH_MEM_BLOCK_SIZE   256
@@ -95,9 +95,9 @@
 # define DEFAULT_ICLASS_KEYS_OFFSET_P(p64k) (DEFAULT_T55XX_KEYS_OFFSET_P(p64k) - DEFAULT_ICLASS_KEYS_LEN)
 #endif
 
-// Reserved space for MIFARE Keys = 12 kb
+// Reserved space for MIFARE Keys = 24 kb
 #ifndef DEFAULT_MF_KEYS_OFFSET
-# define DEFAULT_MF_KEYS_LEN (0x3000)
+# define DEFAULT_MF_KEYS_LEN (0x6000)
 # define DEFAULT_MF_KEYS_OFFSET (DEFAULT_ICLASS_KEYS_OFFSET - DEFAULT_MF_KEYS_LEN)
 # define DEFAULT_MF_KEYS_MAX ((DEFAULT_MF_KEYS_LEN - 2) / 6)
 #endif


### PR DESCRIPTION
This extends reserved area in SPI flash memory (RDV4.x, some PM3 Easy devices) from 2047 keys to 4095 keys.
Also updates related documentation.

Tested to work correctly on Proxmark3 RDV4.01

![image](https://github.com/user-attachments/assets/bda30c4a-c3df-464f-82f8-e4ac572d43e8)
