### PR TITLE
Fix getIndalaBits checksum logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Changed `hf mfu sim` - now support UL-C simulation (@iceman1001)
 - Added `!` - run system commands from inside the client. Potentially dangerous if running client as SUDO, SU, ROOT (@iceman1001)
 - Implemented `hf felica scsvcode` - now dumps all service and area codes. (@zinongli)
+- Fixed `lf indala cone` - now writing the right bits when using `--fc` and `--cn`
 
 ## [Daddy Iceman.4.20469][2025-06-16]
 - Fixed edge case in fm11rf08s key recovery tools (@doegox)

--- a/client/src/cmdlfindala.c
+++ b/client/src/cmdlfindala.c
@@ -1163,14 +1163,21 @@ int getIndalaBits(uint8_t fc, uint16_t cn, uint8_t *bits) {
     chk += ((cn >> 2) & 1); //y14 == 89 - 30 = 59
     chk += (cn & 1); //y16 == 71 - 30 = 41
 
-    if ((chk % 2) == 0) { // If the sum is even, checksum is '10' (binary) = 2.
+    if ((chk & 1) == 0) { // If the sum is even, checksum is '10' (binary) = 2.
         bits[62] = 1;
         bits[63] = 0;
     } else {              // If the sum is odd, checksum is '01' (binary) = 1.
         bits[62] = 0;
         bits[63] = 1;
     }
+    
+    // add parity
+    // bits[34] = 1; // p1  64 - 30 = 34
+    // bits[38] = 1; // p2  68 - 30 = 38
 
+    // 92 = 62
+    // 93 = 63
+    
     bits[34] = 0; // parity for odd bits
     bits[38] = 0; // parity for even bits
     uint8_t p1 = 1;

--- a/client/src/cmdlfindala.c
+++ b/client/src/cmdlfindala.c
@@ -1163,20 +1163,13 @@ int getIndalaBits(uint8_t fc, uint16_t cn, uint8_t *bits) {
     chk += ((cn >> 2) & 1); //y14 == 89 - 30 = 59
     chk += (cn & 1); //y16 == 71 - 30 = 41
 
-    if ((chk & 1) == 0) {
-        bits[62] = 0;
-        bits[63] = 1;
-    } else {
+    if ((chk % 2) == 0) { // If the sum is even, checksum is '10' (binary) = 2.
         bits[62] = 1;
         bits[63] = 0;
+    } else {              // If the sum is odd, checksum is '01' (binary) = 1.
+        bits[62] = 0;
+        bits[63] = 1;
     }
-
-    // add parity
-    // bits[34] = 1; // p1  64 - 30 = 34
-    // bits[38] = 1; // p2  68 - 30 = 38
-
-    // 92 = 62
-    // 93 = 63
 
     bits[34] = 0; // parity for odd bits
     bits[38] = 0; // parity for even bits


### PR DESCRIPTION
This fixes #2939
The checksum logic just needs a slight tweak.
I've validated this by writing using a few FC and CN of known valid cards and comparing the bits.
