### PR TITLE
paxton_clone.lua: Detect operating system for logfile handling on Linux environments

### DIFF
--- a/client/luascripts/paxton_clone.lua
+++ b/client/luascripts/paxton_clone.lua
@@ -4,7 +4,16 @@ local ac = require('ansicolors')
 local os = require('os')
 local dash = string.rep('--', 32)
 local dir = os.getenv('HOME') .. '/.proxmark3/logs/'
-local logfile = (io.popen('dir /a-d /o-d /tw /b/s "' .. dir .. '" 2>nul:'):read("*a"):match("%C+"))
+local logfilecmd
+
+--Determine platform for logfile handling (Windows vs Unix/Linux)
+if package.config:sub(1,1) == "\\" then
+  logfilecmd = 'dir /a-d /o-d /tw /b/s "' .. dir .. '" 2>nul:'
+else
+  logfilecmd = 'find "' .. dir .. '" -type f -printf "%T@ %p\\n" | sort -nr | cut -d" " -f2-'
+end
+
+local logfile = (io.popen(logfilecmd):read("*a"):match("%C+"))
 local log_file_path = dir .. "Paxton_log.txt"
 local nam = ""
 local pm3 = require('pm3')


### PR DESCRIPTION
Related to: #2919 

This does OS detection to modify the logfile handling. The current version assumes Windows only using `dir`, this is not compatible with Linux.

The original dir command has been translated to an equivalent Linux command. This was done with the help of AI, to quikcly translate the Windows only parameters to Linux.

@jareckib This shouldn't affect Windows, but I have the reverse problem of not having an proxmark environment on Windows to ensure the detection continues to use the dir command as the original script.