### PR TITLE
Fix facility code and card number checking in LF HID Brute

### DIFF
--- a/client/src/cmdlfhid.c
+++ b/client/src/cmdlfhid.c
@@ -544,7 +544,7 @@ static int CmdHIDBrute(const char *Cmd) {
     }
 
     wiegand_card_t card_hi, card_low;
-    cardformatlimit_t limit = get_card_format_limit(format_idx);
+    cardformatdescriptor_t card_descriptor = HIDGetCardFormat(format_idx).Fields;
     memset(&card_hi, 0, sizeof(wiegand_card_t));
 
     char field[3] = {0};
@@ -624,13 +624,13 @@ static int CmdHIDBrute(const char *Cmd) {
                 return PM3_ESOFT;
             }
             if (strcmp(field, "fc") == 0) {
-                if (card_hi.FacilityCode < limit.FacilityCode) {
+                if (card_hi.FacilityCode < card_descriptor.MaxFC) {
                     card_hi.FacilityCode++;
                 } else {
                     fin_hi = true;
                 }
             } else if (strcmp(field, "cn") == 0) {
-                if (card_hi.CardNumber < limit.CardNumber) {
+                if (card_hi.CardNumber < card_descriptor.MaxCN) {
                     card_hi.CardNumber++;
                 } else {
                     fin_hi = true;

--- a/client/src/cmdlfhid.c
+++ b/client/src/cmdlfhid.c
@@ -544,6 +544,7 @@ static int CmdHIDBrute(const char *Cmd) {
     }
 
     wiegand_card_t card_hi, card_low;
+    cardformatlimit_t limit = get_card_format_limit(format_idx);
     memset(&card_hi, 0, sizeof(wiegand_card_t));
 
     char field[3] = {0};
@@ -623,13 +624,13 @@ static int CmdHIDBrute(const char *Cmd) {
                 return PM3_ESOFT;
             }
             if (strcmp(field, "fc") == 0) {
-                if (card_hi.FacilityCode < 0xFF) {
+                if (card_hi.FacilityCode < limit.FacilityCode) {
                     card_hi.FacilityCode++;
                 } else {
                     fin_hi = true;
                 }
             } else if (strcmp(field, "cn") == 0) {
-                if (card_hi.CardNumber < 0xFFFF) {
+                if (card_hi.CardNumber < limit.CardNumber) {
                     card_hi.CardNumber++;
                 } else {
                     fin_hi = true;

--- a/client/src/wiegand_formats.c
+++ b/client/src/wiegand_formats.c
@@ -1499,46 +1499,46 @@ static void hid_print_card(wiegand_card_t *card, const cardformat_t format) {
 }
 
 static const cardformat_t FormatTable[] = {
-    {"H10301",  Pack_H10301,  Unpack_H10301,  "HID H10301 26-bit",          {1, 1, 0, 0, 1}}, // imported from old pack/unpack
-    {"ind26",   Pack_ind26,   Unpack_ind26,   "Indala 26-bit",              {1, 1, 0, 0, 1}}, // from cardinfo.barkweb.com.au
-    {"ind27",   Pack_ind27,   Unpack_ind27,   "Indala 27-bit",              {1, 1, 0, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"indasc27", Pack_indasc27, Unpack_indasc27, "Indala ASC 27-bit",       {1, 1, 0, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"Tecom27", Pack_Tecom27, Unpack_Tecom27, "Tecom 27-bit",               {1, 1, 0, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"2804W",   Pack_2804W,   Unpack_2804W,   "2804 Wiegand 28-bit",        {1, 1, 0, 0, 1}}, // from cardinfo.barkweb.com.au
-    {"ind29",   Pack_ind29,   Unpack_ind29,   "Indala 29-bit",              {1, 1, 0, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"ATSW30",  Pack_ATSW30,  Unpack_ATSW30,  "ATS Wiegand 30-bit",         {1, 1, 0, 0, 1}}, // from cardinfo.barkweb.com.au
-    {"ADT31",   Pack_ADT31,   Unpack_ADT31,   "HID ADT 31-bit",             {1, 1, 0, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"HCP32",   Pack_hcp32,   Unpack_hcp32,   "HID Check Point 32-bit",     {1, 0, 0, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"HPP32",   Pack_hpp32,   Unpack_hpp32,   "HID Hewlett-Packard 32-bit", {1, 1, 0, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"Kastle",  Pack_Kastle,  Unpack_Kastle,  "Kastle 32-bit",              {1, 1, 1, 0, 1}}, // from @xilni; PR #23 on RfidResearchGroup/proxmark3
-    {"Kantech", Pack_Kantech, Unpack_Kantech, "Indala/Kantech KFS 32-bit",  {1, 1, 0, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"WIE32",   Pack_wie32,   Unpack_wie32,   "Wiegand 32-bit",             {1, 1, 0, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"D10202",  Pack_D10202,  Unpack_D10202,  "HID D10202 33-bit",          {1, 1, 0, 0, 1}}, // from cardinfo.barkweb.com.au
-    {"H10306",  Pack_H10306,  Unpack_H10306,  "HID H10306 34-bit",          {1, 1, 0, 0, 1}}, // imported from old pack/unpack
-    {"N10002",  Pack_N10002,  Unpack_N10002,  "Honeywell/Northern N10002 34-bit", {1, 1, 0, 0, 1}}, // from proxclone.com
-    {"Optus34", Pack_Optus,   Unpack_Optus,   "Indala Optus 34-bit",        {1, 1, 0, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"SMP34",   Pack_Smartpass, Unpack_Smartpass, "Cardkey Smartpass 34-bit", {1, 1, 1, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"BQT34",   Pack_bqt34,   Unpack_bqt34,   "BQT 34-bit",                 {1, 1, 0, 0, 1}}, // from cardinfo.barkweb.com.au
-    {"C1k35s",  Pack_C1k35s,  Unpack_C1k35s,  "HID Corporate 1000 35-bit std", {1, 1, 0, 0, 1}}, // imported from old pack/unpack
-    {"C15001",  Pack_C15001,  Unpack_C15001,  "HID KeyScan 36-bit",         {1, 1, 0, 1, 1}}, // from Proxmark forums
-    {"S12906",  Pack_S12906,  Unpack_S12906,  "HID Simplex 36-bit",         {1, 1, 1, 0, 1}}, // from cardinfo.barkweb.com.au
-    {"Sie36",   Pack_Sie36,   Unpack_Sie36,   "HID 36-bit Siemens",         {1, 1, 0, 0, 1}}, // from cardinfo.barkweb.com.au
-    {"H10320",  Pack_H10320,  Unpack_H10320,  "HID H10320 37-bit BCD",      {1, 0, 0, 0, 1}}, // from Proxmark forums
-    {"H10302",  Pack_H10302,  Unpack_H10302,  "HID H10302 37-bit huge ID",  {1, 0, 0, 0, 1}}, // from Proxmark forums
-    {"H10304",  Pack_H10304,  Unpack_H10304,  "HID H10304 37-bit",          {1, 1, 0, 0, 1}}, // from cardinfo.barkweb.com.au
-    {"P10004",  Pack_P10004,  Unpack_P10004,  "HID P10004 37-bit PCSC",     {1, 1, 0, 0, 0}}, // from @bthedorff; PR #1559
-    {"HGen37",  Pack_HGeneric37, Unpack_HGeneric37,  "HID Generic 37-bit", {1, 0, 0, 0, 1}}, // from cardinfo.barkweb.com.au
-    {"MDI37",   Pack_MDI37,   Unpack_MDI37,   "PointGuard MDI 37-bit",         {1, 1, 0, 0, 1}}, // from cardinfo.barkweb.com.au
-    {"BQT38",   Pack_bqt38,   Unpack_bqt38,   "BQT 38-bit",                    {1, 1, 1, 0, 1}}, // from cardinfo.barkweb.com.au
-    {"ISCS",    Pack_iscs38,  Unpack_iscs38,  "ISCS 38-bit",                   {1, 1, 0, 1, 1}}, // from cardinfo.barkweb.com.au
-    {"PW39",    Pack_pw39,    Unpack_pw39,    "Pyramid 39-bit wiegand format", {1, 1, 0, 0, 1}},  // from cardinfo.barkweb.com.au
-    {"P10001",  Pack_P10001,  Unpack_P10001,  "HID P10001 Honeywell 40-bit",   {1, 1, 0, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"Casi40",  Pack_CasiRusco40, Unpack_CasiRusco40, "Casi-Rusco 40-bit",     {1, 0, 0, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"C1k48s",  Pack_C1k48s,  Unpack_C1k48s,  "HID Corporate 1000 48-bit std", {1, 1, 0, 0, 1}}, // imported from old pack/unpack
-    {"BC40",    Pack_bc40,    Unpack_bc40,    "Bundy TimeClock 40-bit",     {1, 1, 0, 1, 1}}, // from
-    {"Avig56", Pack_Avig56, Unpack_Avig56, "Avigilon 56-bit", {1, 1, 0, 0, 1}},
-    {"Defcon32",  Pack_Defcon32,  Unpack_Defcon32,  "Custom Defcon RFCTF 42 BIT format",          {1, 1, 1, 0, 1}}, // Created by (@micsen) for the CTF
-    {NULL, NULL, NULL, NULL, {0, 0, 0, 0, 0}} // Must null terminate array
+    {"H10301",  Pack_H10301,  Unpack_H10301,  "HID H10301 26-bit",          {1, 1, 0, 0, 1}, {0xFF, 0xFFFF, 0, 0}}, // imported from old pack/unpack
+    {"ind26",   Pack_ind26,   Unpack_ind26,   "Indala 26-bit",              {1, 1, 0, 0, 1}, {0xFFF, 0xFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"ind27",   Pack_ind27,   Unpack_ind27,   "Indala 27-bit",              {1, 1, 0, 0, 0}, {0x1FFF, 0x3FFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"indasc27", Pack_indasc27, Unpack_indasc27, "Indala ASC 27-bit",       {1, 1, 0, 0, 0}, {0x1FFF, 0x3FFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"Tecom27", Pack_Tecom27, Unpack_Tecom27, "Tecom 27-bit",               {1, 1, 0, 0, 0}, {0x7FF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"2804W",   Pack_2804W,   Unpack_2804W,   "2804 Wiegand 28-bit",        {1, 1, 0, 0, 1}, {0xFF, 0x7FFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"ind29",   Pack_ind29,   Unpack_ind29,   "Indala 29-bit",              {1, 1, 0, 0, 0}, {0x1FFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"ATSW30",  Pack_ATSW30,  Unpack_ATSW30,  "ATS Wiegand 30-bit",         {1, 1, 0, 0, 1}, {0xFFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"ADT31",   Pack_ADT31,   Unpack_ADT31,   "HID ADT 31-bit",             {1, 1, 0, 0, 0}, {0xF, 0x7FFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"HCP32",   Pack_hcp32,   Unpack_hcp32,   "HID Check Point 32-bit",     {1, 0, 0, 0, 0}, {0, 0x3FFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"HPP32",   Pack_hpp32,   Unpack_hpp32,   "HID Hewlett-Packard 32-bit", {1, 1, 0, 0, 0}, {0xFFF, 0x1FFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"Kastle",  Pack_Kastle,  Unpack_Kastle,  "Kastle 32-bit",              {1, 1, 1, 0, 1}, {0xFF, 0xFFFF, 0x1F, 0}}, // from @xilni; PR #23 on RfidResearchGroup/proxmark3
+    {"Kantech", Pack_Kantech, Unpack_Kantech, "Indala/Kantech KFS 32-bit",  {1, 1, 0, 0, 0}, {0xFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"WIE32",   Pack_wie32,   Unpack_wie32,   "Wiegand 32-bit",             {1, 1, 0, 0, 0}, {0xFFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"D10202",  Pack_D10202,  Unpack_D10202,  "HID D10202 33-bit",          {1, 1, 0, 0, 1}, {0x7F, 0xFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"H10306",  Pack_H10306,  Unpack_H10306,  "HID H10306 34-bit",          {1, 1, 0, 0, 1}, {0xFFFF, 0xFFFF, 0, 0}}, // imported from old pack/unpack
+    {"N10002",  Pack_N10002,  Unpack_N10002,  "Honeywell/Northern N10002 34-bit", {1, 1, 0, 0, 1}, {0xFFFF, 0xFFFF, 0, 0}}, // from proxclone.com
+    {"Optus34", Pack_Optus,   Unpack_Optus,   "Indala Optus 34-bit",        {1, 1, 0, 0, 0}, {0x3FF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"SMP34",   Pack_Smartpass, Unpack_Smartpass, "Cardkey Smartpass 34-bit", {1, 1, 1, 0, 0}, {0x3FF, 0xFFFF, 0x7, 0}}, // from cardinfo.barkweb.com.au
+    {"BQT34",   Pack_bqt34,   Unpack_bqt34,   "BQT 34-bit",                 {1, 1, 0, 0, 1}, {0xFF, 0xFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"C1k35s",  Pack_C1k35s,  Unpack_C1k35s,  "HID Corporate 1000 35-bit std", {1, 1, 0, 0, 1}, {0xFFF, 0xFFFFF, 0, 0}}, // imported from old pack/unpack
+    {"C15001",  Pack_C15001,  Unpack_C15001,  "HID KeyScan 36-bit",         {1, 1, 0, 1, 1}, {0xFF, 0xFFFF, 0, 0x3FF}}, // from Proxmark forums
+    {"S12906",  Pack_S12906,  Unpack_S12906,  "HID Simplex 36-bit",         {1, 1, 1, 0, 1}, {0xFF, 0x3, 0xFFFFFF, 0}}, // from cardinfo.barkweb.com.au
+    {"Sie36",   Pack_Sie36,   Unpack_Sie36,   "HID 36-bit Siemens",         {1, 1, 0, 0, 1}, {0x3FFFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"H10320",  Pack_H10320,  Unpack_H10320,  "HID H10320 37-bit BCD",      {1, 0, 0, 0, 1}, {0, 99999999, 0, 0}}, // from Proxmark forums
+    {"H10302",  Pack_H10302,  Unpack_H10302,  "HID H10302 37-bit huge ID",  {1, 0, 0, 0, 1}, {0, 0x7FFFFFFFF, 0, 0}}, // from Proxmark forums
+    {"H10304",  Pack_H10304,  Unpack_H10304,  "HID H10304 37-bit",          {1, 1, 0, 0, 1}, {0xFFFF, 0x7FFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"P10004",  Pack_P10004,  Unpack_P10004,  "HID P10004 37-bit PCSC",     {1, 1, 0, 0, 0}, {0x1FFF, 0x3FFFF, 0, 0}}, // from @bthedorff; PR #1559
+    {"HGen37",  Pack_HGeneric37, Unpack_HGeneric37,  "HID Generic 37-bit",  {1, 0, 0, 0, 1}, {0, 0x7FFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"MDI37",   Pack_MDI37,   Unpack_MDI37,   "PointGuard MDI 37-bit",         {1, 1, 0, 0, 1}, {0xF, 0x1FFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"BQT38",   Pack_bqt38,   Unpack_bqt38,   "BQT 38-bit",                    {1, 1, 1, 0, 1}, {0xFFF, 0x3FFFF, 0x7, 0}}, // from cardinfo.barkweb.com.au
+    {"ISCS",    Pack_iscs38,  Unpack_iscs38,  "ISCS 38-bit",                   {1, 1, 0, 1, 1}, {0x3FF, 0xFFFFFF, 0, 0x7}}, // from cardinfo.barkweb.com.au
+    {"PW39",    Pack_pw39,    Unpack_pw39,    "Pyramid 39-bit wiegand format", {1, 1, 0, 0, 1}, {0xFFFF, 0xFFFFF, 0, 0}},  // from cardinfo.barkweb.com.au
+    {"P10001",  Pack_P10001,  Unpack_P10001,  "HID P10001 Honeywell 40-bit",   {1, 1, 0, 0, 0}, {0xFFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"Casi40",  Pack_CasiRusco40, Unpack_CasiRusco40, "Casi-Rusco 40-bit",     {1, 0, 0, 0, 0}, {0, 0xFFFFFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"C1k48s",  Pack_C1k48s,  Unpack_C1k48s,  "HID Corporate 1000 48-bit std", {1, 1, 0, 0, 1}, {0x003FFFFF, 0x007FFFFF, 0, 0}}, // imported from old pack/unpack
+    {"BC40",    Pack_bc40,    Unpack_bc40,    "Bundy TimeClock 40-bit",        {1, 1, 0, 1, 1}, {0xFFF, 0xFFFFF, 0, 0x7F}}, // from
+    {"Avig56",  Pack_Avig56,  Unpack_Avig56,  "Avigilon 56-bit",               {1, 1, 0, 0, 1}, {0xFFFFF, 0x3FFFFFFFF, 0, 0}},
+    {"Defcon32",  Pack_Defcon32,  Unpack_Defcon32,  "Custom Defcon RFCTF 42 BIT format",  {1, 1, 1, 0, 1}, {0xFFFF, 0xFFFFF, 0xF, 0}}, // Created by (@micsen) for the CTF
+    {NULL, NULL, NULL, NULL, {0, 0, 0, 0, 0}, {0, 0, 0, 0}} // Must null terminate array
 };
 
 void HIDListFormats(void) {
@@ -1664,74 +1664,9 @@ void HIDUnpack(int idx, wiegand_message_t *packed) {
     }
 }
 
-int HIDDumpPACSBits(const uint8_t *const data, const uint8_t length, bool verbose) {
-    uint8_t n = length - 1;
-    uint8_t pad = data[0];
-    char *binstr = (char *)calloc((length * 8) + 1, sizeof(uint8_t));
-    if (binstr == NULL) {
-        return PM3_EMALLOC;
-    }
-
-    bytes_2_binstr(binstr, data + 1, n);
-
-    PrintAndLogEx(NORMAL, "");
-    PrintAndLogEx(SUCCESS, "PACS......... " _GREEN_("%s"), sprint_hex_inrow(data, length));
-    PrintAndLogEx(SUCCESS, "padded bin... " _GREEN_("%s") " ( %zu )", binstr, strlen(binstr));
-
-    binstr[strlen(binstr) - pad] = '\0';
-    PrintAndLogEx(SUCCESS, "bin.......... " _GREEN_("%s") " ( %zu )", binstr, strlen(binstr));
-
-    size_t hexlen = 0;
-    uint8_t hex[16] = {0};
-    binstr_2_bytes(hex, &hexlen, binstr);
-    PrintAndLogEx(SUCCESS, "hex.......... " _GREEN_("%s"), sprint_hex_inrow(hex, hexlen));
-
-    uint32_t top = 0, mid = 0, bot = 0;
-    if (binstring_to_u96(&top, &mid, &bot, binstr) != strlen(binstr)) {
-        PrintAndLogEx(ERR, "Binary string contains none <0|1> chars");
-        free(binstr);
-        return PM3_EINVARG;
-    }
-
-    PrintAndLogEx(NORMAL, "");
-    PrintAndLogEx(INFO, "Wiegand decode");
-    wiegand_message_t packed = initialize_message_object(top, mid, bot, strlen(binstr));
-    HIDTryUnpack(&packed);
-
-    PrintAndLogEx(NORMAL, "");
-
-    if (strlen(binstr) >= 26 && verbose) {
-
-        // iCLASS Legacy
-        PrintAndLogEx(INFO, "Clone to " _YELLOW_("iCLASS Legacy"));
-        PrintAndLogEx(SUCCESS, "    hf iclass encode --ki 0 --bin %s", binstr);
-        PrintAndLogEx(NORMAL, "");
-
-        // HID Prox II
-        PrintAndLogEx(INFO, "Downgrade to " _YELLOW_("HID Prox II"));
-        PrintAndLogEx(SUCCESS, "    lf hid clone -w H10301 --bin %s", binstr);
-        PrintAndLogEx(NORMAL, "");
-
-        // MIFARE Classic
-        char mfcbin[28] = {0};
-        mfcbin[0] = '1';
-        memcpy(mfcbin + 1, binstr, strlen(binstr));
-        binstr_2_bytes(hex, &hexlen, mfcbin);
-
-        PrintAndLogEx(INFO, "Downgrade to " _YELLOW_("MIFARE Classic") " (Pm3 simulation)");
-        PrintAndLogEx(SUCCESS, "    hf mf eclr;");
-        PrintAndLogEx(SUCCESS, "    hf mf esetblk --blk 0 -d 049DBA42A23E80884400C82000000000;");
-        PrintAndLogEx(SUCCESS, "    hf mf esetblk --blk 1 -d 1B014D48000000000000000000000000;");
-        PrintAndLogEx(SUCCESS, "    hf mf esetblk --blk 3 -d A0A1A2A3A4A5787788C189ECA97F8C2A;");
-        PrintAndLogEx(SUCCESS, "    hf mf esetblk --blk 5 -d 020000000000000000000000%s;", sprint_hex_inrow(hex, hexlen));
-        PrintAndLogEx(SUCCESS, "    hf mf esetblk --blk 7 -d 484944204953787788AA204752454154;");
-        PrintAndLogEx(SUCCESS, "    hf mf sim --1k -i;");
-        PrintAndLogEx(NORMAL, "");
-
-        PrintAndLogEx(INFO, "Downgrade to " _YELLOW_("MIFARE Classic 1K"));
-        PrintAndLogEx(SUCCESS, "    hf mf encodehid --bin %s", binstr);
-        PrintAndLogEx(NORMAL, "");
-    }
-    free(binstr);
-    return PM3_SUCCESS;
+cardformatlimit_t get_card_format_limit(int format_idx){
+    if ((format_idx < 0) || (format_idx > ARRAYLEN(FormatTable) - 2))
+        return FormatTable[ARRAYLEN(FormatTable) - 1].FieldLimits;
+    else
+        return FormatTable[format_idx].FieldLimits;
 }

--- a/client/src/wiegand_formats.c
+++ b/client/src/wiegand_formats.c
@@ -1499,46 +1499,46 @@ static void hid_print_card(wiegand_card_t *card, const cardformat_t format) {
 }
 
 static const cardformat_t FormatTable[] = {
-    {"H10301",  Pack_H10301,  Unpack_H10301,  "HID H10301 26-bit",          {1, 1, 0, 0, 1}, {0xFF, 0xFFFF, 0, 0}}, // imported from old pack/unpack
-    {"ind26",   Pack_ind26,   Unpack_ind26,   "Indala 26-bit",              {1, 1, 0, 0, 1}, {0xFFF, 0xFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"ind27",   Pack_ind27,   Unpack_ind27,   "Indala 27-bit",              {1, 1, 0, 0, 0}, {0x1FFF, 0x3FFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"indasc27", Pack_indasc27, Unpack_indasc27, "Indala ASC 27-bit",       {1, 1, 0, 0, 0}, {0x1FFF, 0x3FFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"Tecom27", Pack_Tecom27, Unpack_Tecom27, "Tecom 27-bit",               {1, 1, 0, 0, 0}, {0x7FF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"2804W",   Pack_2804W,   Unpack_2804W,   "2804 Wiegand 28-bit",        {1, 1, 0, 0, 1}, {0xFF, 0x7FFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"ind29",   Pack_ind29,   Unpack_ind29,   "Indala 29-bit",              {1, 1, 0, 0, 0}, {0x1FFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"ATSW30",  Pack_ATSW30,  Unpack_ATSW30,  "ATS Wiegand 30-bit",         {1, 1, 0, 0, 1}, {0xFFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"ADT31",   Pack_ADT31,   Unpack_ADT31,   "HID ADT 31-bit",             {1, 1, 0, 0, 0}, {0xF, 0x7FFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"HCP32",   Pack_hcp32,   Unpack_hcp32,   "HID Check Point 32-bit",     {1, 0, 0, 0, 0}, {0, 0x3FFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"HPP32",   Pack_hpp32,   Unpack_hpp32,   "HID Hewlett-Packard 32-bit", {1, 1, 0, 0, 0}, {0xFFF, 0x1FFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"Kastle",  Pack_Kastle,  Unpack_Kastle,  "Kastle 32-bit",              {1, 1, 1, 0, 1}, {0xFF, 0xFFFF, 0x1F, 0}}, // from @xilni; PR #23 on RfidResearchGroup/proxmark3
-    {"Kantech", Pack_Kantech, Unpack_Kantech, "Indala/Kantech KFS 32-bit",  {1, 1, 0, 0, 0}, {0xFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"WIE32",   Pack_wie32,   Unpack_wie32,   "Wiegand 32-bit",             {1, 1, 0, 0, 0}, {0xFFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"D10202",  Pack_D10202,  Unpack_D10202,  "HID D10202 33-bit",          {1, 1, 0, 0, 1}, {0x7F, 0xFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"H10306",  Pack_H10306,  Unpack_H10306,  "HID H10306 34-bit",          {1, 1, 0, 0, 1}, {0xFFFF, 0xFFFF, 0, 0}}, // imported from old pack/unpack
-    {"N10002",  Pack_N10002,  Unpack_N10002,  "Honeywell/Northern N10002 34-bit", {1, 1, 0, 0, 1}, {0xFFFF, 0xFFFF, 0, 0}}, // from proxclone.com
-    {"Optus34", Pack_Optus,   Unpack_Optus,   "Indala Optus 34-bit",        {1, 1, 0, 0, 0}, {0x3FF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"SMP34",   Pack_Smartpass, Unpack_Smartpass, "Cardkey Smartpass 34-bit", {1, 1, 1, 0, 0}, {0x3FF, 0xFFFF, 0x7, 0}}, // from cardinfo.barkweb.com.au
-    {"BQT34",   Pack_bqt34,   Unpack_bqt34,   "BQT 34-bit",                 {1, 1, 0, 0, 1}, {0xFF, 0xFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"C1k35s",  Pack_C1k35s,  Unpack_C1k35s,  "HID Corporate 1000 35-bit std", {1, 1, 0, 0, 1}, {0xFFF, 0xFFFFF, 0, 0}}, // imported from old pack/unpack
-    {"C15001",  Pack_C15001,  Unpack_C15001,  "HID KeyScan 36-bit",         {1, 1, 0, 1, 1}, {0xFF, 0xFFFF, 0, 0x3FF}}, // from Proxmark forums
-    {"S12906",  Pack_S12906,  Unpack_S12906,  "HID Simplex 36-bit",         {1, 1, 1, 0, 1}, {0xFF, 0x3, 0xFFFFFF, 0}}, // from cardinfo.barkweb.com.au
-    {"Sie36",   Pack_Sie36,   Unpack_Sie36,   "HID 36-bit Siemens",         {1, 1, 0, 0, 1}, {0x3FFFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"H10320",  Pack_H10320,  Unpack_H10320,  "HID H10320 37-bit BCD",      {1, 0, 0, 0, 1}, {0, 99999999, 0, 0}}, // from Proxmark forums
-    {"H10302",  Pack_H10302,  Unpack_H10302,  "HID H10302 37-bit huge ID",  {1, 0, 0, 0, 1}, {0, 0x7FFFFFFFF, 0, 0}}, // from Proxmark forums
-    {"H10304",  Pack_H10304,  Unpack_H10304,  "HID H10304 37-bit",          {1, 1, 0, 0, 1}, {0xFFFF, 0x7FFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"P10004",  Pack_P10004,  Unpack_P10004,  "HID P10004 37-bit PCSC",     {1, 1, 0, 0, 0}, {0x1FFF, 0x3FFFF, 0, 0}}, // from @bthedorff; PR #1559
-    {"HGen37",  Pack_HGeneric37, Unpack_HGeneric37,  "HID Generic 37-bit",  {1, 0, 0, 0, 1}, {0, 0x7FFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"MDI37",   Pack_MDI37,   Unpack_MDI37,   "PointGuard MDI 37-bit",         {1, 1, 0, 0, 1}, {0xF, 0x1FFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"BQT38",   Pack_bqt38,   Unpack_bqt38,   "BQT 38-bit",                    {1, 1, 1, 0, 1}, {0xFFF, 0x3FFFF, 0x7, 0}}, // from cardinfo.barkweb.com.au
-    {"ISCS",    Pack_iscs38,  Unpack_iscs38,  "ISCS 38-bit",                   {1, 1, 0, 1, 1}, {0x3FF, 0xFFFFFF, 0, 0x7}}, // from cardinfo.barkweb.com.au
-    {"PW39",    Pack_pw39,    Unpack_pw39,    "Pyramid 39-bit wiegand format", {1, 1, 0, 0, 1}, {0xFFFF, 0xFFFFF, 0, 0}},  // from cardinfo.barkweb.com.au
-    {"P10001",  Pack_P10001,  Unpack_P10001,  "HID P10001 Honeywell 40-bit",   {1, 1, 0, 0, 0}, {0xFFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"Casi40",  Pack_CasiRusco40, Unpack_CasiRusco40, "Casi-Rusco 40-bit",     {1, 0, 0, 0, 0}, {0, 0xFFFFFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
-    {"C1k48s",  Pack_C1k48s,  Unpack_C1k48s,  "HID Corporate 1000 48-bit std", {1, 1, 0, 0, 1}, {0x003FFFFF, 0x007FFFFF, 0, 0}}, // imported from old pack/unpack
-    {"BC40",    Pack_bc40,    Unpack_bc40,    "Bundy TimeClock 40-bit",        {1, 1, 0, 1, 1}, {0xFFF, 0xFFFFF, 0, 0x7F}}, // from
-    {"Avig56",  Pack_Avig56,  Unpack_Avig56,  "Avigilon 56-bit",               {1, 1, 0, 0, 1}, {0xFFFFF, 0x3FFFFFFFF, 0, 0}},
-    {"Defcon32",  Pack_Defcon32,  Unpack_Defcon32,  "Custom Defcon RFCTF 42 BIT format",  {1, 1, 1, 0, 1}, {0xFFFF, 0xFFFFF, 0xF, 0}}, // Created by (@micsen) for the CTF
-    {NULL, NULL, NULL, NULL, {0, 0, 0, 0, 0}, {0, 0, 0, 0}} // Must null terminate array
+    {"H10301",  Pack_H10301,  Unpack_H10301,  "HID H10301 26-bit",          {1, 1, 0, 0, 1, 0xFF, 0xFFFF, 0, 0}}, // imported from old pack/unpack
+    {"ind26",   Pack_ind26,   Unpack_ind26,   "Indala 26-bit",              {1, 1, 0, 0, 1, 0xFFF, 0xFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"ind27",   Pack_ind27,   Unpack_ind27,   "Indala 27-bit",              {1, 1, 0, 0, 0, 0x1FFF, 0x3FFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"indasc27", Pack_indasc27, Unpack_indasc27, "Indala ASC 27-bit",       {1, 1, 0, 0, 0, 0x1FFF, 0x3FFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"Tecom27", Pack_Tecom27, Unpack_Tecom27, "Tecom 27-bit",               {1, 1, 0, 0, 0, 0x7FF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"2804W",   Pack_2804W,   Unpack_2804W,   "2804 Wiegand 28-bit",        {1, 1, 0, 0, 1, 0xFF, 0x7FFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"ind29",   Pack_ind29,   Unpack_ind29,   "Indala 29-bit",              {1, 1, 0, 0, 0, 0x1FFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"ATSW30",  Pack_ATSW30,  Unpack_ATSW30,  "ATS Wiegand 30-bit",         {1, 1, 0, 0, 1, 0xFFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"ADT31",   Pack_ADT31,   Unpack_ADT31,   "HID ADT 31-bit",             {1, 1, 0, 0, 0, 0xF, 0x7FFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"HCP32",   Pack_hcp32,   Unpack_hcp32,   "HID Check Point 32-bit",     {1, 0, 0, 0, 0, 0, 0x3FFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"HPP32",   Pack_hpp32,   Unpack_hpp32,   "HID Hewlett-Packard 32-bit", {1, 1, 0, 0, 0, 0xFFF, 0x1FFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"Kastle",  Pack_Kastle,  Unpack_Kastle,  "Kastle 32-bit",              {1, 1, 1, 0, 1, 0xFF, 0xFFFF, 0x1F, 0}}, // from @xilni; PR #23 on RfidResearchGroup/proxmark3
+    {"Kantech", Pack_Kantech, Unpack_Kantech, "Indala/Kantech KFS 32-bit",  {1, 1, 0, 0, 0, 0xFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"WIE32",   Pack_wie32,   Unpack_wie32,   "Wiegand 32-bit",             {1, 1, 0, 0, 0, 0xFFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"D10202",  Pack_D10202,  Unpack_D10202,  "HID D10202 33-bit",          {1, 1, 0, 0, 1, 0x7F, 0xFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"H10306",  Pack_H10306,  Unpack_H10306,  "HID H10306 34-bit",          {1, 1, 0, 0, 1, 0xFFFF, 0xFFFF, 0, 0}}, // imported from old pack/unpack
+    {"N10002",  Pack_N10002,  Unpack_N10002,  "Honeywell/Northern N10002 34-bit", {1, 1, 0, 0, 1, 0xFFFF, 0xFFFF, 0, 0}}, // from proxclone.com
+    {"Optus34", Pack_Optus,   Unpack_Optus,   "Indala Optus 34-bit",        {1, 1, 0, 0, 0, 0x3FF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"SMP34",   Pack_Smartpass, Unpack_Smartpass, "Cardkey Smartpass 34-bit", {1, 1, 1, 0, 0, 0x3FF, 0xFFFF, 0x7, 0}}, // from cardinfo.barkweb.com.au
+    {"BQT34",   Pack_bqt34,   Unpack_bqt34,   "BQT 34-bit",                 {1, 1, 0, 0, 1, 0xFF, 0xFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"C1k35s",  Pack_C1k35s,  Unpack_C1k35s,  "HID Corporate 1000 35-bit std", {1, 1, 0, 0, 1, 0xFFF, 0xFFFFF, 0, 0}}, // imported from old pack/unpack
+    {"C15001",  Pack_C15001,  Unpack_C15001,  "HID KeyScan 36-bit",         {1, 1, 0, 1, 1, 0xFF, 0xFFFF, 0, 0x3FF}}, // from Proxmark forums
+    {"S12906",  Pack_S12906,  Unpack_S12906,  "HID Simplex 36-bit",         {1, 1, 1, 0, 1, 0xFF, 0x3, 0xFFFFFF, 0}}, // from cardinfo.barkweb.com.au
+    {"Sie36",   Pack_Sie36,   Unpack_Sie36,   "HID 36-bit Siemens",         {1, 1, 0, 0, 1, 0x3FFFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"H10320",  Pack_H10320,  Unpack_H10320,  "HID H10320 37-bit BCD",      {1, 0, 0, 0, 1, 0, 99999999, 0, 0}}, // from Proxmark forums
+    {"H10302",  Pack_H10302,  Unpack_H10302,  "HID H10302 37-bit huge ID",  {1, 0, 0, 0, 1, 0, 0x7FFFFFFFF, 0, 0}}, // from Proxmark forums
+    {"H10304",  Pack_H10304,  Unpack_H10304,  "HID H10304 37-bit",          {1, 1, 0, 0, 1, 0xFFFF, 0x7FFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"P10004",  Pack_P10004,  Unpack_P10004,  "HID P10004 37-bit PCSC",     {1, 1, 0, 0, 0, 0x1FFF, 0x3FFFF, 0, 0}}, // from @bthedorff; PR #1559
+    {"HGen37",  Pack_HGeneric37, Unpack_HGeneric37,  "HID Generic 37-bit",  {1, 0, 0, 0, 1, 0, 0x7FFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"MDI37",   Pack_MDI37,   Unpack_MDI37,   "PointGuard MDI 37-bit",         {1, 1, 0, 0, 1, 0xF, 0x1FFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"BQT38",   Pack_bqt38,   Unpack_bqt38,   "BQT 38-bit",                    {1, 1, 1, 0, 1, 0xFFF, 0x3FFFF, 0x7, 0}}, // from cardinfo.barkweb.com.au
+    {"ISCS",    Pack_iscs38,  Unpack_iscs38,  "ISCS 38-bit",                   {1, 1, 0, 1, 1, 0x3FF, 0xFFFFFF, 0, 0x7}}, // from cardinfo.barkweb.com.au
+    {"PW39",    Pack_pw39,    Unpack_pw39,    "Pyramid 39-bit wiegand format", {1, 1, 0, 0, 1, 0xFFFF, 0xFFFFF, 0, 0}},  // from cardinfo.barkweb.com.au
+    {"P10001",  Pack_P10001,  Unpack_P10001,  "HID P10001 Honeywell 40-bit",   {1, 1, 0, 0, 0, 0xFFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"Casi40",  Pack_CasiRusco40, Unpack_CasiRusco40, "Casi-Rusco 40-bit",     {1, 0, 0, 0, 0, 0, 0xFFFFFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
+    {"C1k48s",  Pack_C1k48s,  Unpack_C1k48s,  "HID Corporate 1000 48-bit std", {1, 1, 0, 0, 1, 0x003FFFFF, 0x007FFFFF, 0, 0}}, // imported from old pack/unpack
+    {"BC40",    Pack_bc40,    Unpack_bc40,    "Bundy TimeClock 40-bit",        {1, 1, 0, 1, 1, 0xFFF, 0xFFFFF, 0, 0x7F}}, // from
+    {"Avig56",  Pack_Avig56,  Unpack_Avig56,  "Avigilon 56-bit",               {1, 1, 0, 0, 1, 0xFFFFF, 0x3FFFFFFFF, 0, 0}},
+    {"Defcon32",  Pack_Defcon32,  Unpack_Defcon32,  "Custom Defcon RFCTF 42 BIT format",  {1, 1, 1, 0, 1, 0xFFFF, 0xFFFFF, 0xF, 0}}, // Created by (@micsen) for the CTF
+    {NULL, NULL, NULL, NULL, {0, 0, 0, 0, 0, 0, 0, 0, 0}} // Must null terminate array
 };
 
 void HIDListFormats(void) {
@@ -1664,9 +1664,74 @@ void HIDUnpack(int idx, wiegand_message_t *packed) {
     }
 }
 
-cardformatlimit_t get_card_format_limit(int format_idx){
-    if ((format_idx < 0) || (format_idx > ARRAYLEN(FormatTable) - 2))
-        return FormatTable[ARRAYLEN(FormatTable) - 1].FieldLimits;
-    else
-        return FormatTable[format_idx].FieldLimits;
+int HIDDumpPACSBits(const uint8_t *const data, const uint8_t length, bool verbose) {
+    uint8_t n = length - 1;
+    uint8_t pad = data[0];
+    char *binstr = (char *)calloc((length * 8) + 1, sizeof(uint8_t));
+    if (binstr == NULL) {
+        return PM3_EMALLOC;
+    }
+
+    bytes_2_binstr(binstr, data + 1, n);
+
+    PrintAndLogEx(NORMAL, "");
+    PrintAndLogEx(SUCCESS, "PACS......... " _GREEN_("%s"), sprint_hex_inrow(data, length));
+    PrintAndLogEx(SUCCESS, "padded bin... " _GREEN_("%s") " ( %zu )", binstr, strlen(binstr));
+
+    binstr[strlen(binstr) - pad] = '\0';
+    PrintAndLogEx(SUCCESS, "bin.......... " _GREEN_("%s") " ( %zu )", binstr, strlen(binstr));
+
+    size_t hexlen = 0;
+    uint8_t hex[16] = {0};
+    binstr_2_bytes(hex, &hexlen, binstr);
+    PrintAndLogEx(SUCCESS, "hex.......... " _GREEN_("%s"), sprint_hex_inrow(hex, hexlen));
+
+    uint32_t top = 0, mid = 0, bot = 0;
+    if (binstring_to_u96(&top, &mid, &bot, binstr) != strlen(binstr)) {
+        PrintAndLogEx(ERR, "Binary string contains none <0|1> chars");
+        free(binstr);
+        return PM3_EINVARG;
+    }
+
+    PrintAndLogEx(NORMAL, "");
+    PrintAndLogEx(INFO, "Wiegand decode");
+    wiegand_message_t packed = initialize_message_object(top, mid, bot, strlen(binstr));
+    HIDTryUnpack(&packed);
+
+    PrintAndLogEx(NORMAL, "");
+
+    if (strlen(binstr) >= 26 && verbose) {
+
+        // iCLASS Legacy
+        PrintAndLogEx(INFO, "Clone to " _YELLOW_("iCLASS Legacy"));
+        PrintAndLogEx(SUCCESS, "    hf iclass encode --ki 0 --bin %s", binstr);
+        PrintAndLogEx(NORMAL, "");
+
+        // HID Prox II
+        PrintAndLogEx(INFO, "Downgrade to " _YELLOW_("HID Prox II"));
+        PrintAndLogEx(SUCCESS, "    lf hid clone -w H10301 --bin %s", binstr);
+        PrintAndLogEx(NORMAL, "");
+
+        // MIFARE Classic
+        char mfcbin[28] = {0};
+        mfcbin[0] = '1';
+        memcpy(mfcbin + 1, binstr, strlen(binstr));
+        binstr_2_bytes(hex, &hexlen, mfcbin);
+
+        PrintAndLogEx(INFO, "Downgrade to " _YELLOW_("MIFARE Classic") " (Pm3 simulation)");
+        PrintAndLogEx(SUCCESS, "    hf mf eclr;");
+        PrintAndLogEx(SUCCESS, "    hf mf esetblk --blk 0 -d 049DBA42A23E80884400C82000000000;");
+        PrintAndLogEx(SUCCESS, "    hf mf esetblk --blk 1 -d 1B014D48000000000000000000000000;");
+        PrintAndLogEx(SUCCESS, "    hf mf esetblk --blk 3 -d A0A1A2A3A4A5787788C189ECA97F8C2A;");
+        PrintAndLogEx(SUCCESS, "    hf mf esetblk --blk 5 -d 020000000000000000000000%s;", sprint_hex_inrow(hex, hexlen));
+        PrintAndLogEx(SUCCESS, "    hf mf esetblk --blk 7 -d 484944204953787788AA204752454154;");
+        PrintAndLogEx(SUCCESS, "    hf mf sim --1k -i;");
+        PrintAndLogEx(NORMAL, "");
+
+        PrintAndLogEx(INFO, "Downgrade to " _YELLOW_("MIFARE Classic 1K"));
+        PrintAndLogEx(SUCCESS, "    hf mf encodehid --bin %s", binstr);
+        PrintAndLogEx(NORMAL, "");
+    }
+    free(binstr);
+    return PM3_SUCCESS;
 }

--- a/client/src/wiegand_formats.h
+++ b/client/src/wiegand_formats.h
@@ -38,6 +38,13 @@ typedef struct {
     bool hasParity;
 } cardformatdescriptor_t;
 
+typedef struct {
+    uint32_t FacilityCode;
+    uint64_t CardNumber;
+    uint32_t IssueLevel;
+    uint32_t OEM;
+} cardformatlimit_t;
+
 // Structure for defined Wiegand card formats available for packing/unpacking
 typedef struct {
     const char *Name;
@@ -45,6 +52,7 @@ typedef struct {
     bool (*Unpack)(wiegand_message_t *packed, wiegand_card_t *card);
     const char *Descrp;
     cardformatdescriptor_t Fields;
+    cardformatlimit_t FieldLimits;
 } cardformat_t;
 
 void HIDListFormats(void);
@@ -54,7 +62,7 @@ bool HIDPack(int format_idx, wiegand_card_t *card, wiegand_message_t *packed, bo
 bool HIDTryUnpack(wiegand_message_t *packed);
 void HIDPackTryAll(wiegand_card_t *card, bool preamble);
 void HIDUnpack(int idx, wiegand_message_t *packed);
-int HIDDumpPACSBits(const uint8_t *const data, const uint8_t length, bool verbose);
 void print_wiegand_code(wiegand_message_t *packed);
 void print_desc_wiegand(cardformat_t *fmt, wiegand_message_t *packed);
+cardformatlimit_t get_card_format_limit(int format_idx);
 #endif

--- a/client/src/wiegand_formats.h
+++ b/client/src/wiegand_formats.h
@@ -36,14 +36,11 @@ typedef struct {
     bool hasIssueLevel;
     bool hasOEMCode;
     bool hasParity;
+    uint32_t MaxFC; // max Facility Code
+    uint64_t MaxCN; // max CardNumber
+    uint32_t MaxIL; // max IssueLevel
+    uint32_t MaxOEM;// max OEM
 } cardformatdescriptor_t;
-
-typedef struct {
-    uint32_t FacilityCode;
-    uint64_t CardNumber;
-    uint32_t IssueLevel;
-    uint32_t OEM;
-} cardformatlimit_t;
 
 // Structure for defined Wiegand card formats available for packing/unpacking
 typedef struct {
@@ -52,7 +49,6 @@ typedef struct {
     bool (*Unpack)(wiegand_message_t *packed, wiegand_card_t *card);
     const char *Descrp;
     cardformatdescriptor_t Fields;
-    cardformatlimit_t FieldLimits;
 } cardformat_t;
 
 void HIDListFormats(void);
@@ -62,7 +58,7 @@ bool HIDPack(int format_idx, wiegand_card_t *card, wiegand_message_t *packed, bo
 bool HIDTryUnpack(wiegand_message_t *packed);
 void HIDPackTryAll(wiegand_card_t *card, bool preamble);
 void HIDUnpack(int idx, wiegand_message_t *packed);
+int HIDDumpPACSBits(const uint8_t *const data, const uint8_t length, bool verbose);
 void print_wiegand_code(wiegand_message_t *packed);
 void print_desc_wiegand(cardformat_t *fmt, wiegand_message_t *packed);
-cardformatlimit_t get_card_format_limit(int format_idx);
 #endif


### PR DESCRIPTION
In  `lf hid brute` command, there's a checking on the range of facility code and card number to determine when it should stop. The original code (`card_hi.FacilityCode < 0xFF` and `card_hi.CardNumber < 0xFFFF`) does not account for different card formats.

Fix it by pulling the corresponding card format limit from FormatTable.