### PR TITLE
Fix `ROTR` conflict

### DIFF
--- a/common/generator.c
+++ b/common/generator.c
@@ -143,7 +143,7 @@ uint32_t ul_ev1_pwdgenC(const uint8_t *uid) {
     memcpy(base, uid, 7);
 
     for (int i = 0; i < 8; i++) {
-        pwd = base[i] + ROTR(pwd, 25) + ROTR(pwd, 10) - pwd;
+        pwd = base[i] + PM3_ROTR(pwd, 25) + PM3_ROTR(pwd, 10) - pwd;
     }
     return BSWAP_32(pwd);
 }

--- a/include/common.h
+++ b/include/common.h
@@ -94,8 +94,8 @@ extern bool g_tearoff_enabled;
 //#define RAMFUNC __attribute((long_call, section(".ramfunc")))
 #define RAMFUNC __attribute((long_call, section(".ramfunc"))) __attribute__((target("arm")))
 
-#ifndef ROTR
-# define ROTR(x,n) (((uintmax_t)(x) >> (n)) | ((uintmax_t)(x) << ((sizeof(x) * 8) - (n))))
+#ifndef PM3_ROTR
+# define PM3_ROTR(x,n) (((uintmax_t)(x) >> (n)) | ((uintmax_t)(x) << ((sizeof(x) * 8) - (n))))
 #endif
 
 #ifndef PM3_ROTL


### PR DESCRIPTION
MbedTLS also defines a `ROTR` method, but does not check if it has already been defined elsewhere. This PR renames the usages in the main Proxmark code to avoid this conflict.