### PR TITLE
Fix invalid  country code len for lf fdxb reader command

### DIFF
--- a/client/src/cmdlffdxb.c
+++ b/client/src/cmdlffdxb.c
@@ -569,7 +569,7 @@ int demodFDXB(bool verbose) {
 
     if (verbose == false) {
         PROMPT_CLEARLINE;
-        PrintAndLogEx(SUCCESS, "Animal ID........... " _GREEN_("%04u-%012"PRIu64), countryCode, NationalCode);
+        PrintAndLogEx(SUCCESS, "Animal ID........... " _GREEN_("%03u-%012"PRIu64), countryCode, NationalCode);
         return PM3_SUCCESS;
     }
 


### PR DESCRIPTION
When running "lf fdxb reader" in continuous mode, the country code was formatted as 4 chars long instead of 3. 