### PR TITLE
`hf 14b mobib`: Less Strict Loop Logic 

### DIFF
--- a/client/src/cmdhf14b.c
+++ b/client/src/cmdhf14b.c
@@ -2797,12 +2797,12 @@ static int CmdHF14BCalypsoRead(const char *Cmd) {
         }
 
         uint16_t sw = get_sw(response, resplen);
-        if (sw != ISO7816_OK) {
-            PrintAndLogEx(INFO, "%s - command failed (%04x - %s).", cmds[i].desc, sw, GetAPDUCodeDescription(sw >> 8, sw & 0xff));
-            continue;
+        if (sw == ISO7816_OK) {
+            PrintAndLogEx(SUCCESS, "%-22s - %s", cmds[i].desc, sprint_hex(response, resplen - 2));
+        } else {
+            PrintAndLogEx(INFO, "%-22s - Sending command failed (%04x - %s).", cmds[i].desc, sw, GetAPDUCodeDescription(sw >> 8, sw & 0xff));
         }
-
-        PrintAndLogEx(INFO, "%-22s - %s", cmds[i].desc, sprint_hex(response, resplen - 2));
+        
         activate_field = false;
     }
 
@@ -2968,12 +2968,11 @@ static int CmdHF14BMobibRead(const char *Cmd) {
         }
 
         uint16_t sw = get_sw(response, resplen);
-        if (sw != ISO7816_OK) {
-            PrintAndLogEx(ERR, "Sending command failed (%04x - %s).", sw, GetAPDUCodeDescription(sw >> 8, sw & 0xff));
-            switch_off_field_14b();
-            return PM3_ESOFT;
+        if (sw == ISO7816_OK) {
+            PrintAndLogEx(SUCCESS, "%-22s - %s", cmds[i].desc, sprint_hex(response, resplen - 2));
+        } else {
+            PrintAndLogEx(INFO, "%-22s - Sending command failed (%04x - %s).", cmds[i].desc, sw, GetAPDUCodeDescription(sw >> 8, sw & 0xff));
         }
-        PrintAndLogEx(INFO, "%-22s - %s", cmds[i].desc, sprint_hex(response, resplen - 2));
         activate_field = false;
     }
 


### PR DESCRIPTION
In the same spirit as #2952, the recent improvements in Mobib works better if we are less strict about "every file must exist or else we break the loop". This PR makes it so that we continue to try next file even if the previous one gave us a bad response. 

Also slight changes in the output flag: a successful command -> `[+]` and a failed command -> `[=]` so that both kinds of logs are aligned while still distinguishable. If there are certain style rules that this violates I can change it back. 

An example is shown below. I used `mobib -o` because my tag is old version.

```
[usb] pm3 --> hf 14b calypso
[=] Select ICC             - Sending command failed (6700 - Wrong length).
[=] - ICC                  - Sending command failed (6986 - Command not allowed (no current EF)).
[=] Select EnvHol          - Sending command failed (6700 - Wrong length).
[=] - EnvHol1              - Sending command failed (6986 - Command not allowed (no current EF)).
[=] Select EvLog           - Sending command failed (6700 - Wrong length).
[=] - EvLog1               - Sending command failed (6986 - Command not allowed (no current EF)).
[=] - EvLog2               - Sending command failed (6986 - Command not allowed (no current EF)).
[=] - EvLog3               - Sending command failed (6986 - Command not allowed (no current EF)).
[=] Select ConList         - Sending command failed (6700 - Wrong length).
[=] - ConList              - Sending command failed (6986 - Command not allowed (no current EF)).
[=] Select Contra          - Sending command failed (6700 - Wrong length).
[=] - Contra1              - Sending command failed (6986 - Command not allowed (no current EF)).
[=] - Contra2              - Sending command failed (6986 - Command not allowed (no current EF)).
[=] - Contra3              - Sending command failed (6986 - Command not allowed (no current EF)).
[=] - Contra4              - Sending command failed (6986 - Command not allowed (no current EF)).
[=] Select Counter         - Sending command failed (6700 - Wrong length).
[=] - Counter              - Sending command failed (6986 - Command not allowed (no current EF)).
[=] Select SpecEv          - Sending command failed (6700 - Wrong length).
[=] - SpecEv1              - Sending command failed (6986 - Command not allowed (no current EF)).
[+] Select Purse           - 85 17 15 04 04 1D 03 1F 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 10 15 
[+] - Purse1               - FD A8 28 34 03 93 C0 AE 12 E0 25 30 40 70 00 1B 58 00 07 F0 66 0D 00 00 00 00 00 00 00 
[+] - Purse2               - FE 0C 28 33 04 F8 C0 AE C9 49 C8 18 07 A1 00 1D B0 00 06 D2 5B E8 00 00 00 00 00 00 00 
[+] - Purse3               - FE 0C 28 33 04 F6 C0 AE C9 49 CD 05 22 C9 00 1F A4 00 05 B1 89 52 00 00 00 00 00 00 00 
[+] Select Top Up          - 85 17 14 04 04 1D 01 1F 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 10 14 
[+] - Topup1               - 28 32 00 C0 00 00 27 10 00 13 88 03 E6 AE 10 D1 6E 0E AE 5D 00 02 11 04 CB 00 00 00 00 
[+] Select 1TIC.ICA        - 6F 28 84 0E 31 54 49 43 2E 49 43 41 D4 84 01 01 91 01 A5 16 BF 0C 13 C7 08 00 00 00 00 95 17 07 59 53 07 0A C0 26 C0 20 0B 20 
[usb] pm3 --> hf 14b mobib -o
[+] SELECT AID 1TIC.ICA    - 6F 28 84 0E 31 54 49 43 2E 49 43 41 D4 84 01 01 91 01 A5 16 BF 0C 13 C7 08 00 00 00 00 95 17 07 59 53 07 0A C0 26 C0 20 0B 20 
[=] Select ICC file a      - Sending command failed (6a82 - File not found).
[=] Select ICC file b      - Sending command failed (6a82 - File not found).
[=] - ICC                  - Sending command failed (6986 - Command not allowed (no current EF)).
[=] Select Holder file     - Sending command failed (6a82 - File not found).
[=] - Holder1              - Sending command failed (6986 - Command not allowed (no current EF)).
[=] - Holder2              - Sending command failed (6986 - Command not allowed (no current EF)).
[=] Select EnvHol file a   - Sending command failed (6b00 - Wrong parameter(s) P1-P2).
[+] Select EnvHol file b   - 85 17 00 02 00 00 00 10 10 00 00 01 03 00 00 00 C0 C0 C0 21 27 30 00 20 00 
[+] Select EnvHol file c   - 85 17 07 04 02 1D 02 1F 10 00 00 00 01 00 00 00 00 00 00 00 00 00 00 20 01 
[+] - EnvHol1              - 14 84 01 32 00 00 00 00 28 1C 36 5F 00 00 01 01 01 00 00 00 00 00 00 00 00 00 00 00 00 
[+] - EnvHol2              - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[+] Select EvLog file      - 85 17 08 04 04 1D 03 1F 10 10 10 00 03 03 03 00 00 00 00 00 00 00 00 20 10 
[+] - EvLog1               - 01 00 00 07 03 01 07 71 25 01 35 01 64 A2 00 02 58 07 71 25 01 35 01 64 A2 01 01 00 00 
[+] - EvLog2               - 01 00 00 06 03 01 32 22 35 01 35 00 66 CC 00 01 F4 32 22 35 01 35 00 66 CC 01 01 00 00 
[+] - EvLog3               - 01 00 00 05 03 01 32 22 35 0B 35 00 66 4B 00 01 F4 32 22 35 0B 35 00 66 4B 01 01 00 00 
[+] Select ConList file    - 85 17 1E 04 02 1D 01 1F 10 00 00 00 03 00 00 00 00 00 00 00 00 00 00 20 50 
[+] - ConList              - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[+] Select Contra file     - 85 17 09 04 02 1D 08 1F 10 10 00 00 02 03 00 00 00 00 00 00 00 00 00 20 20 
[+] - Contra1              - 01 01 17 CD 3C 01 32 81 80 00 00 00 00 00 00 00 28 32 AE 10 D1 6E 00 5A D4 C4 86 95 E3 
[+] - Contra2              - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[+] - Contra3              - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[+] - Contra4              - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[+] - Contra5              - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[+] - Contra6              - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[+] - Contra7              - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[+] - Contra8              - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[=] - Contra9              - Sending command failed (6a83 - Record not found).
[=] - ContraA              - Sending command failed (6a83 - Record not found).
[=] - ContraB              - Sending command failed (6a83 - Record not found).
[=] - ContraC              - Sending command failed (6a83 - Record not found).
[+] Select Counter file    - 85 17 19 04 09 1D 01 1F 10 10 10 00 02 03 02 00 00 00 00 00 00 00 00 20 69 
[+] - Counter              - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[=] Select LoadLog file a  - Sending command failed (6b00 - Wrong parameter(s) P1-P2).
[=] Select LoadLog file b  - Sending command failed (6a82 - File not found).
[=] Select LoadLog file c  - Sending command failed (6a82 - File not found).
[+] - LoadLog              - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[=] Select Purcha file     - Sending command failed (6a82 - File not found).
[+] - Purcha1              - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[=] - Purcha2              - Sending command failed (6a83 - Record not found).
[=] - Purcha3              - Sending command failed (6a83 - Record not found).
[=] Select SpecEv file a   - Sending command failed (6b00 - Wrong parameter(s) P1-P2).
[+] Select SpecEv file b   - 85 17 00 02 00 00 00 10 10 00 00 01 03 00 00 00 C0 C0 C0 21 27 30 00 20 00 
[+] Select SpecEv file c   - 85 17 1D 04 02 1D 01 1F 10 00 00 00 03 00 00 00 00 00 00 00 00 00 00 20 40 
[+] - SpecEv1              - 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
[=] - SpecEv2              - Sending command failed (6a83 - Record not found).
[=] - SpecEv3              - Sending command failed (6a83 - Record not found).
[=] - SpecEv4              - Sending command failed (6a83 - Record not found).
```