### PR TITLE
Fix UDEV warnings

### DIFF
--- a/driver/77-pm3-usb-device-blacklist-uucp.rules
+++ b/driver/77-pm3-usb-device-blacklist-uucp.rules
@@ -10,13 +10,13 @@
 ACTION!="add|change", GOTO="pm3_usb_device_blacklist_end"
 SUBSYSTEM!="tty", GOTO="pm3_ignore"
 
-ATTRS{idVendor}=="2d2d" ATTRS{idProduct}=="504d", ENV{ID_MM_DEVICE_IGNORE}="1" SYMLINK+="pm3-%n" MODE="660" GROUP="uucp"
-ATTRS{idVendor}=="9ac4" ATTRS{idProduct}=="4b8f", ENV{ID_MM_DEVICE_IGNORE}="1" SYMLINK+="pm3-%n" MODE="660" GROUP="uucp"
-ATTRS{idVendor}=="502d" ATTRS{idProduct}=="502d", ENV{ID_MM_DEVICE_IGNORE}="1" SYMLINK+="pm3-%n" MODE="660" GROUP="uucp"
+ATTRS{idVendor}=="2d2d", ATTRS{idProduct}=="504d", ENV{ID_MM_DEVICE_IGNORE}="1", SYMLINK+="pm3-%n", MODE="660", GROUP="uucp"
+ATTRS{idVendor}=="9ac4", ATTRS{idProduct}=="4b8f", ENV{ID_MM_DEVICE_IGNORE}="1", SYMLINK+="pm3-%n", MODE="660", GROUP="uucp"
+ATTRS{idVendor}=="502d", ATTRS{idProduct}=="502d", ENV{ID_MM_DEVICE_IGNORE}="1", SYMLINK+="pm3-%n", MODE="660", GROUP="uucp"
 
 LABEL="pm3_ignore"
-ATTRS{idVendor}=="2d2d" ATTRS{idProduct}=="504d", ENV{ID_MM_DEVICE_IGNORE}="1"
-ATTRS{idVendor}=="9ac4" ATTRS{idProduct}=="4b8f", ENV{ID_MM_DEVICE_IGNORE}="1"
-ATTRS{idVendor}=="502d" ATTRS{idProduct}=="502d", ENV{ID_MM_DEVICE_IGNORE}="1"
+ATTRS{idVendor}=="2d2d", ATTRS{idProduct}=="504d", ENV{ID_MM_DEVICE_IGNORE}="1"
+ATTRS{idVendor}=="9ac4", ATTRS{idProduct}=="4b8f", ENV{ID_MM_DEVICE_IGNORE}="1"
+ATTRS{idVendor}=="502d", ATTRS{idProduct}=="502d", ENV{ID_MM_DEVICE_IGNORE}="1"
 
 LABEL="pm3_usb_device_blacklist_end"


### PR DESCRIPTION
On Linux, running `udevadm verify` results in the following warnings:
```
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:13 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:13 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:13 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:13 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:14 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:14 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:14 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:14 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:15 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:15 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:15 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:15 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:18 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:19 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules:20 style: a comma between tokens is expected.
/etc/udev/rules.d/77-pm3-usb-device-blacklist.rules: udev rules have style issues.
```

This PR fixes these warnings.