### PR TITLE
cardhopper fixes

### DIFF
--- a/armsrc/usart.c
+++ b/armsrc/usart.c
@@ -218,7 +218,7 @@ uint32_t usart_read_ng(uint8_t *data, size_t len) {
 }
 
 // transfer from device to client
-int usart_writebuffer_sync(uint8_t *data, size_t len) {
+int usart_writebuffer_sync(const uint8_t *data, size_t len) {
 
     // Wait for current PDC bank to be free
     // (and check next bank too, in case there will be a usart_writebuffer_async)

--- a/armsrc/usart.h
+++ b/armsrc/usart.h
@@ -25,7 +25,7 @@ extern uint32_t g_usart_baudrate;
 extern uint8_t g_usart_parity;
 
 void usart_init(uint32_t baudrate, uint8_t parity);
-int usart_writebuffer_sync(uint8_t *data, size_t len);
+int usart_writebuffer_sync(const uint8_t *data, size_t len);
 uint32_t usart_read_ng(uint8_t *data, size_t len);
 uint16_t usart_rxdata_available(void);
 


### PR DESCRIPTION
make usart write buffer const
sub out magic numbers with defines
fix edge case handling 255/256 byte frames (including crc) add sanity checks to avoid buffer overrun on some "should never happen" edge cases don't wait for rats reply from card before listening to next reader frame cap fsci to 8 (256 bytes) as that's the most the proxmark3 codebase currently handles eliminate 1k of ram usage by tweaking how emulation responses are sent