### PR TITLE
Add continuous mode to 'hf gst read'

### DIFF
--- a/client/src/cmdhfgst.c
+++ b/client/src/cmdhfgst.c
@@ -35,6 +35,7 @@
 #include <zlib.h>
 #endif
 #include "cliparser.h"
+#include "cmdhf14a.h"
 #include "cmdparser.h"
 #include "cmdtrace.h"
 #include "commonutil.h"
@@ -46,6 +47,7 @@
 #include "protocols.h"
 #include "ui.h"
 #include "util.h"
+#include "util_posix.h"
 
 #define GST_MAX_BUFFER 4096
 #define GST_MAX_NDEF_BUFFER 2048
@@ -886,12 +888,12 @@ static bool gst_should_select_smart_tap(gst_select_behavior_t behavior, const gs
     return (!allow_skip || !have_device_nonce);
 }
 
-static int gst_select_ose(gst_ose_info_t *info, bool keep_field_on) {
+static int gst_select_ose(gst_ose_info_t *info, bool activate_field, bool keep_field_on) {
     uint8_t response[GST_MAX_BUFFER] = {0};
     size_t response_len = 0;
     uint16_t sw = 0;
 
-    int res = gst_exchange_chained(true, keep_field_on, 0x00, ISO7816_SELECT_FILE, 0x04, 0x00,
+    int res = gst_exchange_chained(activate_field, keep_field_on, 0x00, ISO7816_SELECT_FILE, 0x04, 0x00,
                                    GST_OSE_AID, sizeof(GST_OSE_AID),
                                    response, sizeof(response), &response_len, &sw);
     if (res != PM3_SUCCESS) {
@@ -1896,7 +1898,7 @@ static int gst_extract_record_bundle(const uint8_t *response_data, size_t respon
 
 static int gst_info(gst_select_behavior_t select_behavior) {
     gst_ose_info_t ose_info;
-    int res = gst_select_ose(&ose_info, true);
+    int res = gst_select_ose(&ose_info, true, true);
     if (res != PM3_SUCCESS) {
         DropField();
         return res;
@@ -2020,7 +2022,7 @@ static int gst_read(const gst_read_config_t *cfg) {
     session_id = MemBeToUint8byte(session_id_be);
 
     gst_ose_info_t ose_info;
-    status = gst_select_ose(&ose_info, true);
+    status = gst_select_ose(&ose_info, false, true);
     if (status != PM3_SUCCESS) {
         goto out;
     }
@@ -2344,7 +2346,8 @@ static int CmdHFGSTRead(const char *Cmd) {
                   "hf gst read --cid 20180608 --rpk \"-----BEGIN EC PRIVATE KEY-----\\nMHcCAQEEIIJtF+UHZ7FlsOTZ4zL40dHiAiQoT7Ta8eUKAyRucHl9oAoGCCqGSM49\\nAwEHoUQDQgAEchyXj869zfmKhRi9xP7f2AK07kEo4lE7ZlWTN14jh4YBTny+hRGR\\nXcUzevV9zSSPJlPHpqqu5pEwlv1xyFvE1w==\\n-----END EC PRIVATE KEY-----\"\n"
                   "hf gst read --cid 20180608 --rpk MHcCAQEEIIJtF+UHZ7FlsOTZ4zL40dHiAiQoT7Ta8eUKAyRucHl9oAoGCCqGSM49AwEHoUQDQgAEchyXj869zfmKhRi9xP7f2AK07kEo4lE7ZlWTN14jh4YBTny+hRGRXcUzevV9zSSPJlPHpqqu5pEwlv1xyFvE1w==\n"
                   "hf gst read --collector-id 20180608 --reader-private-key gst.google.der\n"
-                  "hf gst read --collector-id 20180608 --reader-private-key 826d17e50767b165b0e4d9e332f8d1d1e20224284fb4daf1e50a03246e70797d");
+                  "hf gst read --collector-id 20180608 --reader-private-key 826d17e50767b165b0e4d9e332f8d1d1e20224284fb4daf1e50a03246e70797d\n"
+                  "hf gst read --cid 20180608 --rpk gst.google.der -@");
 
     void *argtable[] = {
         arg_param_begin,
@@ -2357,6 +2360,7 @@ static int CmdHFGSTRead(const char *Cmd) {
         arg_str0(NULL, "mode", "<pass-only|payment-only|pass-and-payment|pass-over-payment>", "Reader mode (default: pass-over-payment)"),
         arg_str0(NULL, "select-smarttap2", "<auto|yes|no>", "Whether to perform Smart Tap applet select (default: auto)"),
         arg_lit0(NULL, "no-live-auth", "Use zeroed handset nonce for reader signature"),
+        arg_lit0("@", NULL, "continuous mode"),
         arg_lit0("a", "apdu", "Show APDU requests and responses"),
         arg_lit0("v", "verbose", "Verbose output"),
         arg_param_end
@@ -2460,14 +2464,50 @@ static int CmdHFGSTRead(const char *Cmd) {
     }
 
     cfg.live_authentication = !arg_get_lit(ctx, 9);
-    cfg.apdu_logging = arg_get_lit(ctx, 10);
-    cfg.verbose = arg_get_lit(ctx, 11);
+    bool continuous = arg_get_lit(ctx, 10);
+    cfg.apdu_logging = arg_get_lit(ctx, 11);
+    cfg.verbose = arg_get_lit(ctx, 12);
 
     CLIParserFree(ctx);
 
+    if (continuous) {
+        PrintAndLogEx(INFO, "Press " _GREEN_("<Enter>") " to exit");
+    }
+
     bool restore_apdu_logging = GetAPDULogging();
     SetAPDULogging(cfg.apdu_logging);
-    int res = gst_read(&cfg);
+
+    int res = PM3_SUCCESS;
+    do {
+        if (continuous && kbd_enter_pressed()) {
+            break;
+        }
+        clearCommandBuffer();
+
+        int discovery_res = SelectCard14443A_4(false, false, NULL);
+        if (discovery_res != PM3_SUCCESS) {
+            if (!continuous) {
+                PrintAndLogEx(WARNING, "No ISO14443-A card in field");
+            }
+            if (res == PM3_SUCCESS) {
+                res = discovery_res;
+            }
+            msleep(300);
+            continue;
+        }
+
+        int iter_res = gst_read(&cfg);
+        if (iter_res != PM3_SUCCESS && res == PM3_SUCCESS) {
+            res = iter_res;
+        }
+
+        if (continuous) {
+            msleep(3000);
+        }
+        PrintAndLogEx(NORMAL, "");
+        msleep(300);
+    } while (continuous);
+
     SetAPDULogging(restore_apdu_logging);
     return res;
 }


### PR DESCRIPTION
This PR adds continuous reading mode through `-@` param to `hf gst read`.

Example:

```log
[usb] pm3 --> hf gst read --cid 20180608 --rpk gst.google.der -@
[=] Press <Enter> to exit
[!] ⚠️  Wallet type............... ApplePay
[!] ⚠️  Wallet type is not AndroidPay. This likely isn't Google Smart Tap.
[=] Hint: detected Apple VAS flavor of OSE.VAS.01. Try hf vas commands.

[=] 
[=] GET DATA status........... 9302 (DISAMBIGUATION_SCREEN_SHOWN)

[=] 
[=] -------------------------------- Service objects ---------------------------------
[=] Object #1
[=]   kind.................... loyalty
[=]   issuer_type............. merchant (0x01)
[=]   issuer_id............... 00000000
[=]   object_id............... 04339AA74173C475AA
[=]   service_number.......... "2018" (fmt=0x00, ASCII)
[=] 
[=] Object #2
[=]   kind.................... customer
[=]   issuer_type............. wallet (0x02)
[=]   issuer_id............... 71797971
[=]   customer_id............. 0400000000000000000000000000000000
[=]   language................ "en" (fmt=0x00, ASCII)

[=] 
[=] -------------------------------- Service objects ---------------------------------
[=] Object #1
[=]   kind.................... customer
[=]   issuer_type............. wallet (0x02)
[=]   issuer_id............... 71797971
[=]   customer_id............. 0400000000000000000000000000000000
[=]   language................ "en" (fmt=0x00, ASCII)
[=] 
[=] Object #2
[=]   kind.................... loyalty
[=]   issuer_type............. merchant (0x01)
[=]   issuer_id............... 00000000
[=]   object_id............... 045A6F330F444D0F4B
[=]   service_number.......... "{"data-0":"data_here0","data-1":"data_here1","data-2":"data_here2","data-3":"data_here3","data-4":"data_here4","data-5":"data_here5","data-6":"data_here6","data-7":"data_here7","data-8":"data_here8","data-9":"data_here9","data-10":"data_here10","data-11":"data_here11","data-12":"data_here12","data-13":"data_here13","data-14":"data_here14","data-15":"data_here15","data-16":"data_here16","data-17":"data_here17","data-18":"data_here18","data-19":"data_here19","data-20":"data_here20","data-21":"data_here21","data-22":"data_here22","data-23":"data_here23","data-24":"data_here24","data-25":"data_here25","data-26":"data_here26","data-27":"data_here27","data-28":"data_here28","data-29":"data_here29","data-30":"data_here30","data-31":"data_here31","data-32":"data_here32","data-33":"data_here33","data-34":"data_here34","data-35":"data_here35","data-36":"data_here36","data-37":"data_here37","data-38":"data_here38","data-39":"data_here39","data-40":"data_here40","data-41":"data_here41","data-42":"data_here42","data-43":"data_here43","data-44":"data_here44","data-45":"data_here45","data-46":"data_here46","data-47":"data_here47","data-48":"data_here48","data-49":"data_here49"}" (fmt=0x00, ASCII)
```

To handle tag presence versus GST applet presence better, I've moved out tag detection outside of `gst_read`, and used `14a` mode of detection, which doesn't need to send a ISO7816 command, and it's supported by all Android devices anyway.

Currently GST, and VAS in continuous mode just drop the field for 3 seconds after the read, which seems to work alright, but for better behavior rigidity, I'd like to implement functions for "presence checking", as they could be useful for continuous mode, to prevent repeated reads if user doesn't get their device off in time. 