### PR TITLE
hf mfdes bruteaid: fix byte order

### DIFF
--- a/client/src/cmdhfmfdes.c
+++ b/client/src/cmdhfmfdes.c
@@ -2133,6 +2133,9 @@ static int CmdHF14ADesBruteApps(const char *Cmd) {
         startAid[1] = 0x00;
         startAid[2] = 0x0F;
     }
+
+    reverse_array(startAid, 3);
+    reverse_array(endAid, 3);
     uint32_t idStart = DesfireAIDByteToUint(startAid);
     uint32_t idEnd = DesfireAIDByteToUint(endAid);
     if (idStart > idEnd) {


### PR DESCRIPTION
`hf mfdes bruteaid` was mixing byte order in the arguments:

Before fix:
```
[usb] pm3 --> hf mfdes bruteaid --start 0000F0 --end 000100

[!!] 🚨 Start should be lower than end. start: f00000 end: 000100
```

After fix:
```
[usb] pm3 --> hf mfdes bruteaid --start 0000F0 --end 000100
[=] Bruteforce from 0000f0 to 000100
[=] Enumerating through all AIDs manually, this will take a while!
 🕙 Progress: 100 %, current AID: 000100
[+] Done!
[usb] pm3 --> trace list -t des
[+] Recorded activity ( 811 bytes )
[=] start = start of start frame. end = end of frame. src = source of transfer.
[=] ISO14443A - all times are in carrier periods (1/13.56MHz)

      Start |        End | Src | Data (! denotes parity error)                                           | CRC | Annotation
------------+------------+-----+-------------------------------------------------------------------------+-----+--------------------
[...]
    5532288 |    5546208 | Rdr |02  90  5A  00  00  03  FF  00  00  00  B3  ED                           |  ok | SELECT APPLICATION (appId 0000ff)
    5552324 |    5558212 | Tag |02  91  A0  23  B5                                                       |     | 
    5856000 |    5869984 | Rdr |03  90  5A  00  00  03  00  01  00  00  9A  5E                           |  ok | SELECT APPLICATION (appId 000100)
    5876036 |    5881924 | Tag |03  91  A0  FF  EF                                                       |     | 
```
