### PR TITLE
Update mfc_default_keys.dic

### DIFF
--- a/client/dictionaries/mfc_default_keys.dic
+++ b/client/dictionaries/mfc_default_keys.dic
@@ -3159,3 +3159,5 @@ A662F9DC0D3D
 4D4941413236
 414D504F3243
 434C414E3639
+# Key for Waferlock shadow programming card and shadow user card
+333030313536


### PR DESCRIPTION
add key for Waferlock shadow programming card and shadow user card