### PR TITLE
Fix `smart pcsc`: card is never detected and a buffer overflow with 20+ bytes ATRs

### DIFF
--- a/client/src/cmdsmartcard.c
+++ b/client/src/cmdsmartcard.c
@@ -1312,6 +1312,8 @@ static int CmdPCSC(const char *Cmd) {
                         }
                     }
 
+                    // ISO 7816-3 specifies that ATRs can be 2 to 33 bytes long
+                    // but some custom cards may support up to 256 bytes long ATRs
                     uint8_t res[2 + 256] = {0};
                     res[1] = atrLen;
                     memcpy(res + 2, atr, atrLen);


### PR DESCRIPTION
This PR fixes issue #3163.

Two bugs in `CmdPCSC()` in `client/src/cmdsmartcard.c`:

  - `smart_select()` returns `bool` but was compared with `== PM3_SUCCESS` (which is `0`), so the card detection condition always evaluated to `false` and `have_card` was never set. Fixed by removing the comparison and using the return value directly as a boolean.
  - `res[22]` was too small to hold the `2`-byte vpcd length prefix plus an ATR up to the _ISO 7816-3_ maximum of `33` bytes, let alone custom cards with ATRs of up to 256 bytes. Increased to `res[2 + 256]`.