### PR TITLE
Add Gen2 Magic Card Detection method responds

### DIFF
--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -3051,6 +3051,12 @@ void MifareCIdent(bool is_mfc, uint8_t keytype, uint8_t *key) {
         } else if (memcmp(card->ats, "\x85\x00\x00\xA0\x00\x00\x0A\xA5\x00\x04\x04\x02\x01\x00\x0F\x03\x79\x0C", 18) == 0) {
             // test for NTAG213 magic gen2
             isGen2 = true;
+        } else if (memcmp(card->ats, "\x85\x00\x00\xA0\x00\x00\x0A\xAA\x00\x04\x04\x02\x01\x00\x13\x03\x60\xA6", 18) == 0) {
+            // test for non-standard NTAG216 magic gen2 888bytes (NT2H1611G0DU) ( USCUID-UL )
+            isGen2 = true;
+        } else if (memcmp(card->ats, "\x85\x00\x85\xA0\x00\x00\x0A\x5A\x00\x04\x04\x02\x01\x00\x11\x03\x44\xB4", 18) == 0) {
+            // test for non-standard NTAG215 magic gen2 504bytes (NT2H1511G0DU) ( USCUID-UL )
+            isGen2 = true;
         }
 
         if (isGen2) {

--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -3033,33 +3033,30 @@ void MifareCIdent(bool is_mfc, uint8_t keytype, uint8_t *key) {
         if (memcmp(card->ats, "\x09\x78\x00\x91\x02\xDA\xBC\x19\x10", 9) == 0) {
             // test for some MFC gen2
             isGen2 = true;
-            flag |= MAGIC_FLAG_GEN_2_ATS;
         } else if (memcmp(card->ats, "\x0D\x78\x00\x71\x02\x88\x49\xA1\x30\x20\x15\x06\x08\x56\x3D", 15) == 0) {
             // test for some MFC 7b gen2
             isGen2 = true;
-            flag |= MAGIC_FLAG_GEN_2_ATS;
         } else if (memcmp(card->ats, "\x0A\x78\x00\x81\x02\xDB\xA0\xC1\x19\x40\x2A\xB5", 12) == 0) {
             // test for Ultralight magic gen2
             isGen2 = true;
-            flag |= MAGIC_FLAG_GEN_2_ATS;
         } else if (memcmp(card->ats, "\x85\x00\x00\xA0\x00\x00\x0A\xC3\x00\x04\x03\x01\x01\x00\x0B\x03\x41\xDF", 18) == 0) {
             // test for Ultralight EV1 magic gen2
             isGen2 = true;
-            flag |= MAGIC_FLAG_GEN_2_ATS;
         } else if (memcmp(card->ats, "\x85\x00\x00\xA0\x0A\x00\x0A\xC3\x00\x04\x03\x01\x01\x00\x0B\x03\x16\xD7", 18) == 0) {
             // test for some other Ultralight EV1 magic gen2
             isGen2 = true;
-            flag |= MAGIC_FLAG_GEN_2_ATS;
         } else if (memcmp(card->ats, "\x85\x00\x00\xA0\x0A\x00\x0A\xB0\x00\x00\x00\x00\x00\x00\x00\x00\x18\x4D", 18) == 0) {
             // test for some other Ultralight magic gen2
             isGen2 = true;
-            flag |= MAGIC_FLAG_GEN_2_ATS;
         } else if (memcmp(card->ats, "\x85\x00\x00\xA0\x00\x00\x0A\xA5\x00\x04\x04\x02\x01\x00\x0F\x03\x79\x0C", 18) == 0) {
             // test for NTAG213 magic gen2
             isGen2 = true;
-            flag |= MAGIC_FLAG_GEN_2_ATS;
         }
 
+        if (isGen2) {
+            flag |= MAGIC_FLAG_GEN_2_ATS;  // for detection flag on the above tests
+        }
+        
         // test for super card
         ReaderTransmit(superGen1, sizeof(superGen1), NULL);
         res = ReaderReceive(buf, PM3_CMD_DATA_SIZE, par);

--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -3033,31 +3033,31 @@ void MifareCIdent(bool is_mfc, uint8_t keytype, uint8_t *key) {
         if (memcmp(card->ats, "\x09\x78\x00\x91\x02\xDA\xBC\x19\x10", 9) == 0) {
             // test for some MFC gen2
             isGen2 = true;
-            flag |= MAGIC_FLAG_GEN_2;
+            flag |= MAGIC_FLAG_GEN_2_ATS;
         } else if (memcmp(card->ats, "\x0D\x78\x00\x71\x02\x88\x49\xA1\x30\x20\x15\x06\x08\x56\x3D", 15) == 0) {
             // test for some MFC 7b gen2
             isGen2 = true;
-            flag |= MAGIC_FLAG_GEN_2;
+            flag |= MAGIC_FLAG_GEN_2_ATS;
         } else if (memcmp(card->ats, "\x0A\x78\x00\x81\x02\xDB\xA0\xC1\x19\x40\x2A\xB5", 12) == 0) {
             // test for Ultralight magic gen2
             isGen2 = true;
-            flag |= MAGIC_FLAG_GEN_2;
+            flag |= MAGIC_FLAG_GEN_2_ATS;
         } else if (memcmp(card->ats, "\x85\x00\x00\xA0\x00\x00\x0A\xC3\x00\x04\x03\x01\x01\x00\x0B\x03\x41\xDF", 18) == 0) {
             // test for Ultralight EV1 magic gen2
             isGen2 = true;
-            flag |= MAGIC_FLAG_GEN_2;
+            flag |= MAGIC_FLAG_GEN_2_ATS;
         } else if (memcmp(card->ats, "\x85\x00\x00\xA0\x0A\x00\x0A\xC3\x00\x04\x03\x01\x01\x00\x0B\x03\x16\xD7", 18) == 0) {
             // test for some other Ultralight EV1 magic gen2
             isGen2 = true;
-            flag |= MAGIC_FLAG_GEN_2;
+            flag |= MAGIC_FLAG_GEN_2_ATS;
         } else if (memcmp(card->ats, "\x85\x00\x00\xA0\x0A\x00\x0A\xB0\x00\x00\x00\x00\x00\x00\x00\x00\x18\x4D", 18) == 0) {
             // test for some other Ultralight magic gen2
             isGen2 = true;
-            flag |= MAGIC_FLAG_GEN_2;
+            flag |= MAGIC_FLAG_GEN_2_ATS;
         } else if (memcmp(card->ats, "\x85\x00\x00\xA0\x00\x00\x0A\xA5\x00\x04\x04\x02\x01\x00\x0F\x03\x79\x0C", 18) == 0) {
             // test for NTAG213 magic gen2
             isGen2 = true;
-            flag |= MAGIC_FLAG_GEN_2;
+            flag |= MAGIC_FLAG_GEN_2_ATS;
         }
 
         // test for super card
@@ -3114,7 +3114,7 @@ void MifareCIdent(bool is_mfc, uint8_t keytype, uint8_t *key) {
                 if (mifare_classic_authex(pcs, cuid, 0, keytype, tmpkey, AUTH_FIRST, NULL, NULL) == 0) {
 
                     if ((mifare_sendcmd_short(pcs, 1, ISO14443A_CMD_WRITEBLOCK, 0, buf, PM3_CMD_DATA_SIZE, par, NULL) == 1) && (buf[0] == 0x0A)) {
-                        flag |= MAGIC_FLAG_GEN_2;
+                        flag |= MAGIC_FLAG_GEN_2_INVASIVE;
                         // turn off immediately to ensure nothing ever accidentally writes to the block
                         FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
                     }

--- a/client/src/cmdhf14a.c
+++ b/client/src/cmdhf14a.c
@@ -3256,7 +3256,9 @@ int infoHF14A(bool verbose, bool do_nack_test, bool do_aid_search) {
             PrintAndLogEx(HINT, "Hint: Use `" _YELLOW_("hf mf gdm*") "` magic commands");
         }
 
-        if ((isMagic & MAGIC_FLAG_GEN_2) == MAGIC_FLAG_GEN_2) {
+        if ((isMagic & MAGIC_FLAG_GEN_2_ATS) == MAGIC_FLAG_GEN_2_ATS) {
+            PrintAndLogEx(HINT, "Hint: Use `" _YELLOW_("hf mf") "` commands");
+        } else if ((isMagic & MAGIC_FLAG_GEN_2_INVASIVE) == MAGIC_FLAG_GEN_2_INVASIVE) {
             PrintAndLogEx(HINT, "Hint: Use `" _YELLOW_("hf mf") "` commands");
         } else {
             PrintAndLogEx(HINT, "Hint: Try " _YELLOW_("`hf mf info`"));

--- a/client/src/mifare/mifarehost.c
+++ b/client/src/mifare/mifarehost.c
@@ -1677,8 +1677,16 @@ uint16_t detect_mf_magic(bool is_mfc, uint8_t key_type, uint64_t key) {
         PrintAndLogEx(SUCCESS, "Magic capabilities... " _GREEN_("Gen 1b"));
     }
 
-    if ((isMagic & MAGIC_FLAG_GEN_2) == MAGIC_FLAG_GEN_2) {
-        PrintAndLogEx(SUCCESS, "Magic capabilities... " _GREEN_("Gen 2 / CUID"));
+    if ((isMagic & MAGIC_FLAG_GEN_2) == MAGIC_FLAG_GEN_2) {  // deprecated
+        PrintAndLogEx(SUCCESS, "Magic capabilities... " _GREEN_("Gen 2 / CUID"));  // deprecated
+    }  // deprecated
+
+    if ((isMagic & MAGIC_FLAG_GEN_2_ATS) == MAGIC_FLAG_GEN_2_ATS) {
+        PrintAndLogEx(SUCCESS, "Magic capabilities... " _GREEN_("Gen 2 / CUID") " ( detected via ATS signature )");
+    }
+
+    if ((isMagic & MAGIC_FLAG_GEN_2_INVASIVE) == MAGIC_FLAG_GEN_2_INVASIVE) {
+        PrintAndLogEx(SUCCESS, "Magic capabilities... " _GREEN_("Gen 2 / CUID") " ( detected via invasive test )");
     }
 
     if ((isMagic & MAGIC_FLAG_GEN_3) == MAGIC_FLAG_GEN_3) {

--- a/client/src/mifare/mifarehost.c
+++ b/client/src/mifare/mifarehost.c
@@ -1677,10 +1677,6 @@ uint16_t detect_mf_magic(bool is_mfc, uint8_t key_type, uint64_t key) {
         PrintAndLogEx(SUCCESS, "Magic capabilities... " _GREEN_("Gen 1b"));
     }
 
-    if ((isMagic & MAGIC_FLAG_GEN_2) == MAGIC_FLAG_GEN_2) {  // deprecated
-        PrintAndLogEx(SUCCESS, "Magic capabilities... " _GREEN_("Gen 2 / CUID"));  // deprecated
-    }  // deprecated
-
     if ((isMagic & MAGIC_FLAG_GEN_2_ATS) == MAGIC_FLAG_GEN_2_ATS) {
         PrintAndLogEx(SUCCESS, "Magic capabilities... " _GREEN_("Gen 2 / CUID") " ( detected via ATS signature )");
     }

--- a/include/protocols.h
+++ b/include/protocols.h
@@ -272,7 +272,7 @@ ISO 7816-4 Basic interindustry commands. For command APDU's.
 #define MAGIC_FLAG_NONE            0x0000
 #define MAGIC_FLAG_GEN_1A          0x0001
 #define MAGIC_FLAG_GEN_1B          0x0002
-#define MAGIC_FLAG_GEN_2           0x0004
+#define MAGIC_FLAG_GEN_2_ATS       0x0004   // Gen 2 detected via ATS signature
 #define MAGIC_FLAG_GEN_UNFUSED     0x0008
 #define MAGIC_FLAG_SUPER_GEN1      0x0010
 #define MAGIC_FLAG_SUPER_GEN2      0x0020
@@ -284,7 +284,7 @@ ISO 7816-4 Basic interindustry commands. For command APDU's.
 #define MAGIC_FLAG_GDM_WUP_20      0x0800
 #define MAGIC_FLAG_GDM_WUP_40      0x1000
 #define MAGIC_FLAG_GDM_WUP_40_ZUID 0x2000
-
+#define MAGIC_FLAG_GEN_2_INVASIVE  0x4000   // Gen 2 detected via invasive test
 
 // Commands for configuration of Gen4 GTU cards.
 // see https://github.com/RfidResearchGroup/proxmark3/blob/master/doc/magic_cards_notes.md


### PR DESCRIPTION
1. **Expanded ATS Signature Dictionary**
- NT2H1611G0DU and NT2H1511G0DU ATS responds

2. **Improved Detection Method Classification**
- Distinguished between ATS-based detection (`MAGIC_FLAG_GEN_2_ATS`) and invasive detection (`MAGIC_FLAG_GEN_2_INVASIVE`)

![ATS S](https://github.com/user-attachments/assets/508e0d70-f913-44ce-ace7-5155902f3611)
![invasive](https://github.com/user-attachments/assets/4d18ee86-2cac-489e-8b89-5f5f464d25bf)
