### PR TITLE
[hf seos] Allow short SIO

### DIFF
--- a/client/src/cmdhfseos.c
+++ b/client/src/cmdhfseos.c
@@ -349,7 +349,7 @@ static int seos_get_data(uint8_t *rndICC, uint8_t *rndIFD, uint8_t *diversified_
     int getDataSize = 0;
 
     // ------------------- Cryptogram Response -------------------
-    if (resplen >= 2 && response[0] == 0x85 && response[1] >= 0x40) {
+    if (resplen >= 2 && response[0] == 0x85) {
         uint8_t cryptogram_length = response[1];
         uint8_t cryptogram[cryptogram_length];
         uint8_t decrypted[cryptogram_length];


### PR DESCRIPTION
Normally, a standard HID SIO should be long enough to result in a cryptogram of at least 0x40 bytes. However, the Seos card has no requirement for minimum data length, so it would be nice to be able to store and retrieve any length value.

This is especially useful while playing with writing, as nothing technically prevents you from just writing `0500` to the card.