### PR TITLE
Implemented hf iclass sim -t 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 ## [unreleased][unreleased]
 - Updated the ATR list (@iceman1001)
 - Fixed fpga binary images to use fixed seed 2 (@n-hutton)
-- Changed `hf iclass sim -t 6` - implemented simulation that glitches specific block responses (@antiklesys)
+- Changed `hf iclass sim -t 7` - implemented simulation that glitches key block responses (@antiklesys)
+- Changed `hf iclass sim -t 6` - implemented simulation that glitches sio block (@antiklesys)
 - Changed `hf iclass legbrute` - implemented multithreading support (@antiklesys)
+- Changed `hf iclass legrec` - added a --sl option for further speed increase by tweaking the communication delays (@antiklesys)
 - Changed `hf iclass legrec` - added a --fast option for further speed increase and automated AA2 block selection (@antiklesys)
 - Changed `hf iclass legrec` - additional code optimizations gaining a ~147% speed increase (@antiklesys)
 - Changed `hf iclass tear` - readability improvements for erase phase (@antiklesys)

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -845,7 +845,8 @@ static int CmdHFiClassSim(const char *Cmd) {
                   "hf iclass sim -t 2                          --> execute loclass attack online part\n"
                   "hf iclass sim -t 3                          --> simulate full iCLASS 2k tag\n"
                   "hf iclass sim -t 4                          --> Reader-attack, adapted for KeyRoll mode, gather reader responses to extract elite key\n"
-                  "hf iclass sim -t 6                          --> simulate full iCLASS 2k tag that doesn't respond to r/w requests to the last SIO block");
+                  "hf iclass sim -t 6                          --> simulate full iCLASS 2k tag that doesn't respond to r/w requests to the last SIO block\n"
+                  "hf iclass sim -t 7                          --> simulate full iCLASS 2k tag that doesn't XOR or respond to r/w requests on block 3");
 
     void *argtable[] = {
         arg_param_begin,
@@ -876,7 +877,7 @@ static int CmdHFiClassSim(const char *Cmd) {
 
     CLIParserFree(ctx);
 
-    if (sim_type > 4 && sim_type != 6) {
+    if (sim_type > 4 && sim_type != 6 && sim_type != 7) {
         PrintAndLogEx(ERR, "Undefined simtype %d", sim_type);
         return PM3_EINVARG;
     }
@@ -1030,6 +1031,7 @@ static int CmdHFiClassSim(const char *Cmd) {
         case ICLASS_SIM_MODE_CSN_DEFAULT:
         case ICLASS_SIM_MODE_FULL:
         case ICLASS_SIM_MODE_FULL_GLITCH:
+        case ICLASS_SIM_MODE_FULL_GLITCH_KEY:
         default: {
             PrintAndLogEx(INFO, "Starting iCLASS simulation");
             PrintAndLogEx(INFO, "Press " _GREEN_("`pm3 button`") " to abort");
@@ -1037,7 +1039,7 @@ static int CmdHFiClassSim(const char *Cmd) {
             clearCommandBuffer();
             SendCommandMIX(CMD_HF_ICLASS_SIMULATE, sim_type, numberOfCSNs, 1, csn, 8);
 
-            if (sim_type == ICLASS_SIM_MODE_FULL || sim_type ==  ICLASS_SIM_MODE_FULL_GLITCH)
+            if (sim_type == ICLASS_SIM_MODE_FULL || sim_type ==  ICLASS_SIM_MODE_FULL_GLITCH || sim_type ==  ICLASS_SIM_MODE_FULL_GLITCH_KEY)
                 PrintAndLogEx(HINT, "Hint: Try `" _YELLOW_("hf iclass esave -h") "` to save the emulator memory to file");
             break;
         }

--- a/include/iclass_cmd.h
+++ b/include/iclass_cmd.h
@@ -49,6 +49,7 @@
 #define ICLASS_SIM_MODE_READER_ATTACK_KEYROLL 4
 #define ICLASS_SIM_MODE_EXIT_AFTER_MAC        5  // note: device internal only
 #define ICLASS_SIM_MODE_FULL_GLITCH           6
+#define ICLASS_SIM_MODE_FULL_GLITCH_KEY       7
 
 
 // iCLASS auth request data structure


### PR DESCRIPTION
Implemented an iclass sim function that prevents simulated card responses after updating block 3. Block 3 gets updated with the XOR key as if it was in personalization mode.