### PR TITLE
[hf seos] Carry when incrementing

### DIFF
--- a/client/src/cmdhfseos.c
+++ b/client/src/cmdhfseos.c
@@ -164,9 +164,10 @@ static int decrypt_cryptogram(uint8_t *key, uint8_t *input, uint8_t *out, int in
 
 static void increment_command_wrapper(uint8_t *input, int input_len) {
     // Increment the end of the header by 1
-    uint32_t value = MemBeToUint4byte(&input[input_len - sizeof(uint32_t)]);
+    uint8_t* offset = &input[input_len - sizeof(uint32_t)];
+    uint32_t value = MemBeToUint4byte(offset);
     value++;
-    Uint4byteToMemBe(&input[input_len - sizeof(uint32_t)], value);
+    Uint4byteToMemBe(offset, value);
 }
 
 static void padToBlockSize(const uint8_t *input, int *inputSize, int blockSize, uint8_t *output) {


### PR DESCRIPTION
Currently we only increment the last byte of the input, even if it overflows from 0xFF back to 0x00. I tested this behavior against a real Seos card by setting the RND.IFD to all-0xFFs and the card failed to read. After adding this patch and testing again, the card was successfully read.