### PR TITLE
fix card limits for S12906 format

### DIFF
--- a/client/src/wiegand_formats.c
+++ b/client/src/wiegand_formats.c
@@ -1477,7 +1477,7 @@ static const cardformat_t FormatTable[] = {
     {"BQT34",   Pack_bqt34,   Unpack_bqt34,   "BQT 34-bit", 34,                       {1, 1, 0, 0, 1, 0xFF, 0xFFFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
     {"C1k35s",  Pack_C1k35s,  Unpack_C1k35s,  "HID Corporate 1000 35-bit std", 35,    {1, 1, 0, 0, 1, 0xFFF, 0xFFFFF, 0, 0}}, // imported from old pack/unpack
     {"C15001",  Pack_C15001,  Unpack_C15001,  "HID KeyScan 36-bit", 36,               {1, 1, 0, 1, 1, 0xFF, 0xFFFF, 0, 0x3FF}}, // from Proxmark forums
-    {"S12906",  Pack_S12906,  Unpack_S12906,  "HID Simplex 36-bit", 36,               {1, 1, 1, 0, 1, 0xFF, 0x3, 0xFFFFFF, 0}}, // from cardinfo.barkweb.com.au
+    {"S12906",  Pack_S12906,  Unpack_S12906,  "HID Simplex 36-bit", 36,               {1, 1, 1, 0, 1, 0xFF, 0xFFFFFF, 0x3, 0}}, // from cardinfo.barkweb.com.au
     {"Sie36",   Pack_Sie36,   Unpack_Sie36,   "HID 36-bit Siemens", 36,               {1, 1, 0, 0, 1, 0x3FFFF, 0xFFFF, 0, 0}}, // from cardinfo.barkweb.com.au
     {"H10320",  Pack_H10320,  Unpack_H10320,  "HID H10320 37-bit BCD", 37,            {1, 0, 0, 0, 1, 0, 99999999, 0, 0}}, // from Proxmark forums
     {"H10302",  Pack_H10302,  Unpack_H10302,  "HID H10302 37-bit huge ID", 37,        {1, 0, 0, 0, 1, 0, 0x7FFFFFFFF, 0, 0}}, // from Proxmark forums


### PR DESCRIPTION
- As S12906 pack function suggests, the issue level field takes 2 bits, thus ranging from 0 to 3. The card number takes 24 bits, ranging from 0 to 0xffffff. Reference from [1](https://acre.my.site.com/knowledgearticles/s/article/x107), [2](https://www.everythingid.com.au/hid-card-formats-i-15?srsltid=AfmBOor2UAGlvB7R6Zmj7B7rtL-LExfBjh7I3ZEyoLLbg7Pk7UbC1za-) also confirms the CN should be ranging from 0 to 0xffffff. https://github.com/RfidResearchGroup/proxmark3/blob/61a993de826335db2d92d1f60c3ef4ae64439b73/client/src/wiegand_formats.c#L684-L685
- That shows an inconsistent with the limits defined in the format table. Specifically, the IL/CN limits in the table was reversed, accidentally.
https://github.com/RfidResearchGroup/proxmark3/blob/61a993de826335db2d92d1f60c3ef4ae64439b73/client/src/wiegand_formats.c#L1480
- I propose to fix the limits of S12906 format.
