### PR TITLE
`hf 14b calypso`: Less Strict Loop Logic and Additional Files to Dump from

### DIFF
--- a/client/src/cmdhf14b.c
+++ b/client/src/cmdhf14b.c
@@ -2708,25 +2708,32 @@ static int CmdHF14BCalypsoRead(const char *Cmd) {
     CLIParserFree(ctx);
 
     transport_14b_apdu_t cmds[] = {
-        {"01.Select ICC file",     "\x94\xa4\x08\x00\x04\x3f\x00\x00\x02", 9},
-        {"02.ICC",                 "\x94\xb2\x01\x04\x1d", 5},
-        {"03.Select EnvHol file",  "\x94\xa4\x08\x00\x04\x20\x00\x20\x01", 9},
-        {"04.EnvHol1",             "\x94\xb2\x01\x04\x1d", 5},
-        {"05.Select EvLog file",   "\x94\xa4\x08\x00\x04\x20\x00\x20\x10", 9},
-        {"06.EvLog1",              "\x94\xb2\x01\x04\x1d", 5},
-        {"07.EvLog2",              "\x94\xb2\x02\x04\x1d", 5},
-        {"08.EvLog3",              "\x94\xb2\x03\x04\x1d", 5},
-        {"09.Select ConList file", "\x94\xa4\x08\x00\x04\x20\x00\x20\x50", 9},
-        {"10.ConList",             "\x94\xb2\x01\x04\x1d", 5},
-        {"11.Select Contra file",  "\x94\xa4\x08\x00\x04\x20\x00\x20\x20", 9},
-        {"12.Contra1",             "\x94\xb2\x01\x04\x1d", 5},
-        {"13.Contra2",             "\x94\xb2\x02\x04\x1d", 5},
-        {"14.Contra3",             "\x94\xb2\x03\x04\x1d", 5},
-        {"15.Contra4",             "\x94\xb2\x04\x04\x1d", 5},
-        {"16.Select Counter file", "\x94\xa4\x08\x00\x04\x20\x00\x20\x69", 9},
-        {"17.Counter",             "\x94\xb2\x01\x04\x1d", 5},
-        {"18.Select SpecEv file",  "\x94\xa4\x08\x00\x04\x20\x00\x20\x40", 9},
-        {"19.SpecEv1",             "\x94\xb2\x01\x04\x1d", 5},
+        {"01.Select ICC     ",      "\x94\xa4\x08\x00\x04\x3f\x00\x00\x02", 9},
+        {"02.ICC            ",             "\x94\xb2\x01\x04\x1d", 5},
+        {"03.Select EnvHol  ",   "\x94\xa4\x08\x00\x04\x20\x00\x20\x01", 9},
+        {"04.EnvHol1        ",         "\x94\xb2\x01\x04\x1d", 5},
+        {"05.Select EvLog   ",    "\x94\xa4\x08\x00\x04\x20\x00\x20\x10", 9},
+        {"06.EvLog1         ",          "\x94\xb2\x01\x04\x1d", 5},
+        {"07.EvLog2         ",          "\x94\xb2\x02\x04\x1d", 5},
+        {"08.EvLog3         ",          "\x94\xb2\x03\x04\x1d", 5},
+        {"09.Select ConList ",  "\x94\xa4\x08\x00\x04\x20\x00\x20\x50", 9},
+        {"10.ConList        ",         "\x94\xb2\x01\x04\x1d", 5},
+        {"11.Select Contra  ",   "\x94\xa4\x08\x00\x04\x20\x00\x20\x20", 9},
+        {"12.Contra1        ",         "\x94\xb2\x01\x04\x1d", 5},
+        {"13.Contra2        ",         "\x94\xb2\x02\x04\x1d", 5},
+        {"14.Contra3        ",         "\x94\xb2\x03\x04\x1d", 5},
+        {"15.Contra4        ",         "\x94\xb2\x04\x04\x1d", 5},
+        {"16.Select Counter ",  "\x94\xa4\x08\x00\x04\x20\x00\x20\x69", 9},
+        {"17.Counter        ",         "\x94\xb2\x01\x04\x1d", 5},
+        {"18.Select SpecEv  ",   "\x94\xa4\x08\x00\x04\x20\x00\x20\x40", 9},
+        {"19.SpecEv1        ",         "\x94\xb2\x01\x04\x1d", 5},
+        {"20.Select Purse   ",    "\x00\xa4\x00\x00\x02\x10\x15", 7},
+        {"21.Purse1         ",          "\x00\xb2\x01\x04\x1d", 5},
+        {"22.Purse2         ",          "\x00\xb2\x02\x04\x1d", 5},
+        {"23.Purse3         ",          "\x00\xb2\x03\x04\x1d", 5},
+        {"24.Select Top Up  ",   "\x00\xa4\x00\x00\x02\x10\x14", 7},
+        {"25.Topup1         ",          "\x00\xb2\x01\x04\x1d", 5},
+        {"26.Select 1TIC.ICA", "\x00\xa4\x04\x00\x08\x31\x54\x49\x43\x2e\x49\x43\x41", 13},
     };
 
     /*
@@ -2780,9 +2787,8 @@ static int CmdHF14BCalypsoRead(const char *Cmd) {
 
         uint16_t sw = get_sw(response, resplen);
         if (sw != ISO7816_OK) {
-            PrintAndLogEx(ERR, "Sending command failed (%04x - %s).", sw, GetAPDUCodeDescription(sw >> 8, sw & 0xff));
-            switch_off_field_14b();
-            return PM3_ESOFT;
+            PrintAndLogEx(INFO, "%s - command failed (%04x - %s).", cmds[i].desc, sw, GetAPDUCodeDescription(sw >> 8, sw & 0xff));
+            continue;
         }
 
         PrintAndLogEx(INFO, "%s - %s", cmds[i].desc, sprint_hex(response, resplen));


### PR DESCRIPTION
Old calypso loop break whenever we encounter on file that we can't select or read. But some cards can have some of the files and not others. The loop should continue to check the next file instead of breaking the entire workflow. 

Also, some additional file ids are included. 

Here's an example of the new output:

```
[usb] pm3 --> hf 14b calypso
[=] 01.Select ICC      - command failed (6700 - Wrong length).
[=] 02.ICC             - command failed (6986 - Command not allowed (no current EF)).
[=] 03.Select EnvHol   - command failed (6700 - Wrong length).
[=] 04.EnvHol1         - command failed (6986 - Command not allowed (no current EF)).
[=] 05.Select EvLog    - command failed (6700 - Wrong length).
[=] 06.EvLog1          - command failed (6986 - Command not allowed (no current EF)).
[=] 07.EvLog2          - command failed (6986 - Command not allowed (no current EF)).
[=] 08.EvLog3          - command failed (6986 - Command not allowed (no current EF)).
[=] 09.Select ConList  - command failed (6700 - Wrong length).
[=] 10.ConList         - command failed (6986 - Command not allowed (no current EF)).
[=] 11.Select Contra   - command failed (6700 - Wrong length).
[=] 12.Contra1         - command failed (6986 - Command not allowed (no current EF)).
[=] 13.Contra2         - command failed (6986 - Command not allowed (no current EF)).
[=] 14.Contra3         - command failed (6986 - Command not allowed (no current EF)).
[=] 15.Contra4         - command failed (6986 - Command not allowed (no current EF)).
[=] 16.Select Counter  - command failed (6700 - Wrong length).
[=] 17.Counter         - command failed (6986 - Command not allowed (no current EF)).
[=] 18.Select SpecEv   - command failed (6700 - Wrong length).
[=] 19.SpecEv1         - command failed (6986 - Command not allowed (no current EF)).
[=] 20.Select Purse    - 85 17 15 04 04 1D 03 1F 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 10 15 90 00 
[=] 21.Purse1          - FD A8 28 34 03 93 C0 AE 12 E0 25 30 40 70 00 1B 58 00 07 F0 66 0D 00 00 00 00 00 00 00 90 00 
[=] 22.Purse2          - FE 0C 28 33 04 F8 C0 AE C9 49 C8 18 07 A1 00 1D B0 00 06 D2 5B E8 00 00 00 00 00 00 00 90 00 
[=] 23.Purse3          - FE 0C 28 33 04 F6 C0 AE C9 49 CD 05 22 C9 00 1F A4 00 05 B1 89 52 00 00 00 00 00 00 00 90 00 
[=] 24.Select Top Up   - 85 17 14 04 04 1D 01 1F 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 10 14 90 00 
[=] 25.Topup1          - 28 32 00 C0 00 00 27 10 00 13 88 03 E6 AE 10 D1 6E 0E AE 5D 00 02 11 04 CB 00 00 00 00 90 00 
[=] 26.Select 1TIC.ICA - 6F 28 84 0E 31 54 49 43 2E 49 43 41 D4 84 01 01 91 01 A5 16 BF 0C 13 C7 08 00 00 00 00 95 17 07 59 53 07 0A C0 26 C0 20 0B 20 90 00 
```