### PR TITLE
Rollback em4x50_read() to remove a segv

### DIFF
--- a/client/src/cmdlfem4x50.c
+++ b/client/src/cmdlfem4x50.c
@@ -639,10 +639,8 @@ int em4x50_read(em4x50_data_t *etd, em4x50_word_t *out) {
         return PM3_ESOFT;
     }
 
-    em4x50_read_data_response_t *o = (em4x50_read_data_response_t *)resp.data.asBytes;
-
     em4x50_word_t words[EM4X50_NO_WORDS] = {0};
-    em4x50_prepare_result((uint8_t *)o->words, etd->addresses & 0xFF, (etd->addresses >> 8) & 0xFF, words);
+    em4x50_prepare_result(resp.data.asBytes, etd->addresses & 0xFF, (etd->addresses >> 8) & 0xFF, words);
 
     if (out != NULL) {
         memcpy(out, &words, sizeof(em4x50_word_t) * EM4X50_NO_WORDS);


### PR DESCRIPTION
Client was expecting a struct starting with an object count but ARM directly sends the array. The struct is only used on this line in the whole repository, so reverting client is the easiest way to solve the issue.