### PR TITLE
Standalone mode Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The Proxmark3 is the swiss-army tool of RFID, allowing for interactions with the
 | [Linux - Important notes on ModemManager](/doc/md/Installation_Instructions/ModemManager-Must-Be-Discarded.md) | [Validating Proxmark3 Client Functionality](/doc/md/Use_of_Proxmark/1_Validation.md)|
 | [macOS - Homebrew & Upgrading HomeBrew Tap Formula](/doc/md/Installation_Instructions/macOS-Homebrew-Installation-Instructions.md) | [First Use and Verification](/doc/md/Use_of_Proxmark/2_Configuration-and-Verification.md)|
 | [macOS - MacPorts](/doc/md/Installation_Instructions/macOS-MacPorts-Installation-Instructions.md) | [Commands & Features](/doc/md/Use_of_Proxmark/3_Commands-and-Features.md)|
-| [macOS - Setup and Build](/doc/md/Installation_Instructions/macOS-Compile-From-Source-Instructions.md) ||
+| [macOS - Setup and Build](/doc/md/Installation_Instructions/macOS-Compile-From-Source-Instructions.md) |[Standalone Modes](/doc/standalone/)|
 | [Windows - Setup and Build](/doc/md/Installation_Instructions/Windows-Installation-Instructions.md) ||
 | [Termux / Android - Setup and Build](/doc/termux_notes.md) ||
 | [iOS - Setup and Build](/doc/md/Installation_Instructions/iOS-Installation-Instructions.md)
@@ -46,6 +46,7 @@ The Proxmark3 is the swiss-army tool of RFID, allowing for interactions with the
 | [Advanced Compilation Parameters](/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md) | [More Cheat Sheets](https://github.com/RfidResearchGroup/proxmark3/wiki/More-cheat-sheets)|
 | [Troubleshooting](/doc/md/Installation_Instructions/Troubleshooting.md) | [Complete Client Command Set](/doc/commands.md) |
 | [JTAG](/doc/jtag_notes.md) | [T5577 Introduction Guide](/doc/T5577_Guide.md)|
+
 
 
 

--- a/armsrc/Standalone/readme.md
+++ b/armsrc/Standalone/readme.md
@@ -5,6 +5,9 @@
 # Table of Contents
 - [Standalone Modes](#standalone-modes)
 - [Table of Contents](#table-of-contents)
+- [What are standalone modes?](#what-are-standalone-modes)
+   - [Individual mode documentation](#individual-mode-documentation)
+- [Developing Standalone Modes](#developing-standalone-modes)
   - [Implementing a standalone mode](#implementing-a-standalone-mode)
   - [Naming your standalone mode](#naming-your-standalone-mode)
   - [Update MAKEFILE.HAL](#update-makefilehal)
@@ -14,7 +17,67 @@
   - [Submitting your code](#submitting-your-code)
 
 
+Standalone modes run directly on the Proxmark3 device without a connected host computer.
+See [Developing Standalone Modes](#developing-standalone-modes) for how to build your own.
+> Only one (1) mode can be compiled into the firmware at a time (except via [DANKARMULTI](../../doc/standalone/dankarmulti.md)).
 
+## Individual Mode Documentation
+
+### LF (Low Frequency — 125 kHz) Standalone Modes
+
+| Mode ID | Document | Description | Hardware |
+|---------|----------|-------------|----------|
+| LF_SAMYRUN | [SamyRun](../../doc/standalone/lf_samyrun.md) | HID26 read/clone/simulate (Samy Kamkar) | Generic |
+| LF_EM4100EMUL | [EM4100 Emulator](../../doc/standalone/lf_em4100emul.md) | Simulate predefined EM4100 tag IDs | Generic |
+| LF_EM4100RSWB | [EM4100 RSWB](../../doc/standalone/lf_em4100rswb.md) | Read/simulate/write/brute EM4100 (4 slots) | RDV4 (flash) |
+| LF_EM4100RSWW | [EM4100 RSWW](../../doc/standalone/lf_em4100rsww.md) | Read/simulate/write/wipe/validate EM4100 | RDV4 (flash) |
+| LF_EM4100RWC | [EM4100 RWC](../../doc/standalone/lf_em4100rwc.md) | Read/simulate/clone EM4100 (16 slots) | RDV4 (flash) |
+| LF_HIDBRUTE | [HID Corporate Brute](../../doc/standalone/lf_hidbrute.md) | HID Corporate 1000 card number bruteforce | Generic |
+| LF_HIDFCBRUTE | [HID FC Brute](../../doc/standalone/lf_hidfcbrute.md) | HID facility code bruteforce (0–255) | RDV4 (flash) |
+| LF_ICEHID | [IceHID Collector](../../doc/standalone/lf_icehid.md) | Multi-format LF credential collector to flash | RDV4 (flash) |
+| LF_MULTIHID | [MultiHID](../../doc/standalone/lf_multihid.md) | HID 26-bit multi-card simulator | Generic |
+| LF_NEDAP_SIM | [Nedap Simulator](../../doc/standalone/lf_nedap_sim.md) | Nedap RFID simple tag simulator | Generic |
+| LF_NEXID | [NexID Collector](../../doc/standalone/lf_nexid.md) | Nexwatch credential collector to flash | RDV4 (flash) |
+| LF_PROXBRUTE | [ProxBrute](../../doc/standalone/lf_proxbrute.md) | HID ProxII card number bruteforce | Generic |
+| LF_PROX2BRUTE | [Prox2Brute](../../doc/standalone/lf_prox2brute.md) | HID ProxII bruteforce v2 (faster, configurable) | Generic |
+| LF_THAREXDE | [Tharexde EM4x50](../../doc/standalone/lf_tharexde.md) | EM4x50 simulate/read/collect | RDV4 (flash) |
+| LF_SKELETON | [Skeleton Template](../../doc/standalone/lf_skeleton.md) | Development template for new LF modes | Generic |
+
+### HF (High Frequency — 13.56 MHz) Standalone Modes
+
+| Mode ID | Document | Description | Hardware |
+|---------|----------|-------------|----------|
+| HF_14ASNIFF | [14A Sniffer](../../doc/standalone/hf_14asniff.md) | ISO14443A passive sniffer to flash | RDV4 (flash) |
+| HF_14BSNIFF | [14B Sniffer](../../doc/standalone/hf_14bsniff.md) | ISO14443B passive sniffer to flash | RDV4 (flash) |
+| HF_15SNIFF | [15693 Sniffer](../../doc/standalone/hf_15sniff.md) | ISO15693 sniffer to flash | RDV4 (flash) |
+| HF_15SIM | [15693 Simulator](../../doc/standalone/hf_15sim.md) | ISO15693 dump and simulate | RDV4 (flash) |
+| HF_AVEFUL | [Aveful UL Reader](../../doc/standalone/hf_aveful.md) | MIFARE Ultralight read and emulate | Generic |
+| HF_BOG | [BogitoRun Auth Sniffer](../../doc/standalone/hf_bog.md) | 14A sniff with ULC/ULEV1/NTAG auth capture | RDV4 (flash) |
+| HF_CARDHOPPER | [CardHopper Relay](../../doc/standalone/hf_cardhopper.md) | Long-range 14A relay over serial/IP | RDV4 (BT) |
+| HF_COLIN | [VIGIKPWN](../../doc/standalone/hf_colin.md) | MIFARE Classic ultra-fast sniff/sim/clone | RDV4 (flash) |
+| HF_CRAFTBYTE | [CraftByte UID Stealer](../../doc/standalone/hf_craftbyte.md) | Scan and emulate ISO14443A UIDs | Generic |
+| HF_DOEGOX_AUTH0 | [UL-C/UL-AES Unlocker](../../doc/standalone/hf_doegox_auth0.md) | Unlock password-protected Ultralight tags | Generic |
+| HF_EMVPNG | [EMV Visa Reader/Emulator](../../doc/standalone/hf_emvpng.md) | Read Visa EMV cards and emulate transactions | RDV4 (flash) |
+| HF_ICECLASS | [IceClass iCLASS](../../doc/standalone/hf_iceclass.md) | iCLASS multi-mode: sim/dump/attack/config | RDV4 (flash) |
+| HF_LEGIC | [Legic Prime Reader](../../doc/standalone/hf_legic.md) | Read and simulate Legic Prime tags | Generic |
+| HF_LEGICSIM | [Legic Prime Simulator](../../doc/standalone/hf_legicsim.md) | Simulate Legic Prime dumps from flash (15 slots) | RDV4 (flash) |
+| HF_MATTYRUN | [MattyRun MFC Clone](../../doc/standalone/hf_mattyrun.md) | MIFARE Classic key check, dump, and emulate | Generic |
+| HF_MFCSIM | [MFC Simulator](../../doc/standalone/hf_mfcsim.md) | Simulate MIFARE Classic 1K from flash (15 slots) | RDV4 (flash) |
+| HF_MSDSAL | [MSD Visa Reader](../../doc/standalone/hf_msdsal.md) | Read and emulate Visa MSD cards | Generic |
+| HF_REBLAY | [Reblay BT Relay](../../doc/standalone/hf_reblay.md) | ISO14443A relay over Bluetooth | RDV4 (BT) |
+| HF_ST25_TEAROFF | [ST25TB Tear-off](../../doc/standalone/hf_st25_tearoff.md) | ST25TB store/restore with counter tear-off | RDV4 (flash) |
+| HF_TCPRST | [IKEA Rothult](../../doc/standalone/hf_tcprst.md) | IKEA Rothult ST25TA master key dump/emulation | Generic |
+| HF_TMUDFORD | [ISO15693 UID Emulator](../../doc/standalone/hf_tmudford.md) | Read and emulate ISO15693 UIDs | Generic |
+| HF_UNISNIFF | [Universal Sniffer](../../doc/standalone/hf_unisniff.md) | Multi-protocol sniffer (14A/14B/15/iCLASS) | RDV4 (flash) |
+| HF_YOUNG | [Young MFC Sniff/Sim](../../doc/standalone/hf_young.md) | MIFARE sniff/simulation with 2-bank storage | Generic |
+
+### Multi-Mode Loader
+
+| Mode ID | Document | Description |
+|---------|----------|-------------|
+| DANKARMULTI | [Dankarmulti Loader](../../doc/standalone/dankarmulti.md) | Combine multiple standalone modes into one firmware image |
+
+# Developing Standalone Modes
 This contains functionality for different StandAlone modes. The fullimage will be built given the correct compiler flags used. Build targets for these files are contained in `Makefile.inc` and `Makefile.hal`
 
 If you want to implement a new standalone mode, you need to implement the methods provided in `standalone.h`.

--- a/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md
+++ b/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md
@@ -111,7 +111,7 @@ You can also define multiple options like
 ^[Top](#top)
 
 The Iceman repository gives you to easily choose which standalone mode to embed in the firmware.
-
+Documentation for each standalone mode can be found in the [Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation).
 Here are the supported values you can assign to `STANDALONE` in `Makefile.platform`:
 
 | STANDALONE      | DESCRIPTION                            |

--- a/doc/standalone/dankarmulti.md
+++ b/doc/standalone/dankarmulti.md
@@ -1,0 +1,106 @@
+# DANKARMULTI — Multi-Mode Standalone Loader
+
+> **Author:** Daniel Karling (dankarmulti)
+> **Frequency:** Multi (LF + HF)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/dankarmulti.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+A meta-standalone mode that bundles **multiple** standalone modes into a single firmware image and lets you select which one to run at boot time using the button.
+
+## Why
+
+Normally the Proxmark3 can only have one standalone mode compiled in. If you want to switch modes, you must reflash the firmware. DANKARMULTI solves this by wrapping multiple standalone modes into one firmware — you cycle through them with button presses and hold to execute your chosen mode. This is ideal for field work where you need multiple capabilities without a laptop.
+
+## How
+
+1. **Boot**: On entering standalone mode, LEDs indicate the currently selected sub-mode.
+2. **Cycle**: Press the button to cycle through available sub-modes. LEDs change to indicate the new selection.
+3. **Execute**: Hold the button to launch the selected sub-mode. Once launched, that sub-mode takes full control (LEDs, button, etc.).
+4. **Exit**: Exiting the sub-mode returns to the DANKARMULTI selector.
+
+### Default Bundled Modes
+
+By default, DANKARMULTI includes:
+
+| Slot | Mode | Description |
+|------|------|-------------|
+| 1 | [HF_MATTYRUN](hf_mattyrun.md) | MIFARE Classic key check → nested → dump → emulate |
+| 2 | [LF_EM4100RSWB](lf_em4100rswb.md) | EM4100 read/sim/write/brute |
+| 3 | [HF_TCPRST](hf_tcprst.md) | IKEA Rothult / ST25TA password extractor |
+
+> Modes can be customized by editing the `dankarmulti.c` source — add or remove `#include`s and update the mode array.
+
+## LED Indicators
+
+| LED | Meaning (Selector) |
+|-----|---------------------|
+| **A** only | Mode 1 selected |
+| **B** only | Mode 2 selected |
+| **C** only | Mode 3 selected |
+| **D** only | Mode 4 selected (if present) |
+| **A+B** | Mode 5 selected (if present) |
+
+> Once a sub-mode is launched, that sub-mode's own LED scheme takes over.
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Single click** | Cycle to next sub-mode |
+| **Long hold** | Launch selected sub-mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Selector : Enter standalone
+
+    state Selector {
+        [*] --> Mode1
+        Mode1 --> Mode2 : Click
+        Mode2 --> Mode3 : Click
+        Mode3 --> Mode1 : Click\n(wraps)
+    }
+
+    Selector --> RunSubMode : Long hold
+
+    state RunSubMode {
+        [*] --> SubModeActive
+        SubModeActive --> SubModeActive : Sub-mode running\n(own LEDs/button)
+    }
+
+    RunSubMode --> Selector : Sub-mode exits
+    Selector --> [*] : USB connection
+```
+
+## Customising Bundled Modes
+
+Edit `armsrc/Standalone/dankarmulti.c`:
+
+1. Add `#include` for the desired standalone mode header
+2. Add entry to the `modes[]` array with the mode's `RunMod()` and `ModInfo()` functions
+3. Recompile:
+
+```bash
+make clean
+make STANDALONE=DANKARMULTI -j
+./pm3-flash-fullimage
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=DANKARMULTI -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [Standalone Modes Overview](../../armsrc/Standalone/readme.md) — Full list of all standalone modes
+- [Advanced Compilation](../md/Installation_Instructions/4_Advanced-compilation-parameters.md) — Compilation with STANDALONE= parameter

--- a/doc/standalone/hf_14asniff.md
+++ b/doc/standalone/hf_14asniff.md
@@ -1,0 +1,81 @@
+# HF_14ASNIFF — ISO14443A Passive Sniffer
+
+> **Author:** Micolous
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** RDV4 (flash and battery recommended)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_14asniff.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Passively sniffs ISO14443A (NFC Type A) communication between a reader and a card, storing captured frames to the RDV4's onboard flash memory (or RAM on generic hardware).
+
+## Why
+
+Many HF access control and payment systems use ISO14443A. By placing the Proxmark3 between a legitimate reader and card, you can capture the full communication — revealing authentication exchanges, data reads/writes, and protocol behavior. This is essential for:
+
+- **Protocol reverse engineering**: Understand how a reader communicates with cards
+- **Authentication capture**: Record authentication handshakes for later analysis
+- **System documentation**: Capture real traffic to document proprietary protocols
+
+## How
+
+1. Position the Proxmark3 antenna between a reader and card
+2. The device captures both reader-to-card and card-to-reader frames with timestamps
+3. Frames are buffered in RAM and flushed to flash on button press
+4. Retrieve the trace file from flash via the client for analysis with `hf 14a list`
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **1** (A) | Sniffing active |
+| **2** (B) | Tag command detected (off when reader finishes) |
+| **3** (C) | Reader command detected (off when tag finishes) |
+| **4** (D) | Flash unmounting / sync |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Short press** | Stop sniffing, save trace to flash, exit |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Sniffing : Startup\nFPGA HF mode
+
+    Sniffing --> Sniffing : Capture frames\nLEDs show activity
+    Sniffing --> SaveToFlash : Button press
+    
+    SaveToFlash --> [*] : Trace saved\nLED_D during unmount
+```
+
+## Retrieved Data
+
+After sniffing, connect via client and retrieve the trace:
+```
+mem spiffs dump -s hf_14asniff.trace -d hf_14asniff.trace
+trace load -f hf_14asniff.trace
+hf 14a list
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_14ASNIFF -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [14B Sniffer](hf_14bsniff.md) — ISO14443B sniffer
+- [15693 Sniffer](hf_15sniff.md) — ISO15693 sniffer
+- [Universal Sniffer](hf_unisniff.md) — Multi-protocol sniffer with runtime selection
+- [BogitoRun Auth Sniffer](hf_bog.md) — 14A sniffer with auth capture
+- [Trace Notes](../trace_notes.md) — Working with trace files

--- a/doc/standalone/hf_14bsniff.md
+++ b/doc/standalone/hf_14bsniff.md
@@ -1,0 +1,59 @@
+# HF_14BSNIFF — ISO14443B Passive Sniffer
+
+> **Author:** jacopo-j
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** RDV4 (flash recommended, optional)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_14bsniff.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Passively sniffs ISO14443B communication between a reader and card, saving captured frames to flash (or RAM).
+
+## Why
+
+ISO14443B is used by certain transit cards, national ID cards, and access control systems (e.g., CEPAS, Calypso). This sniffer captures the full communication exchange for protocol analysis.
+
+## How
+
+Identical workflow to [14A Sniffer](hf_14asniff.md) but tuned for the 14443B modulation scheme. Captured frames include both PICC (card) and PCD (reader) traffic.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **1** (A) | Sniffing active |
+| **2** (B) | Tag command |
+| **3** (C) | Reader command |
+| **4** (D) | Flash unmounting |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Short press** | Stop sniffing, save to flash, exit |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Sniffing : Startup
+
+    Sniffing --> SaveToFlash : Button press
+    SaveToFlash --> [*] : Saved to hf_14bsniff.trace
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_14BSNIFF -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [14A Sniffer](hf_14asniff.md) — ISO14443A sniffer
+- [Universal Sniffer](hf_unisniff.md) — Multi-protocol sniffer

--- a/doc/standalone/hf_15sim.md
+++ b/doc/standalone/hf_15sim.md
@@ -1,0 +1,66 @@
+# HF_15SIM — ISO15693 Dump and Simulate
+
+> **Author:** lnv42
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** RDV4 (flash memory)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_15sim.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Dumps an ISO15693 tag's complete memory, then simulates it. Auto-detects tag type (MIM1024, etc.) and specific attributes like DSFID and AFI.
+
+## Why
+
+ISO15693 tags are used in libraries, laundry systems, industrial asset tracking, and some access control. This mode enables read-then-replay attacks: capture a tag's full contents and then emulate it at a reader without the original tag present.
+
+## How
+
+1. **Wait**: Scans for an ISO15693 tag in the field
+2. **Dump**: On detection, reads all memory blocks and tag system info (DSFID, AFI, block size)
+3. **Simulate**: Begins emulating the captured tag with full memory contents
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **B** (solid) | Waiting for a dumpable tag |
+| LEDs off | Dumping / simulating |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Hold 500ms** | Exit standalone mode |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> WaitForTag : Startup\nLED_B on
+
+    WaitForTag --> DumpTag : ISO15693 tag found
+    WaitForTag --> WaitForTag : No tag / incompatible
+
+    DumpTag --> Simulate : Dump complete\n(all blocks read)
+    DumpTag --> WaitForTag : Dump failed
+
+    Simulate --> [*] : Button hold 500ms
+    WaitForTag --> [*] : Button hold 500ms
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_15SIM -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [ISO15693 UID Emulator](hf_tmudford.md) — Simpler 15693 UID emulation
+- [15693 Sniffer](hf_15sniff.md) — ISO15693 protocol sniffer

--- a/doc/standalone/hf_15sniff.md
+++ b/doc/standalone/hf_15sniff.md
@@ -1,0 +1,66 @@
+# HF_15SNIFF — ISO15693 Sniffer
+
+> **Author:** Nathan Glaser
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** RDV4 (flash recommended)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_15sniff.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Passively sniffs ISO15693 communication between reader and tag, storing captured frames to flash.
+
+## Why
+
+Capture and analyze the communication protocol between ISO15693 readers and tags for reverse engineering or security assessment.
+
+## How
+
+Captures bidirectional 15693 frames with timestamps. Note: timestamp counter overflows after approximately 5 minutes 16 seconds of continuous sniffing.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **1** (A) | Sniffing active |
+| **2** (B) | Tag command |
+| **3** (C) | Reader command |
+| **4** (D) | Flash sync |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Short press** | Stop and save trace to flash |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Sniffing : Startup
+
+    Sniffing --> SaveTrace : Button press
+    SaveTrace --> [*] : Saved
+
+    note right of Sniffing
+        Timestamp overflow
+        at ~5min 16sec
+    end note
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_15SNIFF -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [14A Sniffer](hf_14asniff.md) — ISO14443A sniffer
+- [14B Sniffer](hf_14bsniff.md) — ISO14443B sniffer
+- [Universal Sniffer](hf_unisniff.md) — Multi-protocol sniffer
+- [15693 Simulator](hf_15sim.md) — ISO15693 dump and simulate

--- a/doc/standalone/hf_aveful.md
+++ b/doc/standalone/hf_aveful.md
@@ -1,0 +1,84 @@
+# HF_AVEFUL — MIFARE Ultralight Read/Simulation
+
+> **Author:** Ave Ozkal
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_aveful.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Reads MIFARE Ultralight family cards (UL, ULEV1, UL Nano, My-d Move) and then emulates the captured card. Auto-detects the card type and block count.
+
+## Why
+
+MIFARE Ultralight is widely used in transit systems, event tickets, and small-value tokens. This mode enables standalone read-and-replay for:
+
+- **Transit fare evasion testing**: Capture a valid ticket and present it at a gate
+- **Ticket cloning assessment**: Demonstrate that UL tickets can be replayed
+- **NFC application testing**: Verify that applications properly validate UL tags
+
+## How
+
+1. **SEARCH**: Scans for MIFARE Ultralight cards using anticollision
+2. **READ**: Upon finding a card, detects its type via the VERSION command and reads all accessible blocks
+3. **EMULATE**: Loads the captured data into the emulator and broadcasts it as a MIFARE Ultralight tag
+
+Supports auto-detection of: MIFARE Ultralight, Ultralight EV1, Ultralight Nano, and My-d Move.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **D** (off during idle) | Blinks during tag search |
+| LED patterns | Success/failure indication |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Hold 1000ms** | Cycle states or exit: SEARCH → READ → EMULATE → exit |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> SEARCH : Startup
+
+    SEARCH --> READ : UL card found
+    SEARCH --> SEARCH : No card / incompatible
+
+    READ --> EMULATE : All blocks read
+    READ --> SEARCH : Read failed
+
+    EMULATE --> SEARCH : Button hold\n(cycle back)
+    EMULATE --> [*] : Button hold\n(exit)
+
+    SEARCH --> [*] : Button hold (exit)
+```
+
+## Supported Cards
+
+| Card Type | Detection |
+|-----------|-----------|
+| MIFARE Ultralight | VERSION command response |
+| MIFARE Ultralight EV1 | VERSION command response |
+| MIFARE Ultralight Nano | VERSION command response |
+| My-d Move | VERSION command response |
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_AVEFUL -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [UL-C/UL-AES Unlocker](hf_doegox_auth0.md) — Unlock password-protected UL cards
+- [BogitoRun Auth Sniffer](hf_bog.md) — Capture UL authentication passwords
+- [CraftByte UID Stealer](hf_craftbyte.md) — Generic 14A UID emulator

--- a/doc/standalone/hf_bog.md
+++ b/doc/standalone/hf_bog.md
@@ -1,0 +1,68 @@
+# HF_BOG — 14A Sniffer with ULC/ULEV1/NTAG Auth Capture
+
+> **Author:** Bogito
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** RDV4 (requires flash memory)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_bog.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+An enhanced ISO14443A sniffer that specifically extracts and stores ULC, ULEV1, and NTAG authentication passwords from sniffed traffic.
+
+## Why
+
+Many MIFARE Ultralight deployments use password authentication (PWD_AUTH) to protect data. By sniffing the communication between a legitimate reader and card, you capture the authentication passwords in plaintext. This is more targeted than generic sniffing — it automatically extracts and logs just the passwords.
+
+## How
+
+1. Passively sniffs ISO14443A traffic
+2. Parses captured frames looking for authentication commands (PWD_AUTH, 3DES AUTH for ULC)
+3. Extracts up to 64 authentication attempts per session
+4. Saves extracted passwords to `hf_bog.log` on flash
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | Sniffing activity |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Short press** | Stop sniffing, save auth data to flash |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Sniffing : Startup
+
+    Sniffing --> Sniffing : Parse frames\nExtract auth attempts
+    Sniffing --> SaveAuth : Button press
+
+    SaveAuth --> [*] : Saved to hf_bog.log\n(up to 64 auth attempts)
+```
+
+## Flash Storage
+
+- **Log file**: `hf_bog.log`
+- Stores extracted authentication passwords/keys
+- Up to 64 auth attempts per session
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_BOG -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [14A Sniffer](hf_14asniff.md) — Generic 14A sniffer (captures all frames)
+- [Aveful UL Reader](hf_aveful.md) — Read and emulate UL cards
+- [UL-C/UL-AES Unlocker](hf_doegox_auth0.md) — Unlock password-protected UL cards

--- a/doc/standalone/hf_cardhopper.md
+++ b/doc/standalone/hf_cardhopper.md
@@ -1,0 +1,90 @@
+# HF_CARDHOPPER — Long-Range 14A Relay over IP
+
+> **Author:** Sam Haskins
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** RDV4 with Bluetooth (BlueShark) or serial add-on
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_cardhopper.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+A relay attack framework that tunnels ISO14443A communication over a serial/IP backbone. One Proxmark3 sits near the target reader (CARD mode), another near the victim's card (READER mode), and the relayed data bridges any distance.
+
+## Why
+
+Relay attacks demonstrate that proximity-based access control can be defeated remotely. Even "tap to pay" and "tap to enter" systems are vulnerable when the communication can be tunneled over the internet. CardHopper demonstrates this in a practical, standalone way without requiring a laptop at either end.
+
+Use cases:
+- **Relay attacks on NFC payments**: Demonstrate contactless payment relay risks
+- **Access control relay**: Bypass door readers by relaying a badge from another location
+- **Security awareness**: Show stakeholders that NFC proximity offers limited protection
+
+## How
+
+1. **CARD mode** (at reader): Emulates an ISO14443A card and forwards all reader commands over serial/BT
+2. **READER mode** (at card): Receives forwarded commands, sends them to the real card, and returns responses
+3. The two devices communicate via serial/Bluetooth/IP, transparently relaying the full ISO14443A session
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A + D** (solid) | Alive / running indicator |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Button press** | Exit mode |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Init : Startup
+
+    state Init {
+        [*] --> READER : Config = Reader mode
+        [*] --> CARD : Config = Card mode
+    }
+
+    state READER {
+        WaitCommand --> SendToCard : Command from serial
+        SendToCard --> SendResponse : Card responds
+        SendResponse --> WaitCommand : Response sent to serial
+    }
+
+    state CARD {
+        WaitReaderCmd --> ForwardToRemote : Reader command received
+        ForwardToRemote --> ForwardToReader : Remote card response
+        ForwardToReader --> WaitReaderCmd : Response forwarded
+    }
+
+    READER --> [*] : Button / Reset
+    CARD --> [*] : Button / Reset
+```
+
+## Setup
+
+Requires two Proxmark3 RDV4 devices:
+1. **Near reader**: Running in CARD mode with BT/serial connection
+2. **Near card**: Running in READER mode with BT/serial connection
+3. Both connected via serial link (direct, Bluetooth, or TCP/IP bridge)
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_CARDHOPPER -j
+./pm3-flash-fullimage
+```
+
+Requires `PLATFORM_EXTRAS=BTADDON` or FPC serial connection.
+
+## Related
+
+- [Reblay BT Relay](hf_reblay.md) — Similar 14A relay over Bluetooth
+- [14A Sniffer](hf_14asniff.md) — Passive capture instead of active relay

--- a/doc/standalone/hf_colin.md
+++ b/doc/standalone/hf_colin.md
@@ -1,0 +1,71 @@
+# HF_COLIN — VIGIKPWN MIFARE Classic Ultra-Fast Sniff/Sim/Clone
+
+> **Author:** Colin Brigato
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** RDV4 (requires flash memory)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_colin.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+A specialized MIFARE Classic attack mode designed for French VIGIK access control systems. It performs fast authentication attempts using ~37 hardcoded VIGIK keys, dumps the card, and can simulate or clone it.
+
+## Why
+
+VIGIK is a widely deployed intercom/access control system in French apartment buildings. It uses MIFARE Classic with a known set of keys. This mode automates the entire VIGIK attack chain — from key discovery to cloning — entirely on-device.
+
+## How
+
+1. **SEARCH**: Scans for MIFARE Classic cards
+2. **READ**: Attempts authentication with hardcoded VIGIK keys, reads accessible sectors
+3. **LOAD**: Loads captured data for simulation via JSON schema
+4. **EMULATE**: Simulates the captured card
+
+The mode uses a terminal-style UI with cursor positioning for status display.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| Complex terminal UI | Uses debug output for status rather than traditional LED patterns |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| Various presses | Trigger different functions in the UI |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> SEARCH : Startup
+
+    SEARCH --> READ : MFC card found
+    READ --> LOAD : Keys found,\nsectors dumped
+    LOAD --> EMULATE : Data loaded
+
+    EMULATE --> SEARCH : Cycle back
+    
+    READ --> SEARCH : No valid keys
+    
+    SEARCH --> [*] : Exit
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_COLIN -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [MattyRun MFC Clone](hf_mattyrun.md) — Generic MIFARE Classic attack
+- [MFC Simulator](hf_mfcsim.md) — MFC simulation from flash
+- [Young MFC Sniff/Sim](hf_young.md) — MFC sniff and simulation
+- [MIFARE Classic Notes](../mfc_notes.md) — Key recovery techniques
+- [Magic Cards Notes](../magic_cards_notes.md) — Writable magic card types

--- a/doc/standalone/hf_craftbyte.md
+++ b/doc/standalone/hf_craftbyte.md
@@ -1,0 +1,67 @@
+# HF_CRAFTBYTE — ISO14443A UID Stealer/Emulator
+
+> **Author:** Anze Jensterle
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_craftbyte.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Continuously scans for ISO14443A cards, captures their UIDs, and emulates them. Auto-detects card type (MFC 1K/4K, MIFARE Ultralight, DESFire).
+
+## Why
+
+Many access control systems rely primarily (or solely) on the UID of an NFC card for identification, without performing proper cryptographic authentication. CraftByte exploits this by capturing and replaying UIDs — demonstrating that UID-based access control is trivially defeated.
+
+## How
+
+1. **READ**: Performs ISO14443A anticollision to read the card's UID, ATQA, and SAK
+2. **EMULATE**: Uses the captured UID to emulate the card at a reader
+
+The mode detects the card type from ATQA/SAK and configures emulation accordingly.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| Minimal LED usage | Focus on read/emulate cycle |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Hold 1000ms** | Cycle: READ → EMULATE, or exit if held continuously |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> READ : Startup
+
+    READ --> EMULATE : UID captured\n(button hold)
+    EMULATE --> READ : Button hold\n(scan new card)
+    
+    READ --> READ : Scanning...
+    EMULATE --> EMULATE : Emulating...
+
+    READ --> [*] : Long hold / USB data
+    EMULATE --> [*] : Long hold / USB data
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_CRAFTBYTE -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [Aveful UL Reader](hf_aveful.md) — Full UL read/emulate (not just UID)
+- [MattyRun MFC Clone](hf_mattyrun.md) — Full MFC attack (keys + data)
+- [Young MFC Sniff/Sim](hf_young.md) — MFC UID capture with 2-bank storage

--- a/doc/standalone/hf_doegox_auth0.md
+++ b/doc/standalone/hf_doegox_auth0.md
@@ -1,0 +1,77 @@
+# HF_DOEGOX_AUTH0 — Ultralight C / Ultralight AES Unlocker
+
+> **Author:** Philippe Teuwen (doegox)
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** Generic Proxmark3 (RDV4 with 9V antenna recommended)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_doegox_auth0.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Performs a relay-style attack to unlock password-protected MIFARE Ultralight C or Ultralight AES tags by rewriting the AUTH0 configuration byte during an authenticated session.
+
+## Why
+
+MIFARE Ultralight C and AES variants can password-protect their memory by setting an AUTH0 byte that specifies the first page requiring authentication. If AUTH0 itself is writable during an authenticated session, this mode exploits that window — during a legitimate reader's auth handshake — to rewrite AUTH0 to a higher page number, effectively unlocking all previously protected pages.
+
+This is a sophisticated attack that requires precise timing and makes protected data permanently accessible.
+
+## How
+
+1. **LOOK**: Search for an Ultralight C or AES tag
+2. **SNIFF**: Position the Proxmark3 to sniff the authentication exchange between the legitimate reader and the card
+3. **WAIT**: Press button when ready to attempt the AUTH0 rewrite
+4. **WRITE**: During the next auth session, inject a write command to AUTH0 that unlocks the card
+5. **Result**: LED indicates success (solid) or failure (blink)
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | Looking for card / preparing |
+| **B** (solid) | Card found |
+| **C** (solid) | Sniffing for auth exchange |
+| **D** (solid) | Write successful |
+| **D** (blinking) | Write failed |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Press (1 sec)** | Initiate AUTH0 write during next auth sniff |
+| **Button press** | Exit mode (from other states) |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> LOOK_FOR_CARD : Startup\nLED_A
+
+    LOOK_FOR_CARD --> SNIFF_AUTH : ULC/ULAES found\nLED_B → LED_C
+    LOOK_FOR_CARD --> LOOK_FOR_CARD : No compatible card
+
+    SNIFF_AUTH --> WAIT_BUTTON : Auth detected
+    WAIT_BUTTON --> WAIT_RELEASE : Button pressed\n(ready to write)
+    WAIT_RELEASE --> WRITE_AUTH0 : Button released
+
+    WRITE_AUTH0 --> EXIT_SUCCESS : AUTH0 rewritten\nLED_D solid
+    WRITE_AUTH0 --> EXIT_FAIL : Write failed\nLED_D blink
+
+    EXIT_SUCCESS --> [*]
+    EXIT_FAIL --> [*]
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_DOEGOX_AUTH0 -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [BogitoRun Auth Sniffer](hf_bog.md) — Capture UL auth passwords
+- [Aveful UL Reader](hf_aveful.md) — Read/emulate UL cards

--- a/doc/standalone/hf_emvpng.md
+++ b/doc/standalone/hf_emvpng.md
@@ -1,0 +1,72 @@
+# HF_EMVPNG — EMV Visa Card Reader/Emulator
+
+> **Author:** Davi Mikael (Penegui)
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** RDV4 (flash memory)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_emvpng.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Reads Visa EMV contactless payment cards and emulates the captured transaction data with a fixed ARQC (Authorization Request Cryptogram). **For educational and lab use only.**
+
+## Why
+
+Demonstrates the theoretical vulnerability of contactless payment cards to replay attacks when terminals don't properly validate cryptograms. This mode is designed for controlled lab environments to:
+
+- **Educate**: Show how EMV contactless transactions work at the protocol level
+- **Research**: Study EMV protocol behavior and terminal validation
+- **Test terminals**: Verify that terminals properly reject replayed transactions
+
+> ⚠ **Warning**: This mode uses a fixed ARQC. Modern payment terminals will reject these transactions. This is for educational purposes only.
+
+## How
+
+1. **READ**: Select the Visa application (PPSE/AID), read Track 2 data
+2. **EMULATE**: Present captured Track 2 data with a fixed ARQC when queried by a terminal
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | Reading mode |
+| **B** (solid) | Activity indicator |
+| **C** (solid) | Emulation mode |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Single click** | Toggle between READ and EMULATE modes |
+| **Long hold** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> READ : Startup
+
+    READ --> EMULATE : Card read\n+ button click
+    EMULATE --> READ : Button click
+
+    READ --> READ : Waiting for Visa card
+    EMULATE --> EMULATE : Emulating with fixed ARQC
+
+    READ --> [*] : Long hold / USB data
+    EMULATE --> [*] : Long hold / USB data
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_EMVPNG -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [MSD Visa Reader](hf_msdsal.md) — Visa MSD (older format) reader/emulator
+- [EMV Notes](../emv_notes.md) — EMV protocol documentation

--- a/doc/standalone/hf_iceclass.md
+++ b/doc/standalone/hf_iceclass.md
@@ -1,0 +1,105 @@
+# HF_ICECLASS — iCLASS Multi-Mode Standalone
+
+> **Author:** Iceman
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** RDV4 (requires flash memory)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_iceclass.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+A multi-mode iCLASS standalone with **7 selectable modes** for different operations: full simulation, reader attack, dump-and-simulate, read-and-simulate, and configuration card creation. Only one mode is active per compile.
+
+## Why
+
+HID iCLASS is a widely deployed access control system. This mode provides a comprehensive toolkit for iCLASS assessment:
+
+- **Credential recovery**: Capture authentication data for offline key recovery (loclass attack)
+- **Badge simulation**: Emulate captured iCLASS credentials at readers
+- **Reader configuration**: Create config cards that can reconfigure iCLASS readers (e.g., downgrade attacks)
+
+## How
+
+The mode selected at compile time (`ICE_USE` macro) determines behavior:
+
+| ICE_USE Value | Mode | Description |
+|---------------|------|-------------|
+| ICE_USE_FULLSIM | Full Simulation | Emulate a complete iCLASS card from EEPROM dump |
+| ICE_USE_READER_ATTACK | Reader Attack | Capture authentication MACs for loclass recovery |
+| ICE_USE_DUMP_SIM | Dump & Simulate | Dump a card then immediately simulate it |
+| ICE_USE_READ_SIM | Read & Simulate | Read credential blocks and simulate |
+| ICE_USE_CONFIG_CARD | Config Card | Create configuration cards for reader reprogramming |
+
+The reader attack mode is particularly powerful: it captures the authentication exchange between a reader and cards, producing MAC pairs that feed into the loclass attack for key recovery.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **B** (solid/blink) | Attack mode activity |
+| **D** (solid) | General operation indicator |
+| Mode-specific patterns | Vary by selected ICE_USE mode |
+
+## Button Controls
+
+Vary by selected mode. Generally:
+
+| Action | Effect |
+|--------|--------|
+| **Button press** | Mode-specific action |
+| **Hold** | Exit standalone mode |
+
+## State Machine (Reader Attack Mode)
+
+```mermaid
+stateDiagram-v2
+    [*] --> WaitCard : Startup\n(Reader Attack mode)
+
+    WaitCard --> Authenticate : iCLASS card detected
+    Authenticate --> CaptureMAC : Auth exchange\ncaptured
+    CaptureMAC --> SaveFlash : MAC pair logged
+
+    SaveFlash --> WaitCard : Continue collecting
+    WaitCard --> [*] : Button hold / USB data
+
+    note right of CaptureMAC
+        MAC pairs used for
+        loclass key recovery
+    end note
+```
+
+## State Machine (Dump & Simulate Mode)
+
+```mermaid
+stateDiagram-v2
+    [*] --> ScanCard : Startup
+
+    ScanCard --> DumpCard : iCLASS card found
+    DumpCard --> LoadEmulator : Dump complete
+    LoadEmulator --> Simulate : Data loaded
+
+    Simulate --> [*] : Button hold / USB data
+    DumpCard --> ScanCard : Dump failed
+```
+
+## Flash Storage
+
+- Captured MAC pairs stored on SPI flash for later retrieval
+- EEPROM dumps stored for simulation modes
+- Configuration card templates
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_ICECLASS -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [Loclass Notes](../loclass_notes.md) — Loclass attack documentation
+- [HID Downgrade Attacks](../hid_downgrade.md) — Reader downgrade techniques
+- [IceHID Collector](lf_icehid.md) — LF HID credential collection (different protocol)

--- a/doc/standalone/hf_legic.md
+++ b/doc/standalone/hf_legic.md
@@ -1,0 +1,66 @@
+# HF_LEGIC — Legic Prime Read/Simulate
+
+> **Author:** uhei
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_legic.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Reads Legic Prime tags and simulates them. Auto-detects card type (MIM256, MIM512, MIM1024).
+
+## Why
+
+Legic Prime is a proprietary HF contactless technology used in European access control, time & attendance, and vending systems. This mode provides standalone read-and-replay capability.
+
+## How
+
+1. **Search**: Continuously scans for Legic Prime tags
+2. **Read**: On detection, dumps the tag memory (auto-detects size)
+3. **Simulate**: Broadcasts the captured tag data
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **C** (solid) | Searching for tag |
+| **A + B + C** (solid) | Reading tag |
+| **A + D** (solid) | Simulating tag |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Hold 280ms** | Exit standalone mode |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Search : Startup\nLED_C
+
+    Search --> Read : Legic Prime found\nLED_A+B+C
+    Read --> Simulate : Tag dumped\nLED_A+D
+
+    Simulate --> Search : Loop back
+    Read --> Search : Read failed
+
+    Search --> [*] : Button hold / USB data
+    Simulate --> [*] : Button hold / USB data
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_LEGIC -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [Legic Prime Simulator](hf_legicsim.md) — Multi-slot Legic simulation from flash

--- a/doc/standalone/hf_legicsim.md
+++ b/doc/standalone/hf_legicsim.md
@@ -1,0 +1,81 @@
+# HF_LEGICSIM — Legic Prime Multi-Slot Simulator
+
+> **Author:** uhei
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** RDV4 (requires flash memory)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_legicsim.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Simulates Legic Prime MIM1024 dumps stored on flash memory. Supports up to **15 dump slots** that can be cycled through. Changes made by readers during simulation are written back to the dump.
+
+## Why
+
+When you need to emulate multiple Legic Prime cards on-site — for example, testing which credentials grant access to different areas. The 15-slot capacity and flash persistence means dumps survive power cycles.
+
+## How
+
+1. On startup, loads the first dump from flash (`hf_legicsim_dump_01.bin`)
+2. Simulates the loaded dump as a Legic Prime MIM1024 tag
+3. Short press cycles to the next slot
+4. After simulation, any changes written by readers are saved back to the dump file
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| LEDs (1–15) | Current slot number indication |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Short press** | Next dump slot |
+| **Hold 500ms** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> LoadSlot1 : Startup
+
+    LoadSlot1 --> Simulate : Dump loaded
+    Simulate --> WriteBack : Simulation stopped
+    WriteBack --> LoadSlot2 : Short press\nSave changes, next slot
+
+    LoadSlot2 --> Simulate : Dump loaded
+    
+    Simulate --> [*] : Hold 500ms
+
+    note right of Simulate
+        Slots 01-15
+        Files: hf_legicsim_dump_XX.bin
+        Each 1024 bytes (MIM1024)
+    end note
+```
+
+## Flash Files
+
+Upload dumps before use:
+```
+mem spiffs load -s hf_legicsim_dump_01.bin -d hf_legicsim_dump_01.bin
+mem spiffs load -s hf_legicsim_dump_02.bin -d hf_legicsim_dump_02.bin
+...
+```
+
+Each file is 1024 bytes (Legic Prime MIM1024 dump).
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_LEGICSIM -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [Legic Prime Reader](hf_legic.md) — Read and simulate Legic tags (single shot)

--- a/doc/standalone/hf_mattyrun.md
+++ b/doc/standalone/hf_mattyrun.md
@@ -1,0 +1,88 @@
+# HF_MATTYRUN — MIFARE Classic Key Check/Dump/Emulate
+
+> **Author:** Matías A. Ré Medina
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_mattyrun.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+A full MIFARE Classic attack chain: discovers MFC cards, checks keys from a built-in dictionary, dumps the card using ecfill, then emulates it. Supports MIFARE Classic 1K and 4K.
+
+## Why
+
+MIFARE Classic is the most widely deployed contactless smart card worldwide — used in transit, access control, and loyalty systems. MattyRun automates the complete attack pipeline on-device:
+
+1. Find the card
+2. Recover the keys (from dictionary)
+3. Dump all data
+4. Emulate the full card at a reader
+
+No laptop required at any step.
+
+## How
+
+1. **READ**: Scans for MIFARE Classic cards (anticollision, ATQA/SAK check)
+2. **ATTACK**: Checks keys from the built-in dictionary against all sectors. Uses nested authentication attack if partial keys are found
+3. **LOAD**: Performs ecfill to dump the card data into the emulator memory
+4. **EMULATE**: Simulates the complete MIFARE Classic card including all sector keys and data
+
+LED D lit during emulation indicates a partial dump (some sectors couldn't be read).
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **C + D** (solid) | Idle / searching for card |
+| **C + D** (blinking) | Authenticating / checking keys |
+| **B** (solid) | Attack mode (nested) |
+| **A + B + C** (solid) | Loading data to emulator |
+| **A + B + C + D** (solid) | Emulating (D = partial dump warning) |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Hold 280ms** | Exit standalone mode |
+| **Short press** | No effect (purely state-machine driven) |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> READ : Startup\nLED_C+D
+
+    READ --> ATTACK : MFC card found\nLED_C+D blink
+    READ --> READ : No card found
+
+    ATTACK --> LOAD : Keys recovered\nLED_B
+    ATTACK --> READ : No keys found\n(retry with new card)
+
+    LOAD --> EMULATE : ecfill complete\nLED_A+B+C
+    
+    EMULATE --> [*] : Button hold\nLED_A+B+C+D
+
+    note right of EMULATE
+        LED_D lit = partial dump
+        (some sectors unreadable)
+    end note
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_MATTYRUN -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [VIGIKPWN](hf_colin.md) — MIFARE Classic with VIGIK-specific keys
+- [MFC Simulator](hf_mfcsim.md) — Simulate MFC from flash dumps
+- [Young MFC Sniff/Sim](hf_young.md) — UID-based MFC sniff and sim
+- [MIFARE Classic Notes](../mfc_notes.md) — Key recovery and attack techniques
+- [Magic Cards Notes](../magic_cards_notes.md) — Writing to magic/CUID cards

--- a/doc/standalone/hf_mfcsim.md
+++ b/doc/standalone/hf_mfcsim.md
@@ -1,0 +1,84 @@
+# HF_MFCSIM — MIFARE Classic 1K Multi-Slot Simulator
+
+> **Author:** Ray Lee
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** RDV4 (requires flash memory)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_mfcsim.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Simulates MIFARE Classic 1K cards from dump files stored on flash. Supports up to **15 dump slots**. Changes written by readers during simulation are saved back to the dump file.
+
+## Why
+
+When you have multiple MIFARE Classic card dumps (from `hf mf dump` or other tools) and need to emulate them on-site without a laptop. The 15-slot capacity covers multiple credentials, and the write-back feature preserves any reader-induced changes.
+
+## How
+
+1. Loads dump number 1 from flash (`hf_mfcsim_dump_01.bin`)
+2. Configures the emulator with full card data including all sector keys
+3. Begins simulation
+4. Cycle through slots for different cards
+5. Any writes from readers are saved back to the dump file
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| LEDs | Indicate current dump slot number (1–15) |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Short press** | Next dump slot |
+| **Hold 500ms** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> LoadSlot : Startup
+
+    LoadSlot --> Simulate : Dump loaded into emulator
+    Simulate --> WriteBack : Simulation stopped
+
+    WriteBack --> LoadNext : Short press\nSave, advance slot
+    LoadNext --> LoadSlot : Load next dump
+
+    Simulate --> [*] : Hold 500ms
+
+    note right of Simulate
+        Slots 01-15
+        Files: hf_mfcsim_dump_XX.bin
+        Each 1024 bytes (MFC 1K)
+    end note
+```
+
+## Flash Files
+
+Upload dumps before use:
+```
+mem spiffs load -s hf_mfcsim_dump_01.bin -d hf_mfcsim_dump_01.bin
+mem spiffs load -s hf_mfcsim_dump_02.bin -d hf_mfcsim_dump_02.bin
+...
+```
+
+Each file is 1024 bytes (MIFARE Classic 1K dump including sector keys).
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_MFCSIM -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [MattyRun MFC Clone](hf_mattyrun.md) — Full MFC attack chain (discover → dump → emulate)
+- [VIGIKPWN](hf_colin.md) — VIGIK-specific MFC attacks
+- [MIFARE Classic Notes](../mfc_notes.md) — Key recovery techniques

--- a/doc/standalone/hf_msdsal.md
+++ b/doc/standalone/hf_msdsal.md
@@ -1,0 +1,68 @@
+# HF_MSDSAL — Visa MSD Card Reader/Emulator
+
+> **Author:** Salvador Mendoza
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_msdsal.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Reads Visa MSD (Magnetic Stripe Data) cards and emulates the captured Track 2 equivalent data. MSD is an older EMV contactless mode that mirrors magnetic stripe data over NFC.
+
+## Why
+
+Visa MSD mode transmits Track 2 data in a format similar to magnetic stripe cards. This mode demonstrates the risk of MSD mode by capturing and replaying the transaction data. MSD has largely been superseded by EMV contactless (qVSDC), but some terminals still support it as a fallback.
+
+> ⚠ **Note**: MSD mode is deprecated in many markets. Modern terminals may reject MSD transactions.
+
+## How
+
+1. **READ**: Selects PPSE → Visa AID → reads PDOL/SFI → extracts 19-byte Track 2 data
+2. **EMULATE**: Presents the captured Track 2 data when queried by a terminal
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | Reading mode |
+| **B** (solid) | Activity indicator |
+| **C** (solid) | Emulation mode (Track 2 loaded) |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Single click** | Toggle between READ and EMULATE |
+| **Long hold** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> READ : Startup
+
+    READ --> EMULATE : Track2 captured\n+ button click
+    EMULATE --> READ : Button click
+
+    READ --> READ : Waiting for Visa MSD card
+    EMULATE --> EMULATE : Emulating Track2
+
+    READ --> [*] : Long hold / USB data
+    EMULATE --> [*] : Long hold / USB data
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_MSDSAL -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [EMV Visa Reader/Emulator](hf_emvpng.md) — Modern EMV Visa reader/emulator
+- [EMV Notes](../emv_notes.md) — EMV protocol documentation

--- a/doc/standalone/hf_reblay.md
+++ b/doc/standalone/hf_reblay.md
@@ -1,0 +1,87 @@
+# HF_REBLAY — ISO 14443-A Relay over Bluetooth
+
+> **Author:** Salvador Mendoza
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** RDV4 with Bluetooth module (required)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_reblay.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Relays ISO 14443-A NFC communications between a real card and a remote reader over Bluetooth. One Proxmark3 RDV4 acts as the reader (captures card responses), the other as the emulator (presents them to a terminal), with Bluetooth bridging the two.
+
+## Why
+
+Relay attacks demonstrate a fundamental weakness in proximity-based authentication: the assumption that the card is physically near the reader. By relaying messages in real-time, an attacker can use a card that is far away — for example, performing a contactless payment using a card in someone else's pocket. This mode is an educational tool for understanding relay attack mechanics.
+
+> ⚠ **Security Research Only**: This tool demonstrates a known class of NFC vulnerability for research purposes.
+
+## How
+
+1. **Device A (Reader side)**: Placed near the victim's card. Receives APDU commands from Device B over BT, sends them to the card, relays responses back over BT.
+2. **Device B (Emulator side)**: Placed near the target terminal. Receives terminal commands, forwards them to Device A over BT, plays back card responses to the terminal.
+3. **Bluetooth Link**: USART-based BT serial bridge with a custom framing protocol (preamble `0xAA`, length, data, postamble `0xBB`).
+4. **Timing**: Implements WTX (Waiting Time eXtension) and ACK management to keep the terminal patient during relay delay. This is important for terminals like SumUp that have tight timing requirements.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | Reader mode active (proximate to card) |
+| **C** (solid) | Emulation mode active (proximate to terminal) |
+| **A+C** (blink) | BT data exchange in progress |
+| **B+D** (blink) | Error / timeout |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Button press** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Init : Startup
+
+    Init --> ReaderMode : BT connected\n(reader side)
+    Init --> EmulatorMode : BT connected\n(emulator side)
+
+    state ReaderMode {
+        WaitBT_Cmd --> SendToCard : Receive APDU via BT
+        SendToCard --> WaitCard_Resp : ISO14443A transceive
+        WaitCard_Resp --> SendBT_Resp : Card responds
+        SendBT_Resp --> WaitBT_Cmd : Response sent over BT
+    }
+
+    state EmulatorMode {
+        WaitTerminal_Cmd --> SendBT_Relay : Terminal sends APDU
+        SendBT_Relay --> WaitBT_Reply : Relay to reader via BT
+        WaitBT_Reply --> RespondTerminal : Card response received
+        RespondTerminal --> WaitTerminal_Cmd : Response sent to terminal
+    }
+
+    ReaderMode --> [*] : Button / disconnect
+    EmulatorMode --> [*] : Button / disconnect
+```
+
+## Prerequisites
+
+- **Two** Proxmark3 RDV4 devices
+- Both with Bluetooth modules connected and paired
+- Flash each with `HF_REBLAY` standalone firmware
+- One device near the card, one near the terminal
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_REBLAY -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [Card Hopper](hf_cardhopper.md) — Similar relay concept using BLE and phone-based bridge

--- a/doc/standalone/hf_st25_tearoff.md
+++ b/doc/standalone/hf_st25_tearoff.md
@@ -1,0 +1,91 @@
+# HF_ST25_TEAROFF — ST25TB Tear-Off / Counter Restore
+
+> **Author:** Doegox, Iceman
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** RDV4 with flash (required)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_st25_tearoff.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Store and restore ST25TB/SRx tags using a power tear-off technique on their decrementing counters (blocks 5 and 6). These counters normally can only count down, but a precisely timed tear-off can corrupt and reset them.
+
+## Why
+
+ST25TB and SRx NFC tags (used in transport tickets, access systems, etc.) contain one-way counters that decrement on each use. Normally these counters cannot be reset. The tear-off technique exploits the fact that if the RF field drops at the precise moment a counter write is completing, the write may fail or partially complete — potentially restoring a previous counter value. This enables research into counter-based anti-replay mechanisms.
+
+## How
+
+1. **LEARN mode**: Reads up to 8 ST25TB tags and stores their complete memory dump (including counter blocks 5 & 6) to Proxmark3 flash memory.
+2. **RESTORE mode**: Reads a previously-learned tag, compares current counter values to stored values, and if the counters have decremented, attempts a tear-off write to restore the original counter values.
+3. **Tear-off mechanism**: Rapidly toggles the RF field at the precise moment the counter write completes, attempting to corrupt the write. Retries with varied timing until the counter is restored or the maximum attempt count is reached.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **D** (solid) | LEARN mode active |
+| **C** (solid) | RESTORE mode active |
+| **A** (solid) | Operation succeeded (counter restored) |
+| **B** (solid) | Operation failed |
+| **A+B+C+D** (blink) | Searching for tag |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Single click** | Toggle between LEARN and RESTORE mode |
+| **Long hold** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> LEARN : Startup
+
+    state LEARN {
+        WaitTag_L --> ReadTag : Tag detected
+        ReadTag --> StoreFlash : Read all blocks
+        StoreFlash --> WaitTag_L : Saved (up to 8 tags)
+    }
+
+    state RESTORE {
+        WaitTag_R --> MatchTag : Tag detected
+        MatchTag --> CompareCounters : UID matched to stored
+        CompareCounters --> TearOff : Counter decremented
+        CompareCounters --> SkipRestore : Counter matches stored
+        TearOff --> VerifyRestore : RF tear-off attempt
+        VerifyRestore --> Success : Counter restored
+        VerifyRestore --> TearOff : Counter still low, retry
+        VerifyRestore --> Fail : Max attempts reached
+        Success --> WaitTag_R
+        SkipRestore --> WaitTag_R
+        Fail --> WaitTag_R
+    }
+
+    LEARN --> RESTORE : Button click
+    RESTORE --> LEARN : Button click
+
+    LEARN --> [*] : Long hold
+    RESTORE --> [*] : Long hold
+```
+
+## Stored Data
+
+| Flash File | Contents |
+|------------|----------|
+| Tag dumps | Full block data for up to 8 ST25TB tags |
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_ST25_TEAROFF -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [ST25TA / IKEA Rothult](hf_tcprst.md) — Similar ST25 family, different attack

--- a/doc/standalone/hf_tcprst.md
+++ b/doc/standalone/hf_tcprst.md
@@ -1,0 +1,94 @@
+# HF_TCPRST — IKEA Rothult / ST25TA Password Extractor
+
+> **Author:** Nick Draffen (tcprst)
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_tcprst.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Reads, simulates, dumps, and emulates IKEA Rothult NFC lock tags (ST25TA series). Extracts the 16-byte password stored on the tag, which acts as the key to the lock.
+
+## Why
+
+The IKEA Rothult is a battery-operated NFC lock that uses ST25TA02K tags (ISO 14443A, Type 4 tag). The lock authenticates by reading a specific NDEF record from the tag. By extracting this 16-byte password, you can clone the tag or emulate it — useful for creating backup keys or for security research on the lock mechanism.
+
+## How
+
+1. **READ**: Selects the ST25TA tag via ISO 14443A anticollision, sends NDEF SELECT commands, reads the NDEF file containing the 16-byte password.
+2. **SIM**: Simulates a tag with the previously read UID (basic UID-level simulation).
+3. **DUMP**: Outputs the extracted password over USB debug (requires client connection).
+4. **EMUL**: Full tag emulation — responds to reader commands with the captured NDEF data including password.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | READ mode |
+| **B** (solid) | SIM mode (UID simulation) |
+| **C** (solid) | DUMP mode |
+| **D** (solid) | EMUL mode (full emulation) |
+| **A-D** (sequential) | Cycling through active mode indicator |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Single click** | Advance to next mode (READ→SIM→DUMP→EMUL→READ) |
+| **Long hold** | Execute current mode action |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> READ : Startup
+
+    READ --> SIM : Button click
+    SIM --> DUMP : Button click
+    DUMP --> EMUL : Button click
+    EMUL --> READ : Button click
+
+    state READ {
+        [*] --> WaitCard_R
+        WaitCard_R --> SelectTag : Tag detected
+        SelectTag --> ReadNDEF : ST25TA selected
+        ReadNDEF --> ExtractPwd : NDEF file read
+        ExtractPwd --> Done_R : 16-byte password stored
+    }
+
+    state SIM {
+        [*] --> Simulating
+        Simulating --> Done_S : Button press stops sim
+    }
+
+    state DUMP {
+        [*] --> PrintPwd
+        PrintPwd --> Done_D : Password printed to debug
+    }
+
+    state EMUL {
+        [*] --> Emulating
+        Emulating --> Done_E : Button press stops emul
+    }
+
+    READ --> [*] : USB connection
+    SIM --> [*] : USB connection
+    DUMP --> [*] : USB connection
+    EMUL --> [*] : USB connection
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_TCPRST -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [ST25TB Tear-Off](hf_st25_tearoff.md) — Related ST25 family tag manipulation
+- [MIFARE Classic Simulator](hf_mfcsim.md) — Another HF tag emulator

--- a/doc/standalone/hf_tmudford.md
+++ b/doc/standalone/hf_tmudford.md
@@ -1,0 +1,74 @@
+# HF_TMUDFORD — ISO 15693 UID Emulator
+
+> **Author:** Tim Mudford
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_tmudford.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Reads an ISO 15693 tag UID and emulates it. Simple two-state mode: read a tag, then replay its UID to 15693 readers.
+
+## Why
+
+ISO 15693 (iCODE, Tag-it, I-Code) tags are used in library systems, industrial automation, and access control. This mode provides a quick way to clone and emulate a 15693 tag's UID for testing readers and access systems that rely solely on UID-based identification.
+
+## How
+
+1. **READ**: Sends an ISO 15693 inventory request. When a tag responds, captures its 8-byte UID.
+2. **EMULATE**: Emulates a 15693 tag with the captured UID, responding to inventory and select commands from a reader.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A+D** (solid) | READ mode — waiting for tag |
+| **B+C** (solid) | EMULATE mode — replaying UID |
+| **A-D** (sequential blink) | Transition / activity |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Long hold (≥1000ms)** | Switch between READ and EMULATE modes |
+| **Button press** | Exit standalone mode (while idle) |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> READ : Startup
+
+    state READ {
+        [*] --> Inventory
+        Inventory --> Captured : Tag responds with UID
+        Captured --> Inventory : Continue scanning
+    }
+
+    state EMULATE {
+        [*] --> SimUID
+        SimUID --> SimUID : Responding to readers
+    }
+
+    READ --> EMULATE : Long hold\n(UID captured)
+    EMULATE --> READ : Long hold
+
+    READ --> [*] : Button press / USB
+    EMULATE --> [*] : Button press / USB
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_TMUDFORD -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [ISO 15693 Dump & Simulate](hf_15sim.md) — Full 15693 memory dump and emulation
+- [ISO 15693 Sniffer](hf_15sniff.md) — Passive 15693 sniffing

--- a/doc/standalone/hf_unisniff.md
+++ b/doc/standalone/hf_unisniff.md
@@ -1,0 +1,109 @@
+# HF_UNISNIFF — Multi-Protocol HF Sniffer
+
+> **Author:** Equip
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** RDV4 recommended (flash for config persistence)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_unisniff.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+A universal HF sniffer that supports multiple protocols — ISO 14443A, ISO 14443B, ISO 15693, and iCLASS — selectable at runtime via button press before sniffing begins.
+
+## Why
+
+Rather than flashing different standalone firmware for each protocol you want to sniff, this mode combines all four HF sniffing protocols into a single firmware. You select the protocol at startup using the button, then sniff. This is especially useful when you don't know which protocol a target system uses.
+
+## How
+
+1. **Protocol Selection**: On startup, the LEDs indicate the currently selected protocol. Press the button to cycle through protocols.
+2. **Sniff**: Hold the button to start sniffing the selected protocol. The Proxmark3 passively captures RF traffic between a reader and tag.
+3. **Data Storage**: If flash is available, captured trace data is saved to `hf_unisniff.trace`. Otherwise data is held in BigBuf (volatile — lost on power cycle).
+4. **Retrieval**: Connect to the client and download the trace data for analysis.
+
+## LED Indicators — Protocol Selection
+
+| LED Pattern | Protocol |
+|-------------|----------|
+| **A** only | ISO 14443A |
+| **B** only | ISO 14443B |
+| **C** only | ISO 15693 |
+| **D** only | iCLASS |
+
+## LED Indicators — Operation
+
+| LED | Meaning |
+|-----|---------|
+| **Selected LED** (blink) | Sniffing in progress |
+| **A+B+C+D** (solid) | Error |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Single click** | Cycle to next protocol (A→B→C→D→A) |
+| **Long hold** | Start sniffing selected protocol |
+| **Press during sniff** | Stop sniffing |
+
+## Configuration File
+
+If flash is available, the mode reads `hf_unisniff.conf` to remember the last-used protocol. Format is a single byte:
+
+| Value | Protocol |
+|-------|----------|
+| `0x01` | ISO 14443A |
+| `0x02` | ISO 14443B |
+| `0x03` | ISO 15693 |
+| `0x04` | iCLASS |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> SelectProtocol : Startup
+
+    state SelectProtocol {
+        [*] --> ISO14443A
+        ISO14443A --> ISO14443B : Button click
+        ISO14443B --> ISO15693 : Button click
+        ISO15693 --> iCLASS : Button click
+        iCLASS --> ISO14443A : Button click
+    }
+
+    SelectProtocol --> Sniffing : Long hold
+
+    state Sniffing {
+        [*] --> Capture
+        Capture --> Capture : Logging packets
+    }
+
+    Sniffing --> SaveTrace : Button press / buffer full
+    SaveTrace --> SelectProtocol : Trace saved to flash
+    SaveTrace --> [*] : No flash (data in BigBuf)
+
+    SelectProtocol --> [*] : USB connection
+```
+
+## Flash Files
+
+| File | Contents |
+|------|----------|
+| `hf_unisniff.conf` | Last-selected protocol (1 byte) |
+| `hf_unisniff.trace` | Captured trace data |
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_UNISNIFF -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [ISO 14443A Sniffer](hf_14asniff.md) — Dedicated 14443A sniffer
+- [ISO 14443B Sniffer](hf_14bsniff.md) — Dedicated 14443B sniffer
+- [ISO 15693 Sniffer](hf_15sniff.md) — Dedicated 15693 sniffer
+- [iCLASS](hf_iceclass.md) — iCLASS multi-mode (includes sniffing)

--- a/doc/standalone/hf_young.md
+++ b/doc/standalone/hf_young.md
@@ -1,0 +1,86 @@
+# HF_YOUNG — MIFARE Classic Sniffer/Simulator (2-Bank)
+
+> **Author:** Craig Young
+> **Frequency:** HF (13.56 MHz)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/hf_young.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Sniffs MIFARE Classic 1K communications between a reader and card, then simulates or clones the captured data. Features two memory banks for storing different card captures.
+
+## Why
+
+MIFARE Classic is the most widely deployed contactless smart card. This mode enables field-based capture of reader-card transactions followed by immediate simulation or cloning — useful for testing access control systems and understanding their authentication sequences without needing a laptop.
+
+## How
+
+1. **RECORD**: Places the Proxmark3 in sniffer mode to capture ISO 14443A / MIFARE Classic communications. The captured UID, ATQA, SAK, and key data are stored in the selected bank.
+2. **PLAY**: Emulates a MIFARE Classic card using the captured UID and data, responding to reader authentication requests.
+3. **CLONE**: Writes captured data to a "magic" Gen1a MIFARE Classic card (one with a writable Block 0).
+
+Each of the two banks can independently store a captured card's data.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | Bank 0 selected |
+| **B** (solid) | Bank 1 selected |
+| **C** (solid) | RECORD mode |
+| **D** (solid) | PLAY (simulate) mode |
+| **C+D** (solid) | CLONE mode |
+| **A-D** (blink) | Activity |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Single click** | Advance state: RECORD → PLAY → CLONE → RECORD |
+| **Long hold** | Switch between Bank 0 and Bank 1 |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Bank0_RECORD : Startup
+
+    state Bank0 {
+        Bank0_RECORD --> Bank0_PLAY : Click
+        Bank0_PLAY --> Bank0_CLONE : Click
+        Bank0_CLONE --> Bank0_RECORD : Click
+    }
+
+    state Bank1 {
+        Bank1_RECORD --> Bank1_PLAY : Click
+        Bank1_PLAY --> Bank1_CLONE : Click
+        Bank1_CLONE --> Bank1_RECORD : Click
+    }
+
+    Bank0_RECORD --> Bank1_RECORD : Long hold
+    Bank0_PLAY --> Bank1_PLAY : Long hold
+    Bank0_CLONE --> Bank1_CLONE : Long hold
+    Bank1_RECORD --> Bank0_RECORD : Long hold
+    Bank1_PLAY --> Bank0_PLAY : Long hold
+    Bank1_CLONE --> Bank0_CLONE : Long hold
+
+    Bank0_RECORD --> [*] : USB connection
+    Bank1_RECORD --> [*] : USB connection
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=HF_YOUNG -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [MattyRun](hf_mattyrun.md) — Automated MFC key check, nested attack, dump, and emulate
+- [CraftByte](hf_craftbyte.md) — 14443A UID stealer/emulator
+- [MIFARE Classic Simulator](hf_mfcsim.md) — Multi-slot MFC simulator from flash dumps

--- a/doc/standalone/lf_em4100emul.md
+++ b/doc/standalone/lf_em4100emul.md
@@ -1,0 +1,83 @@
+# LF_EM4100EMUL — EM4100 Simulator
+
+> **Author:** temskiy
+> **Frequency:** LF (125 kHz)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/lf_em4100emul.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Simulates a set of predefined EM4100 tag IDs in sequence. The Proxmark3 cycles through a list of hardcoded EM4100 IDs, broadcasting each one for a period before moving to the next.
+
+## Why
+
+This is useful when you already know the EM4100 IDs you want to replay and need a simple, standalone way to cycle through them without a host connection. Common scenarios:
+
+- **Testing access control readers**: Verify which IDs are accepted
+- **Red team walk-through**: Pre-load known badges and cycle through them at doors
+- **Development & debugging**: Verify your EM4100 reader code against known-good IDs
+
+## How
+
+1. The firmware contains a hardcoded array of EM4100 IDs
+2. On startup, it selects the first slot and begins simulating
+3. It automatically advances to the next slot after each simulation cycle
+4. The device shows the current slot number via LED binary encoding
+
+The simulation uses Manchester encoding at the configured bit rate to emulate an EM4100 tag.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A/B/C/D** (binary) | Current slot number displayed in binary (LED A = bit 0, etc.) |
+| All LEDs off | Idle / transitioning between slots |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Hold 500ms** | Exit standalone mode |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> SelectSlot0 : Startup
+
+    SelectSlot0 --> Emulate0 : Auto
+    Emulate0 --> SelectSlot1 : Simulation complete
+
+    SelectSlot1 --> Emulate1 : Auto
+    Emulate1 --> SelectSlot2 : Simulation complete
+
+    SelectSlot2 --> Emulate2 : Auto
+    Emulate2 --> SelectSlot3 : Simulation complete
+
+    SelectSlot3 --> Emulate3 : Auto
+    Emulate3 --> SelectSlot0 : Cycle back
+
+    Emulate0 --> [*] : Button hold 500ms
+    Emulate1 --> [*] : Button hold 500ms
+    Emulate2 --> [*] : Button hold 500ms
+    Emulate3 --> [*] : Button hold 500ms
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=LF_EM4100EMUL -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [EM4100 RSWB](lf_em4100rswb.md) — Full read/sim/write/brute for EM4100
+- [EM4100 RSWW](lf_em4100rsww.md) — Read/sim/write/wipe/validate
+- [EM4100 RWC](lf_em4100rwc.md) — Read/sim/clone with 16 slots
+- [T5577 Introduction Guide](../T5577_Guide.md) — Background on T5577/EM4100 technology

--- a/doc/standalone/lf_em4100rswb.md
+++ b/doc/standalone/lf_em4100rswb.md
@@ -1,0 +1,90 @@
+# LF_EM4100RSWB — EM4100 Read/Simulate/Write/Brute
+
+> **Author:** Monster1024
+> **Frequency:** LF (125 kHz)
+> **Hardware:** RDV4 (requires flash memory for slot storage)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/lf_em4100rswb.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+A full-featured EM4100 attack mode with four operations: **read**, **simulate**, **write to T55x7**, and **brute force**. Supports 4 card storage slots with flash persistence on RDV4 hardware.
+
+## Why
+
+This is the most versatile EM4100 standalone mode. While simpler modes only read or simulate, RSWB combines all four essential operations — plus brute forcing — into a single firmware image. This is ideal for:
+
+- **Pentesting EM4100 access control**: Read a badge, simulate it, then write a clone, all standalone
+- **Brute force attacks**: Iterate through card numbers to find valid ones when you don't have a known-good badge
+- **Multi-target assessments**: Store up to 4 different badges and switch between them on-site
+
+## How
+
+1. **READ mode**: Listens for EM4100 cards. On successful read, stores the ID in the current slot and automatically transitions to SIM mode
+2. **SIM mode**: Broadcasts the stored EM4100 ID. Button press moves to WRITE mode
+3. **WRITE mode**: Writes the stored ID to a T55x7 blank card placed on the antenna
+4. **BRUTE mode**: Sequentially transmits incrementing card numbers. Double-click saves a working number; hold changes brute speed
+
+Slot data persists across reboots via the RDV4's SPI flash memory.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A, B** (binary) | Current mode: 00=READ, 01=SIM, 10=WRITE, 11=BRUTE |
+| **C, D** (binary) | Current slot: 00=Slot1, 01=Slot2, 10=Slot3, 11=Slot4 |
+| All flash on operation | Success confirmation |
+
+## Button Controls
+
+| Context | Action | Effect |
+|---------|--------|--------|
+| Any mode | **Single click** | Switch mode (READ → SIM → WRITE → BRUTE → READ) |
+| Any mode | **Hold** | Switch slot (1 → 2 → 3 → 4 → 1) |
+| BRUTE | **Single click** | Exit brute mode → READ |
+| BRUTE | **Double-click** | Save current brute position |
+| BRUTE | **Hold** | Change brute speed |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> READ : Startup (load slots from flash)
+
+    READ --> SIM : Card read successfully\n(auto-transition)
+    READ --> SIM : Single click
+    SIM --> WRITE : Single click
+    WRITE --> BRUTE : Single click
+    BRUTE --> READ : Single click\nor brute complete
+
+    READ --> READ : Hold (switch slot)
+    SIM --> SIM : Hold (switch slot)
+    WRITE --> WRITE : Hold (switch slot)
+    BRUTE --> BRUTE : Hold (change speed)\nDouble-click (save position)
+
+    READ --> [*] : USB data received
+    SIM --> [*] : USB data received
+```
+
+## Flash Storage
+
+- Slot data is saved to and loaded from the RDV4 SPI flash
+- 4 slots, each storing the raw EM4100 ID
+- Data persists across power cycles
+
+## Compilation
+
+```
+make clean
+make STANDALONE=LF_EM4100RSWB -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [EM4100 Emulator](lf_em4100emul.md) — Simple predefined EM4100 simulator
+- [EM4100 RSWW](lf_em4100rsww.md) — Read/sim/write/wipe/validate variant
+- [EM4100 RWC](lf_em4100rwc.md) — 16-slot read/sim/clone
+- [T5577 Introduction Guide](../T5577_Guide.md) — Background on T5577/EM4100

--- a/doc/standalone/lf_em4100rsww.md
+++ b/doc/standalone/lf_em4100rsww.md
@@ -1,0 +1,89 @@
+# LF_EM4100RSWW — EM4100 Read/Simulate/Write/Wipe/Validate
+
+> **Author:** Łukasz "zabszk" Jurczyk
+> **Frequency:** LF (125 kHz)
+> **Hardware:** RDV4 (requires flash memory)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/lf_em4100rsww.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+An EM4100 multi-tool that adds **wipe** and **validate** operations on top of read/simulate/write. Automatically saves read IDs to flash memory for persistence across power cycles.
+
+## Why
+
+Unlike RSWB which focuses on brute forcing, RSWW focuses on the **clone verification workflow**: read a tag, write it to a T55x7, then validate the clone reads back correctly. The wipe function lets you reset T55x7 cards to a blank state. This is the mode to use when:
+
+- **Quality-checking clones**: Verify the written data matches the original
+- **Preparing blank cards**: Wipe T55x7 cards back to factory state
+- **Field work with persistence**: Read IDs survive reboots via flash
+
+## How
+
+1. **READ**: Listens for EM4100 tags and stores the ID to flash
+2. **EMULATE**: Broadcasts the stored ID (defaults to this mode if flash has data from a previous session)
+3. **WRITE**: Writes the stored ID to a T55x7 tag
+4. **VALIDATE**: Reads back a T55x7 and compares it to the stored ID to confirm a successful clone
+5. **WIPE**: Resets a T55x7 tag to its default (empty) configuration
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | READ mode active |
+| **B** (solid) | EMULATE mode active |
+| **C** (solid) | VALIDATE mode active |
+| **D** (solid) | WIPE mode active |
+| Blink pattern | Success/failure indication after operations |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Single click** | Advance mode (READ → EMULATE → WRITE/VALIDATE) |
+| **Hold** | Toggle between READ and EMULATE |
+| **Double-click in READ** | Enter WIPE mode |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> READ : Startup (no flash data)
+    [*] --> EMULATE : Startup (flash has saved ID)
+
+    READ --> EMULATE : Single click\n(ID captured)
+    EMULATE --> READ : Hold (toggle)
+    
+    EMULATE --> WRITE : Single click
+    WRITE --> VALIDATE : Auto after write
+    VALIDATE --> EMULATE : Validation complete
+
+    READ --> WIPE : Double-click
+    WIPE --> READ : Wipe complete
+
+    READ --> [*] : USB data received
+    EMULATE --> [*] : USB data received
+```
+
+## Flash Storage
+
+- Automatically saves the most recent read ID to SPI flash
+- Loads stored ID on startup; if found, starts in EMULATE mode
+- One slot for persistent storage
+
+## Compilation
+
+```
+make clean
+make STANDALONE=LF_EM4100RSWW -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [EM4100 RSWB](lf_em4100rswb.md) — 4-slot variant with brute force
+- [EM4100 Emulator](lf_em4100emul.md) — Simple hardcoded EM4100 simulator
+- [EM4100 RWC](lf_em4100rwc.md) — 16-slot read/sim/clone

--- a/doc/standalone/lf_em4100rwc.md
+++ b/doc/standalone/lf_em4100rwc.md
@@ -1,0 +1,79 @@
+# LF_EM4100RWC — EM4100 Read/Write/Clone (16 Slots)
+
+> **Author:** temskiy
+> **Frequency:** LF (125 kHz)
+> **Hardware:** RDV4 (flash memory for slot storage)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/lf_em4100rwc.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Read, simulate, and clone EM4100 tags with **16 storage slots**. Pre-loaded with 3 sample IDs. Provides the largest card storage capacity of any EM4100 standalone mode.
+
+## Why
+
+When you need to collect and manage many EM4100 IDs on a single assessment — for example, reading badges from multiple employees — having 16 slots lets you capture a full team's credentials on-device. Each slot is independently selectable for simulation or cloning.
+
+## How
+
+1. **SELECT**: Navigate between the 16 slots using button clicks
+2. **READ**: Read an EM4100 tag and store it in the currently selected slot
+3. **SIMULATE**: Broadcast the selected slot's ID
+4. **WRITE**: Clone the selected slot's ID to a T5555 card
+
+The mode cycles through these four states with button holds to switch modes and clicks to execute within a mode.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A/B/C/D** (binary) | Slot number in binary (0–15) |
+| Blink patterns | Operation success/failure |
+
+## Button Controls
+
+| State | Action | Effect |
+|-------|--------|--------|
+| SELECT | **Single click** | Next slot |
+| SELECT | **Hold** | Switch to SIMULATE mode |
+| READ | **Single click** | Read tag into current slot |
+| READ | **Hold** | Switch to WRITE mode |
+| SIMULATE | **Single click** | Start simulation |
+| SIMULATE | **Hold** | Switch to READ mode |
+| WRITE | **Single click** | Write current slot to T5555 |
+| WRITE | **Hold** | Switch to SELECT mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> SELECT : Startup
+
+    SELECT --> SIMULATE : Hold
+    SIMULATE --> READ : Hold
+    READ --> WRITE : Hold
+    WRITE --> SELECT : Hold
+
+    SELECT --> SELECT : Click (next slot)
+    READ --> READ : Click (read tag)
+    SIMULATE --> SIMULATE : Click (simulate)
+    WRITE --> WRITE : Click (write)
+
+    SELECT --> [*] : USB data received
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=LF_EM4100RWC -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [EM4100 RSWB](lf_em4100rswb.md) — 4-slot variant with brute force
+- [EM4100 Emulator](lf_em4100emul.md) — Simple predefined simulator
+- [EM4100 RSWW](lf_em4100rsww.md) — Read/sim/write/wipe/validate

--- a/doc/standalone/lf_hidbrute.md
+++ b/doc/standalone/lf_hidbrute.md
@@ -1,0 +1,82 @@
+# LF_HIDBRUTE — HID Corporate 1000 Bruteforce
+
+> **Authors:** Federico Dotta & Maurizio Agazzini
+> **Frequency:** LF (125 kHz)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/lf_hidbrute.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Reads an HID Corporate 1000 (35-bit) card, then brute forces the card number up/down from the captured value while preserving the facility code. Also supports direct simulation and cloning.
+
+## Why
+
+HID Corporate 1000 uses a 35-bit format with a facility code and card number. If you can read one card, you likely know the facility code for that site. By brute forcing the card number, you can test other valid badge numbers in the same facility — for example, finding an admin badge number when you only have a standard user badge.
+
+Use cases:
+- **Privilege escalation**: Find higher-privilege card numbers in the same facility
+- **Adjacent badge discovery**: Walk through card numbers near a known-good badge
+- **Access control testing**: Verify whether sequential card numbers are provisioned
+
+## How
+
+1. **Record**: Read an HID Corporate 1000 card to capture facility code + card number
+2. **Clone**: Write the captured credentials to a T55x7 card
+3. **Brute**: Simulate incrementing/decrementing card numbers with the same facility code
+
+The brute force iterates the card number portion while keeping the facility code constant from the originally recorded card.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | Slot 0 selected / cloning active |
+| **B** (solid) | Slot 1 selected / simulation active |
+| **C** (solid) | Slot 2 selected |
+| **D** (solid) | Status indicator |
+| LED(slot+1) | Indicates currently active slot during recording |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Hold 280ms** | Advance state (select → record → clone/brute → repeat) |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> SlotSelect : Startup
+
+    SlotSelect --> Record : Button hold (280ms)
+    Record --> Clone : Button hold (card captured)
+    Record --> Record : Button hold (no card)
+    
+    Clone --> BruteForce : Button hold
+    BruteForce --> Record : Button hold (exit brute)
+    
+    Clone --> SlotSelect : Operation complete
+    
+    SlotSelect --> [*] : USB data received
+    Record --> [*] : USB data received
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=LF_HIDBRUTE -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [SamyRun](lf_samyrun.md) — HID26 read/clone/simulate
+- [HID FC Brute](lf_hidfcbrute.md) — Brute force HID facility codes
+- [ProxBrute](lf_proxbrute.md) — HID ProxII card number brute force
+- [Prox2Brute](lf_prox2brute.md) — ProxII brute force v2
+- [HID Downgrade Attacks](../hid_downgrade.md) — Reader downgrade methods

--- a/doc/standalone/lf_hidfcbrute.md
+++ b/doc/standalone/lf_hidfcbrute.md
@@ -1,0 +1,92 @@
+# LF_HIDFCBRUTE — HID Facility Code Bruteforce
+
+> **Author:** ss23
+> **Frequency:** LF (125 kHz)
+> **Hardware:** RDV4 (requires flash for logging)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/lf_hidfcbrute.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Brute forces all 256 possible HID facility codes (0–255) using a static card number of 1, and logs results to flash memory. When a reader accepts a facility code, you can mark it with a button press.
+
+## Why
+
+HID 26-bit (H10301) cards encode a facility code (FC, 0–255) and a card number (CN, 0–65535). If you don't have a valid card to clone, but you do have physical access to a reader, you can discover the correct facility code by trying all 256 possibilities. Once you know the FC, you can pair it with brute-forced card numbers.
+
+This is the first step in a blind HID attack when you have no captured credentials.
+
+## How
+
+1. The mode simulates an HID 26-bit tag with FC cycling from 0 to 255 and CN fixed at 1
+2. During each simulation, LED C toggles to show progress
+3. Press the button to log the current FC to `lf_hid_fcbrute.log` on flash (this is your "the door opened" marker)
+4. Hold the button for 1 second to exit
+5. After completion, retrieve the log file via the client
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | Brute force active |
+| **C** (toggling) | Toggles on each FC attempt — visual progress indicator |
+| **D** (solid) | Simulation transmission active |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Click / hold 10ms** | Begin brute force |
+| **Single click** (during brute) | Log current FC to flash file |
+| **Hold ≥ 1 second** | Exit brute force |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> WaitStart : Startup
+
+    WaitStart --> BruteFC0 : Button press
+
+    BruteFC0 --> BruteFC1 : Simulate FC=0, advance
+    BruteFC1 --> BruteFC2 : Simulate FC=1, advance
+    BruteFC2 --> BruteFC_N : ...
+    BruteFC_N --> BruteFC255 : Simulate FC=N, advance
+    BruteFC255 --> Complete : All FCs tested
+
+    BruteFC_N --> LogFC : Button click\n(door opened!)
+    LogFC --> BruteFC_N : Continue brute
+
+    BruteFC_N --> [*] : Button hold ≥ 1s
+    Complete --> [*] : Done
+
+    note right of LogFC
+        Writes current FC
+        to lf_hid_fcbrute.log
+        on SPI flash
+    end note
+```
+
+## Flash Storage
+
+- **Log file**: `lf_hid_fcbrute.log` on SPI flash
+- Contains facility codes that were manually marked via button press
+- Retrieve with the client after the assessment
+
+## Compilation
+
+```
+make clean
+make STANDALONE=LF_HIDFCBRUTE -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [HID Corporate Brute](lf_hidbrute.md) — Brute force card numbers with known FC
+- [SamyRun](lf_samyrun.md) — Read/clone/sim HID26
+- [ProxBrute](lf_proxbrute.md) — HID ProxII brute force
+- [IceHID Collector](lf_icehid.md) — Passive HID credential collection

--- a/doc/standalone/lf_icehid.md
+++ b/doc/standalone/lf_icehid.md
@@ -1,0 +1,96 @@
+# LF_ICEHID — Multi-Format LF Credential Collector
+
+> **Author:** Iceman
+> **Frequency:** LF (125 kHz)
+> **Hardware:** RDV4 (requires flash memory and battery)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/lf_icehid.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+A passive LF credential collector that continuously listens for **HID, IOprox, AWID, and EM4100** cards and logs all captured credentials to flash memory. Runs unattended — just power on and leave it.
+
+## Why
+
+This is the ultimate "drop and collect" standalone mode. Place a powered Proxmark3 RDV4 (with battery) near a high-traffic area (like a card reader or badge check-in point) and it silently captures every LF credential that comes into range. Unlike single-protocol modes, IceHID tries all four common LF formats on every signal, catching whatever cards employees are carrying.
+
+Use cases:
+- **Passive badge collection**: Covert long-duration credential harvesting
+- **Multi-format sites**: Sites using a mix of HID, AWID, IOprox, and EM4100
+- **Physical penetration testing**: Leave device near a turnstile, collect badges over hours
+
+## How
+
+1. The Proxmark3 continuously samples the LF antenna
+2. On each sample, it attempts demodulation in four formats: HID → AWID → IOprox → EM4100
+3. If any format decodes successfully, the credential is logged to `lf_hidcollect.log` on flash
+4. The cycle repeats indefinitely until the button is held or USB data is received
+
+The multi-format approach uses `ASKDemod()` and protocol-specific decoders in sequence.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | Reading / recording LF signal |
+| **B** (solid) | Writing captured data to flash |
+| **C** (solid) | Unmounting / syncing flash filesystem |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Hold 280ms** | Exit standalone mode |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Sample : Startup
+
+    Sample --> DemodHID : LF signal detected
+    DemodHID --> LogFlash : HID decoded
+    DemodHID --> DemodAWID : HID failed
+
+    DemodAWID --> LogFlash : AWID decoded
+    DemodAWID --> DemodIO : AWID failed
+
+    DemodIO --> LogFlash : IOprox decoded
+    DemodIO --> DemodEM : IOprox failed
+
+    DemodEM --> LogFlash : EM4100 decoded
+    DemodEM --> Sample : All decoders failed
+
+    LogFlash --> Sample : Logged, continue
+
+    Sample --> [*] : Button hold / USB data
+
+    note right of Sample
+        Continuous loop
+        Tries 4 demod formats
+        per signal capture
+    end note
+```
+
+## Flash Storage
+
+- **Log file**: `lf_hidcollect.log` on SPI flash
+- Each entry contains the decoded credential data and format type
+- Retrieve with client: `mem spiffs dump -s lf_hidcollect.log -d lf_hidcollect.log`
+
+## Compilation
+
+```
+make clean
+make STANDALONE=LF_ICEHID -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [NexID Collector](lf_nexid.md) — Similar collector for Nexwatch credentials
+- [SamyRun](lf_samyrun.md) — Active HID read/clone/sim
+- [HID FC Brute](lf_hidfcbrute.md) — Active HID facility code brute force

--- a/doc/standalone/lf_multihid.md
+++ b/doc/standalone/lf_multihid.md
@@ -1,0 +1,81 @@
+# LF_MULTIHID — HID 26-Bit Multi-Card Simulator
+
+> **Author:** Shain Lakin
+> **Frequency:** LF (125 kHz)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/lf_multihid.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Cycles through 4 predefined HID 26-bit (H10301) raw card IDs, simulating each one in sequence automatically.
+
+## Why
+
+When you have multiple known-valid HID credentials and want to try them all at a reader without manual intervention. Edit the source with your target IDs, compile, and the device will automatically cycle through each one at the reader.
+
+## How
+
+1. The firmware contains 4 hardcoded raw HID values
+2. On startup, it selects the first slot and begins simulating
+3. After each simulation interval, it advances to the next slot
+4. The cycle repeats continuously until exit
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A/B/C/D** (binary) | Currently selected slot number |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Sim_Slot0 : Startup
+
+    Sim_Slot0 --> Sim_Slot1 : Auto-advance
+    Sim_Slot1 --> Sim_Slot2 : Auto-advance
+    Sim_Slot2 --> Sim_Slot3 : Auto-advance
+    Sim_Slot3 --> Sim_Slot0 : Auto-advance (cycle)
+
+    Sim_Slot0 --> [*] : USB data received
+    Sim_Slot1 --> [*] : USB data received
+    Sim_Slot2 --> [*] : USB data received
+    Sim_Slot3 --> [*] : USB data received
+```
+
+## Customization
+
+Edit the raw ID array in the source code before compiling:
+
+```c
+// Example: change these to your target IDs
+static const uint32_t ids[] = {
+    0x2006EC0C86,  // Slot 0
+    0x2006EC0C87,  // Slot 1
+    0x2006EC0C88,  // Slot 2
+    0x2006EC0C89,  // Slot 3
+};
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=LF_MULTIHID -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [SamyRun](lf_samyrun.md) — Read/clone/simulate single HID26
+- [HID Corporate Brute](lf_hidbrute.md) — Brute force card numbers
+- [IceHID Collector](lf_icehid.md) — Passive multi-format collector

--- a/doc/standalone/lf_nedap_sim.md
+++ b/doc/standalone/lf_nedap_sim.md
@@ -1,0 +1,74 @@
+# LF_NEDAP_SIM — Nedap RFID Simple Simulator
+
+> **Frequency:** LF (125 kHz)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/lf_nedap_sim.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Simulates a Nedap RFID tag with a hardcoded ID. Supports both 64-bit and 128-bit Nedap formats, including proper CRC and framing.
+
+## Why
+
+Nedap is a less common but still-deployed access control system, particularly in Europe. This mode lets you test Nedap readers by simulating a known tag. Since Nedap cards are less commonly available than HID, having a simulator is valuable for testing.
+
+## How
+
+1. The firmware encodes a hardcoded Nedap tag structure (subType, customerCode, id)
+2. It generates the proper bit sequence with CRC calculation
+3. Continuously transmits the encoded tag via LF modulation
+4. Supports 128-bit "long" format when `isLong=1`
+
+Default hardcoded values: `subType=5`, `customerCode=0x123`, `id=42424`, `isLong=1`
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| Minimal LED usage | Simple continuous simulation mode |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Hold 1000ms** | Exit standalone mode |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Simulate : Startup
+
+    Simulate --> Simulate : Continuous transmission
+    Simulate --> [*] : Button hold 1s / USB data
+```
+
+## Customization
+
+To change the simulated tag, edit the hardcoded values in the source:
+
+```c
+static NedapTag_t tag = {
+    .subType = 0x5,
+    .customerCode = 0x123,
+    .id = 42424,
+    .isLong = 1,
+};
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=LF_NEDAP_SIM -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [EM4100 Emulator](lf_em4100emul.md) — Simple EM4100 simulator
+- [Skeleton Template](lf_skeleton.md) — Template for building new LF modes

--- a/doc/standalone/lf_nexid.md
+++ b/doc/standalone/lf_nexid.md
@@ -1,0 +1,77 @@
+# LF_NEXID — Nexwatch Credential Collector
+
+> **Authors:** jrjgjk & Zolorah
+> **Frequency:** LF (125 kHz)
+> **Hardware:** RDV4 (requires flash for logging)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/lf_nexid.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Passively sniffs and logs Nexwatch/NexKey ID credentials to flash memory. Decodes the magic bytes and mode information from each captured card.
+
+## Why
+
+Nexwatch (by Honeywell) is an access control card format found in commercial buildings. This collector silently harvests Nexwatch credentials over time, analogous to [IceHID](lf_icehid.md) but specifically targeting the Nexwatch protocol with full decode information.
+
+## How
+
+1. Continuously samples the LF antenna using PSK demodulation
+2. Attempts Nexwatch-specific decode on each signal burst
+3. On successful decode, extracts the magic bytes, mode, and ID
+4. Logs the decoded credential to `lf_nexcollect.log` on flash
+5. Repeats until button hold or USB exit
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | Reading / recording LF signal |
+| **B** (solid) | Writing to flash |
+| **C** (solid) | Unmounting / syncing flash |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Hold 280ms** | Exit standalone mode |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Sample : Startup
+
+    Sample --> PSKDemod : LF signal detected
+    PSKDemod --> NexDecode : PSK decoded
+    PSKDemod --> Sample : PSK decode failed
+
+    NexDecode --> LogFlash : Nexwatch ID found
+    NexDecode --> Sample : Not Nexwatch
+
+    LogFlash --> Sample : Logged, continue
+
+    Sample --> [*] : Button hold / USB data
+```
+
+## Flash Storage
+
+- **Log file**: `lf_nexcollect.log` on SPI flash
+- Each entry contains decoded Nexwatch credentials with magic bytes and mode
+- Retrieve with: `mem spiffs dump -s lf_nexcollect.log -d lf_nexcollect.log`
+
+## Compilation
+
+```
+make clean
+make STANDALONE=LF_NEXID -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [IceHID Collector](lf_icehid.md) — Multi-format LF collector (HID/AWID/IO/EM)
+- [Tharexde EM4x50](lf_tharexde.md) — EM4x50 collector

--- a/doc/standalone/lf_prox2brute.md
+++ b/doc/standalone/lf_prox2brute.md
@@ -1,0 +1,96 @@
+# LF_PROX2BRUTE — HID ProxII Bruteforce v2
+
+> **Author:** Yann Gascuel
+> **Frequency:** LF (125 kHz)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/lf_prox2brute.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+An improved version of [ProxBrute](lf_proxbrute.md) that brute forces HID ProxII H10301 26-bit card numbers over a **configurable range** with compile-time settings for facility code, start number, and end number.
+
+## Why
+
+The original ProxBrute requires reading a card first and only goes downward. Prox2Brute lets you pre-configure the exact facility code and card number range to test — no need to capture a card first. It's faster because it's purpose-built for the H10301 26-bit format with optimized timing between attempts.
+
+Use this when:
+- You already know the facility code (from reconnaissance or a previous capture)
+- You want to test a specific card number range
+- You need faster iteration than the original ProxBrute
+
+## How
+
+1. Configure the target parameters at compile time via `#define` directives: `FACILITY_CODE`, `CARDNUM_START`, `CARDNUM_END`
+2. On startup, press the button to begin
+3. The device iterates through each card number, simulating the HID 26-bit format
+4. LEDs cycle in binary to show progress
+5. Hold button for 1 second to exit
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** | Inverts every attempt — fast blink = running |
+| **B** | Inverts every 8 attempts |
+| **C** | Inverts every 16 attempts |
+| **D** | Inverts every 32 attempts — slow blink = progress |
+| **D** (initial) | Waiting for button press to start |
+| **C** (initial) | Ready indicator |
+
+The LED pattern creates a visual binary counter showing brute force progress at a glance.
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Hold 200ms** | Start brute force |
+| **Hold ≥ 1 second** (during brute) | Exit brute force |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> WaitStart : Startup\nLED_D on
+
+    WaitStart --> BruteLoop : Button hold 200ms\nLED_C on (ready)
+
+    BruteLoop --> BruteLoop : Simulate CN++\nLEDs show binary progress
+    BruteLoop --> Complete : CN > CARDNUM_END
+
+    BruteLoop --> [*] : Button hold ≥ 1s
+    Complete --> [*] : All numbers tested
+
+    note right of BruteLoop
+        FC = FACILITY_CODE (compile-time)
+        CN iterates CARDNUM_START → CARDNUM_END
+        LEDs A/B/C/D show binary counter
+    end note
+```
+
+## Compile-Time Configuration
+
+Edit the `#define` values in the source code before compiling:
+
+```c
+#define FACILITY_CODE  111  // Target facility code
+#define CARDNUM_START  1    // First card number to try
+#define CARDNUM_END    65535 // Last card number to try
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=LF_PROX2BRUTE -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [ProxBrute](lf_proxbrute.md) — Original ProxII brute (reads card first, goes downward)
+- [HID Corporate Brute](lf_hidbrute.md) — Corporate 1000 format brute force
+- [HID FC Brute](lf_hidfcbrute.md) — Facility code brute force

--- a/doc/standalone/lf_proxbrute.md
+++ b/doc/standalone/lf_proxbrute.md
@@ -1,0 +1,71 @@
+# LF_PROXBRUTE — HID ProxII Bruteforce
+
+> **Author:** Brad Antoniewicz
+> **Frequency:** LF (125 kHz)
+> **Hardware:** Generic Proxmark3
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/lf_proxbrute.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+Reads an HID ProxII tag, then brute forces all card numbers **downward** from the captured value, keeping the same facility code.
+
+## Why
+
+HID ProxII is one of the most widely deployed access control card formats. If you have one valid card, you can enumerate other valid card numbers by brute forcing downward (most organizations assign card numbers sequentially, so badges with lower numbers often belong to employees with longer tenure or higher access).
+
+## How
+
+1. **READ**: Capture an HID ProxII card to learn the facility code and starting card number
+2. **BRUTE**: Simulate the card with decrementing card numbers, pausing briefly at each one
+3. The facilty code is preserved from the original capture
+4. Hold button during brute to exit back to READ
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | Reading / simulation active |
+| **C** (solid) | Brute force mode |
+| **A+B+C+D** (flash) | Error or exiting |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Hold 280ms** | Advance state (READ → BRUTE) |
+| **Hold during brute** | Exit brute → back to READ |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> READ : Startup
+
+    READ --> BRUTE : Button hold\n(card captured)
+    READ --> READ : Button hold\n(no card)
+    
+    BRUTE --> BRUTE : Decrement card number\nand simulate
+    BRUTE --> READ : Button hold\n(exit brute)
+    
+    READ --> [*] : USB data received
+    BRUTE --> [*] : USB data received
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=LF_PROXBRUTE -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [Prox2Brute](lf_prox2brute.md) — Faster, configurable ProxII brute force v2
+- [HID Corporate Brute](lf_hidbrute.md) — Corporate 1000 brute force
+- [SamyRun](lf_samyrun.md) — HID26 read/clone/sim
+- [HID FC Brute](lf_hidfcbrute.md) — Facility code brute force

--- a/doc/standalone/lf_samyrun.md
+++ b/doc/standalone/lf_samyrun.md
@@ -1,0 +1,95 @@
+# LF_SAMYRUN — HID26 Read/Clone/Simulate
+
+> **Author:** Samy Kamkar
+> **Frequency:** LF (125 kHz)
+> **Hardware:** Generic Proxmark3 (no special requirements)
+> **Default mode:** Yes — this is the factory-default standalone mode
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/lf_samyrun.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+SamyRun reads an HID 26-bit (H10301) proximity card, then allows you to simulate or clone that card to a T55x7 blank. It supports **2 storage banks**, so you can capture and replay two different cards without reconnecting to a host.
+
+## Why
+
+This is the classic "sniff and replay" attack for HID access control systems. Many physical security assessments require demonstrating that credentials can be captured and replayed. SamyRun is the simplest, most direct tool for this: walk up to a card, read it, then walk up to a reader and replay it — entirely on-device with no laptop required.
+
+Use cases:
+- **Red team engagements**: Capture a badge and replay it at a door reader
+- **Credential cloning**: Write captured credentials to a T55x7 blank card
+- **Physical security audits**: Demonstrate that HID 26-bit (H10301) is trivially clonable
+
+## How
+
+1. The Proxmark3 enters LF read mode and waits for an HID card to come into field range
+2. The card's raw data (high + low words) is decoded and stored into the selected bank (0 or 1)
+3. On the next button press, the Proxmark3 simulates the captured card — it acts as the card itself and will unlock any reader expecting that credential
+4. On the next button press, the data is written to a T55x7 card, creating a physical clone
+5. The mode then cycles to the second bank and repeats
+
+The firmware uses `lf_hid_watch()` for reading, `CmdHIDsimTAGEx()` for simulation, and `CopyHIDtoT55x7()` for cloning.
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | Bank 0 selected, reading mode |
+| **B** (solid) | Bank 1 selected, reading mode |
+| **A or B** (blinking) | Error — zero data read, retry |
+| **C** (solid) | Simulation active |
+| **D** (solid) | Cloning active |
+| **A+B+C+D** (rapid blink) | Exiting standalone mode |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Hold 280ms** | Advance to next state (READ → SIM → CLONE → next bank) |
+| **USB command** | Exit standalone mode and return to host shell |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Read_Bank0 : Power on / Standalone start
+    
+    Read_Bank0 --> Sim_Bank0 : Button hold\n(card captured)
+    Read_Bank0 --> Read_Bank0 : Button hold\n(no card / zeros)
+    
+    Sim_Bank0 --> Clone_Bank0 : Button hold
+    Clone_Bank0 --> Read_Bank1 : Button hold\n(switch to bank 1)
+    
+    Read_Bank1 --> Sim_Bank1 : Button hold\n(card captured)
+    Read_Bank1 --> Read_Bank1 : Button hold\n(no card / zeros)
+    
+    Sim_Bank1 --> Clone_Bank1 : Button hold
+    Clone_Bank1 --> Read_Bank0 : Button hold\n(cycle back to bank 0)
+    
+    Read_Bank0 --> [*] : USB data received
+    Read_Bank1 --> [*] : USB data received
+    Sim_Bank0 --> [*] : USB data received
+    Sim_Bank1 --> [*] : USB data received
+```
+
+## Compilation
+
+```
+make clean
+make STANDALONE=LF_SAMYRUN -j
+./pm3-flash-fullimage
+```
+
+Or in `Makefile.platform`:
+```
+STANDALONE=LF_SAMYRUN
+```
+
+## Related
+
+- [HID Corporate Brute](lf_hidbrute.md) — Bruteforce HID Corporate 1000 card numbers
+- [ProxBrute](lf_proxbrute.md) — Bruteforce HID ProxII card numbers
+- [MultiHID](lf_multihid.md) — Simulate multiple predefined HID26 cards
+- [IceHID Collector](lf_icehid.md) — Log HID credentials to flash memory

--- a/doc/standalone/lf_tharexde.md
+++ b/doc/standalone/lf_tharexde.md
@@ -1,0 +1,99 @@
+# LF_THAREXDE — EM4x50 Simulator/Collector
+
+> **Author:** tharexde
+> **Frequency:** LF (125 kHz)
+> **Hardware:** RDV4 (requires flash memory)
+
+[Back to Standalone Modes Index](../../armsrc/Standalone/readme.md#individual-mode-documentation) | [Source Code](../../armsrc/Standalone/lf_tharexde.c) | [Development Guide](../../armsrc/Standalone/readme.md#developing-standalone-modes)
+
+---
+
+## What
+
+A dual-mode standalone for EM4x50 tags: simulate an EM4x50 tag loaded from a flash dump file, or read/collect EM4x50 data (including passwords) to flash.
+
+## Why
+
+EM4x50 is a more advanced LF tag than EM4100 — it supports password protection, memory blocks, and bidirectional communication. This mode handles both offensive and defensive EM4x50 scenarios:
+
+- **Simulation**: Load a dumped EM4x50 tag and emulate it at a reader
+- **Collection**: Capture EM4x50 data and passwords from cards in the field
+
+## How
+
+**SIM mode:**
+1. Loads tag data from `lf_em4x50_simulate.eml` on flash
+2. Configures the EM4x50 simulation engine
+3. Continuously emulates the tag
+
+**READ mode:**
+1. Listens for EM4x50 tags
+2. Reads all accessible memory blocks
+3. If password authentication is observed, logs it to `lf_em4x50_passwords.log`
+4. Full tag dumps go to `lf_em4x50_collect.log`
+
+## LED Indicators
+
+| LED | Meaning |
+|-----|---------|
+| **A** (solid) | Simulating (blinks if no data or error) |
+| **B** (solid) | Reading / recording |
+| **D** (solid) | Unmounting / syncing flash |
+
+## Button Controls
+
+| Action | Effect |
+|--------|--------|
+| **Single click** | Toggle between SIM and READ modes |
+| **Hold** | Exit to shell |
+| **USB command** | Exit standalone mode |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> SIM : Startup (eml file exists)
+    [*] --> READ : Startup (no eml file)
+
+    SIM --> READ : Button click
+    READ --> SIM : Button click
+
+    SIM --> SIM : Continuous emulation
+    READ --> READ : Continuous collection
+
+    SIM --> [*] : Button hold / USB data
+    READ --> [*] : Button hold / USB data
+
+    note right of SIM
+        Loads from:
+        lf_em4x50_simulate.eml
+    end note
+
+    note right of READ
+        Logs to:
+        lf_em4x50_passwords.log
+        lf_em4x50_collect.log
+    end note
+```
+
+## Flash Files
+
+| File | Purpose |
+|------|---------|
+| `lf_em4x50_simulate.eml` | Input: tag data to simulate |
+| `lf_em4x50_passwords.log` | Output: captured passwords |
+| `lf_em4x50_collect.log` | Output: full tag dumps |
+
+## Compilation
+
+```
+make clean
+make STANDALONE=LF_THAREXDE -j
+./pm3-flash-fullimage
+```
+
+## Related
+
+- [EM4100 RSWB](lf_em4100rswb.md) — EM4100 (simpler format) multi-tool
+- [IceHID Collector](lf_icehid.md) — Multi-format LF collector
+- [NexID Collector](lf_nexid.md) — Nexwatch collector


### PR DESCRIPTION
So users don't have to go digging in source code:
- Pulled out the documentation that existed in the stand alone modes source
- Created a few diagrams of the state machines 
- Description of what the lights mean