### PR TITLE
fix mad v2 cps offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added new standalone mode `HF_ST25_TEAROFF` to store/restore ST25TB tags with tearoff for counters (@seclabz)
 - Added `hf_mfu_ultra.lua` script enables restoring dump to ULTRA/UL-5 tags and clearing previously written ULTRA tags (@mak-42)
 - Fixed `hf mfu sim` to make persistent the counter increases in the emulator memory (@sup3rgiu)
+- Fixed `hf mf mad` to correctly display MAD version 2 card publisher sector (@BIOS9)
 
 ## [Blue Ice.4.20142][2025-03-25]
 - Added `des_talk.py` script for easier MIFARE DESFire handling (@trigat)

--- a/client/src/mifare/mad.c
+++ b/client/src/mifare/mad.c
@@ -408,14 +408,14 @@ int MAD2DecodeAndPrint(uint8_t *sector, bool swapmad, bool verbose) {
         uint16_t aid = madGetAID(sector, swapmad, 2, i);
         if (aid < 6) {
             PrintAndLogEx(INFO,
-                          (ibs == i) ? _MAGENTA_(" %02d [%04X] %s") : " %02d [" _GREEN_("%04X") "] %s",
+                          (ibs == i + 16) ? _MAGENTA_(" %02d [%04X] %s") : " %02d [" _GREEN_("%04X") "] %s",
                           i + 16,
                           aid,
                           aid_admin[aid]
                          );
         } else if (prev_aid == aid) {
             PrintAndLogEx(INFO,
-                          (ibs == i) ? _MAGENTA_(" %02d [%04X] continuation") : " %02d [" _YELLOW_("%04X") "] continuation",
+                          (ibs == i + 16) ? _MAGENTA_(" %02d [%04X] continuation") : " %02d [" _YELLOW_("%04X") "] continuation",
                           i + 16,
                           aid
                          );
@@ -423,7 +423,7 @@ int MAD2DecodeAndPrint(uint8_t *sector, bool swapmad, bool verbose) {
             char fmt[80];
             snprintf(fmt
                      , sizeof(fmt)
-                     , (ibs == i) ?
+                     , (ibs == i + 16) ?
                      _MAGENTA_(" %02d [%04X] %s") :
                      " %02d [" _GREEN_("%04X") "] %s"
                      , i + 16


### PR DESCRIPTION
## Describe the bug

When using the command `hf mf mad` to display a version 2 Mifare Application Directory (MAD), the Card Publisher Sector (CPS) is displayed incorrectly.

The CPS is highlighted in magenta, and the correct sector is highlighted for MAD V1, but for MAD V2 the wrong sector is highlighted or none at all.

I've noticed the [MADv2 code indexes the sectors relative to the start of the Mifare 4K sectors](https://github.com/RfidResearchGroup/proxmark3/blob/3a8c3174a80222e0780e84cc69b2afac12b3c4c6/client/src/mifare/mad.c#L407) and then [compares the CPS](https://github.com/RfidResearchGroup/proxmark3/blob/3a8c3174a80222e0780e84cc69b2afac12b3c4c6/client/src/mifare/mad.c#L411) which I think is an absolute sector index from sector 0.
This results in the wrong sector being highlighted.

As far as I can tell, the CPS is meant to be an absolute sector index from reading [AN10787](https://www.nxp.com/docs/en/application-note/AN10787.pdf) section 3.8:

```
The lower 6 bits (4bits for MAD1) of the Info-byte contain a binary pointer to one of the 38 sectors in use (15
sectors for MAD1). The owner of the corresponding sector is considered to be the card publisher, responsible
for card issue, card maintenance and also for maintenance of the MAD. 0x00 should be used if the card
publishing organization does not use any sector on the MIFARE card.
0x10 shall not be used.
0x28 … 0x3F shall not be used.
```

I don't think the number of bits used and the value restrictions would make sense for a relative sector index, and the specification does not mention relative sector indexing for the CPS anywhere that I can find, so I am pretty confident it's meant to be absolute.

I have included some screenshots below which show how the CPS is displayed before and after this fix.

The specification document is a bit vague around the CPS, and I have inferred quite a bit so please let me know if I have misunderstood it, but I think how the pm3 app currently behaves is a bug.

## To Reproduce

Steps to reproduce the behavior:
1. Create a valid version 2 MAD on a Mifare 4K card with a CPS pointer.
2. Connect a proxmark and place the card on the reader
3. Run `hf mf mad`
4. Observe the wrong sector being highlighted in magenta

## The Fix

I have added 16 to the relative index used in the MADv2 loop. This results in an absolute sector index (relative to sector 0) which can be compared with the CPS.

This results in no sector being highlighted for MADv2 when the sector is less than 17, since it should be highlighted in the MADv1.

## Screenshots

### Screenshot 1

Before fix, CPS value = 0x03
![image](https://github.com/user-attachments/assets/e4aa0564-c3d2-4305-aa81-64c3515dbc53)

### Screenshot 2

After fix, CPS value = 0x03
![image](https://github.com/user-attachments/assets/8258ea61-eb7e-47bc-9a7b-d826efc06e27)

### Screenshot 3

Before fix, CPS value = 0x27 (Note I have not written 0x27 to MADv1 CPS since that would be invalid and not backwards compatible)
![image](https://github.com/user-attachments/assets/37b44030-16a2-4a62-8543-6f38686847da)

### Screenshot 4

After fix, CPS value = 0x27 (Note I have not written 0x27 to MADv1 CPS since that would be invalid and not backwards compatible)
![image](https://github.com/user-attachments/assets/20a834ba-d0c1-431c-b186-8f748f9cf38f)
