### PR TITLE
fix bigbuf allocators (tracing + malloc) overwriting each other

### DIFF
--- a/armsrc/Standalone/hf_bog.c
+++ b/armsrc/Standalone/hf_bog.c
@@ -60,7 +60,6 @@ static void RAMFUNC SniffAndStore(uint8_t param) {
     // free all previous allocations first
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(true);
 
     // Array to store the authpwds
@@ -134,13 +133,13 @@ static void RAMFUNC SniffAndStore(uint8_t param) {
             continue;
 
         // primary buffer was stopped( <-- we lost data!
-        if (!AT91C_BASE_PDC_SSC->PDC_RCR) {
+        if (AT91C_BASE_PDC_SSC->PDC_RCR == 0) {
             AT91C_BASE_PDC_SSC->PDC_RPR = (uint32_t)dmaBuf;
             AT91C_BASE_PDC_SSC->PDC_RCR = DMA_BUFFER_SIZE;
             // Dbprintf("[-] RxEmpty ERROR | data length %d", dataLen); // temporary
         }
         // secondary buffer sets as primary, secondary buffer was stopped
-        if (!AT91C_BASE_PDC_SSC->PDC_RNCR) {
+        if (AT91C_BASE_PDC_SSC->PDC_RNCR == 0) {
             AT91C_BASE_PDC_SSC->PDC_RNPR = (uint32_t)dmaBuf;
             AT91C_BASE_PDC_SSC->PDC_RNCR = DMA_BUFFER_SIZE;
         }

--- a/armsrc/hitag2.c
+++ b/armsrc/hitag2.c
@@ -1036,7 +1036,6 @@ void hitag_sniff(void) {
 
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(true);
 
     // Set up eavesdropping mode, frequency divisor which will drive the FPGA
@@ -1061,7 +1060,6 @@ void SniffHitag2(bool ledcontrol) {
 
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(true);
 
     /*
@@ -1418,7 +1416,6 @@ void SimulateHitag2(bool ledcontrol) {
 
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(true);
 
     // empties bigbuff etc

--- a/armsrc/hitagS.c
+++ b/armsrc/hitagS.c
@@ -708,9 +708,8 @@ void hts_simulate(bool tag_mem_supplied, const uint8_t *data, bool ledcontrol) {
     BigBuf_free();
     BigBuf_Clear_ext(false);
 
-    // Clean up trace and prepare it for storing frames
+    // Enable tracing
     set_tracing(true);
-    clear_trace();
 
     DbpString("Starting Hitag S simulation");
 

--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -728,7 +728,6 @@ void RAMFUNC SniffIso14443a(uint8_t param) {
     // free all previous allocations first
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(true);
 
     // The command (reader -> tag) that we're receiving.
@@ -798,13 +797,13 @@ void RAMFUNC SniffIso14443a(uint8_t param) {
         }
 
         // primary buffer was stopped( <-- we lost data!
-        if (!AT91C_BASE_PDC_SSC->PDC_RCR) {
+        if (AT91C_BASE_PDC_SSC->PDC_RCR == 0) {
             AT91C_BASE_PDC_SSC->PDC_RPR = (uint32_t) dma->buf;
             AT91C_BASE_PDC_SSC->PDC_RCR = DMA_BUFFER_SIZE;
             Dbprintf("[-] RxEmpty ERROR | data length %d", dataLen); // temporary
         }
         // secondary buffer sets as primary, secondary buffer was stopped
-        if (!AT91C_BASE_PDC_SSC->PDC_RNCR) {
+        if (AT91C_BASE_PDC_SSC->PDC_RNCR == 0) {
             AT91C_BASE_PDC_SSC->PDC_RNPR = (uint32_t) dma->buf;
             AT91C_BASE_PDC_SSC->PDC_RNCR = DMA_BUFFER_SIZE;
         }
@@ -3400,7 +3399,6 @@ void ReaderMifare(bool first_try, uint8_t block, uint8_t keytype) {
 
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(true);
 
     uint8_t mf_auth[4] = { keytype, block, 0x00, 0x00 };
@@ -3717,7 +3715,6 @@ void DetectNACKbug(void) {
 
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(true);
     iso14443a_setup(FPGA_HF_ISO14443A_READER_MOD);
 

--- a/armsrc/iso14443b.c
+++ b/armsrc/iso14443b.c
@@ -980,7 +980,6 @@ void Simulate_iso14443b_srx_tag(uint8_t *uid) {
     // allocate command receive buffer
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(true);
 
     uint16_t len, cmdsReceived = 0;
@@ -1381,12 +1380,12 @@ static int Get14443bAnswerFromTag(uint8_t *response, uint16_t max_len, uint32_t 
             if (AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_ENDRX)) {
 
                 // primary buffer was stopped
-                if (AT91C_BASE_PDC_SSC->PDC_RCR == false) {
+                if (AT91C_BASE_PDC_SSC->PDC_RCR == 0) {
                     AT91C_BASE_PDC_SSC->PDC_RPR = (uint32_t) dma->buf;
                     AT91C_BASE_PDC_SSC->PDC_RCR = DMA_BUFFER_SIZE;
                 }
                 // secondary buffer sets as primary, secondary buffer was stopped
-                if (AT91C_BASE_PDC_SSC->PDC_RNCR == false) {
+                if (AT91C_BASE_PDC_SSC->PDC_RNCR == 0) {
                     AT91C_BASE_PDC_SSC->PDC_RNPR = (uint32_t) dma->buf;
                     AT91C_BASE_PDC_SSC->PDC_RNCR = DMA_BUFFER_SIZE;
                 }
@@ -2463,12 +2462,12 @@ void SniffIso14443b(void) {
             if (AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_ENDRX)) {
 
                 // primary buffer was stopped
-                if (AT91C_BASE_PDC_SSC->PDC_RCR == false) {
+                if (AT91C_BASE_PDC_SSC->PDC_RCR == 0) {
                     AT91C_BASE_PDC_SSC->PDC_RPR = (uint32_t) dma->buf;
                     AT91C_BASE_PDC_SSC->PDC_RCR = DMA_BUFFER_SIZE;
                 }
                 // secondary buffer sets as primary, secondary buffer was stopped
-                if (AT91C_BASE_PDC_SSC->PDC_RNCR == false) {
+                if (AT91C_BASE_PDC_SSC->PDC_RNCR == 0) {
                     AT91C_BASE_PDC_SSC->PDC_RNPR = (uint32_t) dma->buf;
                     AT91C_BASE_PDC_SSC->PDC_RNCR = DMA_BUFFER_SIZE;
                 }
@@ -2578,7 +2577,6 @@ void SendRawCommand14443B(iso14b_raw_cmd_t *p) {
 
     if ((p->flags & ISO14B_CLEARTRACE) == ISO14B_CLEARTRACE) {
         clear_trace();
-        BigBuf_Clear_ext(false);
     }
 
     set_tracing(true);

--- a/armsrc/iso15693.c
+++ b/armsrc/iso15693.c
@@ -1032,12 +1032,12 @@ int GetIso15693AnswerFromTag(uint8_t *response, uint16_t max_len, uint16_t timeo
             if (AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_ENDRX)) {
 
                 // primary buffer was stopped
-                if (AT91C_BASE_PDC_SSC->PDC_RCR == false) {
+                if (AT91C_BASE_PDC_SSC->PDC_RCR == 0) {
                     AT91C_BASE_PDC_SSC->PDC_RPR = (uint32_t) dma->buf;
                     AT91C_BASE_PDC_SSC->PDC_RCR = DMA_BUFFER_SIZE;
                 }
                 // secondary buffer sets as primary, secondary buffer was stopped
-                if (AT91C_BASE_PDC_SSC->PDC_RNCR == false) {
+                if (AT91C_BASE_PDC_SSC->PDC_RNCR == 0) {
                     AT91C_BASE_PDC_SSC->PDC_RNPR = (uint32_t) dma->buf;
                     AT91C_BASE_PDC_SSC->PDC_RNCR = DMA_BUFFER_SIZE;
                 }
@@ -1708,12 +1708,12 @@ void SniffIso15693(uint8_t jam_search_len, uint8_t *jam_search_string, bool icla
             if (AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_ENDRX)) {
 
                 // primary buffer was stopped
-                if (AT91C_BASE_PDC_SSC->PDC_RCR == false) {
+                if (AT91C_BASE_PDC_SSC->PDC_RCR == 0) {
                     AT91C_BASE_PDC_SSC->PDC_RPR = (uint32_t) dma->buf;
                     AT91C_BASE_PDC_SSC->PDC_RCR = DMA_BUFFER_SIZE;
                 }
                 // secondary buffer sets as primary, secondary buffer was stopped
-                if (AT91C_BASE_PDC_SSC->PDC_RNCR == false) {
+                if (AT91C_BASE_PDC_SSC->PDC_RNCR == 0) {
                     AT91C_BASE_PDC_SSC->PDC_RNPR = (uint32_t) dma->buf;
                     AT91C_BASE_PDC_SSC->PDC_RNCR = DMA_BUFFER_SIZE;
                 }

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1006,7 +1006,6 @@ void CmdFSKsimTAGEx(uint8_t fchigh, uint8_t fclow, uint8_t separator, uint8_t cl
     // free eventually allocated BigBuf memory
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(false);
 
     int n = 0, i = 0;

--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -385,7 +385,6 @@ void MifareUReadCard(uint8_t arg0, uint16_t arg1, uint8_t arg2, uint8_t *datain)
     // free eventually allocated BigBuf memory
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(true);
 
     // params
@@ -804,7 +803,6 @@ void MifareAcquireNonces(uint32_t arg0, uint32_t flags) {
 
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(true);
 
     if (initialize)
@@ -918,7 +916,6 @@ void MifareAcquireEncryptedNonces(uint32_t arg0, uint32_t arg1, uint32_t flags, 
 
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(false);
 
     if (initialize)
@@ -1069,7 +1066,6 @@ int MifareAcquireStaticEncryptedNonces(uint32_t flags, const uint8_t *key, bool 
 
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(false);
 
     iso14443a_setup(FPGA_HF_ISO14443A_READER_LISTEN);
@@ -1353,9 +1349,6 @@ void MifareNested(uint8_t blockNo, uint8_t keyType, uint8_t targetBlockNo, uint8
     BigBuf_free();
     BigBuf_Clear_ext(false);
 
-    if (calibrate)
-        clear_trace();
-
     set_tracing(true);
 
     // statistics on nonce distance
@@ -1595,7 +1588,6 @@ void MifareStaticNested(uint8_t blockNo, uint8_t keyType, uint8_t targetBlockNo,
     // free eventually allocated BigBuf memory
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(true);
 
     int16_t isOK = PM3_ESOFT;

--- a/armsrc/mifaresniff_disabled.c
+++ b/armsrc/mifaresniff_disabled.c
@@ -50,7 +50,6 @@ void RAMFUNC SniffMifare(uint8_t param) {
     // free all previous allocations first
     BigBuf_free();
     BigBuf_Clear_ext(false);
-    clear_trace();
     set_tracing(true);
 
     // The command (reader -> tag) that we're receiving.
@@ -137,13 +136,13 @@ void RAMFUNC SniffMifare(uint8_t param) {
         if (dataLen < 1) continue;
 
         // primary buffer was stopped ( <-- we lost data!
-        if (!AT91C_BASE_PDC_SSC->PDC_RCR) {
+        if (AT91C_BASE_PDC_SSC->PDC_RCR == 0) {
             AT91C_BASE_PDC_SSC->PDC_RPR = (uint32_t)dmaBuf;
             AT91C_BASE_PDC_SSC->PDC_RCR = DMA_BUFFER_SIZE;
             Dbprintf("[-] RxEmpty ERROR | data length %d", dataLen); // temporary
         }
         // secondary buffer sets as primary, secondary buffer was stopped
-        if (!AT91C_BASE_PDC_SSC->PDC_RNCR) {
+        if (AT91C_BASE_PDC_SSC->PDC_RNCR == 0) {
             AT91C_BASE_PDC_SSC->PDC_RNPR = (uint32_t)dmaBuf;
             AT91C_BASE_PDC_SSC->PDC_RNCR = DMA_BUFFER_SIZE;
         }


### PR DESCRIPTION
* BigBuf.c: use s_ prefix for statics
* BigBuf_Clear_ext already calls clear_trace, so remove extra calls
* add some sanity checking of allocator args
* dont compare PDC_RNCR to false