### PR TITLE
lf em 410x sim - default gap value of 0, extend help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Changed `lf em 410x sim` to use default gap value of 0 and extended help (@piotrva)
 - Added `hf iclass trbl` to perform tear-off attacks on iClass (@antiklesys)
 - Added support for connection to host device in all Docker envs (@doegox)
 - Changed `hf 15 info` to show all type matches and check ST25TVxC signature (@doegox)

--- a/client/src/cmdlfem410x.c
+++ b/client/src/cmdlfem410x.c
@@ -449,17 +449,19 @@ static int CmdEM410xSim(const char *Cmd) {
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "lf em 410x sim",
                   "Enables simulation of EM 410x card.\n"
-                  "Simulation runs until the button is pressed or another USB command is issued.",
+                  "Simulation runs until the button is pressed or another USB command is issued.\n"
+                  "Most common readers expects the code to be sent in loop without a break (i.e. --gap 0).\n"
+                  "For other, more advanced readers there might be a need to set a non-zero gap value.",
                   "lf em 410x sim --id 0F0368568B\n"
                   "lf em 410x sim --id 0F0368568B --clk 32\n"
-                  "lf em 410x sim --id 0F0368568B --gap 0"
+                  "lf em 410x sim --id 0F0368568B --gap 20"
                  );
 
     void *argtable[] = {
         arg_param_begin,
         arg_u64_0(NULL, "clk", "<dec>", "<32|64> clock (default 64)"),
         arg_str1(NULL, "id", "<hex>", "EM Tag ID number (5 hex bytes)"),
-        arg_u64_0(NULL, "gap", "<dec>", "gap (0's) between ID repeats (default 20)"),
+        arg_u64_0(NULL, "gap", "<dec>", "gap (0's) between ID repeats (default 0)"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, false);
@@ -467,7 +469,7 @@ static int CmdEM410xSim(const char *Cmd) {
     // clock is 64 in EM410x tags
     int clk = arg_get_u32_def(ctx, 1, 64);
     int uid_len = 0;
-    int gap = arg_get_u32_def(ctx, 3, 20);
+    int gap = arg_get_u32_def(ctx, 3, 0);
     uint8_t uid[5] = {0};
     CLIGetHexWithReturn(ctx, 2, uid, &uid_len);
     CLIParserFree(ctx);


### PR DESCRIPTION
This changes default gap for simulating em410x tags to zero, as many readers except a looped, uninterrupted stream of data, as many original tags present.

This also extends built-in help to mention this behavior.

This change addresses discussion under #2197