### PR TITLE
Fixed SimulateIso14443aTag() to make MFU counter increments persistent in emulator memory.

### DIFF
--- a/armsrc/Standalone/hf_cardhopper.c
+++ b/armsrc/Standalone/hf_cardhopper.c
@@ -233,10 +233,8 @@ static void become_card(void) {
 
     tag_response_info_t *canned;
     uint32_t cuid;
-    uint32_t counters[3] = { 0 };
-    uint8_t tearings[3] = { 0xbd, 0xbd, 0xbd };
     uint8_t pages;
-    SimulateIso14443aInit(tagType, flags, data, NULL, 0, &canned, &cuid, counters, tearings, &pages);
+    SimulateIso14443aInit(tagType, flags, data, NULL, 0, &canned, &cuid, &pages);
 
     DbpString(_CYAN_("[@]") " Setup done - entering emulation loop");
     int fromReaderLen;

--- a/armsrc/Standalone/hf_msdsal.c
+++ b/armsrc/Standalone/hf_msdsal.c
@@ -379,7 +379,7 @@ void RunMod(void) {
             BigBuf_free_keep_EM();
 
             // tag type: 11 = ISO/IEC 14443-4 - javacard (JCOP)
-            if (SimulateIso14443aInit(11, flags, data, NULL, 0, &responses, &cuid, NULL, NULL, NULL) == false) {
+            if (SimulateIso14443aInit(11, flags, data, NULL, 0, &responses, &cuid, NULL) == false) {
                 BigBuf_free_keep_EM();
                 reply_ng(CMD_HF_MIFARE_SIMULATE, PM3_EINIT, NULL, 0);
                 DbpString(_RED_("Error initializing the emulation process!"));

--- a/armsrc/Standalone/hf_reblay.c
+++ b/armsrc/Standalone/hf_reblay.c
@@ -268,7 +268,7 @@ void RunMod() {
             BigBuf_free_keep_EM();
 
             // 4 = ISO/IEC 14443-4 - javacard (JCOP)
-            if (SimulateIso14443aInit(4, flags, data, NULL, 0, &responses, &cuid, NULL, NULL, NULL) == false) {
+            if (SimulateIso14443aInit(4, flags, data, NULL, 0, &responses, &cuid, NULL) == false) {
                 BigBuf_free_keep_EM();
                 reply_ng(CMD_HF_MIFARE_SIMULATE, PM3_EINIT, NULL, 0);
                 DbpString(_RED_("Error initializing the emulation process!"));

--- a/armsrc/Standalone/hf_tcprst.c
+++ b/armsrc/Standalone/hf_tcprst.c
@@ -118,8 +118,6 @@ void RunMod(void) {
     uint8_t tagType = 10; // 10 = ST25TA IKEA Rothult
     tag_response_info_t *responses;
     uint32_t cuid = 0;
-    uint32_t counters[3] = { 0x00, 0x00, 0x00 };
-    uint8_t tearings[3] = { 0xbd, 0xbd, 0xbd };
     uint8_t pages = 0;
 
     // command buffers
@@ -193,7 +191,7 @@ void RunMod(void) {
 
             memcpy(data, stuid, sizeof(stuid));
 
-            if (SimulateIso14443aInit(tagType, flags, data, NULL, 0, &responses, &cuid, counters, tearings, &pages) == false) {
+            if (SimulateIso14443aInit(tagType, flags, data, NULL, 0, &responses, &cuid, &pages) == false) {
                 BigBuf_free_keep_EM();
                 reply_ng(CMD_HF_MIFARE_SIMULATE, PM3_EINIT, NULL, 0);
                 DbpString(_YELLOW_("!!") "Error initializing the simulation process!");
@@ -371,7 +369,7 @@ void RunMod(void) {
 
             memcpy(data, stuid, sizeof(stuid));
 
-            if (SimulateIso14443aInit(tagType, flags, data, NULL, 0, &responses, &cuid, counters, tearings, &pages) == false) {
+            if (SimulateIso14443aInit(tagType, flags, data, NULL, 0, &responses, &cuid, &pages) == false) {
                 BigBuf_free_keep_EM();
                 reply_ng(CMD_HF_MIFARE_SIMULATE, PM3_EINIT, NULL, 0);
                 DbpString(_YELLOW_("!!") "Error initializing the simulation process!");

--- a/armsrc/iso14443a.h
+++ b/armsrc/iso14443a.h
@@ -152,7 +152,7 @@ void SimulateIso14443aTagAID(uint8_t tagType, uint16_t flags, uint8_t *uid,
 
 bool SimulateIso14443aInit(uint8_t tagType, uint16_t flags, uint8_t *data,
                            uint8_t *ats, size_t ats_len, tag_response_info_t **responses,
-                           uint32_t *cuid, uint32_t counters[3], uint8_t tearings[3], uint8_t *pages);
+                           uint32_t *cuid, uint8_t *pages);
 
 bool GetIso14443aCommandFromReader(uint8_t *received, uint16_t received_maxlen, uint8_t *par, int *len);
 void iso14443a_antifuzz(uint32_t flags);


### PR DESCRIPTION
- Fixed `SimulateIso14443aTag()` to make MFU counter increments persistent in emulator memory:
Previously, the counters were copied to a local variable that was later used in read/write operations. I replaced this local variable with the actual blocks used to store the counters in the emulator memory.

- Fixed arguments for `SimulateIso14443aInit` in `hf_msdsal.c`, `hf_cardhopper.c`, `hf_reblay.c` and `hf_tcprst.c`.