### PR TITLE
R&Y: Updated MAD TTP AID in `aid_desfire.json`

### DIFF
--- a/client/resources/aid_desfire.json
+++ b/client/resources/aid_desfire.json
@@ -908,7 +908,7 @@
         "Vendor": "Invalid / Reserved",
         "Country": "",
         "Name": "Invalid / Reserved",
-        "Description": "Used by ATL Breeze, MAD Tarjeta Transporte Publico, PHL FREEDOM, and YVR Compass",
+        "Description": "Used by ATL Breeze, PHL FREEDOM, and YVR Compass",
         "Type": "transport"
     },
     {
@@ -931,7 +931,7 @@
         "AID": "010000",
         "Vendor": "Consorcio Regional de Transportes Publicos Regulares de Madrid (CRTM)",
         "Country": "ES",
-        "Name": "Tarjeta Transporte Publico (MAD) (Alternative Endian)",
+        "Name": "Tarjeta Transporte Publico (MAD)",
         "Description": "MAD Public Transport Card",
         "Type": "transport"
     },


### PR DESCRIPTION
### Updated
- `000001` is not the MAD Tarjeta Transporte Público AID; it is actually `010000`, so removed references to it on that AID.
- `010000` removed the `(Alternative Endian)` designation.

Many thanks in advance, and kind regards

-R&Y.