### PR TITLE
Improve felica read block

### DIFF
--- a/include/iso18.h
+++ b/include/iso18.h
@@ -88,7 +88,6 @@ typedef struct {
     felica_status_flags_t status_flags;
     uint8_t number_of_block[1];
     uint8_t block_data[16];
-    uint8_t block_element_number[1];
 } PACKED felica_read_without_encryption_response_t;
 
 typedef struct {


### PR DESCRIPTION
- Use 2 bytes when formatting block number in reads (technically, FeliCa supports high block values with 3-byte-long node code);
- Remove `block_element_number` from `felica_read_without_encryption_response_t` as no such field exists in response data in reality. Instead, pass block offset into the printing command from the initial caller;
- Print statuses on a single line to make output format more uniform when "dumping" block data sequentially;
- Add a warning explaining why a response to `rdbl` may not have arrived.
 