### PR TITLE
Allow manual initiation of CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,7 @@
 name: "CodeQL"
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -2,6 +2,7 @@ on: pull_request_target
 name: Changelog Reminder
 jobs:
   remind:
+    if: github.repository_owner = 'RfidResearchGroup'
     name: Changelog Reminder
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
To fully validate a fix, it is necessary for a fork to manually initiate CodeQL.
(there's a hack by doing a draft PR to one's fork's main branch, but ...)

This simply allows the action to be manually initiated (`workflow_dispatch`).

EDIT: Added condition so the CHANGELOG.md reminder is only added for the official depot.