### PR TITLE
Improved hf iclass legrec speed by 147%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Changed `hf iclass legrec` - additional code optimizations gaining a ~147% speed increase (@antiklesys)
 - Changed `hf iclass tear` - readability improvements for erase phase (@antiklesys)
 - Changed `hf iclass legrec` - code optimizations gaining a ~8% speed increase (@antiklesys)
 - Modified `hf iclass tear` - now has a device side implementation also. (@antiklesys) (@iceman1001)

--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -2747,7 +2747,7 @@ void iClass_Recover(iclass_recover_req_t *msg) {
         while (!card_select || !card_auth) {
 
             Iso15693InitReader(); //has to be at the top as it starts tracing
-
+            set_tracing(false); //disable tracing to prevent crashes - set to true for debugging
             //Step0 Card Select Routine
             eof_time = 0; //reset eof time
             res = select_iclass_tag(&hdr, false, &eof_time, shallow_mod);

--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -2778,7 +2778,7 @@ void iClass_Recover(iclass_recover_req_t *msg) {
         }
 
         //Step2 Privilege Escalation: attempt to read AA2 with credentials for AA1
-        uint8_t blockno = 24;
+        uint8_t blockno = 3;
         int priv_esc_tries = 0;
         while (!priv_esc) {
             //The privilege escalation is done with a readcheck and not just a normal read!
@@ -2813,7 +2813,6 @@ void iClass_Recover(iclass_recover_req_t *msg) {
         //Step4 Calculate New Mac
 
         uint8_t wb[9] = {0};
-        blockno = 3;
         wb[0] = blockno;
         memcpy(wb + 1, genkeyblock, 8);
         doMAC_N(wb, sizeof(wb), div_key2, mac2);

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -4842,7 +4842,7 @@ static int CmdHFiClassLegacyRecSim(void) {
             PrintAndLogEx(SUCCESS, "Original Key: " _GREEN_("%s"), sprint_hex(original_key, sizeof(original_key)));
             PrintAndLogEx(SUCCESS, "Weak Key: " _GREEN_("%s"), sprint_hex(key, sizeof(key)));
             PrintAndLogEx(SUCCESS, "Key Updates Required to Weak Key: " _GREEN_("%d"), index);
-            PrintAndLogEx(SUCCESS, "Estimated Time: ~" _GREEN_("%d")" hours", index / 7250);
+            PrintAndLogEx(SUCCESS, "Estimated Time: ~" _GREEN_("%d")" hours", index / 17800);
         }
 
         index++;


### PR DESCRIPTION
Improved the speed of hficlass legrec from 7200 keys / hrs to 17800 keys / hr by removing the need to drop the field and re-select, re-authenticate with the card at every loop.
Re-select and re-authenticate will still happen if there's a read error and a loop needs to be repeated.