### PR TITLE
fix broken logfile location in Paxton_clone.lua

### DIFF
--- a/client/luascripts/paxton_clone.lua
+++ b/client/luascripts/paxton_clone.lua
@@ -10,7 +10,7 @@ local logfilecmd
 if package.config:sub(1,1) == "\\" then
   logfilecmd = 'dir /a-d /o-d /tw /b/s "' .. dir .. '" 2>nul:'
 else
-  logfilecmd = 'find "' .. dir .. '" -type f -printf "%T@ %p\\n" | sort -nr | cut -d" " -f2-'
+  logfilecmd = 'find "' .. dir .. '" -type f | sort -nr | cut -d" " -f2-'
 end
 
 local logfile = (io.popen(logfilecmd):read("*a"):match("%C+"))


### PR DESCRIPTION
fix broken logfile location in Paxton_clone.lua - MacOS doesn't natively support -printf for the gnu "find" utility. This command seems to work just find without the printf formatting.