### PR TITLE
Improve output checks in mf_backdoor_dump.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Fixed `script run hf_mfu_amiibo_restore.lua` - broken reference to a dependency. (@CorySolovewicz)
 - Changed `/client/update_amiibo_tools_lua.py` - updated the output to make things more clear. (@CorySolovewicz)
 - Changed `/client/lualibs/amiibo_tools.lua` - updated to the most recent data. (@CorySolovewicz)
+- Changed `/client/pyscripts/mf_backdoor_dump.py` - fixed output checks to handle whitespace variations. (@robo-w)
 
 
 ## [Daddy Iceman.4.20469][2025-06-16]

--- a/client/pyscripts/mf_backdoor_dump.py
+++ b/client/pyscripts/mf_backdoor_dump.py
@@ -22,18 +22,18 @@ for bk, sz in BACKDOOR_KEYS:
     p.console(f"hf mf ecfill --{sz} -c 4 -k {bk}")
     output = p.grabbed_output.split('\n')
 
-    if "[#] Card not found" in output:
+    if any("Card not found" in output_line for output_line in output):
         print("Error reading the tag:")
         print("\n".join(output))
         break
-    elif "[-] Fill ( fail )" in output:
+    elif any("Fill ( fail )" in output_line for output_line in output):
         continue
-    elif "[+] Fill ( ok )" not in output:
-        print("Unexpected output, exiting:")
-        print("\n".join(output))
+    elif any("Fill ( ok )" in output_line for output_line in output):
+        WORKING_KEY = bk
         break
     else:
-        WORKING_KEY = bk
+        print("Unexpected output, exiting:")
+        print("\n".join(output))
         break
 
 if WORKING_KEY is None:


### PR DESCRIPTION
Apparently the number of whitespaces in the parsed output changed over time. This fix should be able to handle all variations of it.