### PR TITLE
Minor iclass sam comms tweaks

### DIFF
--- a/armsrc/i2c.h
+++ b/armsrc/i2c.h
@@ -36,7 +36,7 @@
 // 8051 speaks with smart card.
 // 1000*50*3.07   = 153.5ms
 // 1 byte transfer == 1ms with max frame being 256 bytes
-#define SIM_WAIT_DELAY  88000 // about 270ms delay // 109773 -- about 337.7ms delay
+#define SIM_WAIT_DELAY  150000 // about 270ms delay // 109773 -- about 337.7ms delay
 
 
 void I2C_recovery(void);

--- a/armsrc/sam_common.c
+++ b/armsrc/sam_common.c
@@ -279,7 +279,7 @@ int sam_get_version(bool info) {
         if (g_dbglevel >= DBG_INFO || info) {
             DbpString(_BLUE_("-- SAM Information --"));
             Dbprintf(_YELLOW_("Firmware version: ")"%X.%X", sam_version_an[2], sam_version_an[3]);
-            Dbprintf(_YELLOW_("Firmware ID     : "));
+            Dbprintf(_YELLOW_("Firmware ID: "));
             Dbhexdump(sam_build_an[1], sam_build_an + 2, false);
         }
         goto out;
@@ -348,7 +348,7 @@ int sam_get_serial_number(void) {
             goto error;
         }
 
-        Dbprintf(_YELLOW_("Sam Serial Number: "));
+        Dbprintf(_YELLOW_("Serial Number: "));
         Dbhexdump(sam_response_an[1],sam_serial_an, false);
 
         goto out;

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -5961,10 +5961,7 @@ static int CmdHFiClassSAM(const char *Cmd) {
     clearCommandBuffer();
     SendCommandNG(CMD_HF_SAM_PICOPASS, data, cmdlen + 1);
     PacketResponseNG resp;
-    if (WaitForResponseTimeout(CMD_HF_SAM_PICOPASS, &resp, 4000) == false) {
-        PrintAndLogEx(WARNING, "SAM timeout");
-        return PM3_ETIMEOUT;
-    }
+    WaitForResponse(CMD_HF_SAM_PICOPASS, &resp);
 
     switch (resp.status) {
         case PM3_SUCCESS:


### PR DESCRIPTION
1- Removed timeout on client side to allow the sam to be slow in responding
2- Increased SIM_WAIT_DELAY to allow for bigger sam responses