### PR TITLE
Add "hf mf bambukeys" command to generate Bambu Lab keys

### DIFF
--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -4503,7 +4503,7 @@ void printKeyTableEx(size_t sectorscnt, sector_t *e_sector, uint8_t start_sector
                       _YELLOW_("H") ":Hardnested / "
                       _YELLOW_("C") ":statiCnested / "
                       _YELLOW_("A") ":keyA "
-                      " )"
+                            " )"
                      );
         if (sectorscnt == 18) {
             PrintAndLogEx(INFO, "( " _MAGENTA_("*") " ) These sectors used for signature. Lays outside of user memory");
@@ -10219,6 +10219,64 @@ static int CmdHF14AMfISEN(const char *Cmd) {
     return PM3_SUCCESS;
 }
 
+static int CmdHF14AMfBambuKeys(const char *Cmd) {
+    CLIParserContext *ctx;
+    CLIParserInit(&ctx, "hf mf bambukeys",
+                  "Generate keys for a Bambu Lab filament tag",
+                  "hf mf bambukeys -r\n"
+                  "hf mf bambukeys -r -d\n"
+                  "hf mf bambukeys -u 11223344\n"
+                 );
+
+    void *argtable[] = {
+        arg_param_begin,
+        arg_str0("u", "uid", "<hex>", "UID (4 hex bytes)"),
+        arg_lit0("r", NULL, "Read UID from tag"),
+        arg_lit0("d", NULL, "Dump keys to file"),
+        arg_param_end
+    };
+    CLIExecWithReturn(ctx, Cmd, argtable, true);
+
+    int u_len = 0;
+    uint8_t uid[7] = {0x00};
+    CLIGetHexWithReturn(ctx, 1, uid, &u_len);
+    bool use_tag = arg_get_lit(ctx, 2);
+    bool dump_keys = arg_get_lit(ctx, 3);
+    CLIParserFree(ctx);
+
+    if (use_tag) {
+        // read uid from tag
+        int res = mf_read_uid(uid, &u_len, NULL);
+        if (res != PM3_SUCCESS) {
+            return res;
+        }
+    }
+
+    if (u_len != 4) {
+        PrintAndLogEx(WARNING, "Key must be 4 hex bytes");
+        return PM3_EINVARG;
+    }
+
+    PrintAndLogEx(INFO, "-----------------------------------");
+    PrintAndLogEx(INFO, " UID 4b... " _YELLOW_("%s"), sprint_hex(uid, 4));
+    PrintAndLogEx(INFO, "-----------------------------------");
+
+    uint8_t keys[32 * 6];
+    mfc_algo_bambu_all(uid, (void*)keys);
+
+    for (int block = 0; block < 32; block++) {
+        PrintAndLogEx(INFO, "%d: %012" PRIX64, block, bytes_to_num(keys + (block * 6), 6));
+    }
+
+    if (dump_keys) {
+        char fn[FILE_PATH_SIZE] = {0};
+        snprintf(fn, sizeof(fn), "hf-mf-%s-key", sprint_hex_inrow(uid, 4));
+        saveFileEx(fn, ".bin", keys, 32 * 6, spDump);
+    }
+
+    return PM3_SUCCESS;
+}
+
 static command_t CommandTable[] = {
     {"help",        CmdHelp,                AlwaysAvailable, "This help"},
     {"list",        CmdHF14AMfList,         AlwaysAvailable, "List MIFARE history"},
@@ -10237,6 +10295,7 @@ static command_t CommandTable[] = {
     {"fchk",        CmdHF14AMfChk_fast,     IfPm3Iso14443a,  "Check keys fast, targets all keys on card"},
     {"decrypt",     CmdHf14AMfDecryptBytes, AlwaysAvailable, "Decrypt Crypto1 data from sniff or trace"},
     {"supercard",   CmdHf14AMfSuperCard,    IfPm3Iso14443a,  "Extract info from a `super card`"},
+    {"bambukeys",   CmdHF14AMfBambuKeys,    AlwaysAvailable, "Generate key table for Bambu Lab filament tag"},
     {"-----------", CmdHelp,                IfPm3Iso14443a,  "----------------------- " _CYAN_("operations") " -----------------------"},
     {"auth4",       CmdHF14AMfAuth4,        IfPm3Iso14443a,  "ISO14443-4 AES authentication"},
     {"acl",         CmdHF14AMfAcl,          AlwaysAvailable, "Decode and print MIFARE Classic access rights bytes"},

--- a/client/src/pm3line_vocabulary.h
+++ b/client/src/pm3line_vocabulary.h
@@ -356,6 +356,7 @@ const static vocabulary_t vocabulary[] = {
     { 0, "hf mf fchk" },
     { 1, "hf mf decrypt" },
     { 0, "hf mf supercard" },
+    { 1, "hf mf blgen" },
     { 0, "hf mf auth4" },
     { 1, "hf mf acl" },
     { 0, "hf mf dump" },

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -4411,6 +4411,23 @@
             ],
             "usage": "hf mf autopwn [-hablv] [-k <hex>]... [-s <dec>] [-f <fn>] [--suffix <txt>] [--slow] [--mem] [--ns] [--mini] [--1k] [--2k] [--4k] [--in] [--im] [--is] [--ia] [--i2] [--i5]"
         },
+        "hf mf bambukeys": {
+            "command": "hf mf bambukeys",
+            "description": "Generate keys for a Bambu Lab filament tag",
+            "notes": [
+                "hf mf bambukeys -r",
+                "hf mf bambukeys -r -d",
+                "hf mf bambukeys -u 11223344"
+            ],
+            "offline": true,
+            "options": [
+                "-h, --help This help",
+                "-u, --uid <hex> UID (4 hex bytes)",
+                "-r Read UID from tag",
+                "-d Dump keys to file"
+            ],
+            "usage": "hf mf bambukeys [-hrd] [-u <hex>]"
+        },
         "hf mf brute": {
             "command": "hf mf brute",
             "description": "This is a smart bruteforce, exploiting common patterns, bugs and bad designs in key generators.",
@@ -5145,7 +5162,7 @@
         },
         "hf mf help": {
             "command": "hf mf help",
-            "description": "help This help list List MIFARE history hardnested Nested attack for hardened MIFARE Classic cards decrypt Decrypt Crypto1 data from sniff or trace acl Decode and print MIFARE Classic access rights bytes mad Checks and prints MAD value Value blocks view Display content from tag dump file ginfo Info about configuration of the card gdmparsecfg Parse config block to card --------------------------------------------------------------------------------------- hf mf list available offline: yes Alias of `trace list -t mf -c` with selected protocol data to annotate trace buffer You can load a trace from file (see `trace load -h`) or it be downloaded from device by default It accepts all other arguments of `trace list`. Note that some might not be relevant for this specific protocol",
+            "description": "help This help list List MIFARE history hardnested Nested attack for hardened MIFARE Classic cards decrypt Decrypt Crypto1 data from sniff or trace bambukeys Generate key table for Bambu Lab filament tag acl Decode and print MIFARE Classic access rights bytes mad Checks and prints MAD value Value blocks view Display content from tag dump file ginfo Info about configuration of the card gdmparsecfg Parse config block to card --------------------------------------------------------------------------------------- hf mf list available offline: yes Alias of `trace list -t mf -c` with selected protocol data to annotate trace buffer You can load a trace from file (see `trace load -h`) or it be downloaded from device by default It accepts all other arguments of `trace list`. Note that some might not be relevant for this specific protocol",
             "notes": [
                 "hf mf list --frame -> show frame delay times",
                 "hf mf list -1 -> use trace buffer"
@@ -13352,8 +13369,8 @@
         }
     },
     "metadata": {
-        "commands_extracted": 767,
+        "commands_extracted": 768,
         "extracted_by": "PM3Help2JSON v1.00",
-        "extracted_on": "2025-05-23T15:21:08"
+        "extracted_on": "2025-05-24T14:16:42"
     }
 }

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -527,6 +527,7 @@ Check column "offline" for their availability.
 |`hf mf fchk             `|N       |`Check keys fast, targets all keys on card`
 |`hf mf decrypt          `|Y       |`Decrypt Crypto1 data from sniff or trace`
 |`hf mf supercard        `|N       |`Extract info from a `super card``
+|`hf mf bambukeys        `|Y       |`Generate key table for Bambu Lab filament tag`
 |`hf mf auth4            `|N       |`ISO14443-4 AES authentication`
 |`hf mf acl              `|Y       |`Decode and print MIFARE Classic access rights bytes`
 |`hf mf dump             `|N       |`Dump MIFARE Classic tag to binary file`


### PR DESCRIPTION
This was cumbersome, it's a bit less so now :)

`hf mf bambukeys` will generate bambu lab filament tag keys using the existing KDF implementation from a provided UID or from one read from a tag, and can generate the necessary hf-mf-UID-key.bin file for a subsequent dump operation.

Like so:
```
hf mf bambukeys -r -d
hf mf dump
```