### PR TITLE
Fix: magic detection for SAK=0x00 cards by forcing RATS

### DIFF
--- a/armsrc/iso14443a.h
+++ b/armsrc/iso14443a.h
@@ -168,7 +168,8 @@ int iso14_apdu(uint8_t *cmd, uint16_t cmd_len, bool send_chaining, void *data, u
 int iso14443a_select_card(uint8_t *uid_ptr, iso14a_card_select_t *p_card, uint32_t *cuid_ptr, bool anticollision, uint8_t num_cascades, bool no_rats);
 int iso14443a_select_cardEx(uint8_t *uid_ptr, iso14a_card_select_t *p_card, uint32_t *cuid_ptr,
                             bool anticollision, uint8_t num_cascades, bool no_rats,
-                            const iso14a_polling_parameters_t *polling_parameters);
+                            const iso14a_polling_parameters_t *polling_parameters, bool force_rats);
+int iso14443a_select_card_for_magic(uint8_t *uid_ptr, iso14a_card_select_t *p_card, uint32_t *cuid_ptr, bool anticollision, uint8_t num_cascades);
 int iso14443a_fast_select_card(const uint8_t *uid_ptr, uint8_t num_cascades);
 void iso14a_set_trigger(bool enable);
 

--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -83,14 +83,14 @@ static bool mifare_wakeup_auth(struct Crypto1State *pcs, MifareWakeupType wakeup
             break;
         }
         case MF_WAKE_WUPA: {
-            if (iso14443a_select_cardEx(NULL, NULL, &cuid, true, 0, true, &WUPA_POLLING_PARAMETERS) == 0) {
+            if (iso14443a_select_cardEx(NULL, NULL, &cuid, true, 0, true, &WUPA_POLLING_PARAMETERS, false) == 0) {
                 if (g_dbglevel >= DBG_ERROR) Dbprintf("Can't select card");
                 return false;
             };
             break;
         }
         case MF_WAKE_REQA: {
-            if (iso14443a_select_cardEx(NULL, NULL, &cuid, true, 0, true, &REQA_POLLING_PARAMETERS) == 0) {
+            if (iso14443a_select_cardEx(NULL, NULL, &cuid, true, 0, true, &REQA_POLLING_PARAMETERS, false) == 0) {
                 if (g_dbglevel >= DBG_ERROR) Dbprintf("Can't select card");
                 return false;
             };
@@ -3022,8 +3022,8 @@ void MifareCIdent(bool is_mfc, uint8_t keytype, uint8_t *key) {
 
     // reset card
     mf_reset_card();
-
-    res = iso14443a_select_card(uid, card, &cuid, true, 0, false);
+    // Use special magic detection function that always attempts RATS regardless of SAK
+    res = iso14443a_select_card_for_magic(uid, card, &cuid, true, 0);
     if (res) {
         if (cuid == 0xAA55C396) {
             flag |= MAGIC_FLAG_GEN_UNFUSED;


### PR DESCRIPTION
fix issue #2922 