### PR TITLE
R&Y: Added SDS 11 A/B MFC Keys & LAS RTC TAP & GO AID

### DIFF
--- a/client/dictionaries/mfc_default_keys.dic
+++ b/client/dictionaries/mfc_default_keys.dic
@@ -1905,15 +1905,14 @@ FF16014FEFC7
 # Food GEM
 6686FADE5566
 #
-# Samsung Data Systems (SDS) — Electronic Locks
-# Gen 1 S10 KA/KB is FFFFFFFFFFFF, incompatible with Gen 2 locks
-#
-# SDS Gen 2 S10 KB
+# Samsung Data Systems (SDS)
+# 10-11 A/B (Gen 2)
+9B7C25052FC3
 C22E04247D9A
+6C4F77534170
+704153564F6C
 #
 # Data from Discord, French pool
-# SDS Gen 2 S10 KA
-9B7C25052FC3
 494446555455
 #
 # Data from Discord, seems to be related to ASSA

--- a/client/resources/aid_desfire.json
+++ b/client/resources/aid_desfire.json
@@ -1304,6 +1304,14 @@
         "Type": "transport"
     },
     {
+        "AID": "7A007A",
+        "Vendor": "Regional Transportation Commission of Southern Nevada (RTC) via Masabi Ltd",
+        "Country": "US",
+        "Name": "RTC TAP & GO (LAS)",
+        "Description": "LAS TAP & GO; Masabi Justride Tap and Ride DESFire Smartcard",
+        "Type": "transport"
+    },
+    {
         "AID": "784000",
         "Vendor": "Roads & Transport Authority (Government of Dubai)",
         "Country": "AE",


### PR DESCRIPTION
# Additions
- Added SDS 11 A/B (Gen 2) keys to `mfc_default_keys.dic` *with thanks to @DrekkCuga*.
- Added LAS RTC TAP & GO AID (`7A007A`) to `aid_desfire.json` *with thanks to Discord\jakkpotts*.

Many thanks in advance, and kind regards,

-R&Y.