### PR TITLE
R&Y: Corrected `Jett's` Keys in `mfc_default_keys.dic`

### DIFF
--- a/client/dictionaries/mfc_default_keys.dic
+++ b/client/dictionaries/mfc_default_keys.dic
@@ -3,7 +3,6 @@
 #   -- Iceman Fork Version --
 #   -- Sharing is Caring --
 #   -- Contribute to This Dictionary --
-#   -- Last Updated Thu 23 Oct 25 (2300hrs CEST [UTC+02:00]) --
 #
 # Default key
 FFFFFFFFFFFF


### PR DESCRIPTION
# Updates
- `#` was removed from the `Jett's` keys making them valid keys once again.

Many thanks in advance, and kind regards,

-randy.