### PR TITLE
R&Y: Updated SOF Sofia City Card AID in `aid_desfire.json`

### DIFF
--- a/client/resources/aid_desfire.json
+++ b/client/resources/aid_desfire.json
@@ -1344,7 +1344,7 @@
         "Type": "transport"
     },
     {
-        "AID": "CA3490",
+        "AID": "9034CA",
         "Vendor": "Urban Mobility Center",
         "Country": "BG",
         "Name": "Sofia City Card (SOF)",


### PR DESCRIPTION
### Update
- SOF Sofia City Card's AID (reversed the endian).

Apologies for the last-minute PR.

Many thanks in advance, and kind regards,

-R&Y.