### PR TITLE
Fix for making ndefread CRC override work

### DIFF
--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -7129,7 +7129,10 @@ int CmdHFMFNDEFRead(const char *Cmd) {
     int res = MADCheck(sector0, sector10, verbose, &haveMAD2);
     if (res != PM3_SUCCESS) {
         PrintAndLogEx(ERR, "MAD error %d", res);
-        return res;
+        if (override)
+            PrintAndLogEx(INFO, "overriding CRC check");
+        else
+            return res;
     }
 
     uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};

--- a/client/src/cmdhfmfp.c
+++ b/client/src/cmdhfmfp.c
@@ -2203,7 +2203,10 @@ int CmdHFMFPNDEFRead(const char *Cmd) {
     int res = MADCheck(sector0, NULL, verbose, &haveMAD2);
     if (res != PM3_SUCCESS) {
         PrintAndLogEx(ERR, "MAD error %d", res);
-        return res;
+        if (override)
+            PrintAndLogEx(INFO, "overriding CRC check");
+        else
+            return res;
     }
 
     if (haveMAD2) {


### PR DESCRIPTION
The override feature from commit c3e29789a9 was incomplete. The return value from `MADCheck`, which happens before `MADDecode`, needs to be ignored also. Let me know if the patch is OK, or needs any changes.