### PR TITLE
Fix: SPI flash area for Mifare keys extended from 2047 to 4095 keys - not all sectors are erased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added JEDEC information for SPI flash W25Q64JV (@ANTodorov)
 - Added special iclass legacy config cards in `hf iclass configcard` (@antiklesys)
 - Added simulation function to `hf iclass legrec` (@antiklesys)
-- Added keys from Momentum firmware projects. (@onovy)
 - Added Dutch Statistics Agency default key (@eagle00789)
 
 ## [Orca.4.19552][2024-11-22]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `mem load --mfc` not erasing all SPI flash blocks after extending to 4095 keys (@piotrva)
 - Extended area for Mifare keys in SPI flash to hold 4095 keys (@piotrva)
 - Fixed DESFire D40 secure channel crypto (@nvx)
 - Fixed `hf mfp info` fix signature check on 4b UID cards (@doegox)
@@ -13,6 +14,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added JEDEC information for SPI flash W25Q64JV (@ANTodorov)
 - Added special iclass legacy config cards in `hf iclass configcard` (@antiklesys)
 - Added simulation function to `hf iclass legrec` (@antiklesys)
+- Added keys from Momentum firmware projects. (@onovy)
 - Added Dutch Statistics Agency default key (@eagle00789)
 
 ## [Orca.4.19552][2024-11-22]

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -2751,34 +2751,34 @@ static void PacketReceived(PacketCommandNG *packet) {
             if (payload->startidx == DEFAULT_T55XX_KEYS_OFFSET_P(spi_flash_pages64k)) {
                 Flash_CheckBusy(BUSY_TIMEOUT);
                 Flash_WriteEnable();
-                Flash_Erase4k(3, 0xC);
+                Flash_Erase4k(spi_flash_pages64k - 1, 0xC);
             } else if (payload->startidx ==  DEFAULT_MF_KEYS_OFFSET_P(spi_flash_pages64k)) {
                 Flash_CheckBusy(BUSY_TIMEOUT);
                 Flash_WriteEnable();
-                Flash_Erase4k(3, 0x5);
+                Flash_Erase4k(spi_flash_pages64k - 1, 0x5);
                 Flash_CheckBusy(BUSY_TIMEOUT);
                 Flash_WriteEnable();
-                Flash_Erase4k(3, 0x6);
+                Flash_Erase4k(spi_flash_pages64k - 1, 0x6);
                 Flash_CheckBusy(BUSY_TIMEOUT);
                 Flash_WriteEnable();
-                Flash_Erase4k(3, 0x7);
+                Flash_Erase4k(spi_flash_pages64k - 1, 0x7);
                 Flash_CheckBusy(BUSY_TIMEOUT);
                 Flash_WriteEnable();
-                Flash_Erase4k(3, 0x8);
+                Flash_Erase4k(spi_flash_pages64k - 1, 0x8);
                 Flash_CheckBusy(BUSY_TIMEOUT);
                 Flash_WriteEnable();
-                Flash_Erase4k(3, 0x9);
+                Flash_Erase4k(spi_flash_pages64k - 1, 0x9);
                 Flash_CheckBusy(BUSY_TIMEOUT);
                 Flash_WriteEnable();
-                Flash_Erase4k(3, 0xA);
+                Flash_Erase4k(spi_flash_pages64k - 1, 0xA);
             } else if (payload->startidx == DEFAULT_ICLASS_KEYS_OFFSET_P(spi_flash_pages64k)) {
                 Flash_CheckBusy(BUSY_TIMEOUT);
                 Flash_WriteEnable();
-                Flash_Erase4k(3, 0xB);
+                Flash_Erase4k(spi_flash_pages64k - 1, 0xB);
             } else if (payload->startidx == FLASH_MEM_SIGNATURE_OFFSET_P(spi_flash_pages64k)) {
                 Flash_CheckBusy(BUSY_TIMEOUT);
                 Flash_WriteEnable();
-                Flash_Erase4k(3, 0xF);
+                Flash_Erase4k(spi_flash_pages64k - 1, 0xF);
             }
 
             uint16_t res = Flash_Write(payload->startidx, payload->data, payload->len);

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -2755,6 +2755,15 @@ static void PacketReceived(PacketCommandNG *packet) {
             } else if (payload->startidx ==  DEFAULT_MF_KEYS_OFFSET_P(spi_flash_pages64k)) {
                 Flash_CheckBusy(BUSY_TIMEOUT);
                 Flash_WriteEnable();
+                Flash_Erase4k(3, 0x5);
+                Flash_CheckBusy(BUSY_TIMEOUT);
+                Flash_WriteEnable();
+                Flash_Erase4k(3, 0x6);
+                Flash_CheckBusy(BUSY_TIMEOUT);
+                Flash_WriteEnable();
+                Flash_Erase4k(3, 0x7);
+                Flash_CheckBusy(BUSY_TIMEOUT);
+                Flash_WriteEnable();
                 Flash_Erase4k(3, 0x8);
                 Flash_CheckBusy(BUSY_TIMEOUT);
                 Flash_WriteEnable();


### PR DESCRIPTION
Fixing bug I created by #2683 
In the original PR I forgot to erase extended area before keys were written.
The bias was created by testing my solution on a blank flash area, and during testing I never changed number of keys nor dictionary contents.