### PR TITLE
fix parity bit in Sie36 format unpack

### DIFF
--- a/client/src/wiegand_formats.c
+++ b/client/src/wiegand_formats.c
@@ -733,7 +733,7 @@ static bool Unpack_Sie36(wiegand_message_t *packed, wiegand_card_t *card) {
     card->CardNumber = get_linear_field(packed, 19, 16);
     card->ParityValid =
     (get_bit_by_position(packed, 0) == oddparity32(get_nonlinear_field(packed, 23, (uint8_t[]) {1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16, 18, 19, 21, 22, 24, 25, 27, 28, 30, 31, 33, 34}))) &&
-    (get_bit_by_position(packed, 35) == oddparity32(get_nonlinear_field(packed, 23, (uint8_t[]) {1, 2, 4, 5, 7, 8, 10, 11, 13, 14, 16, 17, 19, 20, 22, 23, 25, 26, 28, 29, 31, 32, 34})));
+    (get_bit_by_position(packed, 35) == evenparity32(get_nonlinear_field(packed, 23, (uint8_t[]) {1, 2, 4, 5, 7, 8, 10, 11, 13, 14, 16, 17, 19, 20, 22, 23, 25, 26, 28, 29, 31, 32, 34})));
     return true;
 }
 


### PR DESCRIPTION
- As in the pack function for Sie36, i.e., Pack_Sie36, bit 36 is a **EVEN** parity bit for slots `1, 2, 4, 5, 7, 8, 10, 11, 13, 14, 16, 17, 19, 20, 22, 23, 25, 26, 28, 29, 31, 32, 34`. Reference [1](https://www.everythingid.com.au/hid-card-formats-i-15) also confirmed this fact.
https://github.com/RfidResearchGroup/proxmark3/blob/ba14a611e0acadab0cee84527c9be2c987fbb479/client/src/wiegand_formats.c#L718-L720
- However, in the unpack function, the ParityValid fields is wrongly calculated using bit 36 as an **ODD** parity bit, which is a mismatch.
https://github.com/RfidResearchGroup/proxmark3/blob/ba14a611e0acadab0cee84527c9be2c987fbb479/client/src/wiegand_formats.c#L736
- In the proposed fix, I correctted the parity to **EVEN** parity for bit 36.