### PR TITLE
Add --page flag to hf iclass dump

### DIFF
--- a/armsrc/iclass.h
+++ b/armsrc/iclass.h
@@ -67,6 +67,7 @@ void iClass_ReadBlock(uint8_t *msg);
 bool iclass_read_block(uint16_t blockno, uint8_t *data, uint32_t *start_time, uint32_t *eof_time, bool shallow_mod);
 
 bool select_iclass_tag(picopass_hdr_t *hdr, bool use_credit_key, uint32_t *eof_time, bool shallow_mod);
+bool select_iclass_tag_and_page(picopass_hdr_t *hdr, bool use_credit_key, uint32_t *eof_time, bool shallow_mod, uint8_t page);
 bool authenticate_iclass_tag(iclass_auth_req_t *payload, picopass_hdr_t *hdr, uint32_t *start_time, uint32_t *eof_time, uint8_t *mac_out);
 
 uint8_t get_pagemap(const picopass_hdr_t *hdr);

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -1922,6 +1922,7 @@ static int CmdHFiClassDump(const char *Cmd) {
         arg_lit0(NULL, "force", "force unsecure card read"),
         arg_lit0(NULL, "shallow", "use shallow (ASK) reader modulation instead of OOK"),
         arg_lit0(NULL, "ns", "no save to file"),
+        arg_int0(NULL, "page", "<dec>", "which page to dump from"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
@@ -1948,6 +1949,7 @@ static int CmdHFiClassDump(const char *Cmd) {
     bool force = arg_get_lit(ctx, 10);
     bool shallow_mod = arg_get_lit(ctx, 11);
     bool nosave = arg_get_lit(ctx, 12);
+    int page = arg_get_int_def(ctx, 13, 0);
 
     CLIParserFree(ctx);
 
@@ -2107,6 +2109,7 @@ static int CmdHFiClassDump(const char *Cmd) {
         .req.do_auth = auth,
         .req.shallow_mod = shallow_mod,
         .end_block = app_limit1,
+        .page = page,
     };
     memcpy(payload.req.key, key, 8);
 

--- a/include/iclass_cmd.h
+++ b/include/iclass_cmd.h
@@ -78,6 +78,7 @@ typedef struct {
 // iCLASS dump data structure
 typedef struct {
     iclass_auth_req_t req;
+    uint8_t page;
     uint8_t start_block;
     uint8_t end_block;
 } PACKED iclass_dump_req_t;


### PR DESCRIPTION
PicoPass / IClass cards can have multiple pages but right now the Proxmark only allows inspecting and modifying the first page. This is a first step to adding some functionality to work with multi-page Picopass cards. I'm hoping to add some other features as well like being able to simulate an entire 32K picopass card (or just some specific pages if needed).

This is just a rough first attempt that doesn't completely work yet, due to how the iclass dump command reads the card "twice". I wanted to get the code out there and get some feedback first.