### PR TITLE
Add support for reading multiple pass type identifiers in VAS

### DIFF
--- a/client/src/cmdhfvas.c
+++ b/client/src/cmdhfvas.c
@@ -908,10 +908,9 @@ static int CmdVASReader(const char *Cmd) {
     char mode_text[32] = {0};
     int mode_len = 0;
     CLIParamStrToBuf(arg_get_str(ctx, 4), (uint8_t *)mode_text, sizeof(mode_text), &mode_len);
-    (void)mode_len;
     str_lower(mode_text);
-    uint8_t vas_mode = VAS_MODE_VAS_ONLY;
-    if (vas_parse_mode(mode_text, &vas_mode) != PM3_SUCCESS) {
+    uint8_t vas_mode = (pid_count > 1) ? VAS_MODE_VAS_AND_PAY : VAS_MODE_VAS_ONLY;
+    if (mode_len > 0 && vas_parse_mode(mode_text, &vas_mode) != PM3_SUCCESS) {
         VasReaderCleanup(NULL, 0, key_values, key_count, pid_values, pid_count);
         CLIParserFree(ctx);
         return PM3_EINVARG;


### PR DESCRIPTION
This PR makes the following changes to the VAS module:


1) Add support for specifying multiple pass issuer identifiers `--pid` for a single reader session. In this case all of the given pass identifiers will be attempted to be read through GET_DATA;

2) Add support for providing multiple decryption keys by repeating `--key` argument. This allows to decrypt pass payloads in case the same pass identifier utilizes batched keysets, or when multiple pass identifiers are read;
First 4 bytes of a cryptogram returned by a device contains the "key identifier", which helps to find the matching key without having to brute-force decryption.

3) Allow specifying `--mode` argument to specify vasonly/vasorpay/vasandpay modes, [which slightly affects the UI behavior on the device](https://github.com/kormax/apple-vas?tab=readme-ov-file#operation-modes);

4) Even if cryptograms cannot be decrypted, they're printed for possibility of offline decryption;

5) OSE information returned from SELECT is printed in reader mode.

6) Minor adjustments to variable names (key hint -> key id), etc.


With those changes change, it's now possible to utilize the multi-pass-read functionality of the VAS:

### Example

Attempt to read 3 passes from a phone:
* Passkit is available and has a matching key
* Zebra is present, but no key provided
* Springcard is disabled

```log
[usb] pm3 --> hf vas reader --pid pass.com.passkit.pksamples.nfcdemo --pid pass.com.pronto.zebra-wallet-pass.demo --pid pass.com.springcard.springblue.generic  -k vas.passkit.der --mode vasonly
[=] Requesting pass type id entries... 3
[=] 
[=] -------------------------------- OSE Information ---------------------------------
[=] Wallet type.......... ApplePay
[=] VAS version.......... 1.0
[=] Device nonce......... 2FD59726
[=] Mobile capabilities.. 00111110 (0x3E)
[=]    0 ...... - Reserved/unknown bit clear
[=]    .0 ..... - Reserved/unknown bit clear
[=]    ..1 .... - Payment may be performed
[=]    ...1 ... - Payment may be skipped
[=]    ....1 .. - VAS may be performed
[=]    .....1 . - VAS may be skipped
[=]    ......1  - Encrypted VAS data supported
[=]    .......0 - Plaintext VAS data not supported
[=] 
[=] ---------------- VAS Get Data pass.com.passkit.pksamples.nfcdemo -----------------
[=] Pass type id hash...... 03B57CDB3ECA0984BA9ABDC2FB45D86626D87B39D33C5C6DBBC313A6347A3146
[=] GET VAS DATA status.... 9000 (OK)
[+] Pass data
[+]   Timestamp... 795465294 (secs since Jan 1, 2001)
[+]   Message..... 44lfcgPaXLw7vPNNPou3RB
[=] 
[=] -------------- VAS Get Data pass.com.pronto.zebra-wallet-pass.demo ---------------
[=] Pass type id hash...... 8E471B919290E89D0206B523AD5DF82D637B8E9C3D60C3F214F74E31455F06F9
[=] GET VAS DATA status.... 9000 (OK)
[-] ⛔ No matching key identifier found, cannot decrypt VAS data
[=] Cryptogram
[=]   Key id...... 155B426F
[=]   Ciphertext.. 155B426FB0A7336ACB6B25B5AF57787BE35D3417782DD154BD55215115F281B1ADEBBA8F2153B41B1B5E1B00A442C9572D4BF493182B516343AE2160B146FF41EF06DF8B85511D825795ECCF6EDEBBEAAB3254EC47C8578A5532EDA3BBF5385FB2E9A85BC5F7B8C2
[=] 
[=] -------------- VAS Get Data pass.com.springcard.springblue.generic ---------------
[=] Pass type id hash...... 73F1639ABB7AB7AE44A69DCCF6A73DC2ED6D6453363D18E7BC28191EFFFDC3D3
[=] GET VAS DATA status.... 6A83 (DATA_NOT_FOUND)
```

As a result:
* Passkit data is decrypted and parsed out
* Springcard reports DATA_NOT_FOUND
* Zebra cryptogram isn't decrypted, but it's printed for later use


User can use the existing `hf vas decrypt` command do decrypt the cryptogram.

```log
[usb] pm3 --> hf vas decrypt --pid pass.com.pronto.zebra-wallet-pass.demo -k vas.zebra.der -d 155B426FB0A7336ACB6B25B5AF57787BE35D3417782DD154BD55215115F281B1ADEBBA8F2153B41B1B5E1B00A442C9572D4BF493182B516343AE2160B146FF41EF06DF8B85511D825795ECCF6EDEBBEAAB3254EC47C8578A5532EDA3BBF5385FB2E9A85BC5F7B8C2
[+] Timestamp... 795465294 (secs since Jan 1, 2001)
[+] Message..... example@example.com|example|example|+10123456789
```