### PR TITLE
Updated iclass restore to support privilege escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Changed `hf iclass restore` - it now supports privilege escalation to restore card content using replay (@antiklesys)
 - Fixed `hf 15 dump` - now reads sysinfo response correct (@iceman1001)
 - Changed `make clean` - it now removes all __pycache__ folders (@iceman1001)
 - Fixed `hf 15 readmulti` - fix block calculations (@iceman1001)

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -2569,6 +2569,7 @@ static int CmdHFiClassRestore(const char *Cmd) {
         arg_lit0(NULL, "raw", "no computations applied to key"),
         arg_lit0("v", "verbose", "verbose output"),
         arg_lit0(NULL, "shallow", "use shallow (ASK) reader modulation instead of OOK"),
+        arg_lit0(NULL, "nr", "replay of nr mac with privilege escalation"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, false);
@@ -2619,6 +2620,7 @@ static int CmdHFiClassRestore(const char *Cmd) {
     bool rawkey = arg_get_lit(ctx, 8);
     bool verbose = arg_get_lit(ctx, 9);
     bool shallow_mod = arg_get_lit(ctx, 10);
+    bool use_replay = arg_get_lit(ctx, 11);
 
     CLIParserFree(ctx);
 
@@ -2665,7 +2667,7 @@ static int CmdHFiClassRestore(const char *Cmd) {
     payload->req.use_raw = rawkey;
     payload->req.use_elite = elite;
     payload->req.use_credit_key = use_credit_key;
-    payload->req.use_replay = false;
+    payload->req.use_replay = use_replay;
     payload->req.blockno = startblock;
     payload->req.send_reply = true;
     payload->req.do_auth = true;


### PR DESCRIPTION
Updated hf iclass restore to support privilege escalation to restore card's content using a single AA1 --nr mac value.
This allows to write cards for which the debit key is not known.