### PR TITLE
Standalone mattyrun spiffs

### DIFF
--- a/armsrc/Standalone/hf_mattyrun.c
+++ b/armsrc/Standalone/hf_mattyrun.c
@@ -33,6 +33,7 @@
 #include "mifaresim.h"  // mifare1ksim
 #include "mifareutil.h"
 #include "proxmark3_arm.h"
+#include "spiffs.h"
 #include "standalone.h" // standalone definitions
 #include "string.h"
 #include "ticks.h"
@@ -534,7 +535,12 @@ void RunMod(void) {
                 SpinErr(LED_D, 50, 8);
                 partialEmulation = true;
             } else {
-                DbpString("[" _GREEN_("+") "] " _GREEN_("Emulator memory filled completely."));
+                DbpString("[" _GREEN_("+") "] " _GREEN_("Emulator memory filled completely. Start storing card in spiff memory."));
+                uint8_t *emCARD = BigBuf_get_EM_addr();
+                char dumpFileName[30] = {0};
+                sprintf(dumpFileName, DUMP_FILE, mattyrun_card.uid[0], mattyrun_card.uid[1], mattyrun_card.uid[2], mattyrun_card.uid[3]);
+                rdv40_spiffs_write(dumpFileName, emCARD, 1024, RDV40_SPIFFS_SAFETY_SAFE);
+                Dbprintf("[" _GREEN_("+") "] " _GREEN_("Stored card on %s"), dumpFileName);
             }
 
             state = STATE_EMULATE;

--- a/armsrc/Standalone/hf_mattyrun.h
+++ b/armsrc/Standalone/hf_mattyrun.h
@@ -21,6 +21,9 @@
 
 #include <inttypes.h>
 
+// Filename to store the card info in spiff memory 
+#define DUMP_FILE "hf_mattyrun_dump_%02x%02x%02x%02x.bin"
+
 // Set of standard keys to be used
 static uint64_t const MATTYRUN_MFC_DEFAULT_KEYS[] = {
     0xFFFFFFFFFFFF,  // Default key


### PR DESCRIPTION
Greetings,

I did some fieldwork experiments and I noticed there was no reliable and practical way to clone Mifare classic cards in a stand alone mode. Mattyrun comes close to this. It works fine when connected to the computer, but on standalone mode I wasn't able to access the memory again and dumping the contents. Apart from that, if you finally managed to clone a card by copying it from someone, it would be highly unpractical if you lose the contents because of your battery runs flat.

The new model contains spiffs, which is a useful way of storing the contents, which I implemented in this PR. I tested it, and it works fine for the MFC cards I encountered. I tested the cards on 5 different locations.

Before we can merge this, I need to get answers on a few questions:
- What happens if you run this on a proxmark without spiffs memory?
- What happens if the spiffs memory is full?
- For now, I only implemented the 1k cards, because I only encountered those. What would be the best way to add support for 2k and 4k cards, and how do I test it without having access to a system that uses cards like that?
- Most of the times, you first need to get the keys that are being used. There Is currently no easy way to add your keys. The only way is to add your keys to the source code, compile it and upload the new firmware. I thought of using the spiff memory and just add a text file with custom keys. I was wondering if that's the most simple way, or if there are other implementations worth to consider.

Thank you!