### PR TITLE
Move keys library to spiffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- move flash-stored key dictionaries (Mifare, iClass, T55XX) to SPIFFS files (@piotrva)
 - Added support for connection to host device in all Docker envs (@doegox)
 - Changed `hf 15 info` to show all type matches and check ST25TVxC signature (@doegox)
 - Added initial support for ST25TN and its signature verification (@doegox)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
-- Changed flash-stored key dictionaries (Mifare, iClass, T55XX) to SPIFFS files (@piotrva)
+- Changed flash-stored key dictionaries (Mifare, iClass, T55XX) and T55XX configurations to SPIFFS files (@piotrva)
 - Added `hf iclass trbl` to perform tear-off attacks on iClass (@antiklesys)
 - Added support for connection to host device in all Docker envs (@doegox)
 - Changed `hf 15 info` to show all type matches and check ST25TVxC signature (@doegox)

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -441,22 +441,35 @@ static void SendStatus(uint32_t wait) {
 
 #ifdef WITH_FLASH
     DbpString(_CYAN_("Flash memory dictionary loaded"));
+    uint32_t num = 0;
 
-    uint32_t num = size_in_spiffs(MF_KEYS_FILE) / MF_KEY_LENGTH;
+    if (exists_in_spiffs(MF_KEYS_FILE)) {
+        num = size_in_spiffs(MF_KEYS_FILE) / MF_KEY_LENGTH;
+    } else {
+        num = 0;
+    }
     if (num > 0) {
         Dbprintf("  Mifare.................. "_YELLOW_("%u")" keys (spiffs: "_GREEN_("%s")")", num, MF_KEYS_FILE);
     } else {
         Dbprintf("  Mifare.................. "_RED_("%u")" keys (spiffs: "_RED_("%s")")", num, MF_KEYS_FILE);
     }
 
-    num = size_in_spiffs(T55XX_KEYS_FILE) / T55XX_KEY_LENGTH;
+    if (exists_in_spiffs(T55XX_KEYS_FILE)) {
+        num = size_in_spiffs(T55XX_KEYS_FILE) / T55XX_KEY_LENGTH;
+    } else {
+        num = 0;
+    }
     if (num > 0) {
         Dbprintf("  T55xx................... "_YELLOW_("%u")" keys (spiffs: "_GREEN_("%s")")", num, T55XX_KEYS_FILE);
     } else {
         Dbprintf("  T55xx................... "_RED_("%u")" keys (spiffs: "_RED_("%s")")", num, T55XX_KEYS_FILE);
     }
 
-    num = size_in_spiffs(ICLASS_KEYS_FILE) / ICLASS_KEY_LENGTH;
+    if (exists_in_spiffs(ICLASS_KEYS_FILE)) {
+        num = size_in_spiffs(ICLASS_KEYS_FILE) / ICLASS_KEY_LENGTH;
+    } else {
+        num = 0;
+    }
     if (num > 0) {
         Dbprintf("  iClass.................. "_YELLOW_("%u")" keys (spiffs: "_GREEN_("%s")")", num, ICLASS_KEYS_FILE);
     } else {

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -2782,15 +2782,7 @@ static void PacketReceived(PacketCommandNG *packet) {
                 break;
             }
 
-            if (payload->startidx == DEFAULT_T55XX_KEYS_OFFSET_P(spi_flash_pages64k)) {
-                Flash_CheckBusy(BUSY_TIMEOUT);
-                Flash_WriteEnable();
-                Flash_Erase4k(spi_flash_pages64k - 1, 0xC);
-            } else if (payload->startidx == DEFAULT_ICLASS_KEYS_OFFSET_P(spi_flash_pages64k)) {
-                Flash_CheckBusy(BUSY_TIMEOUT);
-                Flash_WriteEnable();
-                Flash_Erase4k(spi_flash_pages64k - 1, 0xB);
-            } else if (payload->startidx == FLASH_MEM_SIGNATURE_OFFSET_P(spi_flash_pages64k)) {
+            if (payload->startidx == FLASH_MEM_SIGNATURE_OFFSET_P(spi_flash_pages64k)) {
                 Flash_CheckBusy(BUSY_TIMEOUT);
                 Flash_WriteEnable();
                 Flash_Erase4k(spi_flash_pages64k - 1, 0xF);

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -440,7 +440,28 @@ static void SendStatus(uint32_t wait) {
     ModInfo();
 
 #ifdef WITH_FLASH
-    Flashmem_print_info();
+    DbpString(_CYAN_("Flash memory dictionary loaded"));
+
+    uint32_t num = size_in_spiffs(MF_KEYS_FILE) / MF_KEY_LENGTH;
+    if (num > 0) {
+        Dbprintf("  Mifare.................. "_YELLOW_("%u")" keys (spiffs: "_GREEN_("%s")")", num, MF_KEYS_FILE);
+    } else {
+        Dbprintf("  Mifare.................. "_RED_("%u")" keys (spiffs: "_RED_("%s")")", num, MF_KEYS_FILE);
+    }
+
+    num = size_in_spiffs(T55XX_KEYS_FILE) / T55XX_KEY_LENGTH;
+    if (num > 0) {
+        Dbprintf("  T55xx................... "_YELLOW_("%u")" keys (spiffs: "_GREEN_("%s")")", num, T55XX_KEYS_FILE);
+    } else {
+        Dbprintf("  T55xx................... "_RED_("%u")" keys (spiffs: "_RED_("%s")")", num, T55XX_KEYS_FILE);
+    }
+
+    num = size_in_spiffs(ICLASS_KEYS_FILE) / ICLASS_KEY_LENGTH;
+    if (num > 0) {
+        Dbprintf("  iClass.................. "_YELLOW_("%u")" keys (spiffs: "_GREEN_("%s")")", num, ICLASS_KEYS_FILE);
+    } else {
+        Dbprintf("  iClass.................. "_RED_("%u")" keys (spiffs: "_RED_("%s")")", num, ICLASS_KEYS_FILE);
+    }
 #endif
     DbpString("");
     reply_ng(CMD_STATUS, PM3_SUCCESS, NULL, 0);

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -2752,25 +2752,6 @@ static void PacketReceived(PacketCommandNG *packet) {
                 Flash_CheckBusy(BUSY_TIMEOUT);
                 Flash_WriteEnable();
                 Flash_Erase4k(spi_flash_pages64k - 1, 0xC);
-            } else if (payload->startidx ==  DEFAULT_MF_KEYS_OFFSET_P(spi_flash_pages64k)) {
-                Flash_CheckBusy(BUSY_TIMEOUT);
-                Flash_WriteEnable();
-                Flash_Erase4k(spi_flash_pages64k - 1, 0x5);
-                Flash_CheckBusy(BUSY_TIMEOUT);
-                Flash_WriteEnable();
-                Flash_Erase4k(spi_flash_pages64k - 1, 0x6);
-                Flash_CheckBusy(BUSY_TIMEOUT);
-                Flash_WriteEnable();
-                Flash_Erase4k(spi_flash_pages64k - 1, 0x7);
-                Flash_CheckBusy(BUSY_TIMEOUT);
-                Flash_WriteEnable();
-                Flash_Erase4k(spi_flash_pages64k - 1, 0x8);
-                Flash_CheckBusy(BUSY_TIMEOUT);
-                Flash_WriteEnable();
-                Flash_Erase4k(spi_flash_pages64k - 1, 0x9);
-                Flash_CheckBusy(BUSY_TIMEOUT);
-                Flash_WriteEnable();
-                Flash_Erase4k(spi_flash_pages64k - 1, 0xA);
             } else if (payload->startidx == DEFAULT_ICLASS_KEYS_OFFSET_P(spi_flash_pages64k)) {
                 Flash_CheckBusy(BUSY_TIMEOUT);
                 Flash_WriteEnable();

--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -38,8 +38,6 @@
 #include "spiffs.h"   // spiffs
 #include "appmain.h"  // print_stack_usage
 
-#define MF_KEYS_FILE "dict_mf.bin"
-
 #ifndef HARDNESTED_AUTHENTICATION_TIMEOUT
 # define HARDNESTED_AUTHENTICATION_TIMEOUT  848     // card times out 1ms after wrong authentication (according to NXP documentation)
 #endif

--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -1924,9 +1924,12 @@ void MifareChkKeys_fast(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_t *da
         if (datain == NULL)
             goto OUT;
 
-        rdv40_spiffs_read_as_filetype(MF_KEYS_FILE, datain, keyCount * MF_KEY_LENGTH, RDV40_SPIFFS_SAFETY_SAFE);
-
-        if (g_dbglevel >= DBG_ERROR) Dbprintf("Loaded %u keys from spiffs file: %s", keyCount, MF_KEYS_FILE);
+        if (SPIFFS_OK == rdv40_spiffs_read_as_filetype(MF_KEYS_FILE, datain, keyCount * MF_KEY_LENGTH, RDV40_SPIFFS_SAFETY_SAFE)) {
+            if (g_dbglevel >= DBG_ERROR) Dbprintf("Loaded %u keys from spiffs file: %s", keyCount, MF_KEYS_FILE);
+        } else {
+            Dbprintf("Spiffs file: %s cannot be read.", MF_KEYS_FILE);
+            goto OUT;
+        }
     }
 #endif
 

--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -1901,9 +1901,13 @@ void MifareChkKeys_fast(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_t *da
     if (use_flashmem) {
         BigBuf_free();
         uint32_t size = 0;
-        size = size_in_spiffs(MF_KEYS_FILE);
-        if (size <= 0)
+        if (exists_in_spiffs(MF_KEYS_FILE)) {
+            size = size_in_spiffs(MF_KEYS_FILE);
+        }
+        if (size == 0) {
+            Dbprintf("Spiffs file: %s does not exists or empty.", MF_KEYS_FILE);
             goto OUT;
+        }
 
         keyCount = size / MF_KEY_LENGTH;
 

--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -1925,6 +1925,7 @@ void MifareChkKeys_fast(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_t *da
             goto OUT;
 
         rdv40_spiffs_read_as_filetype(MF_KEYS_FILE, datain, keyCount * MF_KEY_LENGTH, RDV40_SPIFFS_SAFETY_SAFE);
+
         if (g_dbglevel >= DBG_ERROR) Dbprintf("Loaded %u keys from spiffs file: %s", keyCount, MF_KEYS_FILE);
     }
 #endif

--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -1905,22 +1905,22 @@ void MifareChkKeys_fast(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_t *da
         if (size <= 0)
             goto OUT;
 
-        keyCount = size / 6;
+        keyCount = size / MF_KEY_LENGTH;
 
         if (keyCount == 0)
             goto OUT;
 
         // limit size of available for keys in bigbuff
         // a key is 6bytes
-        uint16_t key_mem_available = MIN(BigBuf_get_size(), keyCount * 6);
+        uint16_t key_mem_available = MIN(BigBuf_get_size(), keyCount * MF_KEY_LENGTH);
 
-        keyCount = key_mem_available / 6;
+        keyCount = key_mem_available / MF_KEY_LENGTH;
 
         datain = BigBuf_malloc(key_mem_available);
         if (datain == NULL)
             goto OUT;
 
-        rdv40_spiffs_read_as_filetype(MF_KEYS_FILE, datain, keyCount * 6, RDV40_SPIFFS_SAFETY_SAFE);
+        rdv40_spiffs_read_as_filetype(MF_KEYS_FILE, datain, keyCount * MF_KEY_LENGTH, RDV40_SPIFFS_SAFETY_SAFE);
         if (g_dbglevel >= DBG_ERROR) Dbprintf("Loaded %u keys from spiffs file: %s", keyCount, MF_KEYS_FILE);
     }
 #endif

--- a/client/src/cmdflashmem.c
+++ b/client/src/cmdflashmem.c
@@ -247,7 +247,7 @@ static int CmdFlashMemLoad(const char *Cmd) {
 
     switch (d) {
         case DICTIONARY_MIFARE:
-            keylen = 6;
+            keylen = MF_KEY_LENGTH;
             res = loadFileDICTIONARY(filename, data, &datalen, keylen, &keycount);
             if (res || !keycount) {
                 free(data);

--- a/client/src/cmdflashmem.c
+++ b/client/src/cmdflashmem.c
@@ -259,7 +259,7 @@ static int CmdFlashMemLoad(const char *Cmd) {
                 free(data);
                 return PM3_EOVFLOW;
             }
-            strcpy_s(spiffsDest, 32, MF_KEYS_FILE);
+            strcpy(spiffsDest, MF_KEYS_FILE);
             break;
         case DICTIONARY_T55XX:
             keylen = T55XX_KEY_LENGTH;
@@ -273,7 +273,7 @@ static int CmdFlashMemLoad(const char *Cmd) {
                 free(data);
                 return PM3_EOVFLOW;
             }
-            strcpy_s(spiffsDest, 32, T55XX_KEYS_FILE);
+            strcpy(spiffsDest, T55XX_KEYS_FILE);
             break;
         case DICTIONARY_ICLASS:
             keylen = ICLASS_KEY_LENGTH;
@@ -287,7 +287,7 @@ static int CmdFlashMemLoad(const char *Cmd) {
                 free(data);
                 return PM3_EOVFLOW;
             }
-            strcpy_s(spiffsDest, 32, ICLASS_KEYS_FILE);
+            strcpy(spiffsDest, ICLASS_KEYS_FILE);
             break;
         case DICTIONARY_NONE:
             res = loadFile_safe(filename, ".bin", (void **)&data, &datalen);

--- a/client/src/cmdflashmem.c
+++ b/client/src/cmdflashmem.c
@@ -17,6 +17,7 @@
 //-----------------------------------------------------------------------------
 #include "cmdflashmem.h"
 #include <ctype.h>
+#include <string.h>
 #include "cmdparser.h"         // command_t
 #include "cliparser.h"
 #include "pmflash.h"           // rdv40validation_t

--- a/client/src/mifare/mifarehost.c
+++ b/client/src/mifare/mifarehost.c
@@ -273,7 +273,7 @@ int mf_check_keys_fast_ex(uint8_t sectorsCnt, uint8_t firstChunk, uint8_t lastCh
         // max timeout for one chunk of 85keys, 60*3sec = 180seconds
         // s70 with 40*2 keys to check, 80*85 = 6800 auth.
         // takes about 97s, still some margin before abort
-        if (timeout > 180) {
+        if (timeout > 60*6) {
             PrintAndLogEx(WARNING, "\nNo response from Proxmark3. Aborting...");
             return PM3_ETIMEOUT;
         }

--- a/client/src/mifare/mifarehost.c
+++ b/client/src/mifare/mifarehost.c
@@ -273,7 +273,9 @@ int mf_check_keys_fast_ex(uint8_t sectorsCnt, uint8_t firstChunk, uint8_t lastCh
         // max timeout for one chunk of 85keys, 60*3sec = 180seconds
         // s70 with 40*2 keys to check, 80*85 = 6800 auth.
         // takes about 97s, still some margin before abort
-        if (timeout > 60*6) {
+        // timeout = 180 => ~360s @ Mifare Classic 1k @ ~2300 keys in dict
+        // ~2300 keys @ Mifare Classic 1k => ~620s
+        if (timeout > 60*12) {
             PrintAndLogEx(WARNING, "\nNo response from Proxmark3. Aborting...");
             return PM3_ETIMEOUT;
         }

--- a/common_arm/flashmem.c
+++ b/common_arm/flashmem.c
@@ -383,43 +383,6 @@ void Flashmem_print_status(void) {
     FlashStop();
 }
 
-void Flashmem_print_info(void) {
-
-    if (!FlashInit()) return;
-
-    DbpString(_CYAN_("Flash memory dictionary loaded"));
-
-    // load dictionary offsets.
-    uint8_t keysum[2];
-    uint16_t num;
-
-    Flash_CheckBusy(BUSY_TIMEOUT);
-    uint16_t isok = Flash_ReadDataCont(DEFAULT_MF_KEYS_OFFSET_P(spi_flash_pages64k), keysum, 2);
-    if (isok == 2) {
-        num = ((keysum[1] << 8) | keysum[0]);
-        if (num != 0xFFFF && num != 0x0)
-            Dbprintf("  Mifare.................. "_YELLOW_("%u")" / "_GREEN_("%u")" keys", num, DEFAULT_MF_KEYS_MAX);
-    }
-
-    Flash_CheckBusy(BUSY_TIMEOUT);
-    isok = Flash_ReadDataCont(DEFAULT_T55XX_KEYS_OFFSET_P(spi_flash_pages64k), keysum, 2);
-    if (isok == 2) {
-        num = ((keysum[1] << 8) | keysum[0]);
-        if (num != 0xFFFF && num != 0x0)
-            Dbprintf("  T55x7................... "_YELLOW_("%u")" / "_GREEN_("%u")" keys", num, DEFAULT_T55XX_KEYS_MAX);
-    }
-
-    Flash_CheckBusy(BUSY_TIMEOUT);
-    isok = Flash_ReadDataCont(DEFAULT_ICLASS_KEYS_OFFSET_P(spi_flash_pages64k), keysum, 2);
-    if (isok == 2) {
-        num = ((keysum[1] << 8) | keysum[0]);
-        if (num != 0xFFFF && num != 0x0)
-            Dbprintf("  iClass.................. "_YELLOW_("%u")" / "_GREEN_("%u")" keys", num, DEFAULT_ICLASS_KEYS_MAX);
-    }
-
-    FlashStop();
-}
-
 bool FlashDetect(void) {
     flash_device_type_t flash_data = {0};
     bool ret = false;

--- a/common_arm/flashmem.h
+++ b/common_arm/flashmem.h
@@ -134,7 +134,6 @@ uint16_t Flash_Write(uint32_t address, uint8_t *in, uint16_t len);
 uint16_t Flash_WriteData(uint32_t address, uint8_t *in, uint16_t len);
 uint16_t Flash_WriteDataCont(uint32_t address, uint8_t *in, uint16_t len);
 void Flashmem_print_status(void);
-void Flashmem_print_info(void);
 
 typedef struct {
     uint8_t  manufacturer_id;

--- a/doc/ext_flash_notes.md
+++ b/doc/ext_flash_notes.md
@@ -37,20 +37,20 @@ Therefore a flash address can be interpreted as such:
 Page 0:
 * available for user data
 * to dump it: `mem dump -f page0_dump -o 0 -l 65536`
-* to erase it: `mem wipe p 0`
+* to erase it: `mem wipe -p 0`
 
 Page 1:
 * available for user data
 * to dump it: `mem dump -f page1_dump -o 65536 -l 65536`
-* to erase it: `mem wipe p 1`
+* to erase it: `mem wipe -p 1`
 
 Page 2:
 * available for user data
 * to dump it: `mem dump -f page2_dump -o 131072 -l 65536`
-* to erase it: `mem wipe p 2`
+* to erase it: `mem wipe -p 2`
 
 Page 3:
-* used by Proxmark3 RDV4 specific functions: flash signature and configurations, see below for details
+* used by Proxmark3 RDV4 specific functions: flash signature, see below for details
 * to dump it: `mem dump -f page3_dump -o 196608 -l 65536`
 * to erase it:
   * **Beware** it will erase your flash signature so better to back it up first as you won't be able to regenerate it by yourself!
@@ -61,10 +61,6 @@ Page 3:
 ^[Top](#top)
 
 Page3 is used as follows by the Proxmark3 RDV4 firmware:
-
-* **T55XX_CONFIG**
-  * offset: page 3 sector 13 (0xD) @ 3*0x10000+13*0x1000=0x3D000
-  * length: 1 sector (actually only a few bytes are used to store `t55xx_config` structure)
 
 * **RSA SIGNATURE**, see below for details
   * offset: page 3 sector 15 (0xF) offset 0xF7F @ 3*0x10000+15*0x1000+0xF7F=0x3FF7F  (decimal 262015)

--- a/doc/ext_flash_notes.md
+++ b/doc/ext_flash_notes.md
@@ -50,7 +50,7 @@ Page 2:
 * to erase it: `mem wipe p 2`
 
 Page 3:
-* used by Proxmark3 RDV4 specific functions: flash signature and keys dictionaries, see below for details
+* used by Proxmark3 RDV4 specific functions: flash signature and configurations, see below for details
 * to dump it: `mem dump -f page3_dump -o 196608 -l 65536`
 * to erase it:
   * **Beware** it will erase your flash signature so better to back it up first as you won't be able to regenerate it by yourself!
@@ -61,18 +61,6 @@ Page 3:
 ^[Top](#top)
 
 Page3 is used as follows by the Proxmark3 RDV4 firmware:
-
-* **MF_KEYS**
-  * offset: page 3 sector  5 (0x5) @ 3*0x10000+5*0x1000=0x35000
-  * length: 6 sectors
-
-* **ICLASS_KEYS**
-  * offset: page 3 sector 11 (0xB) @ 3*0x10000+11*0x1000=0x3B000
-  * length: 1 sector
-
-* **T55XX_KEYS**
-  * offset: page 3 sector 12 (0xC) @ 3*0x10000+12*0x1000=0x3C000
-  * length: 1 sector
 
 * **T55XX_CONFIG**
   * offset: page 3 sector 13 (0xD) @ 3*0x10000+13*0x1000=0x3D000

--- a/include/pmflash.h
+++ b/include/pmflash.h
@@ -65,12 +65,7 @@
 # define T55XX_CONFIG_LEN sizeof( t55xx_configurations_t )
 #endif
 
-#ifndef T55XX_CONFIG_OFFSET
-# define T55XX_CONFIG_OFFSET (FLASH_MEM_MAX_4K_SECTOR - 0x2000)
-#endif
-#ifndef T55XX_CONFIG_OFFSET_P
-# define T55XX_CONFIG_OFFSET_P(p64k) (FLASH_MEM_MAX_4K_SECTOR_P(p64k) - 0x2000)
-#endif
+#define T55XX_CONFIG_FILE "cfg_t55xx.bin"
 
 // T55XX PWD stored in spiffs
 #define T55XX_KEYS_FILE "dict_t55xx.bin"

--- a/include/pmflash.h
+++ b/include/pmflash.h
@@ -26,9 +26,6 @@
 //
 // 0x3F000 - 1 4kb sector = signature
 // 0x3E000 - 1 4kb sector = settings
-// 0x3D000 - 1 4kb sector = default T55XX keys dictionary
-// 0x3B000 - 1 4kb sector = default ICLASS keys dictionary
-// 0x35000 - 6 4kb sectors = default MFC keys dictionary
 //
 #ifndef FLASH_MEM_BLOCK_SIZE
 # define FLASH_MEM_BLOCK_SIZE   256
@@ -75,44 +72,17 @@
 # define T55XX_CONFIG_OFFSET_P(p64k) (FLASH_MEM_MAX_4K_SECTOR_P(p64k) - 0x2000)
 #endif
 
-// Reserved space for T55XX PWD = 4 kb
+// T55XX PWD stored in spiffs
 #define T55XX_KEYS_FILE "dict_t55xx.bin"
 #define T55XX_KEY_LENGTH 4
 
-#ifndef DEFAULT_T55XX_KEYS_OFFSET
-# define DEFAULT_T55XX_KEYS_LEN (0x1000)
-# define DEFAULT_T55XX_KEYS_OFFSET (T55XX_CONFIG_OFFSET - DEFAULT_T55XX_KEYS_LEN)
-# define DEFAULT_T55XX_KEYS_MAX ((DEFAULT_T55XX_KEYS_LEN - 2) / 4)
-#endif
-#ifndef DEFAULT_T55XX_KEYS_OFFSET_P
-# define DEFAULT_T55XX_KEYS_OFFSET_P(p64k) (T55XX_CONFIG_OFFSET_P(p64k) - DEFAULT_T55XX_KEYS_LEN)
-#endif
-
-// Reserved space for iClass keys = 4 kb
+// iClass keys stored in spiffs
 #define ICLASS_KEYS_FILE "dict_iclass.bin"
 #define ICLASS_KEY_LENGTH 8
 
-#ifndef DEFAULT_ICLASS_KEYS_OFFSET
-# define DEFAULT_ICLASS_KEYS_LEN (0x1000)
-# define DEFAULT_ICLASS_KEYS_OFFSET (DEFAULT_T55XX_KEYS_OFFSET - DEFAULT_ICLASS_KEYS_LEN)
-# define DEFAULT_ICLASS_KEYS_MAX ((DEFAULT_ICLASS_KEYS_LEN - 2) / 8)
-#endif
-#ifndef DEFAULT_ICLASS_KEYS_OFFSET_P
-# define DEFAULT_ICLASS_KEYS_OFFSET_P(p64k) (DEFAULT_T55XX_KEYS_OFFSET_P(p64k) - DEFAULT_ICLASS_KEYS_LEN)
-#endif
-
-// Reserved space for MIFARE Keys = 24 kb
+// Mifare keys stored in spiffs
 #define MF_KEYS_FILE "dict_mf.bin"
 #define MF_KEY_LENGTH 6
-
-#ifndef DEFAULT_MF_KEYS_OFFSET
-# define DEFAULT_MF_KEYS_LEN (0x6000)
-# define DEFAULT_MF_KEYS_OFFSET (DEFAULT_ICLASS_KEYS_OFFSET - DEFAULT_MF_KEYS_LEN)
-# define DEFAULT_MF_KEYS_MAX ((DEFAULT_MF_KEYS_LEN - 2) / 6)
-#endif
-#ifndef DEFAULT_MF_KEYS_OFFSET_P
-# define DEFAULT_MF_KEYS_OFFSET_P(p64k) (DEFAULT_ICLASS_KEYS_OFFSET_P(p64k) - DEFAULT_MF_KEYS_LEN)
-#endif
 
 // RDV40,  validation structure to help identifying that client/firmware is talking with RDV40
 typedef struct {

--- a/include/pmflash.h
+++ b/include/pmflash.h
@@ -76,6 +76,9 @@
 #endif
 
 // Reserved space for T55XX PWD = 4 kb
+#define T55XX_KEYS_FILE "dict_t55xx.bin"
+#define T55XX_KEY_LENGTH 4
+
 #ifndef DEFAULT_T55XX_KEYS_OFFSET
 # define DEFAULT_T55XX_KEYS_LEN (0x1000)
 # define DEFAULT_T55XX_KEYS_OFFSET (T55XX_CONFIG_OFFSET - DEFAULT_T55XX_KEYS_LEN)
@@ -86,6 +89,9 @@
 #endif
 
 // Reserved space for iClass keys = 4 kb
+#define ICLASS_KEYS_FILE "dict_iclass.bin"
+#define ICLASS_KEY_LENGTH 8
+
 #ifndef DEFAULT_ICLASS_KEYS_OFFSET
 # define DEFAULT_ICLASS_KEYS_LEN (0x1000)
 # define DEFAULT_ICLASS_KEYS_OFFSET (DEFAULT_T55XX_KEYS_OFFSET - DEFAULT_ICLASS_KEYS_LEN)
@@ -97,6 +103,7 @@
 
 // Reserved space for MIFARE Keys = 24 kb
 #define MF_KEYS_FILE "dict_mf.bin"
+#define MF_KEY_LENGTH 6
 
 #ifndef DEFAULT_MF_KEYS_OFFSET
 # define DEFAULT_MF_KEYS_LEN (0x6000)

--- a/include/pmflash.h
+++ b/include/pmflash.h
@@ -96,6 +96,8 @@
 #endif
 
 // Reserved space for MIFARE Keys = 24 kb
+#define MF_KEYS_FILE "dict_mf.bin"
+
 #ifndef DEFAULT_MF_KEYS_OFFSET
 # define DEFAULT_MF_KEYS_LEN (0x6000)
 # define DEFAULT_MF_KEYS_OFFSET (DEFAULT_ICLASS_KEYS_OFFSET - DEFAULT_MF_KEYS_LEN)


### PR DESCRIPTION
This change moves flash-stored key dictionaries (Mifare, iClass and T55XX) from statically allocated area at the end of FLASH memory to a file located under SPIFFS file system.
This also implements automatic writing of the keys to SPIFFS using legacy methods.

Things to note:
- Currently there seem to be no implementation/use of iClass keys stored in flash, so this change only transfers all the keys to SPIFFS file
- In the future it will be a good idea to consider extension of SPIFFS into the last page of FLASH, as currently most of the page is left blank.
- The change was tested using Proxmark3 RDV4.01 and some Mifare Classic 1k cards and some T5577 tags.
- Cross-testing by other users would be more than welcome.

![image](https://github.com/user-attachments/assets/29afd4ca-1eb3-4b07-881b-2bf0be079240)
![image](https://github.com/user-attachments/assets/153f1f04-b228-4533-9cae-85cc39397d27)
![image](https://github.com/user-attachments/assets/351736a0-82cd-410f-8654-a96f1a29f361)
![image](https://github.com/user-attachments/assets/9a075c6d-1383-4367-ab8d-64bb86cebd83)
