### PR TITLE
Fix Incorrect Wiegand Format Displayed

### DIFF
--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1316,10 +1316,6 @@ int lf_hid_watch(int findone, uint32_t *high, uint32_t *low, bool ledcontrol) {
                         cardnum = (lo >> 1) & 0xFFFF;
                         fac = (lo >> 17) & 0xFF;
                     }
-                    if (bitlen == 37) {
-                        cardnum = (lo >> 1) & 0x7FFFF;
-                        fac = ((hi & 0xF) << 12) | (lo >> 20);
-                    }
                     if (bitlen == 34) {
                         cardnum = (lo >> 1) & 0xFFFF;
                         fac = ((hi & 1) << 15) | (lo >> 17);

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -1451,8 +1451,7 @@ static int iclass_decode_credentials_new_pacs(uint8_t *d) {
 
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "Wiegand decode");
-    wiegand_message_t packed = initialize_message_object(top, mid, bot, 0);
-    HIDTryUnpack(&packed);
+    decode_wiegand(top, mid, bot, 0);
 
     return PM3_SUCCESS;
 }
@@ -1492,8 +1491,7 @@ static void iclass_decode_credentials(uint8_t *data) {
             PrintAndLogEx(SUCCESS, "Binary..................... " _GREEN_("%s"), pbin);
 
             PrintAndLogEx(INFO, "Wiegand decode");
-            wiegand_message_t packed = initialize_message_object(top, mid, bot, 0);
-            HIDTryUnpack(&packed);
+            decode_wiegand(top, mid, bot, 0);
         }
 
     } else {
@@ -2916,8 +2914,7 @@ static int CmdHFiClass_ReadBlock(const char *Cmd) {
                     PrintAndLogEx(SUCCESS, "      bin : %s", pbin);
                     PrintAndLogEx(INFO, "");
                     PrintAndLogEx(INFO, "------------------------------ " _CYAN_("Wiegand") " -------------------------------");
-                    wiegand_message_t packed = initialize_message_object(top, mid, bot, 0);
-                    HIDTryUnpack(&packed);
+                    decode_wiegand(top, mid, bot, 0);
                 }
             } else {
                 PrintAndLogEx(INFO, "no credential found");

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -6293,8 +6293,7 @@ static int CmdHF14AMfMAD(const char *Cmd) {
                 PrintAndLogEx(SUCCESS, "Binary... " _GREEN_("%s"), pbin);
 
                 PrintAndLogEx(INFO, "Wiegand decode");
-                wiegand_message_t packed = initialize_message_object(top, mid, bot, 0);
-                HIDTryUnpack(&packed);
+                decode_wiegand(top, mid, bot, 0);
             }
         }
 

--- a/client/src/cmdlfhid.c
+++ b/client/src/cmdlfhid.c
@@ -160,8 +160,7 @@ int demodHID(bool verbose) {
         return PM3_ESOFT;
     }
 
-    wiegand_message_t packed = initialize_message_object(hi2, hi, lo, 0);
-    if (HIDTryUnpack(&packed) == false) {
+    if (!decode_wiegand(hi2, hi, lo, 0)) { // if failed to unpack wiegand
         printDemodBuff(0, false, false, true);
     }
     PrintAndLogEx(INFO, "raw: " _GREEN_("%08x%08x%08x"), hi2, hi, lo);
@@ -214,8 +213,8 @@ static int CmdHIDReader(const char *Cmd) {
     }
 
     do {
-        lf_read(false, 16000);
-        demodHID(!cm);
+        lf_read(false, 16000); // get data of 16000 samples from proxmark device
+        demodHID(!cm); // demod data and print results if found
     } while (cm && !kbd_enter_pressed());
 
     return PM3_SUCCESS;

--- a/client/src/cmdwiegand.c
+++ b/client/src/cmdwiegand.c
@@ -160,8 +160,7 @@ int CmdWiegandDecode(const char *Cmd) {
         return PM3_EINVARG;
     }
 
-    wiegand_message_t packed = initialize_message_object(top, mid, bot, blen);
-    HIDTryUnpack(&packed);
+    decode_wiegand(top, mid, bot, blen);
     return PM3_SUCCESS;
 }
 

--- a/client/src/wiegand_formats.h
+++ b/client/src/wiegand_formats.h
@@ -58,6 +58,7 @@ bool HIDPack(int format_idx, wiegand_card_t *card, wiegand_message_t *packed, bo
 bool HIDTryUnpack(wiegand_message_t *packed);
 void HIDPackTryAll(wiegand_card_t *card, bool preamble);
 void HIDUnpack(int idx, wiegand_message_t *packed);
+bool decode_wiegand(uint32_t top, uint32_t mid, uint32_t bot, int n);
 int HIDDumpPACSBits(const uint8_t *const data, const uint8_t length, bool verbose);
 void print_wiegand_code(wiegand_message_t *packed);
 void print_desc_wiegand(cardformat_t *fmt, wiegand_message_t *packed);


### PR DESCRIPTION
Original issue: it's hard to detect 26-36 bits (with sentinel), 37 bits (no sentinel), and 38 bits. Also, a 26 bits format can be interpreted as 38 bits as well. The current master cannot display 37 bits format correctly. Per [issue #1773](https://github.com/RfidResearchGroup/proxmark3/issues/1773) and [issue #2727](https://github.com/RfidResearchGroup/proxmark3/issues/2727) (this is fixed already).

Issue reproduced: H10304 37 bits format, fc: 1234, cn: 56789, raw: 104d21bbaa
```
pm3 --> lf hid reader
[+] [HCP32   ] HID Check Point 32-bit             CN: 10109815
[+] [HPP32   ] HID Hewlett-Packard 32-bit       FC: 2468  CN: 116303872
[+] [Kastle  ] Kastle 32-bit                    FC: 144  CN: 56789  Issue: 6  parity ( fail )
[+] [Kantech ] Indala/Kantech KFS 32-bit        FC: 144  CN: 56789
[+] [WIE32   ] Wiegand 32-bit                   FC: 3361  CN: 48042
[=] found 5 matching formats
[+] DemodBuffer:
[+] 1D55565565A659569A9A9999

[=] raw: 00000000000000104d21bbaa

pm3 --> wiegand decode -r 00000000000000104d21bbaa
[+] [HCP32   ] HID Check Point 32-bit             CN: 10109815
[+] [HPP32   ] HID Hewlett-Packard 32-bit       FC: 2468  CN: 116303872
[+] [Kastle  ] Kastle 32-bit                    FC: 144  CN: 56789  Issue: 6  parity ( fail )
[+] [Kantech ] Indala/Kantech KFS 32-bit        FC: 144  CN: 56789
[+] [WIE32   ] Wiegand 32-bit                   FC: 3361  CN: 48042
[=] found 5 matching formats
```
---
Fix: Refer to http://www.proxmark.org/forum/viewtopic.php?pid=5368#p5368 and rewrite the get_length_from_header() function.

After fix:
```
pm3 --> lf hid reader
[+] [H10302  ] HID H10302 37-bit huge ID          CN: 647028181  parity ( ok )
[+] [H10304  ] HID H10304 37-bit                FC: 1234  CN: 56789  parity ( ok )
[+] [P10004  ] HID P10004 37-bit PCSC           FC: 154  CN: 69085
[+] [MDI37   ] PointGuard MDI 37-bit            FC: 1  CN: 110157269  parity ( ok )
[=] found 4 matching formats with bit len 37
[+] [BQT38   ] BQT 38-bit                       FC: 7637  CN: 267080  Issue: 6  parity ( ok )
[+] [ISCS    ] ISCS 38-bit                      FC: 154  CN: 1105365  OEM: 8  parity ( ok )
[=] found 2 matching formats with bit len 38
[=] raw: 00000000000000104d21bbaa

pm3 --> wiegand decode -r 00000000000000104d21bbaa
[+] [H10302  ] HID H10302 37-bit huge ID          CN: 647028181  parity ( ok )
[+] [H10304  ] HID H10304 37-bit                FC: 1234  CN: 56789  parity ( ok )
[+] [P10004  ] HID P10004 37-bit PCSC           FC: 154  CN: 69085
[+] [MDI37   ] PointGuard MDI 37-bit            FC: 1  CN: 110157269  parity ( ok )
[=] found 4 matching formats with bit len 37
[+] [BQT38   ] BQT 38-bit                       FC: 7637  CN: 267080  Issue: 6  parity ( ok )
[+] [ISCS    ] ISCS 38-bit                      FC: 154  CN: 1105365  OEM: 8  parity ( ok )
[=] found 2 matching formats with bit len 38
```
Example of HID C15001 KeyScan 36-bit in [issue #1773](https://github.com/RfidResearchGroup/proxmark3/issues/1773):
```
pm3 --> wiegand decode -r 000000000000003f08ec0c86
[+] [C15001  ] HID KeyScan 36-bit               FC: 118  CN: 1603  OEM: 900  parity ( ok )
[+] [S12906  ] HID Simplex 36-bit               FC: 225  CN: 7734851  Issue: 0  parity ( fail )
[+] [Sie36   ] HID 36-bit Siemens               FC: 230518  CN: 1603  parity ( fail )
[=] found 3 matching formats with bit len 36
[+] [BQT38   ] BQT 38-bit                       FC: 1603  CN: 508475  Issue: 0  parity ( fail )
[+] [ISCS    ] ISCS 38-bit                      FC: 529  CN: 3540547  OEM: 15  parity ( fail )
[=] found 2 matching formats with bit len 38
[!] ⚠️  Wiegand unknown bit len 38
[?] Try 0xFFFF's http://cardinfo.barkweb.com.au/
```
Example of 26 bit HID tag in [issue #1773](https://github.com/RfidResearchGroup/proxmark3/issues/1773):
```
pm3 --> wiegand decode -r 00000000000000020048a2fa4
[+] [H10301  ] HID H10301 26-bit                FC: 69  CN: 6098  parity ( ok )
[+] [ind26   ] Indala 26-bit                    FC: 1105  CN: 2002  parity ( ok )
[=] found 2 matching formats with bit len 26
[+] [BQT38   ] BQT 38-bit                       FC: 6098  CN: 290  Issue: 8  parity ( ok )
[+] [ISCS    ] ISCS 38-bit                      FC: 9  CN: 333778  OEM: 0  parity ( ok )
[=] found 2 matching formats with bit len 38
```