### PR TITLE
Add option to override default USART baud rate in platform settings

### DIFF
--- a/Makefile.platform.sample
+++ b/Makefile.platform.sample
@@ -27,6 +27,10 @@ PLATFORM=PM3RDV4
 # Only available with PLATFORM=PM3GENERIC
 #LED_ORDER=PM3EASY
 
+# Uncomment a line below to change default USART baud rate
+# defaults to 115200 used by HC-05 in Blueshark
+#USART_BAUD_RATE=19200
+
 # Uncomment the lines below in order to make a 256KB image
 # and comment out the lines above
 

--- a/common_arm/Makefile.hal
+++ b/common_arm/Makefile.hal
@@ -252,6 +252,10 @@ endif
 # WITH_FPC_USART_* needs WITH_FPC_USART :
 ifneq (,$(findstring WITH_FPC_USART_,$(PLATFORM_DEFS)))
     PLATFORM_DEFS += -DWITH_FPC_USART
+    ifeq ($(USART_BAUD_RATE),)
+        USART_BAUD_RATE=115200
+    endif
+    PLATFORM_DEFS += -DUSART_BAUD_RATE=$(USART_BAUD_RATE)
 endif
 
 PLATFORM_DEFS_INFO = $(strip $(filter-out STANDALONE%, $(subst -DWITH_,,$(PLATFORM_DEFS))))

--- a/include/usart_defs.h
+++ b/include/usart_defs.h
@@ -16,8 +16,9 @@
 #ifndef __USART_DEFS_H
 #define __USART_DEFS_H
 
-//#define USART_BAUD_RATE 9600
+#ifndef USART_BAUD_RATE
 #define USART_BAUD_RATE 115200
+#endif
 // BT HC-06 physical layer runs at 128kbps
 // so it's possible to gain a little bit by using 230400
 // with some risk to overflow its internal buffers:


### PR DESCRIPTION
With this change, only modifications in `Makefile.platform` are sufficient to get JDY-23 module running and connect with client using [Jakeler/ble-serial](https://github.com/Jakeler/ble-serial).

AT commands differs, but it is possible to configure it solely using `usart txrx` command.
Module manual: https://github.com/xiaolaba/AT3010-JDY-23/blob/master/JDY-23_Notes_xara.pdf