### PR TITLE
Add 'Sources' field to 'aidlist.json'

### DIFF
--- a/client/resources/aidlist.json
+++ b/client/resources/aidlist.json
@@ -2480,7 +2480,32 @@
         "Country": "",
         "Name": "SEOS Mobile",
         "Description": "Declared by some SEOS-compatible HID partner applications for HCE",
-        "Type": "access"
+        "Type": "access",
+        "Sources": [
+            "android://com.lane.lane"
+        ]
+    },
+    {
+        "AID": "A0000004400001010001000003",
+        "Vendor": "HID Global",
+        "Country": "",
+        "Name": "SEOS Mobile",
+        "Description": "Declared by some SEOS-compatible HID partner applications for HCE",
+        "Type": "access",
+        "Sources": [
+            "android://com.assaabloy.stg.msf.config.android"
+        ]
+    },
+    {
+        "AID": "A0000004400001010001000004",
+        "Vendor": "HID Global",
+        "Country": "",
+        "Name": "SEOS Mobile",
+        "Description": "Declared by some SEOS-compatible HID partner applications for HCE",
+        "Type": "access",
+        "Sources": [
+            "android://com.assaabloy.stg.msf.config.android"
+        ]
     },
     {
         "AID": "A00000054000060100010000FF",
@@ -2488,7 +2513,152 @@
         "Country": "",
         "Name": "SEOS Mobile",
         "Description": "Declared by some SEOS-compatible HID partner applications for HCE",
-        "Type": "access"
+        "Type": "access",
+        "Sources": [
+            "android://com.assaabloy.hospitality.mobileaccess.studentliving",
+            "android://com.assaabloy.stg.msf.config.android",
+            "android://com.brivo.pass",
+            "android://com.cardexchangeid.ident",
+            "android://com.cbord.get",
+            "android://com.cohesion.core",
+            "android://com.equiem.equiemandroid",
+            "android://com.hidglobal.pacs.readermanager",
+            "android://com.hotelbird.hbapp",
+            "android://com.hqo",
+            "android://com.kastle.kastlePresence",
+            "android://com.mews.guestPortal",
+            "android://com.soloinsight.cloudpassnew.staging",
+            "android://com.wandera.android",
+            "android://com.workai.app",
+            "android://com.yale.multifamconftool",
+            "android://com.zaplox.premium.*",
+            "android://eu.sharry.swp.gallagherhub",
+            "android://eu.sharry.swp.sharrypartner",
+            "android://eu.sharry.swp.sharryworkplace",
+            "android://io.blinetech.blineandroid",
+            "android://io.swiftconnect.mobile"
+        ]
+    },
+    {
+        "AID": "A0000003820012000101",
+        "Vendor": "HID Global",
+        "Country": "",
+        "Name": "HID Reader Manager mobile admin card",
+        "Description": "",
+        "Type": "configuration",
+        "Sources": [
+            "android://com.hidglobal.pacs.readermanager"
+        ]
+    },
+    {
+        "AID": "A0000003820021000101",
+        "Vendor": "HID Global",
+        "Country": "",
+        "Name": "HID Reader Manager mobile admin card",
+        "Description": "",
+        "Type": "configuration",
+        "Sources": [
+            "android://com.hidglobal.pacs.readermanager"
+        ]
+    },
+    {
+        "AID": "A0000003820025000101",
+        "Vendor": "HID Global",
+        "Country": "",
+        "Name": "HID Reader Manager mobile admin card",
+        "Description": "",
+        "Type": "configuration",
+        "Sources": [
+            "android://com.hidglobal.pacs.readermanager"
+        ]
+    },
+    {
+        "AID": "A0000003820028000101",
+        "Vendor": "HID Global",
+        "Country": "",
+        "Name": "HID Reader Manager mobile admin card",
+        "Description": "",
+        "Type": "configuration",
+        "Sources": [
+            "android://com.hidglobal.pacs.readermanager"
+        ]
+    },
+    {
+        "AID": "A0000003820029000101",
+        "Vendor": "HID Global",
+        "Country": "",
+        "Name": "HID Reader Manager mobile admin card",
+        "Description": "",
+        "Type": "configuration",
+        "Sources": [
+            "android://com.hidglobal.pacs.readermanager"
+        ]
+    },
+    {
+        "AID": "A000000382002A000101",
+        "Vendor": "HID Global",
+        "Country": "",
+        "Name": "HID Reader Manager mobile admin card",
+        "Description": "",
+        "Type": "configuration",
+        "Sources": [
+            "android://com.hidglobal.pacs.readermanager"
+        ]
+    },
+    {
+        "AID": "A000000382002B000101",
+        "Vendor": "HID Global",
+        "Country": "",
+        "Name": "HID Reader Manager mobile admin card",
+        "Description": "",
+        "Type": "configuration",
+        "Sources": [
+            "android://com.hidglobal.pacs.readermanager"
+        ]
+    },
+    {
+        "AID": "A000000382002C000101",
+        "Vendor": "HID Global",
+        "Country": "",
+        "Name": "HID Reader Manager mobile admin card",
+        "Description": "",
+        "Type": "configuration",
+        "Sources": [
+            "android://com.hidglobal.pacs.readermanager"
+        ]
+    },
+    {
+        "AID": "A000000382002D000101",
+        "Vendor": "HID Global",
+        "Country": "",
+        "Name": "HID Reader Manager mobile admin card",
+        "Description": "",
+        "Type": "configuration",
+        "Sources": [
+            "android://com.hidglobal.pacs.readermanager"
+        ]
+    },
+    {
+        "AID": "A000000382002E000101",
+        "Vendor": "HID Global",
+        "Country": "",
+        "Name": "HID Reader Manager mobile admin card",
+        "Description": "",
+        "Type": "configuration",
+        "Sources": [
+            "android://com.hidglobal.pacs.readermanager"
+        ]
+    },
+    {
+        "AID": "A0000003820031000101",
+        "Vendor": "HID Global",
+        "Country": "",
+        "Name": "HID Reader Manager mobile admin card",
+        "Description": "",
+        "Type": "configuration",
+        "Sources": [
+            "android://com.hidglobal.pacs.readermanager"
+        ]
     },
     {
         "AID": "A000000341000101",

--- a/doc/aidlist.md
+++ b/doc/aidlist.md
@@ -17,6 +17,9 @@ Each entry in `client/resources/aidlist.json` must contain all of the fields bel
 
 ## Optional fields
 - `ResponseRegex`: Case-insensitive regex matched against the APDU SELECT response encoded as hex without separators. Current regex subset supports `^`, `$`, `.`, `*`, and `\` escape. Use this field when multiple protocols share the same AID and can be distinguished by response content.
+- `Sources`: Array of strings describing where the AID metadata was sourced from. Supported formats:
+  - `android://<package.name>` for Android apps that declare or use this AID.
+  - `http://...` or `https://...` for public references used to add or verify the entry.
 
 Example:
 ```json
@@ -40,5 +43,21 @@ Response-disambiguation example:
     "Description": "Google Smart Tap",
     "Type": "loyalty",
     "ResponseRegex": ".*500a416e64726f6964506179.*9000$"
+}
+```
+
+Sources example:
+```json
+{
+    "AID": "A0000004400001010001000002",
+    "Vendor": "HID Global",
+    "Country": "",
+    "Name": "SEOS Mobile",
+    "Description": "Declared by some SEOS-compatible HID partner applications for HCE",
+    "Type": "access",
+    "Sources": [
+        "android://com.lane.lane",
+        "https://example.com/reference"
+    ]
 }
 ```


### PR DESCRIPTION
As discussed earlier, this PR introduces `Sources` field into `aidlist.json`.

The format conventions of the field are described in the appropriate docs.

Additionally, this PR adds extra AID entries related to various apps using the HID Mobile Seos SDK, and also a bunch of entries for HID Reader Manager.