### PR TITLE
Update Makefile

### DIFF
--- a/tools/mfd_aes_brute/Makefile
+++ b/tools/mfd_aes_brute/Makefile
@@ -34,8 +34,8 @@ endif
 
 # OS X needs linking to openssl
 ifeq ($(USE_BREW),1)
-    MYCFLAGS += -I$(BREW_PREFIX)/opt/openssl@3/include -I$(BREW_PREFIX)/opt/openssl@1.1/include
-    MYLDFLAGS += -L$(BREW_PREFIX)/opt/openssl@3/lib -L$(BREW_PREFIX)/opt/openssl@1.1/lib
+    MYCFLAGS += -I$(BREW_PREFIX)/opt/openssl@3/include -I$(BREW_PREFIX)/opt/openssl@3.5/include
+    MYLDFLAGS += -L$(BREW_PREFIX)/opt/openssl@3/lib -L$(BREW_PREFIX)/opt/openssl@3.5/lib
 endif
 
 ifeq ($(USE_MACPORTS),1)


### PR DESCRIPTION
Openssl@1.1 was disabled 2024-10-24 due to not being supported upstream and blocked from install. Updated to openssl@3.5 in order for compilation to be successful on machines installed after that date. Older machines is encouraged to update.