### PR TITLE
Modified iclass recover and tear operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Changed `hf iclass legrec` - code optimizations gaining a ~8% speed increase (@antiklesys)
 - Modified `hf iclass tear` - now has a device side implementation also. @antiklesys (@iceman1001)
 - Changed `hf iclass info` - now uses CSN values based checks (@antiklesys)
 - Changed `hf iclass dump` - now uses default AA1 key when called without a key or key index (@iceman1001)
@@ -10,7 +11,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Changed `hw tearoff` - the device side message is now debug log controlled (@iceman1001)
 - Changed `pm3.sh` - Serial ports enumeration on Proxspace3.xx / MINGW environments,  now using powershell.exe since wmic is deprecated (@iceman1001)
 - Fixed and updated `hf iclass trbl` to correctly use the credit key when passed and show partial tearoff results (@antiklesys)
-- Fixed `hf iclass legbrute` was not correctly parsin the index value
+- Fixed `hf iclass legbrute` was not correctly parsing the index value
 - Fixed `hf mf ekeyprn` - failed to download emulator memory due to wrong size calculation (@iceman1001)
 - Fixed `hf mf fchk --mem` to actually use flash dict (@doegox)
 - Fixed `make install` on OSX thanks DaveItsLong (@doegox)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Changed `hf iclass tear` - readability improvements for erase phase (@antiklesys)
 - Changed `hf iclass legrec` - code optimizations gaining a ~8% speed increase (@antiklesys)
-- Modified `hf iclass tear` - now has a device side implementation also. @antiklesys (@iceman1001)
+- Modified `hf iclass tear` - now has a device side implementation also. (@antiklesys) (@iceman1001)
 - Changed `hf iclass info` - now uses CSN values based checks (@antiklesys)
 - Changed `hf iclass dump` - now uses default AA1 key when called without a key or key index (@iceman1001)
 - Renamed `hf iclass trbl` to `hf iclass tear` (@iceman1001)

--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -2311,11 +2311,13 @@ void iClass_TearBlock(iclass_tearblock_req_t *msg) {
             if (memcmp(data_read, ff_data, PICOPASS_BLOCK_SIZE) == 0 &&
                     memcmp(data_read_orig, ff_data, PICOPASS_BLOCK_SIZE) != 0) {
 
-                erase_phase = true;
-                DbpString("");
-                DbpString(_CYAN_("Erase phase hit... ALL ONES"));
+                if(erase_phase == false){
+                    DbpString("");
+                    DbpString(_CYAN_("Erase phase hit... ALL ONES"));
 
-                iclass_cmp_print(data_read_orig, data_read, "Original: ", "Read:     ");
+                    iclass_cmp_print(data_read_orig, data_read, "Original: ", "Read:     ");
+                }
+                erase_phase = true;
 
             } else {
 

--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -2461,7 +2461,7 @@ void iClass_TearBlock(iclass_tearblock_req_t *msg) {
             read_ok = true;
             tear_success = true;
             DbpString("");
-            DbpString("tear success!");
+            DbpString("tear success (expected values)!");
         }
 
         loop_count++;

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -3340,10 +3340,13 @@ static int CmdHFiClass_TearBlock(const char *Cmd) {
 
                 if (memcmp(data_read, ff_data, 8) == 0 &&
                         memcmp(data_read_orig, ff_data, 8) != 0) {
+
+                    if (erase_phase == false){
+                        PrintAndLogEx(NORMAL, "");
+                        PrintAndLogEx(SUCCESS, _CYAN_("Erase phase hit... ALL ONES"));
+                        iclass_cmp_print(data_read_orig, data_read, "Original: ", "Read:     ");
+                    }
                     erase_phase = true;
-                    PrintAndLogEx(NORMAL, "");
-                    PrintAndLogEx(SUCCESS, _CYAN_("Erase phase hit... ALL ONES"));
-                    iclass_cmp_print(data_read_orig, data_read, "Original: ", "Read:     ");
                 } else {
 
                     if (erase_phase) {

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -4578,7 +4578,7 @@ void generate_key_block_inverted(const uint8_t *startingKey, uint64_t index, uin
     }
 }
 
-static int CmdHFiClassLegRecLookUp(const char *Cmd) {
+static int CmdHFiClassLegBrute(const char *Cmd) {
 
     //Standalone Command Start
     CLIParserContext *ctx;
@@ -4805,7 +4805,7 @@ static int CmdHFiClassLegacyRecSim(void) {
             PrintAndLogEx(SUCCESS, "Original Key: " _GREEN_("%s"), sprint_hex(original_key, sizeof(original_key)));
             PrintAndLogEx(SUCCESS, "Weak Key: " _GREEN_("%s"), sprint_hex(key, sizeof(key)));
             PrintAndLogEx(SUCCESS, "Key Updates Required to Weak Key: " _GREEN_("%d"), index);
-            PrintAndLogEx(SUCCESS, "Estimated Time: ~" _GREEN_("%d")" hours", index / 6545);
+            PrintAndLogEx(SUCCESS, "Estimated Time: ~" _GREEN_("%d")" hours", index / 7250);
         }
 
         index++;
@@ -5896,7 +5896,7 @@ static command_t CommandTable[] = {
     {"loclass",     CmdHFiClass_loclass,        AlwaysAvailable, "Use loclass to perform bruteforce reader attack"},
     {"lookup",      CmdHFiClassLookUp,          AlwaysAvailable, "Uses authentication trace to check for key in dictionary file"},
     {"legrec",      CmdHFiClassLegacyRecover,   IfPm3Iclass,     "Recovers 24 bits of the diversified key of a legacy card provided a valid nr-mac combination"},
-    {"legbrute",    CmdHFiClassLegRecLookUp,    AlwaysAvailable, "Bruteforces 40 bits of a partial diversified key, provided 24 bits of the key and two valid nr-macs"},
+    {"legbrute",    CmdHFiClassLegBrute,        AlwaysAvailable, "Bruteforces 40 bits of a partial diversified key, provided 24 bits of the key and two valid nr-macs"},
     {"unhash",      CmdHFiClassUnhash,          AlwaysAvailable, "Reverses a diversified key to retrieve hash0 pre-images after DES encryption"},
     {"-----------", CmdHelp,                    IfPm3Iclass,     "-------------------- " _CYAN_("Simulation") " -------------------"},
     {"sim",         CmdHFiClassSim,             IfPm3Iclass,     "Simulate iCLASS tag"},


### PR DESCRIPTION
1- Renamed legreclookup to legbrute to be in line with the command name 2- Updated estimate values with speed increase gains 3- Improved some if statements readability in iclass.c and added start_time = eof_time + DELAY_ICLASS_VICC_TO_VCD_READER; to increase speed by ~8% (1.86 loops per second to 2.01 loops per second = ~560 more loops per hour).

Tried disabling some arm communications/comments but the speed increase was negligible (~1 sec / 1000 updates).