### PR TITLE
Add ISO14A_CLEARTRACE param to explicitly clear 14a trace

### DIFF
--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -3633,6 +3633,9 @@ void ReaderIso14443a(PacketCommandNG *c) {
 
     if ((param & ISO14A_CONNECT) == ISO14A_CONNECT) {
         iso14_pcb_blocknum = 0;
+    }
+
+    if ((param & ISO14A_CLEARTRACE) == ISO14A_CLEARTRACE) {
         clear_trace();
     }
 

--- a/client/lualibs/read14a.lua
+++ b/client/lualibs/read14a.lua
@@ -31,6 +31,7 @@ local ISO14A_COMMAND = {
     ISO14A_SEND_CHAINING = 0x400,
     ISO14A_USE_ECP = 0x800,
     ISO14A_USE_MAGSAFE = 0x1000,
+    ISO14A_CLEARTRACE = 0x20000,
 }
 
 local ISO14443a_TYPES = {}
@@ -90,7 +91,7 @@ local function read14443a(dont_disconnect, no_rats)
 
     command = Command:newMIX{
             cmd = cmds.CMD_HF_ISO14443A_READER,
-            arg1 = ISO14A_COMMAND.ISO14A_CONNECT
+            arg1 = ISO14A_COMMAND.ISO14A_CONNECT + ISO14A_COMMAND.ISO14A_CLEARTRACE
             }
 
     if dont_disconnect then

--- a/client/luascripts/hf_14a_read_ltocm.lua
+++ b/client/luascripts/hf_14a_read_ltocm.lua
@@ -72,7 +72,7 @@ local function sendRaw(rawdata, options)
     local flags = lib14a.ISO14A_COMMAND.ISO14A_NO_DISCONNECT + lib14a.ISO14A_COMMAND.ISO14A_RAW
 
     if options.connect then
-        flags = flags + lib14a.ISO14A_COMMAND.ISO14A_CONNECT
+        flags = flags + lib14a.ISO14A_COMMAND.ISO14A_CONNECT + lib14a.ISO14A_COMMAND.ISO14A_CLEARTRACE
     end
 
     if options.no_select then

--- a/client/luascripts/hf_mfu_ultra.lua
+++ b/client/luascripts/hf_mfu_ultra.lua
@@ -75,7 +75,7 @@ local function sendRaw(rawdata, options)
     end
 
     if options.connect then
-        flags = flags + lib14a.ISO14A_COMMAND.ISO14A_CONNECT
+        flags = flags + lib14a.ISO14A_COMMAND.ISO14A_CONNECT + lib14a.ISO14A_COMMAND.ISO14A_CLEARTRACE
     end
 
     if options.no_select then

--- a/client/src/cmdhf14a.c
+++ b/client/src/cmdhf14a.c
@@ -618,7 +618,7 @@ static const char *get_uid_type(iso14a_card_select_t *card) {
 
 int Hf14443_4aGetCardData(iso14a_card_select_t *card) {
 
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         PrintAndLogEx(WARNING, "timeout while waiting for reply");
@@ -695,9 +695,10 @@ static int CmdHF14AReader(const char *Cmd) {
 
     bool silent = arg_get_lit(ctx, 2);
 
-    uint32_t cm = ISO14A_CONNECT;
+    uint32_t cm = ISO14A_CONNECT | ISO14A_CLEARTRACE;
     if (arg_get_lit(ctx, 3)) {
         cm &= ~ISO14A_CONNECT;
+        cm &= ~ISO14A_CLEARTRACE;
     }
 
     if (arg_get_lit(ctx, 4)) {
@@ -872,7 +873,7 @@ static int CmdHF14ACUIDs(const char *Cmd) {
         }
 
         // execute anticollision procedure
-        SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_RATS, 0, 0, NULL, 0);
+        SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_RATS, 0, 0, NULL, 0);
         PacketResponseNG resp;
 
         if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
@@ -1225,9 +1226,9 @@ int SelectCard14443A_4_WithParameters(bool disconnect, bool verbose, iso14a_card
     // Anticollision + SELECT card
     PacketResponseNG resp;
     if (polling_parameters != NULL) {
-        SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT | ISO14A_USE_CUSTOM_POLLING, 0, 0, (uint8_t *)polling_parameters, sizeof(iso14a_polling_parameters_t));
+        SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_DISCONNECT | ISO14A_USE_CUSTOM_POLLING, 0, 0, (uint8_t *)polling_parameters, sizeof(iso14a_polling_parameters_t));
     } else {
-        SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
+        SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
     }
 
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2000) == false) {
@@ -1719,6 +1720,7 @@ static int CmdHF14ACmdRaw(const char *Cmd) {
 
     if (active || active_select) {
         flags |= ISO14A_CONNECT;
+        flags |= ISO14A_CLEARTRACE;
         if (active)
             flags |= ISO14A_NO_SELECT;
     }
@@ -2695,7 +2697,7 @@ int infoHF14A(bool verbose, bool do_nack_test, bool do_aid_search) {
     }
 
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select timeout");
@@ -2912,7 +2914,7 @@ int infoHF14A(bool verbose, bool do_nack_test, bool do_aid_search) {
 
                         // reconnect for further tests
                         clearCommandBuffer();
-                        SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
+                        SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
                         if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
                             PrintAndLogEx(WARNING, "timeout while waiting for reply");
                             DropField();

--- a/client/src/cmdhffudan.c
+++ b/client/src/cmdhffudan.c
@@ -111,7 +111,7 @@ static int fudan_get_type(iso14a_card_select_t *card, bool verbose) {
     }
 
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select timeout");

--- a/client/src/cmdhfgallagher.c
+++ b/client/src/cmdhfgallagher.c
@@ -1048,7 +1048,7 @@ static int hfgal_write_classic_card(GallagherCredentials_t *creds, uint8_t cred_
     clearCommandBuffer();
 
     // Select card to get UID
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         PrintAndLogEx(ERR, "Card select timeout");
@@ -1177,7 +1177,7 @@ static int hfgal_read_classic_card(uint8_t *site_key, bool verbose, bool quiet) 
     GallagherCredentials_t creds = {0};
 
     // Select card
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         if (!quiet) {

--- a/client/src/cmdhfict.c
+++ b/client/src/cmdhfict.c
@@ -403,7 +403,7 @@ static int ict_select_card(iso14a_card_select_t *card) {
     }
 
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         return PM3_ESOFT;

--- a/client/src/cmdhflto.c
+++ b/client/src/cmdhflto.c
@@ -107,7 +107,7 @@ static void lto_switch_off_field(void) {
 }
 
 static void lto_switch_on_field(void) {
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_SELECT | ISO14A_NO_DISCONNECT | ISO14A_NO_RATS, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_SELECT | ISO14A_NO_DISCONNECT | ISO14A_NO_RATS, 0, 0, NULL, 0);
 }
 
 // send a raw LTO-CM command, returns the length of the response (0 in case of error)

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -369,7 +369,7 @@ int mfc_ev1_print_signature(uint8_t *uid, uint8_t uidlen, uint8_t *signature, in
 
 int mf_read_uid(uint8_t *uid, int *uidlen, int *nxptype) {
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select failed");
@@ -897,7 +897,7 @@ static int mfc_read_tag(iso14a_card_select_t *card, uint8_t *carddata, uint8_t n
 
     // Select card to get UID/UIDLEN/ATQA/SAK information
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 1500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select timeout");
@@ -3059,7 +3059,7 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
 
     // Select card to get UID/UIDLEN/ATQA/SAK information
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 1500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select timeout");
@@ -6287,7 +6287,7 @@ static int CmdHF14AMfCSave(const char *Cmd) {
 
     // Select card to get UID/UIDLEN information
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 1500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select timeout");
@@ -6437,7 +6437,7 @@ static int CmdHF14AMfCView(const char *Cmd) {
 
     // Select card to get UID/UIDLEN information
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 1500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select timeout");
@@ -7289,7 +7289,7 @@ int CmdHFMFNDEFFormat(const char *Cmd) {
 
     // Select card to get UID/UIDLEN/ATQA/SAK information
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 1500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select timeout");
@@ -8023,7 +8023,7 @@ static int CmdHf14AMfSuperCard(const char *Cmd) {
         for (i = 0; i < FURUI_MAX_TRACES; i++) {
 
             uint8_t data[] = {0xAA, 0xA8, 0x00, i};
-            uint32_t flags = ISO14A_CONNECT | ISO14A_RAW | ISO14A_APPEND_CRC | ISO14A_NO_RATS;
+            uint32_t flags = ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_RAW | ISO14A_APPEND_CRC | ISO14A_NO_RATS;
             clearCommandBuffer();
             SendCommandMIX(CMD_HF_ISO14443A_READER, flags, sizeof(data), 0, data, sizeof(data));
             if (WaitForResponseTimeout(CMD_ACK, NULL, 1500) == false) {
@@ -8054,7 +8054,7 @@ static int CmdHf14AMfSuperCard(const char *Cmd) {
     for (i = 0; i < SUPER_MAX_TRACES; i++) {
 
         uint8_t data[] = {0x30, i};
-        uint32_t flags = ISO14A_CONNECT | ISO14A_RAW | ISO14A_APPEND_CRC | ISO14A_NO_RATS;
+        uint32_t flags = ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_RAW | ISO14A_APPEND_CRC | ISO14A_NO_RATS;
         clearCommandBuffer();
         SendCommandMIX(CMD_HF_ISO14443A_READER, flags, sizeof(data), 0, data, sizeof(data));
         if (WaitForResponseTimeout(CMD_ACK, NULL, 1500) == false) {
@@ -9271,7 +9271,7 @@ static int CmdHF14AGen4Save(const char *Cmd) {
 
     // Select card to get UID/UIDLEN information
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 1500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select timeout");
@@ -10268,7 +10268,7 @@ static int CmdHF14AMfInfo(const char *Cmd) {
     }
 
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select timeout");
@@ -10830,7 +10830,7 @@ static int CmdHF14AMfISEN(const char *Cmd) {
     }
 
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select timeout");

--- a/client/src/cmdhfmfdes.c
+++ b/client/src/cmdhfmfdes.c
@@ -1514,7 +1514,7 @@ static int CmdHF14aDesChk(const char *Cmd) {
     if ((jsonnamelen > 0) && result) {
         DropField();
         // MIFARE DESFire info
-        SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
+        SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE, 0, 0, NULL, 0);
         PacketResponseNG resp;
         if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
             PrintAndLogEx(WARNING, "timeout while waiting for reply");

--- a/client/src/cmdhfmfp.c
+++ b/client/src/cmdhfmfp.c
@@ -221,7 +221,7 @@ static int mfp_read_card_id(iso14a_card_select_t *card, int *nxptype) {
     }
 
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select failed");
@@ -383,7 +383,7 @@ static int CmdHFMFPInfo(const char *Cmd) {
     PrintAndLogEx(INFO, "--- " _CYAN_("Tag Information") " ---------------------------");
 
     // Mifare Plus info
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2000) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select timeout");

--- a/client/src/cmdhfmfu.c
+++ b/client/src/cmdhfmfu.c
@@ -329,7 +329,7 @@ int ul_read_uid(uint8_t *uid) {
     }
     // read uid from tag
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_RATS, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_RATS, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         PrintAndLogEx(WARNING, "timeout while waiting for reply");
@@ -358,7 +358,7 @@ int ul_read_uid(uint8_t *uid) {
 
 static void ul_switch_on_field(void) {
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT | ISO14A_NO_RATS, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_DISCONNECT | ISO14A_NO_RATS, 0, 0, NULL, 0);
 }
 
 static int ul_send_cmd_raw(const uint8_t *cmd, uint8_t cmdlen, uint8_t *response, uint16_t responseLength, bool schann) {
@@ -487,7 +487,7 @@ static int ulc_requestAuthentication(uint8_t *nonce, uint16_t nonceLength) {
 }
 
 int mfuc_test_authentication_support(void) {
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select timeout");
@@ -2004,7 +2004,7 @@ static int mfulc_fingerprint(void) {
     // GT23SC4489
     uint8_t cmd3a[] = {0x26};
     uint8_t cmd3b[] = {0x30};
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_RAW | ISO14A_CONNECT | ISO14A_NO_SELECT | ISO14A_NO_DISCONNECT, 7 << 16, 0, cmd3a, sizeof(cmd3a));
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_RAW | ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_SELECT | ISO14A_NO_DISCONNECT, 7 << 16, 0, cmd3a, sizeof(cmd3a));
     if (WaitForResponseTimeout(CMD_ACK, &resp, 500)) {
         if (resp.oldarg[0] == 2) {
             SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_RAW | ISO14A_NO_SELECT, sizeof(cmd3b), 0, cmd3b, sizeof(cmd3b));
@@ -5187,7 +5187,7 @@ static int CmdHF14AMfUKeyGen(const char *Cmd) {
     if (read_tag) {
         // read uid from tag
         clearCommandBuffer();
-        SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_RATS, 0, 0, NULL, 0);
+        SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_RATS, 0, 0, NULL, 0);
         PacketResponseNG resp;
         if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
             PrintAndLogEx(WARNING, "timeout while waiting for reply");

--- a/client/src/cmdhfsaflok.c
+++ b/client/src/cmdhfsaflok.c
@@ -1128,7 +1128,7 @@ static void saflok_encode(
 //       perhaps by creating a struct to avoid having to pass a length parameter.
 static int saflok_read_sector(int sector, uint8_t *secdata) {
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select failed");

--- a/client/src/cmdhfst25ta.c
+++ b/client/src/cmdhfst25ta.c
@@ -42,7 +42,7 @@ static int CmdHelp(const char *Cmd);
 static bool st25ta_select(iso14a_card_select_t *card) {
 
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT | ISO14A_NO_RATS, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_DISCONNECT | ISO14A_NO_RATS, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 1500) == false) {
         PrintAndLogEx(DEBUG, "iso14443a card select timeout");

--- a/client/src/cmdhftopaz.c
+++ b/client/src/cmdhftopaz.c
@@ -41,7 +41,7 @@
 static topaz_tag_t topaz_tag;
 
 static void topaz_switch_on_field(void) {
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_SELECT | ISO14A_NO_DISCONNECT | ISO14A_TOPAZMODE | ISO14A_NO_RATS, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_SELECT | ISO14A_NO_DISCONNECT | ISO14A_TOPAZMODE | ISO14A_NO_RATS, 0, 0, NULL, 0);
 }
 
 static void topaz_switch_off_field(void) {

--- a/client/src/cmdhfwaveshare.c
+++ b/client/src/cmdhfwaveshare.c
@@ -249,7 +249,7 @@ static int start_drawing(uint8_t model_nr, uint8_t *black, uint8_t *red) {
     uint16_t actrxlen[20];
 
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_NO_DISCONNECT, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         PrintAndLogEx(ERR, "No tag found");

--- a/client/src/mifare/desfirecore.c
+++ b/client/src/mifare/desfirecore.c
@@ -3222,7 +3222,7 @@ int DesfireISOAppendRecord(DesfireContext_t *dctx, uint8_t fileid, uint8_t *data
 int DesfireGetCardUID(DesfireContext_t *ctx) {
     iso14a_card_select_t card = {0};
 
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT, 0, 0, NULL, 0);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE, 0, 0, NULL, 0);
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 2500) == false) {
         PrintAndLogEx(WARNING, "timeout while waiting for reply");

--- a/client/src/mifare/gen4.c
+++ b/client/src/mifare/gen4.c
@@ -60,7 +60,7 @@ static int mfG4ExCommand(uint8_t cmd, uint8_t *pwd, uint8_t *data, size_t datale
     int resplen = 0;
 
     clearCommandBuffer();
-    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_RAW | ISO14A_NO_RATS | ISO14A_APPEND_CRC, 6 + datalen, 0, (uint8_t *)&payload, 6 + datalen);
+    SendCommandMIX(CMD_HF_ISO14443A_READER, ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_RAW | ISO14A_NO_RATS | ISO14A_APPEND_CRC, 6 + datalen, 0, (uint8_t *)&payload, 6 + datalen);
 
     PacketResponseNG resp;
     if (WaitForResponseTimeout(CMD_ACK, &resp, 1500)) {

--- a/client/src/mifare/mifarehost.c
+++ b/client/src/mifare/mifarehost.c
@@ -1392,7 +1392,7 @@ int detect_classic_prng(void) {
 
     PacketResponseNG resp, respA;
     uint8_t cmd[] = {MIFARE_AUTH_KEYA, 0x00};
-    uint32_t flags = ISO14A_CONNECT | ISO14A_RAW | ISO14A_APPEND_CRC | ISO14A_NO_RATS;
+    uint32_t flags = ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_RAW | ISO14A_APPEND_CRC | ISO14A_NO_RATS;
 
     clearCommandBuffer();
     SendCommandMIX(CMD_HF_ISO14443A_READER, flags, sizeof(cmd), 0, cmd, sizeof(cmd));
@@ -1432,7 +1432,7 @@ int detect_classic_auth(uint8_t key_type) {
 
     PacketResponseNG resp, respA;
     uint8_t cmd[] = {MIFARE_AUTH_KEYA + key_type, 0x00};
-    uint32_t flags = ISO14A_CONNECT | ISO14A_RAW | ISO14A_APPEND_CRC | ISO14A_NO_RATS;
+    uint32_t flags = ISO14A_CONNECT | ISO14A_CLEARTRACE | ISO14A_RAW | ISO14A_APPEND_CRC | ISO14A_NO_RATS;
 
     clearCommandBuffer();
     SendCommandMIX(CMD_HF_ISO14443A_READER, flags, sizeof(cmd), 0, cmd, sizeof(cmd));

--- a/include/mifare.h
+++ b/include/mifare.h
@@ -108,6 +108,7 @@ typedef enum ISO14A_COMMAND {
     ISO14A_CRYPTO1MODE = (1 << 14),
     ISO14A_SET_WAIT_US = (1 << 15),
     ISO14A_APPEND_CMAC = (1 << 16),
+    ISO14A_CLEARTRACE = (1 << 17),
 } iso14a_command_t;
 
 typedef struct {


### PR DESCRIPTION
When working on improvements to `hf 14a/b info --aidsearch`, I've noticed that the codebase contains a big discrepancy in how it handles trace clear in 14a vs 14b modes.

With 14b, the trace needs to be cleared explicitly through `ISO14B_CLEARTRACE` flag. While this adds extra characters of code, this allows for more granular control.
For instance, it's possible to keep the trace for a long-running command if you add tag re-connection upon connection loss.

With 14a, the trace was always cleared implicitly when `ISO14A_CONNECT` was sent. While this took less code, this made it impossible to keep the trace,if you attempted reconnection in a long-running command, like `hf 14a --aidsearch`.

This pull request aligns the behavior for 14a by adding the explicit `ISO14A_CLEARTRACE` flag, and adding it to the call sites.

The choice to make "clear" flag explicit VS adding a flag to "keep" the trace was made on purpose, as to be aligned with 14b.