### PR TITLE
Add qrcode sources to CMakeLists in the experimental lib

### DIFF
--- a/client/experimental_lib/CMakeLists.txt
+++ b/client/experimental_lib/CMakeLists.txt
@@ -425,6 +425,7 @@ set (TARGET_SOURCES
         ${PM3_ROOT}/client/src/pm3_binlib.c
         ${PM3_ROOT}/client/src/pm3_bitlib.c
         ${PM3_ROOT}/client/src/pm3line.c
+        ${PM3_ROOT}/client/src/qrcode/qrcode.c
         ${PM3_ROOT}/client/src/scandir.c
         ${PM3_ROOT}/client/src/scripting.c
         ${PM3_ROOT}/client/src/ui.c


### PR DESCRIPTION
The experimental_lib CMakeLists.txt file is missing the source file for the qrcode functionality, which includes symbols for e.g. `qrcode_print_matrix_utf8`. The lib builds without errors, but when trying to use it for example in python an error is presented:
`undefined symbol: qrcode_print_matrix_utf8`. This is fixed by adding the qrcode sources to CMakeLists.txt.