### PR TITLE
Add recognition of Swissbit iShield Key Mifare as MFD EV3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
-- Changed `hf mfdes info` - add recognition of Swissbit iShield Key Mifare
+- Changed `hf mfdes info` - add recognition of Swissbit iShield Key Mifare (@ah01)
 - Changed `hf mf info` - add detection for unknown backdoor keys and for some backdoor variants (@doegox)
 - Changed `mqtt` commnands - now honors preference settings (@iceman1001)
 - Changed `prefs` - now handles MQTT settings too (@iceman1001)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Changed `hf mfdes info` - add recognition of Swissbit iShield Key Mifare
 - Changed `hf mf info` - add detection for unknown backdoor keys and for some backdoor variants (@doegox)
 - Changed `mqtt` commnands - now honors preference settings (@iceman1001)
 - Changed `prefs` - now handles MQTT settings too (@iceman1001)

--- a/client/src/cmdhfmfdes.c
+++ b/client/src/cmdhfmfdes.c
@@ -238,7 +238,7 @@ static char *getProtocolStr(uint8_t id, bool hw) {
 
 static char *getVersionStr(uint8_t type, uint8_t major, uint8_t minor) {
 
-    static char buf[40] = {0x00};
+    static char buf[60] = {0x00};
     char *retStr = buf;
 
     if (type == 0x01 && major == 0x00)
@@ -255,6 +255,8 @@ static char *getVersionStr(uint8_t type, uint8_t major, uint8_t minor) {
         snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV2") " )", major, minor);
     else if (type == 0x01 && major == 0x33 && minor == 0x00)
         snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV3") " )", major, minor);
+    else if (type == 0x81 && major == 0x43 && minor == 0x01)
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV3C implementation on P71D600") " )", major, minor); // Swisskey iShield Key
     else if (type == 0x01 && major == 0x30 && minor == 0x00)
         snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire Light") " )", major, minor);
     else if (type == 0x02 && major == 0x11 && minor == 0x00)
@@ -327,6 +329,9 @@ nxp_cardtype_t getCardType(uint8_t type, uint8_t major, uint8_t minor) {
 
     // DESFire EV3
     if (type == 0x01 && major == 0x33 && minor == 0x00)
+        return DESFIRE_EV3;
+
+    if (type == 0x81 && major == 0x43 && minor == 0x01)
         return DESFIRE_EV3;
 
     // Duox


### PR DESCRIPTION
I got my hands on [iShield Key 2 Pro Mifare](https://www.swissbit.com/en/products/security-products/ishield-key/). This authentication token supports MIFARE DESFire EV3 (info from NXP's TagInfo is _DESFire EV3C implementation on P71D600_). 

It has different version info than typical DESFire, so here it is.

PS: Info from pm3 client before this change:

```
[=] HW Version.. 04810043011A05
[=] SW Version.. 04814603001A05
[=] Version data identification failed. Report to Iceman!
```