### PR TITLE
feat: one-shot Ubuntu setup script, crapto1 mirror URLs, Windows non-ProxSpace build docs

### DIFF
--- a/doc/md/Installation_Instructions/Windows-Non-ProxSpace-Build.md
+++ b/doc/md/Installation_Instructions/Windows-Non-ProxSpace-Build.md
@@ -1,0 +1,88 @@
+# Building Proxmark3 on Windows without ProxSpace
+
+Three approaches for building outside the ProxSpace MSYS2 shell.
+
+## Option 1: PowerShell + ProxSpace toolchain (recommended)
+
+Use the `Build-Proxmark3.ps1` wrapper from [ProxSpace](https://github.com/Gator96100/ProxSpace):
+
+```powershell
+cd C:\ProxSpace
+.\Build-Proxmark3.ps1                     # build all
+.\Build-Proxmark3.ps1 -Flash -Port COM5   # build + flash
+.\Build-Proxmark3.ps1 -Target client      # client only
+```
+
+The wrapper sets `TMP`, `TEMP`, `CC`, `CXX`, `MINGW_HOME` to avoid the `/tmp` path translation bug that causes `Cannot create temporary file in C:\WINDOWS\` linker errors when building from git-bash.
+
+### Manual PowerShell build (without wrapper)
+
+```powershell
+$env:TEMP = 'C:\ProxSpace\msys2\tmp'
+$env:TMP  = 'C:\ProxSpace\msys2\tmp'
+$env:PATH = 'C:\ProxSpace\msys2\mingw64\bin;C:\ProxSpace\msys2\usr\bin;' + $env:PATH
+$env:MSYSTEM = 'MINGW64'
+New-Item -ItemType Directory -Force -Path 'C:\ProxSpace\msys2\tmp'
+
+& 'C:\ProxSpace\msys2\usr\bin\make.exe' -C 'C:\ProxSpace\pm3' bootrom/all
+& 'C:\ProxSpace\msys2\usr\bin\make.exe' -C 'C:\ProxSpace\pm3' armsrc/all
+& 'C:\ProxSpace\msys2\usr\bin\make.exe' -C 'C:\ProxSpace\pm3' SKIPREVENGTEST=1 client
+```
+
+## Option 2: WSL2 (Windows Subsystem for Linux)
+
+Treat it as a standard Linux build. From a WSL2 Ubuntu terminal:
+
+```bash
+# Install dependencies
+bash setup-ubuntu.sh
+
+# Build
+make clean && make -j$(nproc)
+
+# Flash — use the Windows COM port path
+./client/proxmark3 /dev/ttyS4 --flash --unlock-bootloader --image bootrom/obj/bootrom.elf
+./client/proxmark3 /dev/ttyS4 --flash --image armsrc/obj/fullimage.elf
+```
+
+Note: WSL2 COM port mapping is `/dev/ttySN` where N is the Windows COM port number.
+
+## Option 3: Native MSYS2 (without ProxSpace)
+
+Install MSYS2 from https://www.msys2.org/ and add the required packages:
+
+```bash
+pacman -S --needed \
+    mingw-w64-x86_64-gcc \
+    mingw-w64-x86_64-arm-none-eabi-gcc \
+    mingw-w64-x86_64-arm-none-eabi-newlib \
+    mingw-w64-x86_64-qt6-base \
+    mingw-w64-x86_64-readline \
+    mingw-w64-x86_64-lua \
+    mingw-w64-x86_64-jansson \
+    mingw-w64-x86_64-bzip2 \
+    mingw-w64-x86_64-lz4 \
+    mingw-w64-x86_64-python \
+    make git pkg-config
+
+cd /c/path/to/proxmark3
+make clean && make -j$(nproc)
+```
+
+This approach uses a standard MSYS2 installation rather than ProxSpace's bundled snapshot, so packages are always up to date.
+
+## Flash procedure (all options)
+
+Always flash bootrom first, then fullimage:
+
+```bash
+./pm3-flash-bootrom
+./pm3-flash-fullimage
+./pm3
+hw version
+```
+
+Note: The COM port may change after flashing the bootloader. Re-check with:
+```powershell
+Get-PnpDevice -Class 'Ports' -Status OK
+```

--- a/setup-ubuntu.sh
+++ b/setup-ubuntu.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# setup-ubuntu.sh — One-shot Proxmark3 setup for Debian/Ubuntu/Kali
+#
+# Installs all build dependencies, handles ModemManager (udev rule preferred
+# over full disable), installs device permission rules, and adds user to the
+# required groups.
+#
+# Usage: bash setup-ubuntu.sh
+# Idempotent: safe to re-run on an already-configured machine.
+
+set -euo pipefail
+
+# --- Distro check ---
+if ! command -v apt-get &>/dev/null; then
+    echo "ERROR: This script requires apt-get (Debian/Ubuntu/Kali). Exiting." >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> Updating package lists..."
+sudo apt-get update -q
+
+echo "==> Installing build dependencies..."
+sudo apt-get install --no-install-recommends -y \
+    git ca-certificates build-essential pkg-config \
+    libreadline-dev gcc-arm-none-eabi libnewlib-dev \
+    libbz2-dev liblz4-dev zlib1g-dev \
+    libbluetooth-dev libpython3-dev libssl-dev libgd-dev
+
+# Qt6 for GUI support (optional but included by default)
+if apt-cache show qt6-base-dev &>/dev/null 2>&1; then
+    sudo apt-get install --no-install-recommends -y qt6-base-dev
+elif apt-cache show qtbase5-dev &>/dev/null 2>&1; then
+    echo "    Qt6 not available, installing Qt5 fallback..."
+    sudo apt-get install --no-install-recommends -y qtbase5-dev
+else
+    echo "    WARNING: Neither Qt6 nor Qt5 dev packages found. GUI support will be disabled."
+fi
+
+# --- ModemManager handling ---
+echo "==> Handling ModemManager..."
+# ModemManager probes new serial devices with AT commands and can interfere
+# with the Proxmark3. A udev rule to ignore the PM3 VID is preferred over
+# disabling ModemManager entirely (which would break cellular modems).
+UDEV_MM_RULE='/etc/udev/rules.d/77-mm-proxmark3.rules'
+if [[ ! -f "$UDEV_MM_RULE" ]]; then
+    echo 'ATTRS{idVendor}=="9ac4", ENV{ID_MM_DEVICE_IGNORE}="1"' | sudo tee "$UDEV_MM_RULE" > /dev/null
+    echo "    ModemManager ignore rule written to $UDEV_MM_RULE"
+else
+    echo "    ModemManager ignore rule already exists."
+fi
+
+# --- Device permissions ---
+echo "==> Setting device permissions..."
+if [[ -f "$SCRIPT_DIR/Makefile" ]]; then
+    # Use the repo's built-in accessrights target if available
+    make -C "$SCRIPT_DIR" accessrights 2>/dev/null || true
+fi
+
+# Ensure user is in dialout and plugdev groups
+for group in dialout plugdev; do
+    if getent group "$group" &>/dev/null; then
+        if ! id -nG "$USER" | grep -qw "$group"; then
+            sudo usermod -aG "$group" "$USER"
+            echo "    Added $USER to $group group."
+        else
+            echo "    $USER already in $group group."
+        fi
+    fi
+done
+
+# --- Reload udev ---
+echo "==> Reloading udev rules..."
+sudo udevadm control --reload-rules && sudo udevadm trigger
+
+echo ""
+echo "==> Setup complete."
+echo ""
+echo "    ACTION REQUIRED: Log out and back in for group membership to take effect."
+echo ""
+echo "    Then build with:"
+echo "      make clean && make -j\$(nproc)"
+echo ""
+echo "    Flash:"
+echo "      ./pm3-flash-bootrom"
+echo "      ./pm3-flash-fullimage"
+echo ""
+echo "    Run client:"
+echo "      ./pm3"

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -4,11 +4,11 @@ TAR = tar Jxvf
 GIT = git clone
 
 get_craptev1:
-	$(WGET) http://crapto1.netgarage.org/craptev1-v1.1.tar.xz
+	$(WGET) https://raw.githubusercontent.com/ApertureLabsLtd/craptern/master/craptev1-v1.1.tar.xz
 	$(TAR) craptev1-v1.1.tar.xz -C craptev1-v1.1
 
 get_crapto1:
-	$(WGET) http://crapto1.netgarage.org/crapto1-v3.3.tar.xz
+	$(WGET) https://raw.githubusercontent.com/ApertureLabsLtd/craptern/master/crapto1-v3.3.tar.xz
 	$(TAR) Jxvf crapto1-v3.3.tar.xz -C crapto1-v3.3
 
 get_xorsearch:


### PR DESCRIPTION
## Summary\n\n### `setup-ubuntu.sh` — One-shot Linux setup\n\nA single-command setup script for Debian/Ubuntu/Kali that:\n- Installs all build dependencies via apt-get (including Qt6 with Qt5 fallback)\n- Creates a udev rule to ignore Proxmark3 VID from ModemManager (preferred over disabling ModemManager entirely, which would break cellular modems)\n- Runs `make accessrights` for device permissions\n- Adds user to `dialout` and `plugdev` groups\n- Fully idempotent — safe to re-run on an already-configured machine\n\nUsage:\n```bash\ngit clone https://github.com/RfidResearchGroup/proxmark3.git && cd proxmark3\nbash setup-ubuntu.sh\n# Log out and back in, then:\nmake -j$(nproc)\n```\n\n### `tools/Makefile` — Fix crapto1/craptev1 download URLs\n\nThe upstream host `crapto1.netgarage.org` has been unreachable since at least September 2024, causing `make get_craptev1` and `make get_crapto1` to hang indefinitely. Updated both URLs to use the ApertureLabsLtd/craptern GitHub mirror.\n\n### `doc/md/Installation_Instructions/Windows-Non-ProxSpace-Build.md`\n\nNew documentation covering three approaches to building on Windows without the ProxSpace MSYS2 terminal:\n1. PowerShell + ProxSpace toolchain (with `Build-Proxmark3.ps1` wrapper)\n2. WSL2 (treat as Linux build)\n3. Native MSYS2 installation (always up-to-date packages)\n\n## Testing\n\n- `setup-ubuntu.sh` tested on Ubuntu 22.04 LTS (clean install)\n- crapto1 mirror URL verified accessible\n- Windows build docs tested on Windows 11 with ProxSpace v3.11 + Iceman master"