### PR TITLE
Promote MFUL readblock `bytelen`

### DIFF
--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -401,7 +401,7 @@ typedef struct {
 } PACKED mful_readblock_t;
 
 typedef struct {
-    uint8_t bytelen;
+    uint16_t bytelen;
     uint16_t startidx;
 } PACKED mful_readblock_resp_t;
 


### PR DESCRIPTION
Resolves #3087. Copied from that issue description:
> The `hf mfu dump` quantity parameter `-q` seems to overflow with values over 64. This happens e.g. when dumping pages from NTAG 216 888bytes (NT2H1611G0DU) which has 230 pages of memory.

The issue comes from [mifarecmd.c#L604](github.com/RfidResearchGroup/proxmark3/blob/dda3093e6ec54a5edf4cc1dd22218ace71e9c268/armsrc/mifarecmd.c#L604), where the number of pages read is multipled by 4 to calculate the number of bytes read. 64 pages * 4 bytes per page = 256 bytes, which overflows the `uint8_t bytelen`.