### PR TITLE
Skip nodes with PIN attribute when performing node discovery with RequestService in FeliCa

### DIFF
--- a/client/src/cmdhffelica.c
+++ b/client/src/cmdhffelica.c
@@ -110,7 +110,7 @@
 #define FELICA_SERVICE_ATTRIBUTE_PURSE_RO_WITH_KEY_WITH_PIN           0x36U
 #define FELICA_SERVICE_ATTRIBUTE_PURSE_RO_WITHOUT_KEY_WITH_PIN        0x37U
 
-#define FELICA_REQUEST_SERVICE_DISCOVERY_BATCH_SIZE 16U
+#define FELICA_REQUEST_SERVICE_DISCOVERY_BATCH_SIZE 32U
 #define FELICA_MAX_NODE_NUMBER 0x03FFU
 #define FELICA_PRESENCE_SERVICE_CODE_LE ((uint16_t)FELICA_SERVICE_ATTRIBUTE_RANDOM_RO_WITHOUT_KEY)
 
@@ -1992,6 +1992,12 @@ static bool felica_discover_nodes_with_request_service(uint8_t *flags,
             }
 
             const felica_request_service_probe_attribute_t probe_attr = FELICA_REQUEST_SERVICE_PROBE_ATTRIBUTES[j];
+            if (probe_attr.with_pin) {
+                // Some cards do not react well to RequestService probes that include
+                // unsupported node attributes, so PIN-related nodes supported only on mobile are skipped here.
+                continue;
+            }
+
             const uint16_t node_code_le = (uint16_t)((number << 6) | probe_attr.attribute);
 
             batch_codes[batch_count] = node_code_le;


### PR DESCRIPTION
When developing universal node discovery for FeliCa in #3118, I've encountered an issue that some cards weren't responding to RequestService if node count was bigger than 16.

Turns out, that wasn't the exact reason, and instead, the issue happened on some Chinese FeliCa versions (IC 24) when they received a node attribute value that was "unknown" to it.

To avoid this issue, this PR excludes nodes with PIN attributes from RequestService node discovery method, as PIN nodes are supported only on mobile phones anyway, and those support RequestCodeList and SearchServiceCode.

This also allows to increase the probing batch size back to 32, increasing scan speeds 2X, actually, up to 4X, considering that PIN attribute is no longer attempted, cutting amount of probed attributes in half.

As a result, scanning a Pixel 7 Pro with RequestService method now takes ~24000ms instead of ~78000ms. 

```log
[usb] pm3 --> hf felica discnodes --method request_service
[!] ⚠️  No cached IDm available. Polling for a new tag...
[=] Using polled IDm.... XXXX
[?] Area and service codes are printed in network order.
[=] Press <Enter> to abort discovery
[=] Node discovery method used: RequestService
[=] ┌───────────────────────────────────────────────
[=] ├── AREA_0000 (0-?)
[=] ├── AREA_0010 (64-?)
[=] ├── AREA_0110 (64-?)
[=] ├── SVC_0810 (64)
[=] ├── SVC_0811 (68)
[=] ├── SVC_0A11 (68)
[=] ├── SVC_0B11 (68)
[=] ├── SVC_0812 (72)
[=] ├── SVC_1013 (76)
[=] ├── SVC_1213 (76)
[=] ├── SVC_1713 (76)
[=] ├── SVC_0814 (80)
[=] ├── SVC_0A14 (80)
[=] ├── SVC_0815 (84)
[=] ├── SVC_0A15 (84)
[=] ├── SVC_0816 (88)
[=] ├── SVC_0A16 (88)
[=] ├── SVC_0C17 (92)
[=] ├── SVC_0F17 (92)
< OUTPUT TRUNCATED >
[=] ├── AREA_C074 (467-?)
[=] ├── AREA_C174 (467-?)
[=] ├── SVC_C874 (467)
[=] ├── SVC_CA74 (467)
[=] ├── SVC_CB74 (467)
[=] ├── SVC_0875 (468)
[=] ├── SVC_0A75 (468)
[=] ├── SVC_0B75 (468)
[=] ├── SVC_4875 (469)
[=] ├── SVC_4975 (469)
[=] ├── SVC_8975 (470)
[=] └───────────────────────
[=] Node discovery duration: 23867 ms
[+] Service code and area dump complete. Discovered 129 node(s): 19 area(s), 110 service(s).
[usb] pm3 --> ^C
```