### PR TITLE
fix fm11rf08s_full log encoding type error

### DIFF
--- a/client/pyscripts/fm11rf08s_full.py
+++ b/client/pyscripts/fm11rf08s_full.py
@@ -95,7 +95,7 @@ def lprint(s='',  end='\n', flush=False, prompt="[" + color("=", fg="yellow") + 
     if log is True:
         global logbuffer
         if logfile is not None:
-            with open(logfile, 'a') as f:
+            with open(logfile, 'a', encoding='utf-8') as f:
                 f.write(s + end)
         else:
             # buffering


### PR DESCRIPTION
Hi!

I use `fm11rf08s_full` script on a  Chinese version Windows with Proxspace. I got an exception said `gbk` can't encode log character.
I made a simple fix by set encoding type `utf-8` in this script. It works on my computer.

Log:
```
...
[=] =====================
[=]  Access Control List
[=] =====================
[=]
[=]    _______________________________________________________
[=]   |        |                Sector Trailers               |
[=]   |        |----------------------------------------------|
[=]   | Sector |____Key_A_____||_Access_Bits__||____Key_B_____|
[=]   |        | read ¦ write || read ¦ write || read ¦ write |
Traceback (most recent call last):
  File "fm11rf08s_full.py", line 1080, in <module>
    main()
  File "fm11rf08s_full.py", line 171, in main
    dumpAcl(data)
  File "fm11rf08s_full.py", line 1007, in dumpAcl
    lprint(f"  {line}")
  File "fm11rf08s_full.py", line 99, in lprint
    f.write(s + end)
UnicodeEncodeError: 'gbk' codec can't encode character '\xa6' in position 31: illegal multibyte sequence

[!] finished fm11rf08s_full.py with exception
```