### PR TITLE
Add StagecoachSmart card to AID list

### DIFF
--- a/client/resources/aid_desfire.json
+++ b/client/resources/aid_desfire.json
@@ -1251,7 +1251,7 @@
         "AID": "A00216",
         "Vendor": "ITSO Ltd",
         "Country": "UK",
-        "Name": "GWR touch (BRS) / EMR Smartcard (EMA) / WYTCL MCard (LBA)",
+        "Name": "GWR touch (BRS) / EMR Smartcard (EMA) / WYTCL MCard (LBA) / StagecoachSmart card",
         "Description": "ITSO Public Transport Application // Provision of Citizen Services #0",
         "Type": "transport"
     },


### PR DESCRIPTION
Adds the StagecoachSmart card ([yes, it's really called that](https://www.stagecoachbus.com/promos-and-offers/national/stagecoachsmart)) to the DESFire AIDs list.

No changelog entry due to lack of significance.