### PR TITLE
Ignore UnicodeDecodeError in lprint

### DIFF
--- a/client/pyscripts/fm11rf08s_full.py
+++ b/client/pyscripts/fm11rf08s_full.py
@@ -90,13 +90,14 @@ def lprint(s='',  end='\n', flush=False, prompt="[" + color("=", fg="yellow") + 
     - logfile (R)
     """
     s = f"{prompt}" + f"\n{prompt}".join(s.split('\n'))
-    print(s, end=end, flush=flush)
+    safe_s = s.encode('utf-8', errors='ignore').decode('utf-8')
+    print(safe_s, end=end, flush=flush)
 
     if log is True:
         global logbuffer
         if logfile is not None:
             with open(logfile, 'a', encoding='utf-8') as f:
-                f.write(s + end)
+                f.write(safe_s + end)
         else:
             # buffering
             logbuffer += s + end


### PR DESCRIPTION
When dumping data with `fm11rf08s_full.py` it can happen that data is wrongly recognized as unicode which leads to errors like the following 

> UnicodeEncodeError: 'utf-8' codec can't encode character '\udcc0' in position 62: surrogates not allowed

this fix ignores UnicodeEncodeError and properly prints a `.` for data that cant be represented in ASCII