### PR TITLE
Fix help description for lf indala brute command

### DIFF
--- a/client/src/cmdlfindala.c
+++ b/client/src/cmdlfindala.c
@@ -1096,7 +1096,7 @@ static int CmdIndalaBrute(const char *Cmd) {
 
 static command_t CommandTable[] = {
     {"help",     CmdHelp,            AlwaysAvailable, "This help"},
-    {"brute",    CmdIndalaBrute,     IfPm3Lf,         "Demodulate an Indala tag (PSK1) from the GraphBuffer"},
+    {"brute",    CmdIndalaBrute,     IfPm3Lf,         "Bruteforce an Indala reader with a specified facility code"},
     {"demod",    CmdIndalaDemod,     AlwaysAvailable, "Demodulate an Indala tag (PSK1) from the GraphBuffer"},
     {"altdemod", CmdIndalaDemodAlt,  AlwaysAvailable, "Alternative method to demodulate samples for Indala 64 bit UID (option '224' for 224 bit)"},
     {"reader",   CmdIndalaReader,    IfPm3Lf,         "Read an Indala tag from the antenna"},

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1155,7 +1155,7 @@ Check column "offline" for their availability.
 |command                  |offline |description
 |-------                  |------- |-----------
 |`lf indala help         `|Y       |`This help`
-|`lf indala brute        `|N       |`Demodulate an Indala tag (PSK1) from the GraphBuffer`
+|`lf indala brute        `|N       |`Bruteforce an Indala reader with a specified facility code`
 |`lf indala demod        `|Y       |`Demodulate an Indala tag (PSK1) from the GraphBuffer`
 |`lf indala altdemod     `|Y       |`Alternative method to demodulate samples for Indala 64 bit UID (option '224' for 224 bit)`
 |`lf indala reader       `|N       |`Read an Indala tag from the antenna`


### PR DESCRIPTION
Fixes invalid help message for the "lf indala brute" command.