### PR TITLE
Satisfy gst for cppcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 ## [unreleased][unreleased]
 - Fixed `hf mf wrbl` and `hf mfp wrbl` the ACL RO checks on 16-block sectors correct  (@team-orangeBlue)
 - Changed `hf mfp wrbl` command to check for Sector Trailer errors that could potentially lock sectors out (@team-orangeBlue)
-- Changed `hf felica info` and `hf felica rqsyscode` system code name annotation (@team-orangeBlue)
+- Changed `hf felica info` and `hf felica rqsyscode` system code name annotation (@kormax)
 - Added `lf relay` command where it relays between two pm3 devices over internet. Thanks to Moerno for the code! (@iceman1001)
 - Changed `hf mf acl` command to have more recognized generic configurations (@team-orangeBlue)
 - Added `hf mfp acl` command (@team-orangeBlue)

--- a/client/src/cmdhfgst.c
+++ b/client/src/cmdhfgst.c
@@ -1634,12 +1634,12 @@ static int gst_selftest_zlib(void) {
     // Check that inflation worked properly by validating inner data
     if (inflate_ok) {
         size_t offset = 0;
-        gst_ndef_record_view_t first_record;
-        gst_ndef_record_view_t second_record;
-        gst_ndef_record_view_t loyalty_record;
-        gst_ndef_record_view_t object_id_record;
-        gst_ndef_record_view_t customer_record;
-        gst_ndef_record_view_t customer_id_record;
+        gst_ndef_record_view_t first_record = {0};
+        gst_ndef_record_view_t second_record = {0};
+        gst_ndef_record_view_t loyalty_record = {0};
+        gst_ndef_record_view_t object_id_record = {0};
+        gst_ndef_record_view_t customer_record = {0};
+        gst_ndef_record_view_t customer_id_record = {0};
 
         res = gst_ndef_parse_record(decompressed_payload, decompressed_payload_len, &offset, &first_record);
         if (res == PM3_SUCCESS &&


### PR DESCRIPTION
As requested by @doegox, I've added zero-init for a bunch of GST structs that caused warnings.

Additionally, I've fixed a mistake made in CHANGELOG when other contributors were resolving merge issues.

While on that point, I think it's worth discussing the merit of CHANGELOG file.
In my opinion, its existence, alongside the bot nagging contributors to update it, leads to unnecessary merge conflicts, which in turn cause mistakes and dropped lines when no care is taken when resolving the said conflicts.
The intended could be replicated with git history.