### PR TITLE
Move `mag`safe polling argument to `hf 14a config`

### DIFF
--- a/armsrc/iso14443a.h
+++ b/armsrc/iso14443a.h
@@ -157,9 +157,9 @@ bool SimulateIso14443aInit(uint8_t tagType, uint16_t flags, uint8_t *data,
 bool GetIso14443aCommandFromReader(uint8_t *received, uint16_t received_maxlen, uint8_t *par, int *len);
 void iso14443a_antifuzz(uint32_t flags);
 void ReaderIso14443a(PacketCommandNG *c);
-void ReaderTransmit(uint8_t *frame, uint16_t len, uint32_t *timing);
-void ReaderTransmitBitsPar(uint8_t *frame, uint16_t bits, uint8_t *par, uint32_t *timing);
-void ReaderTransmitPar(uint8_t *frame, uint16_t len, uint8_t *par, uint32_t *timing);
+void ReaderTransmit(const uint8_t *frame, uint16_t len, uint32_t *timing);
+void ReaderTransmitBitsPar(const uint8_t *frame, uint16_t bits, uint8_t *par, uint32_t *timing);
+void ReaderTransmitPar(const uint8_t *frame, uint16_t len, uint8_t *par, uint32_t *timing);
 uint16_t ReaderReceive(uint8_t *receivedAnswer, uint16_t answer_maxlen, uint8_t *par);
 
 void iso14443a_setup(uint8_t fpga_minor_mode);

--- a/client/src/cmdhf14a.h
+++ b/client/src/cmdhf14a.h
@@ -70,7 +70,7 @@ int Hf14443_4aGetCardData(iso14a_card_select_t *card);
 int ExchangeAPDU14a(const uint8_t *datain, int datainlen, bool activateField, bool leaveSignalON, uint8_t *dataout, int maxdataoutlen, int *dataoutlen);
 int ExchangeRAW14a(uint8_t *datain, int datainlen, bool activateField, bool leaveSignalON, uint8_t *dataout, int maxdataoutlen, int *dataoutlen, bool silentMode);
 
-iso14a_polling_parameters_t iso14a_get_polling_parameters(bool use_ecp, bool use_magsafe);
+iso14a_polling_parameters_t iso14a_get_polling_parameters(bool use_magsafe);
 int SelectCard14443A_4(bool disconnect, bool verbose, iso14a_card_select_t *card);
 int SelectCard14443A_4_WithParameters(bool disconnect, bool verbose, iso14a_card_select_t *card, iso14a_polling_parameters_t *polling_parameters);
 

--- a/client/src/cmdhf14a.h
+++ b/client/src/cmdhf14a.h
@@ -70,7 +70,6 @@ int Hf14443_4aGetCardData(iso14a_card_select_t *card);
 int ExchangeAPDU14a(const uint8_t *datain, int datainlen, bool activateField, bool leaveSignalON, uint8_t *dataout, int maxdataoutlen, int *dataoutlen);
 int ExchangeRAW14a(uint8_t *datain, int datainlen, bool activateField, bool leaveSignalON, uint8_t *dataout, int maxdataoutlen, int *dataoutlen, bool silentMode);
 
-iso14a_polling_parameters_t iso14a_get_polling_parameters(bool use_magsafe);
 int SelectCard14443A_4(bool disconnect, bool verbose, iso14a_card_select_t *card);
 int SelectCard14443A_4_WithParameters(bool disconnect, bool verbose, iso14a_card_select_t *card, iso14a_polling_parameters_t *polling_parameters);
 

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -1347,7 +1347,7 @@
                 "--crypto1 Use crypto1 session",
                 "<hex> Raw bytes to send"
             ],
-            "usage": "hf 14a raw [-hack3rsv] [-t <ms>] [-b <dec>] [--mag] [--topaz] [--crypto1] <hex> [<hex>]..."
+            "usage": "hf 14a raw [-hack3rsv] [-t <ms>] [-b <dec>] [--topaz] [--crypto1] <hex> [<hex>]..."
         },
         "hf 14a reader": {
             "command": "hf 14a reader",
@@ -1368,7 +1368,7 @@
                 "-@ continuous reader mode",
                 "-w, --wait wait for card"
             ],
-            "usage": "hf 14a reader [-hks@w] [--drop] [--skip] [--mag]"
+            "usage": "hf 14a reader [-hks@w] [--drop] [--skip]"
         },
         "hf 14a sim": {
             "command": "hf 14a sim",

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -1324,7 +1324,6 @@
             "notes": [
                 "hf 14a raw -sc 3000 -> select, crc, where 3000 == 'read block 00'",
                 "hf 14a raw -ak -b 7 40 -> send 7 bit byte 0x40",
-                "hf 14a raw --ecp -s -> send ECP before select",
                 "Crypto1 session example, with special auth shortcut 6xxx<key>:",
                 "hf 14a raw --crypto1 -skc 6000FFFFFFFFFFFF",
                 "hf 14a raw --crypto1 -kc 3000",
@@ -1343,13 +1342,12 @@
                 "-t, --timeout <ms> Timeout in milliseconds",
                 "-b <dec> Number of bits to send. Useful for send partial byte",
                 "-v, --verbose Verbose output",
-                "--ecp Use enhanced contactless polling",
                 "--mag Use Apple magsafe polling",
                 "--topaz Use Topaz protocol to send command",
                 "--crypto1 Use crypto1 session",
                 "<hex> Raw bytes to send"
             ],
-            "usage": "hf 14a raw [-hack3rsv] [-t <ms>] [-b <dec>] [--ecp] [--mag] [--topaz] [--crypto1] <hex> [<hex>]..."
+            "usage": "hf 14a raw [-hack3rsv] [-t <ms>] [-b <dec>] [--mag] [--topaz] [--crypto1] <hex> [<hex>]..."
         },
         "hf 14a reader": {
             "command": "hf 14a reader",
@@ -1357,7 +1355,6 @@
             "notes": [
                 "hf 14a reader",
                 "hf 14a reader -@ -> Continuous mode",
-                "hf 14a reader --ecp -> trigger apple enhanced contactless polling",
                 "hf 14a reader --mag -> trigger apple magsafe polling"
             ],
             "offline": false,
@@ -1367,12 +1364,11 @@
                 "-s, --silent silent (no messages)",
                 "--drop just drop the signal field",
                 "--skip ISO14443-3 select only (skip RATS)",
-                "--ecp Use enhanced contactless polling",
                 "--mag Use Apple magsafe polling",
                 "-@ continuous reader mode",
                 "-w, --wait wait for card"
             ],
-            "usage": "hf 14a reader [-hks@w] [--drop] [--skip] [--ecp] [--mag]"
+            "usage": "hf 14a reader [-hks@w] [--drop] [--skip] [--mag]"
         },
         "hf 14a sim": {
             "command": "hf 14a sim",

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -133,7 +133,7 @@ typedef struct {
 
 
 // Defines a frame that will be used in a polling sequence
-// Polling loop annotations are up to (7 + 16) bytes long, 24 bytes should cover future and other cases
+// Polling loop annotations are up to 20 bytes long, 24 bytes should cover future and other cases
 typedef struct {
     uint8_t frame[24];
     // negative values can be used to carry special info
@@ -144,8 +144,8 @@ typedef struct {
 
 
 // Defines polling sequence configuration
-// 6 would be enough for 4 magsafe, 1 wupa, 1 pla,
 typedef struct {
+    // 6 would be enough for 4 magsafe, 1 wupa, 1 pla,
     iso14a_polling_frame_t frames[6];
     int8_t frame_count;
     uint16_t extra_timeout;
@@ -159,6 +159,7 @@ typedef struct {
     int8_t forcecl2;     // 0:auto 1:force executing CL2 2:force skipping CL2
     int8_t forcecl3;     // 0:auto 1:force executing CL3 2:force skipping CL3
     int8_t forcerats;    // 0:auto 1:force executing RATS 2:force skipping RATS
+    int8_t magsafe;      // 0:disabled 1:enabled
     iso14a_polling_frame_t polling_loop_annotation; // Polling loop annotation
 } PACKED hf14a_config;
 


### PR DESCRIPTION
Additions:
* Move `mag` argument to `hf 14a config` option, allowing to enable/disable magsafe support for all places where HF14A polling is performed, instead of needing to add support on per-command basis;
* ~~Add `m` and `p` shorthands for `mag` and `pla` arguments in `hf 14a config`, allowing to set those options via shorthands like `-mon`, `-moff`, `-poff`~~;
* Mark `frame` argument in `ReaderTransmit*` functions as const to make it useable with const array references;
* Add more aliases for disabling `mag`/`pla` config options (`disable`/`off`/`skip`).

Removals:
* Remove `ecp` argument from all commands where it was present, as this functionality was replaced by more powerful `pla` in `hf 14a config`.
* Remove `mag` argument from all commands where it was present.