### PR TITLE
Fix build errors on Windows 10 machine through ProxSpace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fix issues with building `cmdlf.c` through ProxSpace on Windows 10 (@piotrva)
 - Added `lf relay` command where it relays between two pm3 devices over internet. Thanks to Moerno for the code! (@iceman1001)
 - Changed `hf mf acl` command to have more recognized generic configurations (@team-orangeBlue)
 - Added `hf mfp acl` command (@team-orangeBlue)

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -1730,7 +1730,7 @@ static int lf_relay_tag(uint64_t samples, uint16_t port) {
 
     struct sockaddr_in addr = { .sin_family = AF_INET, .sin_port = htons(port), .sin_addr.s_addr = INADDR_ANY };
     int opt = 1;
-    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char *)&opt, sizeof(opt));
     if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
         PrintAndLogEx(ERR, "Failed to bind to port " _RED_("%u"), port);
         close(sock);
@@ -1768,11 +1768,11 @@ static int lf_relay_tag(uint64_t samples, uint16_t port) {
             PrintAndLogEx(INFO, "Tag detected! Sending %zu samples to Client...", g_GraphTraceLen);
     
             uint32_t len = (uint32_t)g_GraphTraceLen;
-            if (send(client, &len, sizeof(len), 0) < 0) {
+            if (send(client, (const char *)&len, sizeof(len), 0) < 0) {
                 break;
             }
             
-            if (send(client, g_GraphBuffer, len * sizeof(int32_t), 0) < 0) {
+            if (send(client, (const char *)g_GraphBuffer, len * sizeof(int32_t), 0) < 0) {
                 break;
             }
 
@@ -1826,7 +1826,7 @@ static int lf_relay_rdr(const char *ip, uint16_t port) {
 
         uint32_t incoming_len = 0;
 
-        n = recv(sock, &incoming_len, sizeof(incoming_len), MSG_WAITALL);
+        n = recv(sock, (char *)&incoming_len, sizeof(incoming_len), MSG_WAITALL);
 
         if (n > 0 && incoming_len > 0) {
 
@@ -1836,7 +1836,7 @@ static int lf_relay_rdr(const char *ip, uint16_t port) {
             }
 
             PrintAndLogEx(INFO, "Received " _YELLOW_("%u") " samples. Processing...", incoming_len);
-            ssize_t rx = recv(sock, g_GraphBuffer, incoming_len * sizeof(int32_t), MSG_WAITALL);
+            ssize_t rx = recv(sock, (char *)g_GraphBuffer, incoming_len * sizeof(int32_t), MSG_WAITALL);
 
             if (rx != (ssize_t)(incoming_len * sizeof(int32_t))) {
                 PrintAndLogEx(ERR, "Short read: expected %u bytes, got %zd", incoming_len * (uint32_t)sizeof(int32_t), rx);


### PR DESCRIPTION
This fixes nasty Windows errors when building client on Windows 10 through ProxSpace.
```
[-] CC src/cmdlfcotag.c
src/cmdlf.c: In function 'lf_relay_tag':
src/cmdlf.c:1733:48: error: passing argument 4 of 'setsockopt' from incompatible pointer type [ttps://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/Warning-Options.html#index-Wincompatible-pointer-types-Wincompatible-pointer-typesm]
 1733 |     setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
      |                                                ^~~~
      |                                                |
      |                                                int *
In file included from src/cmdlf.c:30:
C:/ProxSpace2/msys2/mingw64/include/winsock2.h:1035:88: note: expected 'const char *' but argument is of type 'int *'
 1035 |   WINSOCK_API_LINKAGE int WSAAPI setsockopt(SOCKET s,int level,int optname,const char *optval,int optlen);
      |                                                                            ~~~~~~~~~~~~^~~~~~
src/cmdlf.c:1771:30: error: passing argument 2 of 'send' from incompatible pointer type [-Wincompatible-pointer-types]
 1771 |             if (send(client, &len, sizeof(len), 0) < 0) {
      |                              ^~~~
      |                              |
      |                              uint32_t * {aka unsigned int *}

                                        ~~~~~~^~~
C:/ProxSpace2/msys2/mingw64/include/winsock2.h:1033:60: note: expected 'const char *' but argument is of type 'uint32_t *' {aka 'unsigned int *'}
 1033 |   WINSOCK_API_LINKAGE int WSAAPI send(SOCKET s,const char *buf,int len,int flags);
      |                                                ~~~~~~~~~~~~^~~
src/cmdlf.c:1775:30: error: passing argument 2 of 'send' from incompatible pointer type [-Wincompatible-pointer-types]
 1775 |             if (send(client, g_GraphBuffer, len * sizeof(int32_t), 0) < 0) {
      |                              ^~~~~~~~~~~~~
      |                              |
      |                              int32_t * {aka int *}
C:/ProxSpace2/msys2/mingw64/include/winsock2.h:1033:60: note: expected 'const char *' but argument is of type 'int32_t
' {aka 'int *'}
 1033 |   WINSOCK_API_LINKAGE int WSAAPI send(SOCKET s,const char *buf,int len,int flags);
      |                                                ~~~~~~~~~~~~^~~
src/cmdlf.c: In function 'lf_relay_rdr':
src/cmdlf.c:1829:24: error: passing argument 2 of 'recv' from incompatible pointer type [-Wincompatible-pointer-types]
 1829 |         n = recv(sock, &incoming_len, sizeof(incoming_len), MSG_WAITALL);
      |                        ^~~~~~~~~~~~~
      |                        |
      |                        uint32_t * {aka unsigned int *}
    
C:/ProxSpace2/msys2/mingw64/include/winsock2.h:1028:54: note: expected 'char *' but argument is of type 'uint32_t *' {aka 'unsigned int *'}
 1028 |   WINSOCK_API_LINKAGE int WSAAPI recv(SOCKET s,char *buf,int len,int flags);
      |                                                ~~~~~~^~~
src/cmdlf.c:1839:37: error: passing argument 2 of 'recv' from incompatible pointer type [-Wincompatible-pointer-types]
 1839 |             ssize_t rx = recv(sock, g_GraphBuffer, incoming_len * sizeof(int32_t), MSG_WAITALL);
      |                                     ^~~~~~~~~~~~~
      |                                     |
      |                                     int32_t * {aka int *}
C:/ProxSpace2/msys2/mingw64/include/winsock2.h:1028:54: note: expected 'char *' but argument is of type 'int32_t *' {aka 'int *'}
 1028 |   WINSOCK_API_LINKAGE int WSAAPI recv(SOCKET s,char *buf,int len,int flags);
      |    
```