### PR TITLE
Fix incorrect encoding for HID with long format on sim and clone

### DIFF
--- a/armsrc/Standalone/lf_hidbrute.c
+++ b/armsrc/Standalone/lf_hidbrute.c
@@ -150,7 +150,7 @@ void RunMod(void) {
             } else if (playing && selected == 2) {
                 // Now it work only with HID Corporate 1000 (35bit), but is easily extensible to others RFID.
                 // It is necessary only to calculate the correct parity.
-
+                
                 // Brute force code
                 // Check if the badge is an HID Corporate 1000
                 if ((high[selected] & 0xFFFFFFF8) != 0x28) {
@@ -257,7 +257,7 @@ void hid_corporate_1000_calculate_checksum_and_set(uint32_t *high, uint32_t *low
 
     // Calculate new high and low base value from card number and facility code, without parity
     new_low = (fc << 21) | (cardnum << 1);
-    new_high = 0x28 | ((fc >> 11) & 1); // 0x28 is 101000
+    new_high = (fc >> 11) & 1;
 
     int n_ones;
     uint32_t i;
@@ -319,6 +319,7 @@ void hid_corporate_1000_calculate_checksum_and_set(uint32_t *high, uint32_t *low
         new_high = new_high | 0x4;
 
     // Setting new calculated values
+    add_HID_preamble(0, &new_high, &new_low, 35);
     *low = new_low;
     *high = new_high;
 }

--- a/armsrc/Standalone/lf_hidfcbrute.c
+++ b/armsrc/Standalone/lf_hidfcbrute.c
@@ -176,8 +176,7 @@ void hid_calculate_checksum_and_set(uint32_t *high, uint32_t *low, uint32_t card
     newlow |= oddparity32((newlow >> 1) & 0xFFF);
     newlow |= (evenparity32((newlow >> 13) & 0xFFF)) << 25;
 
-    newhigh |= 0x20; // Bit 37; standard header
-    newlow |= 1U << 26; // leading 1: start bit
+    add_HID_preamble(NULL, &newhigh, &newlow, 26);
 
     *low = newlow;
     *high = newhigh;

--- a/armsrc/Standalone/lf_prox2brute.c
+++ b/armsrc/Standalone/lf_prox2brute.c
@@ -16,8 +16,8 @@
 //-----------------------------------------------------------------------------
 // LF HID ProxII Brutforce v2 by lnv42 - based on Proxbrute by Brad antoniewicz
 //
-//     Following code is a trivial brute forcer for when you know the facility
-//     code and want to find valid(s) card number(s). It will try all card
+//     Following code is a trivial brute forcer (H10301 26-bit) when you know the
+//     facility code and want to find valid(s) card number(s). It will try all card
 //     fnumbers rom CARDNUM_START to CARDNUM_END one by one (max. ~65k tries).
 //     This brute force will be a lot faster than Proxbrute that will try all
 //     possibles values for LF low, even those with bad checksum (~4g tries).
@@ -46,8 +46,7 @@ void RunMod(void) {
     StandAloneMode();
     Dbprintf(">>  LF HID proxII bruteforce v2 a.k.a Prox2Brute Started <<");
     FpgaDownloadAndGo(FPGA_BITSTREAM_LF);
-
-    const uint32_t high = 0x20; // LF high value is always 0x20 here
+    uint32_t high = 0, low = 0;
 
     uint32_t fac = FACILITY_CODE, cardnum = 0;
 
@@ -79,9 +78,10 @@ void RunMod(void) {
         if (BUTTON_HELD(1000) == BUTTON_HOLD) break; // long button press (>=1sec) exit
 
         // calculate the new LF low value including Card number, Facility code and checksum
-        uint32_t low = (cardnum << 1) | (fac << 17);
+        low = (cardnum << 1) | (fac << 17);
         low |= oddparity32((low >> 1) & 0xFFF);
         low |= evenparity32((low >> 13) & 0xFFF) << 25;
+        add_HID_preamble(NULL, &high, &low, 26);
 
         Dbprintf("[=] trying Facility = %08x, Card = %08x, raw = %08x%08x",
                  fac, cardnum, high, low);

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -968,13 +968,7 @@ void CmdHIDsimTAGEx(uint32_t hi2, uint32_t hi, uint32_t lo, uint8_t longFMT, boo
     uint16_t n = 8;
 
     if (longFMT) {
-        // Ensure no more than 84 bits supplied
-        if (hi2 > 0xFFFFF) {
-            DbpString("Tags can only have 84 bits.");
-            return;
-        }
         bitlen = 8 + 8 * 2 + 84 * 2;
-        hi2 |= 0x9E00000; // 9E: long format identifier
         manchesterEncodeUint32(hi2, 16 + 12, bits, &n);
         manchesterEncodeUint32(hi, 32, bits, &n);
         manchesterEncodeUint32(lo, 32, bits, &n);
@@ -2270,15 +2264,10 @@ void CopyHIDtoT55x7(uint32_t hi2, uint32_t hi, uint32_t lo, uint8_t longFMT, boo
     uint8_t last_block = 0;
 
     if (longFMT) {
-        // Ensure no more than 84 bits supplied
-        if (hi2 > 0xFFFFF) {
-            DbpString("Tags can only have 84 bits");
-            return;
-        }
         // Build the 6 data blocks for supplied 84bit ID
         last_block = 6;
-        // load preamble (1D) & long format identifier (9E manchester encoded)
-        data[1] = 0x1D96A900 | (manchesterEncode2Bytes((hi2 >> 16) & 0xF) & 0xFF);
+        // load preamble (1D)
+        data[1] = 0x1D000000 | (manchesterEncode2Bytes((hi2 >> 16) & 0xFFFF) & 0xFFFFFF);
         // load raw id from hi2, hi, lo to data blocks (manchester encoded)
         data[2] = manchesterEncode2Bytes(hi2 & 0xFFFF);
         data[3] = manchesterEncode2Bytes(hi >> 16);

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -944,6 +944,33 @@ static void fcAll(uint8_t fc, int *n, uint8_t clock, int16_t *remainder) {
     }
 }
 
+bool add_HID_preamble(uint32_t *hi2, uint32_t *hi, uint32_t *lo, uint8_t length){
+    // Invalid value
+    if (length > 84 || length == 0)
+        return false;
+
+    if (length == 48) {
+        *hi |= 1U << (length - 32); // Example leading 1: start bit
+        return true;
+    }
+    if (length >= 64) {
+        *hi2 |= 0x09e00000; // Extended-length header
+        *hi2 |= 1U << (length - 64); // leading 1: start bit
+    } else if (length > 37) {
+        *hi2 |= 0x09e00000; // Extended-length header
+        *hi |= 1U << (length - 32); // leading 1: start bit
+    } else if (length == 37) {
+        // No header bits added to 37-bit cards
+    } else if (length >= 32) {
+        *hi |= 0x20; // Bit 37; standard header
+       *hi |= 1U << (length - 32); // leading 1: start bit
+    } else {
+        *hi |= 0x20; // Bit 37; standard header
+        *lo |= 1U << length; // leading 1: start bit
+    }
+    return true;
+}
+
 // prepare a waveform pattern in the buffer based on the ID given then
 // simulate a HID tag until the button is pressed
 void CmdHIDsimTAGEx(uint32_t hi2, uint32_t hi, uint32_t lo, uint8_t longFMT, bool ledcontrol, int numcycles) {

--- a/armsrc/lfops.h
+++ b/armsrc/lfops.h
@@ -24,7 +24,7 @@
 void ModThenAcquireRawAdcSamples125k(uint32_t delay_off, uint16_t period_0, uint16_t period_1,
                                      const uint8_t *symbol_extra, uint16_t *period_extra, uint8_t *command, bool verbose,
                                      bool keep_field_on, uint32_t samples, bool ledcontrol);
-
+ 
 void ReadTItag(bool ledcontrol);
 void WriteTItag(uint32_t idhi, uint32_t idlo, uint16_t crc, bool ledcontrol);
 
@@ -34,6 +34,7 @@ void SimulateTagLowFrequencyEx(int period, int gap, bool ledcontrol, int numcycl
 void SimulateTagLowFrequency(int period, int gap, bool ledcontrol);
 void SimulateTagLowFrequencyBidir(int divisor, int max_bitlen);
 
+bool add_HID_preamble(uint32_t *hi2, uint32_t *hi, uint32_t *lo, uint8_t length);
 void CmdHIDsimTAGEx(uint32_t hi2, uint32_t hi, uint32_t lo, uint8_t longFMT, bool ledcontrol, int numcycles);
 void CmdHIDsimTAG(uint32_t hi2, uint32_t hi, uint32_t lo, uint8_t longFMT, bool ledcontrol);
 


### PR DESCRIPTION
## **Original Issues:**

1. Per issue at https://github.com/RfidResearchGroup/proxmark3/issues/1791 with regard to the Incorrect encoding for C1k48s with HID preamble. For this issue, @tweathers-sec submitted a [PR](https://github.com/RfidResearchGroup/proxmark3/pull/2407) fixing the HID header of C1k48s of add_HID_header() function in wiegand_formatutils.c.
**However**, since the long format identifier "9E" is added again in "CopyHIDtoT55x7" and "CmdHIDsimTAGEx" function in armsrc/lfops.c, the problem persists. Example:
```
pm3 --> lf hid clone -w C1k48s --fc 12345 --cn 12345
[=] Preparing to clone HID tag
[+] [C1k48s  ] HID Corporate 1000 48-bit std    FC: 12345  CN: 12345  parity ( ok )
[+] Done!
[?] Hint: try `lf hid reader` to verify
[usb] pm3 --> lf hid reader
[+] [C1k48s  ] HID Corporate 1000 48-bit std    FC: 12345  CN: 12345  parity ( ok )
[=] found 1 matching format  with bit len 48
[=] raw: 09e000000001803039006072
```
2. Long format hid failed to clone and sim, for example:
```
pm3 --> lf hid clone -w Avig56 --fc 100000 --cn 1234567
[=] Preparing to clone HID tag
[+] [Avig56  ] Avigilon 56-bit                  FC: 100000  CN: 1234567  parity ( ok )
[#] Tags can only have 84 bits
[!] ⚠️  timeout while waiting for reply.
```
and 
```
pm3 --> lf hid sim -w Avig56 --fc 100000 --cn 1234567
[=] Simulating HID tag
[+] [Avig56  ] Avigilon 56-bit                  FC: 100000  CN: 1234567  parity ( ok )
[=] found 1 matching format  with bit len 56

[=] Press pm3 button or <Enter> to abort simulation
[#] Tags can only have 84 bits.
[=] Done!
```

## **Solution**:
Remove the checking of hi2 and adding 9E preamble for long format in lfops.c since all the preambles are already handled in add_HID_header().
https://github.com/RfidResearchGroup/proxmark3/blob/4d9f443cc05ad89a87962d9613eb235e3cedc527/client/src/wiegand_formatutils.c#L207-L232
After fix:
```
pm3 --> lf hid clone -w C1k48s --fc 12345 --cn 12345
[=] Preparing to clone HID tag
[+] [C1k48s  ] HID Corporate 1000 48-bit std    FC: 12345  CN: 12345  parity ( ok )
[+] Done!
[?] Hint: try `lf hid reader` to verify
[usb] pm3 --> lf hid reader
[+] [C1k48s  ] HID Corporate 1000 48-bit std    FC: 12345  CN: 12345  parity ( ok )
[=] found 1 matching format  with bit len 48
[=] raw: 000000000001803039006072
```
and
```
pm3 --> lf hid clone -w Avig56 --fc 100000 --cn 1234567
[=] Preparing to clone HID tag
[+] [Avig56  ] Avigilon 56-bit                  FC: 100000  CN: 1234567  parity ( ok )
[+] Done!
[?] Hint: try `lf hid reader` to verify
[usb] pm3 --> lf hid reader
[+] [Avig56  ] Avigilon 56-bit                  FC: 100000  CN: 1234567  parity ( ok )
[=] found 1 matching format  with bit len 56
[=] raw: 09e00000010c35000025ad0e
```