### PR TITLE
felica: use NG frames for commands

### DIFF
--- a/include/iso18.h
+++ b/include/iso18.h
@@ -28,6 +28,20 @@ typedef enum FELICA_COMMAND {
     FELICA_NO_SELECT = (1 << 6),
 } felica_command_t;
 
+typedef struct {
+    uint8_t flags;      // PM3 flags, see felica_command_t
+    uint16_t numbits;   // optional number of bits for raw exchange
+    uint16_t rawlen;    // bytes in raw[]
+    uint8_t raw[];
+} PACKED felica_raw_cmd_t;
+
+#define FELICA_RAW_LEN(x) (sizeof(felica_raw_cmd_t) + (x))
+
+typedef struct {
+    uint8_t completed;
+    uint16_t tracelen;
+} PACKED felica_lite_dump_resp_t;
+
 //-----------------------------------------------------------------------------
 // FeliCa
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
* Convert client code felica to NG command format;
* Handle ng frames in felica_sendraw;
* Fix length validation issue in `hf felica raw`.

I've performed a sanity check by running the following `hf felica` commands after the change: 
- reader
- info
- dump
- scsvcode
- litedump
- sniff
- raw

I wasn't sure what to do with sub-command parsing in `appmain.c`, so I've decided to leave it as in there.


As for other improvements: I'm thinking about getting rid of `hf felica litedump` command on the arm side, instead merging that logic right into `hf felica dump` as a special case for systems 0x12fc and 0x88B4.
That change, though, may require some prerequisite ones (add support for specifying request code and system code when CONNECTing, allow commands to work without invoking prior `reader`).