### PR TITLE
fix: use strip() when comparing PLATFORM_DEFS to avoid spurious rebuilds

### DIFF
--- a/common_arm/Makefile.hal
+++ b/common_arm/Makefile.hal
@@ -306,7 +306,7 @@ ifneq ($(PLATFORM), $(CACHED_PLATFORM))
     PLATFORM_CHANGED=true
 else ifneq ($(PLATFORM_EXTRAS), $(CACHED_PLATFORM_EXTRAS))
     PLATFORM_CHANGED=true
-else ifneq ($(PLATFORM_DEFS), $(CACHED_PLATFORM_DEFS))
+else ifneq ($(strip $(PLATFORM_DEFS)), $(strip $(CACHED_PLATFORM_DEFS)))
     PLATFORM_CHANGED=true
 endif
 


### PR DESCRIPTION
## Problem

`PLATFORM_DEFS` is built using `+=` on an initially empty variable in `common_arm/Makefile.hal`:

```makefile
PLATFORM_DEFS =
...
PLATFORM_DEFS += -DWITH_LF
PLATFORM_DEFS += -DWITH_HITAG
...
```

In GNU make, appending to an empty variable with `+=` produces a **leading space**: ` -DWITH_LF -DWITH_HITAG ...`

The cache file (`.Makefile.options.cache`) writes and reads back the value without the leading space: `-DWITH_LF -DWITH_HITAG ...`

So the comparison:
```makefile
ifneq ($(PLATFORM_DEFS), $(CACHED_PLATFORM_DEFS))
    PLATFORM_CHANGED=true
```
...always evaluates to `true` because `" -DWITH_LF..."` ≠ `"-DWITH_LF..."`.

This causes `PLATFORM_CHANGED=true` on **every single invocation**, triggering a clean of `bootrom/`, `armsrc/`, and `recovery/` mid-build — deleting ELF files right after they are produced. This makes `pm3-flash-bootrom` / `pm3-flash-all` fail with `Error - can't find bootrom.elf`.

## Fix

Wrap both sides of the `PLATFORM_DEFS` comparison with `$(strip ...)` so leading/trailing whitespace is ignored:

```makefile
else ifneq ($(strip $(PLATFORM_DEFS)), $(strip $(CACHED_PLATFORM_DEFS)))
```

## Testing

Verified on macOS (Apple Silicon) with `PM3GENERIC` platform. After this fix, `make all` completes without triggering the "Platform definitions changed" clean mid-build, and ELF files persist correctly.