### PR TITLE
Support VC card reading by adding `--dfname` argument to more `mfdes` commands

### DIFF
--- a/client/src/mifare/desfirecrypto.c
+++ b/client/src/mifare/desfirecrypto.c
@@ -101,8 +101,17 @@ void DesfireSetCommMode(DesfireContext_t *ctx, DesfireCommunicationMode commMode
 void DesfireSetKdf(DesfireContext_t *ctx, uint8_t kdfAlgo, uint8_t *kdfInput, uint8_t kdfInputLen) {
     ctx->kdfAlgo = kdfAlgo;
     ctx->kdfInputLen = kdfInputLen;
-    if (kdfInputLen) {
+    if (kdfInputLen)
         memcpy(ctx->kdfInput, kdfInput, kdfInputLen);
+}
+
+void DesfireSetDFName(DesfireContext_t *ctx, uint8_t *dfname, uint8_t dfnameLen) {
+    ctx->selectedDFNameLen = 0;
+    memset(ctx->selectedDFName, 0, sizeof(ctx->selectedDFName));
+    
+    if (dfname && dfnameLen > 0 && dfnameLen <= 16) {
+        ctx->selectedDFNameLen = dfnameLen;
+        memcpy(ctx->selectedDFName, dfname, dfnameLen);
     }
 }
 

--- a/client/src/mifare/desfirecrypto.h
+++ b/client/src/mifare/desfirecrypto.h
@@ -74,6 +74,9 @@ typedef struct {
     bool isoChaining;
     bool appSelected; // for iso auth
     uint32_t selectedAID;
+    
+    uint8_t selectedDFName[16];
+    uint8_t selectedDFNameLen;
 
     uint8_t uid[10];
     uint8_t uidlen;
@@ -97,6 +100,7 @@ void DesfireSetCommandSet(DesfireContext_t *ctx, DesfireCommandSet cmdSet);
 void DesfireSetCommMode(DesfireContext_t *ctx, DesfireCommunicationMode commMode);
 void DesfireSetSecureChannel(DesfireContext_t *ctx, DesfireSecureChannel schann);
 void DesfireSetKdf(DesfireContext_t *ctx, uint8_t kdfAlgo, uint8_t *kdfInput, uint8_t kdfInputLen);
+void DesfireSetDFName(DesfireContext_t *ctx, uint8_t *dfname, uint8_t dfnameLen);
 bool DesfireIsAuthenticated(DesfireContext_t *dctx);
 size_t DesfireGetMACLength(DesfireContext_t *ctx);
 


### PR DESCRIPTION
To support execution of `mfdes` commands with "virtual" cards (VC), such as HCE-based Mifare2GO or cards with Mifare-VCA (Virtual card architecture) feature, an initial DF NAME SELECT must first be performed before any MIFARE commands can be issued. 

To enable that use case, this PR adds `dfname` argument to the following commands:
- `detect`;
- `auth`; 
- `getuid`;
- `freemem`;
- `getkeyversions`;
- `getkeysettings`;
- `getfileids`;
- `getfileisoids`;
- `getfilesettings`;
- `lsfiles`;
- `dump`;

When `dfname` argument is specified, an ISO DF Name select is executed inside of `DesfireSelectAndAuthenticateW` before DESFIRE AID or ISO FID select.

Those updated commands have been tested to work with a virtual card in Google Wallet, and a real NDEF-formatted Mifare DESFire EV3 card. Here's a list of commands executed when validating the implementation:

```pm3
# Executed on NDEF-formatted DESFire EV3 card

# General
hf mfdes detect
hf mfdes detect --dfname D2760000850100
hf mfdes auth -n 0 -t des -k 0000000000000000
hf mfdes auth -n 0 -t des -k 0000000000000000 --dfname D2760000850100

# PICC AID
hf mfdes getuid
hf mfdes freemem
hf mfdes getkeyversions
hf mfdes getkeyversions --aid 000000
hf mfdes getkeysettings
hf mfdes getkeysettings --aid 000000

# PICC DF Name
hf mfdes getuid --dfname D2760000850100
hf mfdes freemem --dfname D2760000850100
hf mfdes getkeyversions --dfname D2760000850100
hf mfdes getkeysettings --dfname D2760000850100

# NDEF AID
hf mfdes getkeysettings --aid 000001
hf mfdes getfileids -n 0 -t des -k 0000000000000000 --aid 000001
hf mfdes getfileisoids --aid 000001
hf mfdes getfilesettings --aid 000001
hf mfdes lsfiles --aid 000001
hf mfdes dump --aid 000001

# NDEF DF Name
hf mfdes getkeysettings --dfname D2760000850101
hf mfdes getfileids -n 0 -t des -k 0000000000000000 --dfname D2760000850101
hf mfdes getfileisoids --dfname D2760000850101
hf mfdes getfilesettings --dfname D2760000850101
hf mfdes lsfiles --dfname D2760000850101
hf mfdes dump --dfname D2760000850101

# DESFIRE DF Name -> NDEF AID
hf mfdes getfileids -n 0 -t des -k 0000000000000000 --dfname D2760000850100 --aid 000001
hf mfdes getfileisoids --dfname D2760000850100 --aid 000001
hf mfdes getfilesettings --dfname D2760000850100 --aid 000001
hf mfdes lsfiles --dfname D2760000850100 --aid 000001
hf mfdes dump --dfname D2760000850100 --aid 000001
```