### PR TITLE
Updated hf iclass tear to not run if the authentication fuses are blown

### DIFF
--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -3137,6 +3137,11 @@ static int CmdHFiClass_TearBlock(const char *Cmd) {
         auth = false;
     }
 
+    if (pagemap == 0x0) {
+            PrintAndLogEx(WARNING, _RED_("No auth possible. Read only if RA is enabled"));
+            goto out;
+    }
+
     bool read_auth = auth;
 
     // perform initial read here, repeat if failed or 00s


### PR DESCRIPTION
Updated hf iclass tear to not run if the authentication fuses are blown. Or it will just get stuck at the beginning and not start anyway. At least this informs the users why this is happening.