### PR TITLE
Fix #3093

### DIFF
--- a/client/luascripts/hf_legic_clone.lua
+++ b/client/luascripts/hf_legic_clone.lua
@@ -342,7 +342,7 @@ local function displaySegments(bytes)
         wrp = ''
         pld = ''
         Seg = getSegmentData(bytes, start, index)
-        if Seg == nil then return OOps("segment is nil") end
+        if Seg == nil then return oops("segment is nil") end
 
         KGH = CheckKgh(bytes, start, (start + Seg[4]))
 


### PR DESCRIPTION
Fixes https://github.com/RfidResearchGroup/proxmark3/issues/3093

This pull request fixes the type errors for the `hf_legic_clone` script.
This works with lua5.4.
I did not test any other lua version.