### PR TITLE
Improve aliro bitmask print format

### DIFF
--- a/client/src/cmdhfaliro.c
+++ b/client/src/cmdhfaliro.c
@@ -1019,29 +1019,39 @@ static int aliro_parse_auth1_plaintext(const uint8_t *buf, size_t len, aliro_aut
     return PM3_SUCCESS;
 }
 
-static void aliro_print_signaling_bitmap(uint16_t bitmap) {
-    static const char *bit_names[] = {
-        "Access document can be retrieved",
-        "Revocation document can be retrieved",
-        "Step-up SELECT required for doc retrieval",
-        "Mailbox has non-zero data",
-        "Mailbox read supported",
-        "Mailbox write/set supported",
-        "Notify backend supported",
-        "Notify bound app supported",
-        "RFU (bit8)",
-        "update_doc supported in expedited phase",
-        "Mailbox in step-up available",
-        "Notify in step-up supported",
-        "update_doc in step-up supported",
-    };
+static void aliro_print_signaling_bit(const char *bits, uint16_t mask, uint8_t bit,
+                                      const char *enabled, const char *disabled) {
+    const bool is_enabled = (mask & (1U << bit)) != 0;
+    const int pad = 15 - bit;
+    PrintAndLogEx(INFO, "   %s",
+                  sprint_breakdown_bin(is_enabled ? C_GREEN : C_NONE, bits, 16, pad, 1,
+                                       is_enabled ? enabled : disabled));
+}
 
-    PrintAndLogEx(INFO, "Signaling bitmap......... " _YELLOW_("0x%04X"), bitmap);
-    for (size_t i = 0; i < ARRAYLEN(bit_names); i++) {
-        if ((bitmap & (1U << i)) != 0) {
-            PrintAndLogEx(INFO, "  " _YELLOW_("bit%-2zu") " set.............. %s", i, bit_names[i]);
-        }
-    }
+static void aliro_print_signaling_bitmap(uint16_t bitmap) {
+    const uint8_t bitmap_bytes[2] = {
+        (uint8_t)((bitmap >> 8) & 0xFF),
+        (uint8_t)(bitmap & 0xFF),
+    };
+    const char *bits = sprint_bin(bitmap_bytes, sizeof(bitmap_bytes));
+
+    PrintAndLogEx(INFO, "Signaling bitmap......... " _YELLOW_("%s") " (" _YELLOW_("0x%04X") ")", bits, bitmap);
+    aliro_print_signaling_bit(bits, bitmap, 15, "Reserved/unknown bit set", "Reserved/unknown bit clear");
+    aliro_print_signaling_bit(bits, bitmap, 14, "Reserved/unknown bit set", "Reserved/unknown bit clear");
+    aliro_print_signaling_bit(bits, bitmap, 13, "Reserved/unknown bit set", "Reserved/unknown bit clear");
+    aliro_print_signaling_bit(bits, bitmap, 12, "Update document in step-up supported", "Update document in step-up not supported");
+    aliro_print_signaling_bit(bits, bitmap, 11, "Notify in step-up supported", "Notify in step-up not supported");
+    aliro_print_signaling_bit(bits, bitmap, 10, "Mailbox in step-up available", "Mailbox in step-up unavailable");
+    aliro_print_signaling_bit(bits, bitmap, 9, "Update document in expedited phase supported", "Update document in expedited phase not supported");
+    aliro_print_signaling_bit(bits, bitmap, 8, "Reserved/unknown bit set", "Reserved/unknown bit clear");
+    aliro_print_signaling_bit(bits, bitmap, 7, "Notify bound app supported", "Notify bound app not supported");
+    aliro_print_signaling_bit(bits, bitmap, 6, "Notify backend supported", "Notify backend not supported");
+    aliro_print_signaling_bit(bits, bitmap, 5, "Mailbox write/set supported", "Mailbox write/set not supported");
+    aliro_print_signaling_bit(bits, bitmap, 4, "Mailbox read supported", "Mailbox read not supported");
+    aliro_print_signaling_bit(bits, bitmap, 3, "Mailbox has non-zero data", "Mailbox has zero data");
+    aliro_print_signaling_bit(bits, bitmap, 2, "Step-up SELECT required for doc retrieval", "Step-up SELECT not required for doc retrieval");
+    aliro_print_signaling_bit(bits, bitmap, 1, "Revocation document retrievable", "Revocation document not retrievable");
+    aliro_print_signaling_bit(bits, bitmap, 0, "Access document retrievable", "Access document not retrievable");
 }
 
 static bool aliro_is_zeroed(const uint8_t *buf, size_t len) {
@@ -1499,6 +1509,7 @@ aliro_append_tlv(0x4D, state->reader_identifier, 32, auth0_data, sizeof(auth0_da
         return PM3_ESOFT;
     }
 
+    PrintAndLogEx(INFO, "");
     PrintAndLogInfoHeader("AUTH0");
     PrintAndLogEx(INFO, "Reader group id........... %s", sprint_hex_inrow(reader_group_identifier, 16));
     PrintAndLogEx(INFO, "Reader sub id............. %s", sprint_hex_inrow(reader_group_sub_identifier, 16));
@@ -1794,6 +1805,7 @@ static void aliro_read_print_auth1_report(const aliro_read_state_t *state) {
         return;
     }
 
+    PrintAndLogEx(INFO, "");
     PrintAndLogInfoHeader("AUTH1");
     PrintAndLogEx(INFO, "AUTH1 signature........... %s", sprint_hex_inrow(state->auth1_parsed.signature, 64));
     if (state->auth1_parsed.have_key_slot) {
@@ -1876,6 +1888,7 @@ static void aliro_read_print_fast_suggestion_note(const char *fast_cmd) {
     if (fast_cmd == NULL || fast_cmd[0] == '\0') {
         return;
     }
+    PrintAndLogEx(INFO, "");
     PrintAndLogInfoHeader("Note");
     PrintAndLogEx(INFO, _GREEN_("use the following command to perform FAST authentication flow for this endpoint:"));
     PrintAndLogEx(INFO, _YELLOW_("%s"), fast_cmd);
@@ -3249,6 +3262,7 @@ static int aliro_read_do_step_up(const aliro_read_state_t *state,
         document_types[document_type_count++] = ALIRO_REVOCATION_DOCUMENT_TYPE;
     }
 
+    PrintAndLogEx(INFO, "");
     PrintAndLogInfoHeader("Step-up");
     if (document_type_count == 0) {
         PrintAndLogEx(WARNING, "Signaling bitmap does not indicate retrievable step-up documents");


### PR DESCRIPTION
This PR updates signaling bit mask print format to adhere to other modules (there is green color coding in the client for SET bits):

```log
[=] Signaling bitmap......... 0000000000110101 (0x0035)
[=]    0 .............. - Reserved/unknown bit clear
[=]    .0 ............. - Reserved/unknown bit clear
[=]    ..0 ............ - Reserved/unknown bit clear
[=]    ...0 ........... - Update document in step-up not supported
[=]    ....0 .......... - Notify in step-up not supported
[=]    .....0 ......... - Mailbox in step-up unavailable
[=]    ......0 ........ - Update document in expedited phase not supported
[=]    .......0 ....... - Reserved/unknown bit clear
[=]    ........0 ...... - Notify bound app not supported
[=]    .........0 ..... - Notify backend not supported
[=]    ..........1 .... - Mailbox write/set supported
[=]    ...........1 ... - Mailbox read supported
[=]    ............0 .. - Mailbox has zero data
[=]    .............1 . - Step-up SELECT required for doc retrieval
[=]    ..............0  - Revocation document not retrievable
[=]    ...............1 - Access document retrievable
```

I've also aded an empty line before each section of the transaction for better visual separation.

```log
[usb] pm3 --> hf aliro read --reader-group-id bb0c286dc0f4ddd34a67e434ed7ad1a3 --reader-private-key wAPEZGNO5JJe9P1TYpabxvoIIc0rCYrUNAwSwSyKbrU=
[=] ------------------------------- Applet information -------------------------------
[=] AID....................... A000000909ACCE5501
[=] Supported protocol versions:
[=]   1) 1.0 (0x0100)
[=]   2) 0.9 (0x0009)
[=] Application type.......... CSA application (0x0000)
[=] Maximum command APDU...... 3584 bytes
[=] Maximum response APDU..... 3584 bytes
[=] Selected protocol version. 0x0100
[=] 
[=] ------------------------------------- AUTH0 --------------------------------------
[=] Reader group id........... BB0C286DC0F4DDD34A67E434ED7AD1A3
[=] Reader sub id............. 00000000000000000000000000000000
[=] Reader id................. BB0C286DC0F4DDD34A67E434ED7AD1A300000000000000000000000000000000
[=] Reader public key......... 04911B219C1879E51C6292ACEA35F9435A60417332A24D8A21F5CEA267D5D6847A21F20A2EF8CCF21A12A9D5FA025487B17D78EDCAF0C322E24E222BD49D96AA62
[=] Reader ePubK.............. 046A179D947B2F59C6F63B54A80A3AB36BCDE6BAD00556CBD15055333BEE2508F97D59D3851FF7F278292780F78766F02DA71A9F47A1E6E4401560B3D48113DD41
[=] Transaction identifier.... CB33F0961886D538142B097E244C3288
[=] Requested AUTH0 flow...... standard
[=] AUTH0 credential ePubK.... 04C781A4FCFC855B93B0039D29333DFADAACDB7FF9AF8388A37719681F4E38A7A3223A723EB9109A968C39DFFE8E889F09A42F100F77686F4A29A77B9B36A028AF
[=] AUTH0 cryptogram.......... not present
[=] 
[=] ------------------------------------- AUTH1 --------------------------------------
[=] AUTH1 signature........... AECBB0134D477CF2F87A2DCB9861882FC7F27EA488DDC1ECDB42BC65BFD01111298345537D97F756E942C19099AD7EE1035E42C0BABBDD172B2CD5473D9FF759
[=] AUTH1 endpoint pubkey..... 043531C9045674039E78E29486D0096DCC14F03DABE2E7653092A7E53D30B094D10D7561EA8ACF8CE3386644F8A14A33041F7F319C14D7AC437ADA5850D90F5C11
[=] AUTH1 signature valid...... yes
[=] Signaling bitmap......... 0000000000110101 (0x0035)
[=]    0 .............. - Reserved/unknown bit clear
[=]    .0 ............. - Reserved/unknown bit clear
[=]    ..0 ............ - Reserved/unknown bit clear
[=]    ...0 ........... - Update document in step-up not supported
[=]    ....0 .......... - Notify in step-up not supported
[=]    .....0 ......... - Mailbox in step-up unavailable
[=]    ......0 ........ - Update document in expedited phase not supported
[=]    .......0 ....... - Reserved/unknown bit clear
[=]    ........0 ...... - Notify bound app not supported
[=]    .........0 ..... - Notify backend not supported
[=]    ..........1 .... - Mailbox write/set supported
[=]    ...........1 ... - Mailbox read supported
[=]    ............0 .. - Mailbox has zero data
[=]    .............1 . - Step-up SELECT required for doc retrieval
[=]    ..............0  - Revocation document not retrievable
[=]    ...............1 - Access document retrievable
[=] Credential timestamp....... 2026-03-11T19:53:29Z
[=] Revocation timestamp....... not present
[=] Derived keys:
[=]   Kdh....................... C35D1EE067B5FA9A249E32AE195C8CFB108B1987D3F29EE58027C8E73B0F09E4
[=]   ExpeditedSKReader......... DDF9D24515015E92156916B683120D5445EFA25F8A0FAFC5C288327464A4D7DF
[=]   ExpeditedSKDevice......... 962869825D7C23634DE1830912DCD6549E1543404378F43AD8E562603473904A
[=]   StepUpSKReader............ 265F59399E2933CEFE05EACDA979E05B8586EB08D26420F874A14384E9696C94
[=]   StepUpSKDevice............ 3FB45BCC4BEB53E13BC0BD016145D2B3D36B6176D26A28DF730C2D0D1DA0614F
[=]   BleSKReader............... 58AAD028781B9A4FCFCC8466DAF05DD12ED0D62645546B0CA1ECB1DA8BC0E542
[=]   BleSKDevice............... 3E5BABE906B768126D8A748B55BA137E11B1F04C403016CE2DEB4B049620A4A2
[=]   URSK...................... A3E5836C9BD1CB6574D0C4E60D2FB753DFFA8449CCDFBDCD9F497A51870C992B
[=]   Kpersistent (derived)..... 0FDEA6E0320258495D483B153B4945B62C7BFA05AD27899ABCEACAB25D40B88C
[=] 
[=] ------------------------------------ Step-up -------------------------------------
[=] Signaling bit0............ set -> requesting `aliro-a`
[=] Requested doc type........ aliro-a
[=] Step-up scopes............ matter1
[=] Step-up SELECT............ ok
[=] DeviceRequest CBOR........ A2613163312E30613281A16131D8185820A26131A167616C69726F2D61A1676D617474657231F5613567616C69726F2D61
[=] DeviceResponse CBOR....... A3613163312E30613281A26131A26131A167616C69726F2D6181D8185837A461310061325820259DC5341A687A8AAB207B5278B4D701DB9AAA271073EC95431444C0C0772C976133676D6174746572316134A1000161328443A10126A104487DBE31CE1CE2404758EED81858EAA7613163312E306132675348412D3235366133A167616C69726F2D61A100582003AAEA0D510D8B5F372AA7B4C7B282BCD3608D6E44BEFFFEE185443FC5633B8B6134A16131A50102032620012158203531C9045674039E78E29486D0096DCC14F03DABE2E7653092A7E53D30B094D12258200D7561EA8ACF8CE3386644F8A14A33041F7F319C14D7AC437ADA5850D90F5C11613567616C69726F2D616136A36131C074323032362D30332D31315431393A35333A32395A6132C074323032362D30332D31315431393A35333A32395A6133C074343030312D30312D30315430303A30303A30305A6137F5584025B05EA9A87678744517A31CD051F148ED0D65C96419327BF79D4D6F6CE5C2FD8C210BB4F33487BDC8A69439610A842C3A5C0CEF11BA02ED2ADF5BCC1C3B651F613567616C69726F2D61613300
[=] DeviceResponse:
[=]   version................. 1.0
[=]   documents:
[=]     Document[0]
[=]       issuerSigned:
[=]         NameSpace[0]............ aliro-a
[=]           IssuerSignedItem[0]
[=]             digest_id............... 0
[=]             random.................. 259DC5341A687A8AAB207B5278B4D701DB9AAA271073EC95431444C0C0772C97
[=]             element_identifier...... matter1
[=]             element_value........... <access data>
[=]               AccessData version...... 1
[=]       issuerAuth:
[=]         signature............... 25B05EA9A87678744517A31CD051F148ED0D65C96419327BF79D4D6F6CE5C2FD8C210BB4F33487BDC8A69439610A842C3A5C0CEF11BA02ED2ADF5BCC1C3B651F
[=]         headers:
[=]           signature algorithm..... -7 (ES256 (ECDSA w/ SHA-256))
[=]           issuer_id............... 7DBE31CE1CE24047
[=]         mso:
[=]           version................. 1.0
[=]           digest algorithm........ SHA-256
[=]           device key:
[=]             device key alg.......... -7 (ES256 (ECDSA w/ SHA-256))
[=]             device pubkey........... 043531C9045674039E78E29486D0096DCC14F03DABE2E7653092A7E53D30B094D10D7561EA8ACF8CE3386644F8A14A33041F7F319C14D7AC437ADA5850D90F5C11
[=]           docType................. aliro-a
[=]           validity:
[=]             signed.................. 2026-03-11T19:53:29Z
[=]             valid from.............. 2026-03-11T19:53:29Z
[=]             valid until............. 4001-01-01T00:00:00Z
[=]           time verify required.... true
[=]       docType................. aliro-a
[=]   status.................. 0
[=] 
[=] -------------------------------------- Note --------------------------------------
[=] use the following command to perform FAST authentication flow for this endpoint:
[=] hf aliro read --reader-group-id BB0C286DC0F4DDD34A67E434ED7AD1A3 --reader-sub-group-id 00000000000000000000000000000000 --reader-private-key C003C464634EE4925EF4FD5362969BC6FA0821CD2B098AD4340C12C12C8A6EB5 --key-persistent 0FDEA6E0320258495D483B153B4945B62C7BFA05AD27899ABCEACAB25D40B88C --endpoint-public-key 043531C9045674039E78E29486D0096DCC14F03DABE2E7653092A7E53D30B094D10D7561EA8ACF8CE3386644F8A14A33041F7F319C14D7AC437ADA5850D90F5C11 --flow fast
```