### PR TITLE
Updated hf iclass sim -t 6

### DIFF
--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -614,9 +614,8 @@ int do_iclass_simulation(int simulationMode, uint8_t *reader_mac_buf) {
                                 goto send;
                             }
                         }else{ //For SE cards we have to account for different SIO lengths depending if a standard or custom key is used
-                            uint8_t sio_size[8] = {0};
-                            memcpy(sio_size,emulator + (current_page * page_size) + (6 * 8), PICOPASS_BLOCK_SIZE);
-                            if (block == 5 + ((sio_size[1]+12)/8)){
+                            uint8_t *sio = emulator + (current_page * page_size) + (6 * 8);
+                            if (block == (5 + ((sio[1] + 12) / 8))) {
                                 goto send;
                             }
                         }
@@ -814,9 +813,8 @@ int do_iclass_simulation(int simulationMode, uint8_t *reader_mac_buf) {
                         goto send;
                     }
                 }else{ //For SE cards we have to account for different SIO lengths depending if a standard or custom key is used
-                    uint8_t sio_size[8] = {0};
-                    memcpy(sio_size,emulator + (current_page * page_size) + (6 * 8), PICOPASS_BLOCK_SIZE);
-                    if (block == 5 + ((sio_size[1]+12)/8)){
+                    uint8_t *sio = emulator + (current_page * page_size) + (6 * 8);
+                    if (block == (5 + ((sio[1] + 12) / 8))) {
                         goto send;
                     }
                 }

--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -805,16 +805,15 @@ int do_iclass_simulation(int simulationMode, uint8_t *reader_mac_buf) {
 
             if (simulationMode == ICLASS_SIM_MODE_FULL_GLITCH){
                 //Jam the read based on the last SIO block
+                uint8_t *sr_or_sio = emulator + (current_page * page_size) + (6 * 8);
                 if (memcmp(emulator + (current_page * page_size) + (5 * 8), ff_data, PICOPASS_BLOCK_SIZE) == 0){ //SR card
                     if (block == 16){ //SR cards use a standard legth SIO
                         //update block 6 byte 1 from 03 to A3
-                        uint8_t *sr = emulator + (current_page * page_size) + (6 * 8);
-                        sr[0] |= 0xA0;
+                        sr_or_sio[0] |= 0xA0;
                         goto send;
                     }
                 }else{ //For SE cards we have to account for different SIO lengths depending if a standard or custom key is used
-                    uint8_t *sio = emulator + (current_page * page_size) + (6 * 8);
-                    if (block == (5 + ((sio[1] + 12) / 8))) {
+                    if (block == (5 + ((sr_or_sio[1] + 12) / 8))) {
                         goto send;
                     }
                 }

--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -608,10 +608,17 @@ int do_iclass_simulation(int simulationMode, uint8_t *reader_mac_buf) {
                     trace_data_size = sizeof(ff_data);
                 } else { // use data from emulator memory
                     if (simulationMode == ICLASS_SIM_MODE_FULL_GLITCH){
-                        uint8_t block_check[8] ={0};
-                        memcpy(block_check, emulator + (current_page * page_size) + (31 * 8), 8);
-                        if (block == block_check[7]){
-                            goto send;
+                        //Jam the read based on the last SIO block
+                        if (memcmp(emulator + (current_page * page_size) + (5 * 8), ff_data, PICOPASS_BLOCK_SIZE) == 0){ //SR card
+                            if (block == 16){ //SR cards use a standard legth SIO
+                                goto send;
+                            }
+                        }else{ //For SE cards we have to account for different SIO lengths depending if a standard or custom key is used
+                            uint8_t sio_size[8] = {0};
+                            memcpy(sio_size,emulator + (current_page * page_size) + (6 * 8), PICOPASS_BLOCK_SIZE);
+                            if (block == 5 + ((sio_size[1]+12)/8)){
+                                goto send;
+                            }
                         }
                     }
 
@@ -798,10 +805,24 @@ int do_iclass_simulation(int simulationMode, uint8_t *reader_mac_buf) {
             }
 
             if (simulationMode == ICLASS_SIM_MODE_FULL_GLITCH){
-                uint8_t block_check[8] ={0};
-                memcpy(block_check, emulator + (current_page * page_size) + (31 * 8), 8);
-                if (block == block_check[7]){
-                    goto send;
+                //Jam the read based on the last SIO block
+                if (memcmp(emulator + (current_page * page_size) + (5 * 8), ff_data, PICOPASS_BLOCK_SIZE) == 0){ //SR card
+                    if (block == 16){ //SR cards use a standard legth SIO
+                        //update block 6 byte 1 from 03 to A3
+                        uint8_t sr_update[8] = {0};
+                        memcpy(sr_update,emulator + (current_page * page_size) + (6 * 8), PICOPASS_BLOCK_SIZE);
+                        if(sr_update[0] == 0x03){
+                            sr_update[0] = 0xA3;
+                        }
+                        memcpy(emulator + (current_page * page_size) + (6 * 8), sr_update, PICOPASS_BLOCK_SIZE);
+                        goto send;
+                    }
+                }else{ //For SE cards we have to account for different SIO lengths depending if a standard or custom key is used
+                    uint8_t sio_size[8] = {0};
+                    memcpy(sio_size,emulator + (current_page * page_size) + (6 * 8), PICOPASS_BLOCK_SIZE);
+                    if (block == 5 + ((sio_size[1]+12)/8)){
+                        goto send;
+                    }
                 }
             }
 

--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -809,12 +809,8 @@ int do_iclass_simulation(int simulationMode, uint8_t *reader_mac_buf) {
                 if (memcmp(emulator + (current_page * page_size) + (5 * 8), ff_data, PICOPASS_BLOCK_SIZE) == 0){ //SR card
                     if (block == 16){ //SR cards use a standard legth SIO
                         //update block 6 byte 1 from 03 to A3
-                        uint8_t sr_update[8] = {0};
-                        memcpy(sr_update,emulator + (current_page * page_size) + (6 * 8), PICOPASS_BLOCK_SIZE);
-                        if(sr_update[0] == 0x03){
-                            sr_update[0] = 0xA3;
-                        }
-                        memcpy(emulator + (current_page * page_size) + (6 * 8), sr_update, PICOPASS_BLOCK_SIZE);
+                        uint8_t *sr = emulator + (current_page * page_size) + (6 * 8);
+                        sr[0] |= 0xA0;
                         goto send;
                     }
                 }else{ //For SE cards we have to account for different SIO lengths depending if a standard or custom key is used

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -845,7 +845,7 @@ static int CmdHFiClassSim(const char *Cmd) {
                   "hf iclass sim -t 2                          --> execute loclass attack online part\n"
                   "hf iclass sim -t 3                          --> simulate full iCLASS 2k tag\n"
                   "hf iclass sim -t 4                          --> Reader-attack, adapted for KeyRoll mode, gather reader responses to extract elite key\n"
-                  "hf iclass sim -t 6                          --> same as -t 3, but doesn't respond to r/w for the block specified in last byte of blk 31");
+                  "hf iclass sim -t 6                          --> simulate full iCLASS 2k tag that doesn't respond to r/w requests to the last SIO block");
 
     void *argtable[] = {
         arg_param_begin,


### PR DESCRIPTION
Updates to the functionality of iclass sim -t 6 to specifically target the last SIO block and to do it automatically. It now checks the AIA to determine if the card is SR or SE and adjust the block to jam based on the SIO length declared in block 6 (if SE) or fixed length if SR.