### PR TITLE
[hf seos] Increase maximum ADF OID length

### DIFF
--- a/client/src/cmdhfseos.c
+++ b/client/src/cmdhfseos.c
@@ -43,6 +43,7 @@
 static uint8_t zeros[16] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
 #define MAX_DIVERSIFIER_LEN 16
+#define MAX_OID_LEN 32
 
 static int CmdHelp(const char *Cmd);
 
@@ -849,7 +850,7 @@ static int select_ADF_decrypt(const char *selectADFOID, uint8_t *CRYPTOGRAM_encr
     // Skip synthesized IV
     for (int i = iv_size * 2; i < CRYPTOGRAM_decrypted_data_length; i++) {
         // ADF OID tag
-        if (CRYPTOGRAM_decrypted_data[i] == 0x06 && CRYPTOGRAM_decrypted_data[i + 1] <= 32) {
+        if (CRYPTOGRAM_decrypted_data[i] == 0x06 && CRYPTOGRAM_decrypted_data[i + 1] <= MAX_OID_LEN) {
             adf_length = ((CRYPTOGRAM_decrypted_data[i + 1]));
             diversifier_length = CRYPTOGRAM_decrypted_data[i + adf_length + 3];
             if (*diversifier_length_out < diversifier_length) {


### PR DESCRIPTION
Some newer MOB/ICE OIDs have gotten quite large. Custom OIDs may also be even larger. I just tried to use my Proxmark with a 20-byte OID, but I've increased the limit to 32 to make sure it won't be a problem in the future.