### PR TITLE
Bugfix/mf_backdoor_dump output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Fixed `script run hf_mfu_amiibo_restore.lua` - broken reference to a dependency. (@CorySolovewicz)
 - Changed `/client/update_amiibo_tools_lua.py` - updated the output to make things more clear. (@CorySolovewicz)
 - Changed `/client/lualibs/amiibo_tools.lua` - updated to the most recent data. (@CorySolovewicz)
-- Changed `/client/pyscripts/mf_backdoor_dump.py` - fixed output checks to handle whitespace variations. (@robo-w)
+- Changed `/client/pyscripts/mf_backdoor_dump.py` - fixed output checks to handle whitespace variations. fixed output of card dump. (@robo-w)
 
 
 ## [Daddy Iceman.4.20469][2025-06-16]

--- a/client/pyscripts/mf_backdoor_dump.py
+++ b/client/pyscripts/mf_backdoor_dump.py
@@ -41,4 +41,4 @@ if WORKING_KEY is None:
 else:
     print(f"Backdoor key {WORKING_KEY} seems to work, dumping data...")
     print("IMPORTANT: Only data blocks and access bytes can be dumped; keys will be shown as all 0's")
-    p.console(f"hf mf eview --{sz}", True)
+    p.console(f"hf mf eview --{sz}", quiet=False)


### PR DESCRIPTION
Second fix to the same script: The final dump is captured but not handled. Therefore it is printed on a second run, or used as grabbed output for any later script. This fix prints it directly.