### PR TITLE
Improve felica validation and cleanup handling

### DIFF
--- a/client/src/cmdhffelica.c
+++ b/client/src/cmdhffelica.c
@@ -610,6 +610,7 @@ static bool waitCmdFelicaEx(bool iSelect, PacketResponseNG *resp, bool verbose, 
             if (logging) {
                 PrintAndLogEx(WARNING, "CRC ( " _RED_("fail") " )");
             }
+            return false;
         }
 
         if (resp->data.asBytes[0] != 0xB2 || resp->data.asBytes[1] != 0x4D) {


### PR DESCRIPTION
This PR fixes three issues in the FeliCa client implementation related to
response handling and parser.

### Changes

1. Reject frames with invalid CRC in `waitCmdFelicaEx()`
   - Previously, CRC verification failures were only logged as warnings and
     the received frame was still processed.
   - CRC mismatches are now treated as fatal and the response is rejected.

2. Fix status flag error handling in authentication paths
   - `felica_internal_authentication()` and
     `felica_external_authentication()` checked `status_flag1` and
     `status_flag2` using `&&`.
   - This only reported an error when both flags were non-zero.
   - The checks now use `||` so a non-zero value in either status flag is
     treated as a failure.

3. Remove duplicate `CLIParserFree()` in `CmdHFFelicaReader()`
   - The reader command freed the same parser context twice.
   - Since the local pointer was not reset between calls, this could result
     in double-free / undefined behavior depending on the implementation of
     `CLIParserFree()`.
   - The parser context is now released only once.