### PR TITLE
Correct Bitlen Calculation and Refactor Wiegand Decoding

### DIFF
--- a/client/src/cmdwiegand.c
+++ b/client/src/cmdwiegand.c
@@ -69,8 +69,7 @@ static int wiegand_new_pacs(uint8_t *padded_pacs, uint8_t plen) {
 
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "------------------------- " _CYAN_("SIO - Wiegand") " ---------------------------");
-    wiegand_message_t packed = initialize_message_object(top, mid, bot, strlen(binstr));
-    HIDTryUnpack(&packed);
+    decode_wiegand(top, mid, bot, strlen(binstr));
     free(binstr);
     return PM3_SUCCESS;
 }
@@ -215,8 +214,7 @@ int CmdWiegandDecode(const char *Cmd) {
 
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "Wiegand decode");
-    wiegand_message_t packed = initialize_message_object(top, mid, bot, blen);
-    HIDTryUnpack(&packed);
+    decode_wiegand(top, mid, bot, blen);
     return PM3_SUCCESS;
 }
 

--- a/client/src/wiegand_formats.c
+++ b/client/src/wiegand_formats.c
@@ -1647,24 +1647,16 @@ bool decode_wiegand(uint32_t top, uint32_t mid, uint32_t bot, int n) {
         return res;
     }
 
-    if (n || ((mid & 0xFFFFFFC0) > 0)) {  // if n > 0 or there's more than 38 bits
+    if (n > 0) {
         wiegand_message_t packed = initialize_message_object(top, mid, bot, n);
         res = HIDTryUnpack(&packed);
-
-    } else { // n <= 0 and 39-64 bits are all 0, try two possible bitlens
-
+    } else {
         wiegand_message_t packed = initialize_message_object(top, mid, bot, n); // 26-37 bits
         res = HIDTryUnpack(&packed);
 
-        n = packed.Length - 1;
-        PrintAndLogEx(INFO, "Trying without a preamble bit...");
-        packed = initialize_message_object(top, mid, bot, n); // iclass has only a preamble bit.
+        PrintAndLogEx(INFO, "Trying with a preamble bit...");
+        packed.Length += 1;
         res |= HIDTryUnpack(&packed);
-
-        if (res == false) {
-            packed = initialize_message_object(top, mid, bot, 38); // 38 bits
-            res |= HIDTryUnpack(&packed);
-        }
     }
 
     if (res == false) {

--- a/client/src/wiegand_formatutils.c
+++ b/client/src/wiegand_formatutils.c
@@ -132,8 +132,6 @@ static uint8_t get_length_from_header(wiegand_message_t *data) {
     /**
      * detect if message has "preamble" / "sentinel bit"
      * Right now we just calculate the highest bit set
-     * 38 bits format is handled by directly setting n=38 in initialize_message_object()
-     * since it's hard to distinguish 38 bits with formats with preamble bit (26-36 bits)
      *
      * (from http://www.proxmark.org/forum/viewtopic.php?pid=5368#p5368)
      * 0000 0010 0000 0000 01xx xxxx xxxx xxxx xxxx xxxx xxxx  26-bit
@@ -148,7 +146,6 @@ static uint8_t get_length_from_header(wiegand_message_t *data) {
      * 0000 0010 1xxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx  35-bit
      * 0000 0011 xxxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx  36-bit
      * 0000 000x xxxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx  37-bit
-     * 0000 00xx xxxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx  38-bit
      */
     uint8_t len = 0;
     uint32_t hfmt = 0; // for calculating card length
@@ -156,36 +153,21 @@ static uint8_t get_length_from_header(wiegand_message_t *data) {
     if ((data->Top & 0x000FFFFF) > 0) { // > 64 bits
         hfmt = data->Top & 0x000FFFFF;
         len = 64;
-    } else if (data->Mid > 0) {
-        // detect HID format b38 set
-        if (data->Mid & 0xFFFFFFC0) { // 39-64 bits
-            hfmt = data->Mid;
-            len = 31; // remove leading 1 (preamble) in 39-64 bits format
-        } else { // detect card format 26-37 bits using "preamble" / "sentinel bit"
-            PrintAndLogEx(DEBUG, "hid preamble detected");
-
-            // if bit 38 is set: => 26-36 bits
-            if (((data->Mid >> 5) & 1) == 1) {
-                hfmt = (((data->Mid & 31) << 12) | (data->Bot >> 26)); //get bits 27-37 to check for format len bit
-                len = 19;
-            } else { // if bit 38 is not set => 37 bits
-                hfmt = 0;
-                len = 37;
-            }
-        }
-    } else {
-        hfmt = data->Bot;
-        len = 0;
+    } else if (data->Mid & 0xFFFFFFC0) { // handle 38bit and above format
+        hfmt = data->Mid;
+        len = 31; // remove leading 1 (preamble) in 38-64 bits format
+    } else if (((data->Mid >> 5) & 1) == 1) { // bit 38 is set => 26-36bit format
+        hfmt = (((data->Mid & 31) << 12) | (data->Bot >> 26)); // get bits 27-37 to check for format len bit
+        len = 19;
+    } else { // if bit 38 is not set => 37bit format
+        hfmt = 0;
+        len = 37;
     }
 
     while (hfmt > 0) {
         hfmt >>= 1;
         len++;
     }
-
-    // everything less than 26 bits found, assume 26 bits
-    if (len < 26)
-        len = 26;
 
     return len;
 }

--- a/client/src/wiegand_formatutils.c
+++ b/client/src/wiegand_formatutils.c
@@ -157,8 +157,8 @@ static uint8_t get_length_from_header(wiegand_message_t *data) {
         hfmt = data->Mid;
         len = 31; // remove leading 1 (preamble) in 38-64 bits format
     } else if (((data->Mid >> 5) & 1) == 1) { // bit 38 is set => 26-36bit format
-        hfmt = (((data->Mid & 31) << 12) | (data->Bot >> 26)); // get bits 27-37 to check for format len bit
-        len = 19;
+        hfmt = (((data->Mid & 31) << 6) | (data->Bot >> 26)); // get bits 27-37 to check for format len bit
+        len = 25;
     } else { // if bit 38 is not set => 37bit format
         hfmt = 0;
         len = 37;


### PR DESCRIPTION
This pull request:

1. Fixes bitlen miscalculation issue
   * The sentinel bit is removed in get_length_from_header function
   * Fix decoding wiegand format with sentinel bit included
2. Refactors implementation using the decode_wiegand function for improved clarity