### PR TITLE
Updated hf iclass info for silicon check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Changed `hf iclass info` - now uses CSN values based checks (@antiklesys)
 - Changed `hf iclass dump` - now uses default AA1 key when called without a key or key index (@iceman1001)
 - Renamed `hf iclass trbl` to `hf iclass tear` (@iceman1001)
 - Changed `hw tearoff` - the device side message is now debug log controlled (@iceman1001)

--- a/client/src/cmdhf14b.c
+++ b/client/src/cmdhf14b.c
@@ -1411,7 +1411,7 @@ static bool HF14B_ask_ct_reader(bool verbose) {
     return false;
 }
 
-bool HF14B_picopass_reader(bool verbose, bool info) {
+static bool HF14B_picopass_reader(bool verbose) {
 
     iso14b_raw_cmd_t packet = {
         .flags = (ISO14B_CONNECT | ISO14B_SELECT_PICOPASS | ISO14B_DISCONNECT),
@@ -1437,10 +1437,8 @@ bool HF14B_picopass_reader(bool verbose, bool info) {
                 return false;
             }
             memcpy(card, resp.data.asBytes, sizeof(picopass_hdr_t));
-            if (info) {
-                PrintAndLogEx(NORMAL, "");
-                PrintAndLogEx(SUCCESS, "iCLASS / Picopass CSN: " _GREEN_("%s"), sprint_hex(card->csn, sizeof(card->csn)));
-            }
+            PrintAndLogEx(NORMAL, "");
+            PrintAndLogEx(SUCCESS, "iCLASS / Picopass CSN: " _GREEN_("%s"), sprint_hex(card->csn, sizeof(card->csn)));
             free(card);
             return true;
         }
@@ -3038,7 +3036,6 @@ int infoHF14B(bool verbose, bool do_aid_search) {
 // get and print general info about all known 14b chips
 int readHF14B(bool loop, bool verbose, bool read_plot) {
     bool found = false;
-    bool info = true;
     int res = PM3_SUCCESS;
     do {
         found = false;
@@ -3054,7 +3051,7 @@ int readHF14B(bool loop, bool verbose, bool read_plot) {
             goto plot;
 
         // Picopass
-        found |= HF14B_picopass_reader(verbose, info);
+        found |= HF14B_picopass_reader(verbose);
         if (found)
             goto plot;
 

--- a/client/src/cmdhf14b.h
+++ b/client/src/cmdhf14b.h
@@ -31,6 +31,5 @@ int select_card_14443b_4(bool disconnect, iso14b_card_select_t *card);
 
 int infoHF14B(bool verbose, bool do_aid_search);
 int readHF14B(bool loop, bool verbose, bool read_plot);
-bool HF14B_picopass_reader(bool verbose, bool info);
 
 #endif

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -40,7 +40,6 @@
 #include "crypto/asn1utils.h"       // ASN1 decoder
 #include "preferences.h"
 #include "generator.h"
-#include "cmdhf14b.h"
 #include "cmdhw.h"
 #include "hidsio.h"
 
@@ -5985,10 +5984,10 @@ int info_iclass(bool shallow_mod) {
     uint8_t cardtype = get_mem_config(hdr);
     PrintAndLogEx(SUCCESS, "    Card type.... " _GREEN_("%s"), card_types[cardtype]);
 
-    if (HF14B_picopass_reader(false, false)) {
-        PrintAndLogEx(SUCCESS, "    Card chip.... "_YELLOW_("Old Silicon (14b support)"));
-    } else {
+    if (memcmp(hdr->csn + 4, "\xFE\xFF\x12\xE0", 4) == 0) {
         PrintAndLogEx(SUCCESS, "    Card chip.... "_YELLOW_("NEW Silicon (No 14b support)"));
+    } else {
+        PrintAndLogEx(SUCCESS, "    Card chip.... "_YELLOW_("Old Silicon (14b support)"));
     }
     if (legacy) {
 


### PR DESCRIPTION

Updated hf iclass info to use silicone identification based on CSN rather than hf 14b responsiveness
This reverted https://github.com/RfidResearchGroup/proxmark3/commit/4f85def6b07ad9cefe78d9bd11b18f14fad5dcb7