### PR TITLE
Refine known AIDs; add Android HCE

### DIFF
--- a/client/resources/aidlist.json
+++ b/client/resources/aidlist.json
@@ -1536,6 +1536,14 @@
         "Type": "EMV"
     },
     {
+        "AID": "A000000476416E64726F6964484345",
+        "Vendor": "Google",
+        "Country": "N/A",
+        "Name": "Android HCE",
+        "Description": "Available on AOSP-based android devices with active HCE",
+        "Type": ""
+    },
+    {
         "AID": "A000000476A010",
         "Vendor": "Google",
         "Country": "United States",
@@ -2275,8 +2283,8 @@
         "AID": "A0000008580102",
         "Vendor": "Apple",
         "Country": "",
-        "Name": "Apple Home Key Framework",
-        "Description": "Home Key configuration applet. Used for attestation exchange",
+        "Name": "Apple Home Key Step Up",
+        "Description": "Used for reading the attestation certificate",
         "Type": ""
     },
     {
@@ -2291,8 +2299,8 @@
         "AID": "A0000008580202",
         "Vendor": "Apple",
         "Country": "",
-        "Name": "Apple Access Key Framework",
-        "Description": "Access Key configuration applet. Used for attestation exchange",
+        "Name": "Apple Access Key Step Up",
+        "Description": "Used for reading the attestation certificate",
         "Type": ""
     },
     {
@@ -2307,16 +2315,16 @@
         "AID": "A000000909ACCE5502",
         "Vendor": "Connectivity Standards Alliance (CSA)",
         "Country": "",
-        "Name": "Aliro Framework",
-        "Description": "Used during key provisioning, configuration, attestation exchange",
+        "Name": "Aliro Step Up",
+        "Description": "Used to retrieve 'access documents' in case a reader needs to verify the validity of a credential",
         "Type": ""
     },
     {
         "AID": "A000000909ACCE5501",
         "Vendor": "Connectivity Standards Alliance (CSA)",
         "Country": "",
-        "Name": "Aliro",
-        "Description": "",
+        "Name": "Aliro Expedited",
+        "Description": "Acts as the primary credential holder applet",
         "Type": "access"
     },
     {

--- a/client/src/cmdhf14a.c
+++ b/client/src/cmdhf14a.c
@@ -242,7 +242,7 @@ static const hintAIDList_t hintAIDList[] = {
     { "\x41\x44\x20\x46\x31", 5, "CIPURSE", "hf cipurse" },
     { "\xA0\x00\x00\x09\x09\xAC\xCE\x55\x01", 9, "Aliro", "hf aliro" },
     { "\xd2\x76\x00\x00\x85\x01\x00", 7, "desfire", "hf mfdes" },
-    { "\x4F\x53\x45\x2E\x56\x41\x53\x2E\x30\x31", 10, "Apple VAS", "hf vas"},
+    { "\x4F\x53\x45\x2E\x56\x41\x53\x2E\x30\x31", 10, "OSE.VAS", "hf vas"},
 };
 
 // iso14a apdu input frame length


### PR DESCRIPTION
This PR fixes up some names and descriptions for entries in aidlist.json.

It also adds an extra entry for "Android HCE" - AID which is available on ALL Android devices, provided they have HCE feature turned on, as that AID SELECT is automatically handled by the system NFC service.

```log
[usb] pm3 --> hf 14a info --aidsearch

[=] ---------- ISO14443-A Information ----------
[+]  UID: 08 07 67 9B   ( RID - random ID )
[+] ATQA: 00 04
[+]  SAK: 20 [1]
[=] -------------------------- ATS ----------------------------------
< OUTPUT TRUNCATED >
[=] -------------------- AID Search --------------------
[+] AID : A000000476416E64726F6964484345 | Google | Android HCE
[+] AID : 4F53452E5641532E3031 | Apple, Google | Value-Added Services (OSE.VAS.01)
[+] AID : A000000476D0000111 | Google | Google SmartTap 2.0
[+] AID : A000000809434343444B467631 | Car Connectivity Consortium (CCC) | Digital Car Key Framework
[+] AID : A000000809434343444B417631 | Car Connectivity Consortium (CCC) | Digital Car Key
[+] AID : A000000909ACCE5502 | Connectivity Standards Alliance (CSA) | Aliro Step Up
[+] AID : A000000909ACCE5501 | Connectivity Standards Alliance (CSA) | Aliro Expedited
[=] ----------------------------------------------------
```

Taking this opportunity, I'd like to ask for an opinion on the following potential change:

Currently, both `hf 14a info` and `hf 14b info` attempt AID selections only with `--aidsearch` argument.

If we could make probing for "Android HCE", and "OSE.VAS" happen regardless of that argument, those 2 SELECTs would give us an opportunity to detect when a mobile phone is used with 99% certainty (in fact, just OSE.VAS would give us a big chunk, minus the Chinese phones), and help to adjust the potential `hf 14{x} info` display format based on that.