### PR TITLE
Fix `hf 15 view` command examples

### DIFF
--- a/client/src/cmdhf15.c
+++ b/client/src/cmdhf15.c
@@ -3337,7 +3337,7 @@ static int CmdHF15View(const char *Cmd) {
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "hf 15 view",
                   "Print a ISO-15693 tag dump file (bin/eml/json)",
-                  "hf 15 view -f hf-iclass-AA162D30F8FF12F1-dump.bin\n"
+                  "hf 15 view -f hf-15-1122334455667788-dump.bin\n"
                  );
     void *argtable[] = {
         arg_param_begin,

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -2081,7 +2081,7 @@
             "command": "hf 15 view",
             "description": "Print a ISO-15693 tag dump file (bin/eml/json)",
             "notes": [
-                "hf 15 view -f hf-iclass-AA162D30F8FF12F1-dump.bin"
+                "hf 15 view -f hf-15-1122334455667788-dump.bin"
             ],
             "offline": true,
             "options": [


### PR DESCRIPTION
Fix a couple of small typos with the file name format for the `hf 15 view` command. This proposed formatting matches the file name format that is produced by dumps.