### PR TITLE
[14a sniff] Stop sniff with Enter key

### DIFF
--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -852,10 +852,19 @@ void RAMFUNC SniffIso14443a(uint8_t param) {
 
     uint32_t rx_samples = 0;
 
+    uint16_t checker = 12000;
+
     // loop and listen
     while (BUTTON_PRESS() == false) {
         WDT_HIT();
         LED_A_ON();
+
+        if (checker-- == 0) {
+            if (data_available()) {
+                break;
+            }
+            checker = 12000;
+        }
 
         register int readBufDataP = data - dma->buf;
         register int dmaBufDataP = DMA_BUFFER_SIZE - AT91C_BASE_PDC_SSC->PDC_RCR;


### PR DESCRIPTION
This PR allows the user to stop an in-progress `hf 14a sniff -i` by pressing the Enter key. This can be useful in situations where the Proxmark's button is inconvenient to access, such as when sandwiched between a tag and a reader.

The value of `checker` is based on the timing [here](https://github.com/RfidResearchGroup/proxmark3/blob/478371222510de5bf02bb71f46e9f6281158c98b/armsrc/iso14443a.c#L1110). I've verified that it still sniffs correctly, but I'm happy to increase this further if necessary.