### PR TITLE
LF HITAG: Adjust timing for LF ADC measurements to increase stability when the tag is in public mode/TTF mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added `hf_mfu_ultra.lua` script enables restoring dump to ULTRA/UL-5 tags and clearing previously written ULTRA tags (@mak-42)
 - Fixed `hf mfu sim` to make persistent the counter increases in the emulator memory (@sup3rgiu)
 - Fixed `hf mf mad` to correctly display MAD version 2 card publisher sector (@BIOS9)
+- Fixed `lf hitag dump` and related commands stability when tag is configured in public mode/TTF mode (@rfidgeek1337)
 
 ## [Blue Ice.4.20142][2025-03-25]
 - Added `des_talk.py` script for easier MIFARE DESFire handling (@trigat)

--- a/armsrc/lfadc.c
+++ b/armsrc/lfadc.c
@@ -240,7 +240,7 @@ void lf_init(bool reader, bool simulate, bool ledcontrol) {
     // minimum: 313T0 = 313 * 8us = 2504us = 2.50ms - Hitag2 tag internal powerup time
     //          280T0 = 280 * 8us = 2240us = 2.24ms - HitagS minimum time before the first command (powerup time)
     // maximum: 545T0 = 545 * 8us = 4360us = 4.36ms - Hitag2 command waiting time before it starts transmitting in public mode (if configured so)
-    //          565T0 = 565 * 8us = 4520us = 4.52ms - HitagS waiting time before entering TTF mode
+    //          565T0 = 565 * 8us = 4520us = 4.52ms - HitagS waiting time before entering TTF mode (if configured so)
     // Thus (2.50 ms + 4.36 ms) / 2 ~= 3 ms, should be a good timing for both tag models
     SpinDelay(3);
 

--- a/armsrc/lfadc.c
+++ b/armsrc/lfadc.c
@@ -241,7 +241,7 @@ void lf_init(bool reader, bool simulate, bool ledcontrol) {
     //          280T0 = 280 * 8us = 2240us = 2.24ms - HitagS minimum time before the first command (powerup time)
     // maximum: 545T0 = 545 * 8us = 4360us = 4.36ms - Hitag2 command waiting time before it starts transmitting in public mode (if configured so)
     //          565T0 = 565 * 8us = 4520us = 4.52ms - HitagS waiting time before entering TTF mode (if configured so)
-    // Thus (2.50 ms + 4.36 ms) / 2 ~= 3 ms, should be a good timing for both tag models
+    // Thus (2.50 ms + 4.36 ms) / 2 ~= 3 ms (rounded down to integer), should be a good timing for both tag models
     SpinDelay(3);
 
     // Steal this pin from the SSP (SPI communication channel with fpga) and use it to control the modulation

--- a/armsrc/lfadc.c
+++ b/armsrc/lfadc.c
@@ -236,8 +236,13 @@ void lf_init(bool reader, bool simulate, bool ledcontrol) {
     FpgaSetupSsc(FPGA_MAJOR_MODE_LF_READER);
 
     // When in reader mode, give the field a bit of time to settle.
-    // 313T0 = 313 * 8us = 2504us = 2.5ms  Hitag2 tags needs to be fully powered.
-    SpinDelay(10);
+    // Optimal timing window for LF ADC measurements to be performed:
+    // minimum: 313T0 = 313 * 8us = 2504us = 2.50ms - Hitag2 tag internal powerup time
+    //          280T0 = 280 * 8us = 2240us = 2.24ms - HitagS minimum time before the first command (powerup time)
+    // maximum: 545T0 = 545 * 8us = 4360us = 4.36ms - Hitag2 command waiting time before it starts transmitting in public mode (if configured so)
+    //          565T0 = 565 * 8us = 4520us = 4.52ms - HitagS waiting time before entering TTF mode
+    // Thus (2.50 ms + 4.36 ms) / 2 ~= 3 ms, should be a good timing for both tag models
+    SpinDelay(3);
 
     // Steal this pin from the SSP (SPI communication channel with fpga) and use it to control the modulation
     AT91C_BASE_PIOA->PIO_PER = GPIO_SSC_DOUT;


### PR DESCRIPTION
resolve #2897

**WIP until the change is tested with different HITAG fobs/cards**