### PR TITLE
Add more AID values to 'aidlist.json'

### DIFF
--- a/client/resources/aidlist.json
+++ b/client/resources/aidlist.json
@@ -2448,11 +2448,19 @@
         "Type": "access"
     },
     {
+        "AID": "A0000004400001010001000002",
+        "Vendor": "HID Global",
+        "Country": "",
+        "Name": "SEOS Mobile",
+        "Description": "Declared by some SEOS-compatible HID partner applications for HCE",
+        "Type": "access"
+    },
+    {
         "AID": "A00000054000060100010000FF",
         "Vendor": "HID Global",
         "Country": "",
         "Name": "SEOS Mobile",
-        "Description": "Declared by some SEOS-compatible applications for HCE",
+        "Description": "Declared by some SEOS-compatible HID partner applications for HCE",
         "Type": "access"
     },
     {
@@ -2501,6 +2509,22 @@
         "Country": "",
         "Name": "Crescendo OATH #2",
         "Description": "HID Crescendo Key OATH instance 2",
+        "Type": "access"
+    },
+    {
+        "AID": "FF55494420414343455353",
+        "Vendor": "UniFi",
+        "Country": "",
+        "Name": "UniFi Access HCE Credential",
+        "Description": "Declared as 'other' service",
+        "Type": "access"
+    },
+    {
+        "AID": "FF55494420414343455356",
+        "Vendor": "UniFi",
+        "Country": "",
+        "Name": "UniFi Access HCE Credential",
+        "Description": "Declared as 'payment' service",
         "Type": "access"
     }
 ]


### PR DESCRIPTION
This PR adds some new AID values encountered on mobile devices with HCE.

I'd like to add some more encountered AID values, I.E. some management AID values in reader configuration apps, but I am currently concerned with polluting the list too much, causing AID brute force and other users of this file to slow down.

As an option to allow expansion of the list, I'd like to suggest adding "tags" field, which would allow to specify additional markers for an AID entry:
- If it's available on `hce` capable devices or `android`.
- Protocol names (I.E. DESFire-related AIDs can be marked as `desfire`)
- If it's available over `contactless` or `contact`.
- If AID is not for a credential, but for a `management`/`technical` app;
- If AID is known, but not usable from outside, like the SEOS file system applet AID. 

I'm suggesting that those markers are to be used downstream to filter-out unneeded entries, refine brute-force lists, provide suggestions, etc.
Perhaps, those "tags" can be expressed as separate fields by themselves, but I'm throwing this idea in just in case, I'd be fine with any implementation.

Additionally, for `android` or `hce` AID values, it could be valuable to store application package names. I.E, that could allow to find out and show which apps the user has, or serve as a general store of info on what apps emulate what kind of credentials.

As a more general use field, we may add "sources" field, which would store both the app package names, but also attribution to web sites (If an AID was taken from a public source).