### PR TITLE
Allow to detect which exact app implements AID via matching response data

### DIFF
--- a/client/src/cmdhf14a.c
+++ b/client/src/cmdhf14a.c
@@ -233,17 +233,17 @@ const char *getTagInfo(uint8_t uid) {
 }
 
 static const hintAIDList_t hintAIDList[] = {
-    // AID, AID len, name, hint - how to use
-    { "\xA0\x00\x00\x06\x47\x2F\x00\x01", 8, "FIDO", "hf fido" },
-    { "\xA0\x00\x00\x03\x08\x00\x00\x10\x00\x01\x00", 11, "PIV", "" },
-    { "\xD2\x76\x00\x01\x24\x01", 8, "OpenPGP", "" },
-    { "\x31\x50\x41\x59\x2E\x53\x59\x53\x2E\x44\x44\x46\x30\x31", 14, "EMV (pse)", "emv" },
-    { "\x32\x50\x41\x59\x2E\x53\x59\x53\x2E\x44\x44\x46\x30\x31", 14, "EMV (ppse)", "emv" },
-    { "\x41\x44\x20\x46\x31", 5, "CIPURSE", "hf cipurse" },
-    { "\xA0\x00\x00\x09\x09\xAC\xCE\x55\x01", 9, "Aliro", "hf aliro" },
-    { "\xd2\x76\x00\x00\x85\x01\x00", 7, "desfire", "hf mfdes" },
-    { "\x4F\x53\x45\x2E\x56\x41\x53\x2E\x30\x31", 10, "OSE.VAS", "hf vas"},
-    { "\xA0\x00\x00\x04\x76\xD0\x00\x01\x11", 9, "Google Smart Tap v2", "hf gst" },
+    { "\xA0\x00\x00\x06\x47\x2F\x00\x01", 8, "", 0, "FIDO", "hf fido" },
+    { "\xA0\x00\x00\x03\x08\x00\x00\x10\x00\x01\x00", 11, "", 0, "PIV", "" },
+    { "\xD2\x76\x00\x01\x24\x01", 8, "", 0, "OpenPGP", "" },
+    { "\x31\x50\x41\x59\x2E\x53\x59\x53\x2E\x44\x44\x46\x30\x31", 14, "", 0, "EMV (pse)", "emv" },
+    { "\x32\x50\x41\x59\x2E\x53\x59\x53\x2E\x44\x44\x46\x30\x31", 14, "", 0, "EMV (ppse)", "emv" },
+    { "\x41\x44\x20\x46\x31", 5, "", 0, "CIPURSE", "hf cipurse" },
+    { "\xA0\x00\x00\x09\x09\xAC\xCE\x55\x01", 9, "", 0, "Aliro", "hf aliro" },
+    { "\xd2\x76\x00\x00\x85\x01\x00", 7, "", 0, "desfire", "hf mfdes" },
+    { "\x4F\x53\x45\x2E\x56\x41\x53\x2E\x30\x31", 10, "ApplePay", 8, "OSE.VAS (Apple Wallet)", "hf vas" },
+    { "\x4F\x53\x45\x2E\x56\x41\x53\x2E\x30\x31", 10, "AndroidPay", 10, "OSE.VAS (Google Wallet)", "hf gst" },
+    { "\xA0\x00\x00\x04\x76\xD0\x00\x01\x11", 9, "", 0, "Google Smart Tap v2", "hf gst" },
 };
 
 // iso14a apdu input frame length
@@ -3407,6 +3407,18 @@ int infoHF14A(bool verbose, bool do_nack_test, bool do_aid_search) {
     return select_status;
 }
 
+static bool hint_aid_match_select_response(const hintAIDList_t *entry, const uint8_t *select_response, size_t select_response_len) {
+    if (entry->select_response_match_length == 0) {
+        return true;
+    }
+
+    if ((entry->select_response_match == NULL) || (select_response == NULL) || (select_response_len < entry->select_response_match_length)) {
+        return false;
+    }
+
+    return byte_strstr(select_response, select_response_len, (const uint8_t *)entry->select_response_match, entry->select_response_match_length) != -1;
+}
+
 int infoHF14A4Applications(bool verbose) {
     bool cardFound[ARRAYLEN(hintAIDList)] = {0};
     bool ActivateField = true;
@@ -3421,6 +3433,10 @@ int infoHF14A4Applications(bool verbose) {
             break;
 
         if (sw == ISO7816_OK || sw == ISO7816_INVALID_DF || sw == ISO7816_FILE_TERMINATED) {
+            if (!hint_aid_match_select_response(&hintAIDList[i], result, resultlen)) {
+                continue;
+            }
+
             if (!found) {
                 if (verbose)
                     PrintAndLogEx(INFO, "----------------- " _CYAN_("Short AID search") " -----------------");
@@ -3431,9 +3447,8 @@ int infoHF14A4Applications(bool verbose) {
                 if (verbose)
                     PrintAndLogEx(SUCCESS, "Application " _CYAN_("%s") " ( " _GREEN_("ok") " )", hintAIDList[i].desc);
                 cardFound[i] = true;
-            } else {
-                if (verbose)
-                    PrintAndLogEx(WARNING, "Application " _CYAN_("%s") " ( " _RED_("blocked") " )", hintAIDList[i].desc);
+            } else if (verbose) {
+                PrintAndLogEx(WARNING, "Application " _CYAN_("%s") " ( " _RED_("blocked") " )", hintAIDList[i].desc);
             }
         }
     }

--- a/client/src/cmdhf14a.h
+++ b/client/src/cmdhf14a.h
@@ -32,6 +32,8 @@ typedef struct {
 typedef struct {
     const char *aid;
     const uint8_t aid_length;
+    const char *select_response_match;
+    const uint8_t select_response_match_length;
     const char *desc;
     const char *hint;
 } hintAIDList_t;


### PR DESCRIPTION
### Overview

This PR allows specifying an optional string to match for in SELECT response when scanning for AID hints.

This allows to differentiate between protocol implementations in cases where multiple ones could use the same AID but are actually different protocols under the hood, which is the case for Apple VAS and Google Smart Tap.

Thanks to this change, the detection can now detect the proper protocol and suggest the matching command:

### Examples

#### Google Pixel
```log
[usb] pm3 --> hf search --verbose
 🕔  Searching for ISO14443-A tag...          
[=] ---------- ISO14443-A Information ----------
[+]  UID: 08 0E 64 59   ( RID - random ID )
[+] ATQA: 00 04
[+]  SAK: 20 [1]
[+] Possible types:
[+]    HID SEOS (smartmx / javacard)
[+]    EMV
[=] -------------------------- ATS ----------------------------------
[+] ATS: 05 78 80 70 02 [ A5 46 ]
[=]      05...............  TL    length is 5 bytes
[=]      ...78............  T0    TA1 is present, TB1 is present, TC1 is present, FSCI is 8 (FSC = 256)
[=]      ......80.........  TA1   different divisors are NOT supported, DR: [], DS: []
[=]      .........70......  TB1   SFGI = 0 (SFGT = (not needed) 0/fc), FWI = 7 (FWT = 524288/fc)
[=]      ............02...  TC1   NAD is NOT supported, CID is supported

[?] Hint: Try `emv reader`
[?] Hint: Try `hf seos info`


[+] Valid ISO 14443-A tag found

[=] ----------------- Short AID search -----------------
[+] Application EMV (ppse) ( ok )
[+] Application Aliro ( ok )
[+] Application OSE.VAS (Google Wallet) ( ok )
[+] Application Google Smart Tap v2 ( ok )
[=] ---------------------------------------------------
[?] Hint: Try `emv` commands
[?] Hint: Try `hf aliro` commands
[?] Hint: Try `hf gst` commands
[?] Hint: Try `hf gst` commands
 🕐  Searching for ISO14443-B tag...          
```

#### Apple iPhone

```log
[usb] pm3 --> hf search --verbose
 🕓  Searching for ISO14443-A tag...          
[=] ---------- ISO14443-A Information ----------
[+]  UID: 08 23 78 C6   ( RID - random ID )
[+] ATQA: 00 04
[+]  SAK: 20 [1]
[+] Possible types:
[+]    HID SEOS (smartmx / javacard)
[+]    EMV
[=] -------------------------- ATS ----------------------------------
[+] ATS: 05 78 80 70 02 [ A5 46 ]
[=]      05...............  TL    length is 5 bytes
[=]      ...78............  T0    TA1 is present, TB1 is present, TC1 is present, FSCI is 8 (FSC = 256)
[=]      ......80.........  TA1   different divisors are NOT supported, DR: [], DS: []
[=]      .........70......  TB1   SFGI = 0 (SFGT = (not needed) 0/fc), FWI = 7 (FWT = 524288/fc)
[=]      ............02...  TC1   NAD is NOT supported, CID is supported

[?] Hint: Try `emv reader`
[?] Hint: Try `hf seos info`


[+] Valid ISO 14443-A tag found

[=] ----------------- Short AID search -----------------
[+] Application EMV (ppse) ( ok )
[+] Application OSE.VAS (Apple Wallet) ( ok )
[=] ---------------------------------------------------
[?] Hint: Try `emv` commands
[?] Hint: Try `hf vas` commands
 🕛  Searching for ISO14443-B tag... 
```