### PR TITLE
Handle Track 2 in GPO and skip unnecessary READ RECORD

### DIFF
--- a/armsrc/Standalone/hf_emvpng.c
+++ b/armsrc/Standalone/hf_emvpng.c
@@ -306,7 +306,7 @@ void RunMod(void) {
                 for (uint8_t i = 0; i < 4; i++) {
 
                     if (i == 3 && chktoken) {
-                        break; // já achei a 57 no GPO, não preciso de READ RECORD
+                        break; // Tag 57 was already found in GPO, no need to issue READ RECORD
                     }
                     
                     LED_C_OFF();


### PR DESCRIPTION
Some EMV cards return Track 2 data (tag 57) directly in the GPO response and do not expose the expected record through READ RECORD.

This change updates the parsing logic to:
- extract tag 57 from either GPO or READ RECORD
- preserve token state across APDU iterations
- skip the fixed READ RECORD step when Track 2 was already found in GPO

This avoids unnecessary 6A83 responses and improves compatibility with cards that do not follow the previously assumed flow.