### PR TITLE
Added pla.c to experimental client lib CMakeLists

### DIFF
--- a/client/experimental_lib/CMakeLists.txt
+++ b/client/experimental_lib/CMakeLists.txt
@@ -420,6 +420,7 @@ set (TARGET_SOURCES
         ${PM3_ROOT}/client/src/iso4217.c
         ${PM3_ROOT}/client/src/jansson_path.c
         ${PM3_ROOT}/client/src/lua_bitlib.c
+        ${PM3_ROOT}/client/src/pla.c
         ${PM3_ROOT}/client/src/preferences.c
         ${PM3_ROOT}/client/src/pm3.c
         ${PM3_ROOT}/client/src/pm3_binlib.c


### PR DESCRIPTION
Added a missing symbol from the experimental client lib: `undefined symbol: pla_parse_ecp_subcommand`