### PR TITLE
Add more mobile credential AID values to `aidlist.json`

### DIFF
--- a/client/resources/aidlist.json
+++ b/client/resources/aidlist.json
@@ -2324,7 +2324,11 @@
         "Country": "",
         "Name": "Digital Car Key Framework",
         "Description": "Used during key provisioning and configuration",
-        "Type": ""
+        "Type": "",
+        "Sources": [
+            "android://com.google.android.gms",
+            "android://com.samsung.android.dkey"
+        ]
     },
     {
         "AID": "A000000809434343444B417631",
@@ -2398,7 +2402,11 @@
         "Country": "",
         "Name": "Aliro Expedited",
         "Description": "Acts as the primary credential holder applet",
-        "Type": "access"
+        "Type": "access",
+        "Sources": [
+            "android://com.google.android.gms",
+            "android://com.samsung.android.dkey"
+        ]
     },
     {
         "AID": "A000000396564341",
@@ -2561,6 +2569,10 @@
         "Description": "Declared by some SEOS-compatible HID partner applications for HCE",
         "Type": "access",
         "Sources": [
+            "android://app.smartspaces.*",
+            "android://co.any2any.badge.app.stage",
+            "android://com.afiaa",
+            "android://com.alertenterprise.android.wallet",
             "android://com.assaabloy.hospitality.mobileaccess.studentliving",
             "android://com.assaabloy.stg.msf.config.android",
             "android://com.brivo.pass",
@@ -2853,7 +2865,8 @@
         "Description": "Declared as 'other' service",
         "Type": "access",
         "Sources": [
-            "android://com.ui.uid.standard"
+            "android://com.ui.uid.standard",
+            "android://com.ui.uid.client"
         ]
     },
     {
@@ -2864,7 +2877,8 @@
         "Description": "Declared as 'payment' service",
         "Type": "access",
         "Sources": [
-            "android://com.ui.uid.standard"
+            "android://com.ui.uid.standard",
+            "android://com.ui.uid.client"
         ]
     }
 ]


### PR DESCRIPTION
This PR adds AID entries for:
* Gallagher Mobile Connect;
* Kastle Presence;
* Protege Mobile Credential;

And also expands `Sources` for existing entries.