### PR TITLE
Fix bug with iclass legbrute index value being ignored

### DIFF
--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -4255,7 +4255,7 @@ static int CmdHFiClassLegRecLookUp(const char *Cmd) {
     uint8_t startingKey[PICOPASS_BLOCK_SIZE] = {0};
     CLIGetHexWithReturn(ctx, 4, startingKey, &startingkey_len);
 
-    uint64_t index = arg_get_int_def(ctx, 6, 0); //has to be 64 as we're bruteforcing 40 bits
+    uint64_t index = arg_get_int_def(ctx, 5, 0); //has to be 64 as we're bruteforcing 40 bits
     index = index * 1000000;
 
     CLIParserFree(ctx);


### PR DESCRIPTION
Fixed issue https://github.com/RfidResearchGroup/proxmark3/issues/2845