### PR TITLE
Improve magic tags notes

### DIFF
--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -46,12 +46,15 @@ Useful docs:
   * [MIFARE Ultralight EV1 DirectWrite](#mifare-ultralight-ev1-directwrite)
   * [MIFARE Ultralight C Gen1A](#mifare-ultralight-c-gen1a)
   * [MIFARE Ultralight C DirectWrite](#mifare-ultralight-c-directwrite)
-  * [UL series (RU)](#ul-series-ru)
+  * [MIFARE Ultralight USCUID-UL](#mifare-ultralight-uscuid-ul)
+    * [UL-2](#ul-2)
+      * [UL-2 (20 blocks)](#ul-2-20-blocks)
+      * [UL-2 (41 blocks)](#ul-2-41-blocks)
+      * [UL-2 (44 blocks)](#ul-2-44-blocks)
     * [UL-Y](#ul-y)
-    * [ULtra](#ultra)
+    * [Ultra](#ultra-ru)
     * [UL-5](#ul-5)
     * [UL, other chips](#ul-other-chips)
-  * [MIFARE Ultralight USCUID-UL](#mifare-ultralight-uscuid-ul)
 * [NTAG](#ntag)
   * [NTAG213 DirectWrite](#ntag213-directwrite)
   * [NTAG21x](#ntag21x)
@@ -2033,121 +2036,6 @@ Anticol shortcut (CL1/3000): fails
 script run hf_mfu_magicwrite -h
 ```
 
-## UL series (RU)
-
-^[Top](#top)
-
-Custom chips, manufactured by iKey LLC for cloning Ultralight tags used in Visit intercoms. That leads to the non-standard for Ultralight chips tag version.
-
-### UL-Y
-
-^[Top](#top)
-
-Ultralight magic, 16 pages. Recommended for Vizit RF3.1 with markings "3.1" or "4.1".
-Behavior: allows writes to page 0-2.
-
-#### Identify
-
-^[Top](#top)
-
-```
-hf mfu rdbl --force -b 16
-hf 14a raw -sct 250 60
-```
-
-If tag replies with
-`Cmd Error: 00`
-`00 00 00 00 00 00 00 00`
-then it is UL-Y.
-
-### ULtra
-
-^[Top](#top)
-
-Ultralight EV1 magic; 41 page. Recommended for Vizit RF3.1 with 41 page.
-Behavior: allows writes to page 0-2.
-
-#### Identify
-
-^[Top](#top)
-
-```
-hf mfu info
-...
-[=] TAG IC Signature: 0000000000000000000000000000000000000000000000000000000000000000
-[=] --- Tag Version
-[=]        Raw bytes: 00 34 21 01 01 00 0E 03
-[=]        Vendor ID: 34, Mikron JSC Russia
-[=]     Product type: 21, unknown
-```
-
-#### ULtra flavour 1
-
-^[Top](#top)
-
-Could be identified by indirect evidence before writing
-
-* Initial UID: `34 D7 08 11 AD D7 D0`
-* `hf mfu dump --ns`
-
-  ```
-  [=]   3/0x03 | CF 39 A1 C8 | 1 | .9..
-  [=]   4/0x04 | B6 69 26 0D | 1 | .i&.
-  [=]   5/0x05 | EC A1 73 C4 | 1 | ..s.
-  [=]   6/0x06 | 81 3D 29 B8 | 1 | .=).
-  [=]  16/0x10 | 6A F0 2D FF | 0 | j.-.
-  [=]  20/0x14 | 6A F0 2D FF | 0 | j.-.
-  [=]  24/0x18 | 6A F0 2D FF | 0 | j.-.
-  [=]  38/0x26 | 00 E2 00 00 | 0 | .... <- E2, Virtual Card Type Identifier is not default
-
-  ```
-
-#### ULtra flavour 2
-
-^[Top](#top)
-
-Could be identified by indirect evidence before writing
-
-* Initial UID: `04 15 4A 23 36 2F 81`
-* Values in pages `3, 4, 5, 6, 16, 20, 24, 38` are default for that tag flavour
-
-### UL-5
-
-^[Top](#top)
-
-Ultralight EV1 magic; 41 page. Recommended for Vizit RF3.1 with 41 page.
-Created as a response to filters that try to overwrite page 0 (as a detection for [ULtra](#mifare-ultra) tags).
-
-Behavior: similar to Ultra, but after editing page 0 become locked and tag becomes the original Mifare Ultralight EV1 (except the tag version, which remains specific).
-
-**WARNING!** When using UL-5 to clone, write UID pages in inverse (from 2 to 0) and do NOT make mistakes! This tag does not allow reversing one-way actions (OTP page, lock bits).
-
-#### Identify
-
-^[Top](#top)
-
-```
-hf mfu info
-...
-TAG IC Signature: 0000000000000000000000000000000000000000000000000000000000000000
-[=] --- Tag Version
-[=]        Raw bytes: 00 34 21 01 01 00 0E 03
-[=]        Vendor ID: 34, Mikron JSC Russia
-```
-
-After personalization it is not possible to identify UL-5.
-
-The manufacturer confirmed unpersonalized tags could be identified by first 3 bytes of UID:
-
-* `AA 55 39...`
-* `AA 55 C3...`
-
-### UL, other chips
-
-**TODO**
-
-UL-X, UL-Z - ?
-
 ## MIFARE Ultralight USCUID-UL
 
 ^[Top](#top)
@@ -2318,7 +2206,9 @@ No implemented commands at time of writing
 No implemented commands at time of writing
 
 ### Variations
+
 ^[Top](#top)
+
 | Factory configuration | Name |
 | --- | --- |
 | 850000A0 00000AC3 00040301 01000B03 | UL-11 |
@@ -2327,6 +2217,172 @@ No implemented commands at time of writing
 | 850085A0 00000AA5 00040402 01000F03 | NTAG213 |
 | 850000A0 00000A5A 00040402 01001103 | NTAG215 |
 | 850000A0 00000AAA 00040402 01001303 | NTAG216 |
+
+Variations of USCUID-UL, that were distributed in ex-USSR countries are known as UL-family.
+Different variarions were targeted for copying different original tags + for bypassing of different filters.
+
+## UL-2
+
+^[Top](#top)
+
+Sold on Russian market in variations with 20, 41 and 44 blocks.
+All variations support direct write to block 0-2.
+
+### UL-2 (20 blocks)
+
+#### Characteristics
+
+^[Top](#top)
+
+* Configuration block value: `850000A000000AC30034210101000B03`.
+* EV1 Version: `0034210101000B03`.
+
+#### Identify
+
+^[Top](#top)
+
+```
+[usb] pm3 --> hf 14a info
+...
+[+] ATS: 85 00 00 A0 00 00 0A C3 00 34 21 01 01 00 0B 03 [ 84 00 ]
+```
+
+### UL-2 (41 blocks)
+
+Default configuration for USCUID-UL with 41 blocks. Can be found in China by names UL-21 or Ultra (targeting Russian market).
+
+In China exists in versions with opened and locked configuration.
+Could be used for intercoms Grazhda (UA) and Vizit (RU) with non-Micron chips (original chips have EV1 Version `0004030101000E03`).
+
+* Other names:
+  * Ultra (China)
+  * UL-21 (China)
+
+#### Characteristics
+
+^[Top](#top)
+
+* Configuration block value: `850000A000000A3C0004030101000E03`.
+* EV1 Version: `0004030101000E03`.
+
+#### Identify
+
+^[Top](#top)
+
+```
+[usb] pm3 --> hf 14a info
+...
+[+] ATS: 85 00 00 A0 00 00 0A 3C 00 04 03 01 01 00 0E 03 [ C8 1D ]
+```
+
+### UL-2 (44 blocks)
+
+#### Characteristics
+
+^[Top](#top)
+
+* Configuration block value: `850000A000000A5A0034210101000E03`.
+* EV1 Version: `0034210101000E03`.
+
+#### Identify
+
+^[Top](#top)
+
+```
+[usb] pm3 --> hf 14a info
+...
+[+] ATS: 85 00 00 A0 00 00 0A 5A 00 34 21 01 01 00 0E 03 [ F1 F3 ]
+```
+
+## UL-Y
+
+^[Top](#top)
+
+### Characteristics
+
+^[Top](#top)
+
+* Configuration block value: `850000A0AA000A5A0000000000000000`.
+* EV1 Version: `0000000000000000`.
+* Has 16 blocks.
+* Allows write to pages 0-2.
+
+### Identify
+
+^[Top](#top)
+
+```
+[usb] pm3 --> hf 14a info
+...
+[+] ATS: 85 00 00 A0 AA 00 0A 5A 00 00 00 00 00 00 00 00 [ D5 F9 ]
+```
+
+## Ultra (RU)
+
+^[Top](#top)
+
+Modification of [UL-2 (41 blocks)](#ul-2-41-blocks) for Vizit (RU) intercoms.
+Suitable for tags with EV1 Version `0034210101000E03`.
+
+After communication to iKey LLC (importer of those tags to Russian market), new revisions, imported to Russia have closed config.
+
+### Characteristics
+
+^[Top](#top)
+
+* Configuration block value: `850000A000000A3C0034210101000E03`.
+* EV1 Version: `0034210101000E03`.
+
+### Identify
+
+^[Top](#top)
+
+```
+[usb] pm3 --> hf 14a info
+...
+[+] ATS: 85 00 00 A0 00 00 0A 3C 00 04 03 01 01 00 0E 03 [ C8 1D ]
+```
+
+## UL-5
+
+^[Top](#top)
+
+Variation of [Ultra](#ultra-ru) tag, which allows to change UID only once.
+
+After editing page 0 become locked and tag becomes the original Mifare Ultralight EV1 (except the tag version, which remains specific).
+
+Created as a response to Vizit (RU) filters that try to overwrite page 0 (as a detection for Ultra (RU) tags).
+
+**WARNING!** When using UL-5 to clone, write UID pages in inverse (from 2 to 0) and do NOT make mistakes! This tag does not allow reversing one-way actions (OTP page, lock bits).
+
+It was confirmed from importers to Russian and Ukrainian market (independently) that UL-5 is a variation of USCUID-UL. But so far it's unknown how to achieve that behaviors, because by default UL-5 has it's config locked.
+
+### Identify
+
+^[Top](#top)
+
+```
+hf mfu info
+...
+TAG IC Signature: 0000000000000000000000000000000000000000000000000000000000000000
+[=] --- Tag Version
+[=]        Raw bytes: 00 34 21 01 01 00 0E 03
+[=]        Vendor ID: 34, Mikron JSC Russia
+```
+
+After personalization it is not possible to identify UL-5.
+
+The manufacturer confirmed unpersonalized tags could be identified by first 2 bytes of UID:
+
+* `AA 55...`
+
+## UL, other chips
+
+** TODO **
+
+* UL
+* UL-X
+* UL-Z
 
 # DESFire
 

--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -27,7 +27,6 @@ Useful docs:
   * [MIFARE Classic block0](#mifare-classic-block0)
   * [MIFARE Classic Gen1A aka UID](#mifare-classic-gen1a-aka-uid)
   * [MIFARE Classic Gen1B](#mifare-classic-gen1b)
-  * [Mifare Classic Direct Write OTP](#mifare-classic-direct-write-otp)
   * [MIFARE Classic OTP 2.0](#mifare-classic-otp-20)
   * [MIFARE Classic MF4](#mifare-classic-mf4)
   * [MIFARE Classic DirectWrite aka Gen2 aka CUID](#mifare-classic-directwrite-aka-gen2-aka-cuid)
@@ -618,7 +617,7 @@ hf mf info
 ^[Top](#top)
 
 Similar to Gen1A, but after first block 0 edit, tag no longer replies to 0x40 command.
-Were manufactured by iKey LLC as a replacement for [OTP](#mifare-classic-direct-write-otp)
+Were manufactured by iKey LLC as a replacement for [OTP](#fuid)
 
 ### Characteristics
 
@@ -743,9 +742,9 @@ Here is how the IC can be configured:
 
 * Other names:
   * MF-8 (RU)
-  * MF-3 (RU) - not susceptible to "field reset bug", a way to detect [OTP](#mifare-classic-direct-write-otp) chips.
-  * MF-3.2 (RU) - static nonce `01200145`, helps avoid magic detection.
-
+  * MF-3 (RU) - not susceptible to "field reset bug", a way to detect [OTP](#fuid) chips.
+  * MF-3.2 (RU) - static nonce `01200145`, potentially fixed chip which can bypass Iron Logic's filters.
+`
 ### Identify
 
 ^[Top](#top)
@@ -1146,13 +1145,26 @@ Well-known variations are described below.
 
 ^[Top](#top)
 
-Known as "write only once", which is only partially true. Please note that some newer FUIDs have had ton configration blocks locked down and are truly a write-once tag.
+* Other names:
+  * OTP (RU)
 
-Allows direct write to block 0 only when UID is default `AA55C396`. If your tag responds to a gen4 magic wakeup, the UID could always be rewritten multiple times with backdoors commands.
+Known as "write only once", which is only partially true, because old revisions had backdoor commands enabled, so you could manipulate the tag, using them.
+Newer FUIDs are based on new implementation of chip and have backdoor commands disabled by default.
 
-Backdoor commands are available even after the personalization and makes that tag detectable.
+Allows direct write to block 0 only when UID is default `AA55C396`. If your tag responds to a `20(7)`, `23` magic wakeup, the UID could always be rewritten multiple times with backdoors commands, but that makes that tag detecteable.
 
-That's a key difference from [OTP](#mifare-classic-direct-write-otp)/[OTP 2.0](#mifare-classic-otp-20) tags.
+### Market Usage
+
+In ex-USSR countries were widely used as a replacement for UID tags. Especially for protected Iron Logic readers.Later filter `OTP` was created in those readers.
+The idea of the filter is that old version's chip had an issue in the protocol implementation.
+
+The reader could interrupt radiofield for 2-3 microseconds (standard pause in the bit period of ISO14443-2).
+After the response to first `26 (7)` command, but before the following `93 70` command. In that case original M1 card will stop the flow, but OTP will continue it.
+
+That issue led to the development of the filters against that card and discontinuation of the production.
+As a successor, [OTP 2.0](#mifare-classic-otp-20) was created for that market.
+
+Newer FUID tags (with backdoor command disabled) has protocol fixed and works fine on Iron Logic readers with firmware older than 7.28, but are filtered by latest filters on mentioned firmware.
 
 ### Characteristics
 
@@ -1177,7 +1189,7 @@ hf mf info
 
 ```
 
-or locked down tag type:
+Or locked down tag type:
 
 ```
 hf mf info

--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -1413,8 +1413,6 @@ hf mf info
 * Magic wakeup: `40(7)`, `43`
   * Backdoor read main block: `30xx+crc`
   * Backdoor write main block: `A0xx+crc`, `[16 bytes data]+crc`
-  * Read hidden block: `38xx+crc`
-  * Write hidden block: `A8xx+crc`, `[16 bytes data]+crc`
   * Read configuration: `E000+crc`
   * Write configuration: `E100+crc`
 


### PR DESCRIPTION
- [x] Merged OTP to FUID as it was confirmed by iKey that is was pure FUIDs
- [x] Deleted mistake from ZUID (it doesn't have hidden blocks)
- [x] Clarified info about UL-family (variations of USCUID-UL, sold in ex-USSR countries market), based on researches + communications with main importers