### PR TITLE
Improve DUOX card identification; reformat modules

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -358,6 +358,7 @@ set (TARGET_SOURCES
         ${PM3_ROOT}/client/src/mifare/mifare4.c
         ${PM3_ROOT}/client/src/mifare/mifaredefault.c
         ${PM3_ROOT}/client/src/mifare/mifarehost.c
+        ${PM3_ROOT}/client/src/mifare/prime.c
         ${PM3_ROOT}/client/src/mifare/gen4.c
         ${PM3_ROOT}/client/src/mifare/lrpcrypto.c
         ${PM3_ROOT}/client/src/mifare/desfirecrypto.c

--- a/client/Makefile
+++ b/client/Makefile
@@ -827,6 +827,7 @@ SRCS =  mifare/aiddesfire.c \
         mifare/mifare4.c \
         mifare/mifaredefault.c \
         mifare/mifarehost.c \
+        mifare/prime.c \
         mifare/gen4.c \
         nfc/ndef.c \
         pm3.c \

--- a/client/resources/aid_desfire.json
+++ b/client/resources/aid_desfire.json
@@ -24,6 +24,14 @@
         "Type": "pacs"
     },
     {
+        "AID": "1010F6",
+        "Vendor": "VDE",
+        "Country": "DE",
+        "Name": "VDE EV charging",
+        "Description": "Found on a DESFire card.",
+        "Type": "payment system"
+    },
+    {
         "AID": "1023F5",
         "Vendor": "Integrated Control Technology Limited (ICT)",
         "Country": "NZ",

--- a/client/resources/aidlist.json
+++ b/client/resources/aidlist.json
@@ -2381,6 +2381,14 @@
         ]
     },
     {
+        "AID": "A0000008450000000000000000000001",
+        "Vendor": "VDE",
+        "Country": "Germany",
+        "Name": "VDE EV charging",
+        "Description": "Found on a DESFire card.",
+        "Type": ""
+    },
+    {
         "AID": "A0000008580102",
         "Vendor": "Apple",
         "Country": "",

--- a/client/src/cmdhfmfdes.c
+++ b/client/src/cmdhfmfdes.c
@@ -254,7 +254,7 @@ static char *getCardSizeStr(uint8_t fsize) {
 
 static char *getProtocolStr(uint8_t id, bool hw) {
 
-    static char buf[50] = {0x00};
+    static char buf[64] = {0x00};
     char *retStr = buf;
 
     if (id == 0x04) {
@@ -264,6 +264,10 @@ static char *getProtocolStr(uint8_t id, bool hw) {
             snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("ISO 14443-2, 14443-3") " )", id);
         else
             snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("ISO 14443-3, 14443-4") " )", id);
+    } else if (id == 0x20) {
+        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("I2C") " )", id);
+    } else if (id == 0x25) {
+        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("I2C and ISO/IEC 14443-4") " )", id);
     } else {
         snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Unknown") " )", id);
     }

--- a/client/src/cmdhfmfdes.c
+++ b/client/src/cmdhfmfdes.c
@@ -47,6 +47,7 @@
 #include "mifare/mifaredefault.h"
 #include "generator.h"
 #include "mifare/aiddesfire.h"
+#include "mifare/prime.h"
 #include "util.h"
 #include "crypto/originality.h"
 
@@ -228,119 +229,6 @@ static int CLIGetUint32Hex(CLIParserContext *ctx, uint8_t paramnum, uint32_t def
     }
 
     return PM3_SUCCESS;
-}
-
-/*
-  The 7 MSBits (= n) code the storage size itself based on 2^n,
-  the LSBit is set to '0' if the size is exactly 2^n
-    and set to '1' if the storage size is between 2^n and 2^(n+1).
-    For this version of DESFire the 7 MSBits are set to 0x0C (2^12 = 4096) and the LSBit is '0'.
-*/
-static char *getCardSizeStr(uint8_t fsize) {
-
-    static char buf[40] = {0x00};
-    char *retStr = buf;
-
-    uint16_t usize = 1 << (((uint16_t)fsize >> 1) + 1);
-    uint16_t lsize = 1 << ((uint16_t)fsize >> 1);
-
-    // is  LSB set?
-    if (fsize & 1)
-        snprintf(retStr, sizeof(buf), "0x%02X ( " _GREEN_("%d - %d bytes") " )", fsize, usize, lsize);
-    else
-        snprintf(retStr, sizeof(buf), "0x%02X ( " _GREEN_("%d bytes") " )", fsize, lsize);
-    return buf;
-}
-
-static char *getProtocolStr(uint8_t id, bool hw) {
-
-    static char buf[64] = {0x00};
-    char *retStr = buf;
-
-    if (id == 0x04) {
-        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("ISO 14443-3 MIFARE, 14443-4") " )", id);
-    } else if (id == 0x05) {
-        if (hw)
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("ISO 14443-2, 14443-3") " )", id);
-        else
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("ISO 14443-3, 14443-4") " )", id);
-    } else if (id == 0x20) {
-        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("I2C") " )", id);
-    } else if (id == 0x25) {
-        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("I2C and ISO/IEC 14443-4") " )", id);
-    } else {
-        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Unknown") " )", id);
-    }
-    return buf;
-}
-
-static char *getVersionStr(uint8_t type, uint8_t major, uint8_t minor) {
-
-    static char buf[60] = {0x00};
-    char *retStr = buf;
-
-    if (type == 0x01 && major == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire MF3ICD40") " )", major, minor);
-    else if (major == 0x10 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("NTAG413DNA") " )", major, minor);
-    else if (type == 0x01 && major == 0x01 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV1") " )", major, minor);
-    else if (type == 0x01 && major == 0x12 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV2") " )", major, minor);
-    else if (type == 0x01 && major == 0x22 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV2 XL") " )", major, minor);
-    else if (type == 0x01 && major == 0x42 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV2") " )", major, minor);
-    else if (type == 0x01 && major == 0x33 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV3") " )", major, minor);
-    else if (type == 0x81 && major == 0x43 && minor == 0x01)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV3C implementation on P71D600") " )", major, minor); // Swisskey iShield Key
-    else if (type == 0x01 && major == 0x30 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire Light") " )", major, minor);
-    else if (type == 0x02 && major == 0x11 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("Plus EV1") " )", major, minor);
-    else if (type == 0x02 && major == 0x22 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("Plus EV2") " )", major, minor);
-    else if (type == 0x01 && major == 0xA0 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DUOX") " )", major, minor);
-    else if ((type & 0x08) == 0x08)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire Light") " )", major, minor);
-    else
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _YELLOW_("Unknown") " )", major, minor);
-    return buf;
-
-//04 01 01 01 00 1A 05
-}
-
-static char *getTypeStr(uint8_t type) {
-
-    static char buf[40] = {0x00};
-    char *retStr = buf;
-
-    switch (type) {
-        case 0x01:
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("DESFire") " )", type);
-            break;
-        case 0x02:
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Plus") " )", type);
-            break;
-        case 0x03:
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Ultralight") " )", type);
-            break;
-        case 0x04:
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("NTAG") " )", type);
-            break;
-        case 0x81:
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Smartcard") " )", type);
-            break;
-        case 0x91:
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Applet") " )", type);
-            break;
-        default:
-            snprintf(retStr, sizeof(buf), "0x%02X", type);
-            break;
-    }
-    return buf;
 }
 
 static const char *getAidCommentStr(uint32_t aid) {
@@ -986,20 +874,20 @@ static int CmdHF14ADesInfo(const char *Cmd) {
     PrintAndLogEx(INFO, "   raw: %s", sprint_hex_inrow(info.versionHW, sizeof(info.versionHW)));
 
     PrintAndLogEx(INFO, "     Vendor Id: " _YELLOW_("%s"), getTagInfo(info.versionHW[0]));
-    PrintAndLogEx(INFO, "          Type: " _YELLOW_("%s"), getTypeStr(info.versionHW[1]));
+    PrintAndLogEx(INFO, "          Type: " _YELLOW_("%s"), mifare_prime_get_type_str(info.versionHW[1]));
     PrintAndLogEx(INFO, "       Subtype: " _YELLOW_("0x%02X"), info.versionHW[2]);
-    PrintAndLogEx(INFO, "       Version: %s", getVersionStr(info.versionHW[1], info.versionHW[3], info.versionHW[4]));
-    PrintAndLogEx(INFO, "  Storage size: %s", getCardSizeStr(info.versionHW[5]));
-    PrintAndLogEx(INFO, "      Protocol: %s", getProtocolStr(info.versionHW[6], true));
+    PrintAndLogEx(INFO, "       Version: %s", mifare_prime_get_version_str(info.versionHW[1], info.versionHW[3], info.versionHW[4]));
+    PrintAndLogEx(INFO, "  Storage size: %s", mifare_prime_get_card_size_str(info.versionHW[5]));
+    PrintAndLogEx(INFO, "      Protocol: %s", mifare_prime_get_protocol_str(info.versionHW[6], true));
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "--- " _CYAN_("Software Information"));
     PrintAndLogEx(INFO, "   raw: %s", sprint_hex_inrow(info.versionSW, sizeof(info.versionSW)));
     PrintAndLogEx(INFO, "     Vendor Id: " _YELLOW_("%s"), getTagInfo(info.versionSW[0]));
-    PrintAndLogEx(INFO, "          Type: " _YELLOW_("%s"), getTypeStr(info.versionSW[1]));
+    PrintAndLogEx(INFO, "          Type: " _YELLOW_("%s"), mifare_prime_get_type_str(info.versionSW[1]));
     PrintAndLogEx(INFO, "       Subtype: " _YELLOW_("0x%02X"), info.versionSW[2]);
     PrintAndLogEx(INFO, "       Version: " _YELLOW_("%d.%d"),  info.versionSW[3], info.versionSW[4]);
-    PrintAndLogEx(INFO, "  Storage size: %s", getCardSizeStr(info.versionSW[5]));
-    PrintAndLogEx(INFO, "      Protocol: %s", getProtocolStr(info.versionSW[6], false));
+    PrintAndLogEx(INFO, "  Storage size: %s", mifare_prime_get_card_size_str(info.versionSW[5]));
+    PrintAndLogEx(INFO, "      Protocol: %s", mifare_prime_get_protocol_str(info.versionSW[6], false));
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "--------------------------------- " _CYAN_("Card capabilities") " ---------------------------------");
     uint8_t major = info.versionSW[3];

--- a/client/src/cmdhfmfp.c
+++ b/client/src/cmdhfmfp.c
@@ -71,7 +71,7 @@ static char *getCardSizeStr(uint8_t fsize) {
 
 static char *getProtocolStr(uint8_t id, bool hw) {
 
-    static char buf[50] = {0x00};
+    static char buf[64] = {0x00};
     char *retStr = buf;
 
     if (id == 0x04) {
@@ -81,6 +81,10 @@ static char *getProtocolStr(uint8_t id, bool hw) {
             snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("ISO 14443-2, 14443-3") " )", id);
         else
             snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("ISO 14443-3, 14443-4") " )", id);
+    } else if (id == 0x20) {
+        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("I2C") " )", id);
+    } else if (id == 0x25) {
+        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("I2C and ISO/IEC 14443-4") " )", id);
     } else {
         snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Unknown") " )", id);
     }

--- a/client/src/cmdhfmfp.c
+++ b/client/src/cmdhfmfp.c
@@ -27,6 +27,7 @@
 #include "cmdhf14a.h"
 #include "mifare/mifare4.h"
 #include "mifare/mad.h"
+#include "mifare/prime.h"
 #include "nfc/ndef.h"
 #include "cliparser.h"
 #include "mifare/mifaredefault.h"
@@ -46,107 +47,6 @@ static uint16_t mfp_card_adresses[] = {0x9000, 0x9001, 0x9002, 0x9003, 0x9004, 0
 #define MFP_CHK_KEY_TRIES  (2)
 
 static int CmdHelp(const char *Cmd);
-
-/*
-  The 7 MSBits (= n) code the storage size itself based on 2^n,
-  the LSBit is set to '0' if the size is exactly 2^n
-    and set to '1' if the storage size is between 2^n and 2^(n+1).
-    For this version of DESFire the 7 MSBits are set to 0x0C (2^12 = 4096) and the LSBit is '0'.
-*/
-static char *getCardSizeStr(uint8_t fsize) {
-
-    static char buf[40] = {0x00};
-    char *retStr = buf;
-
-    uint16_t usize = 1 << ((fsize >> 1) + 1);
-    uint16_t lsize = 1 << (fsize >> 1);
-
-    // is  LSB set?
-    if (fsize & 1)
-        snprintf(retStr, sizeof(buf), "0x%02X ( " _GREEN_("%d - %d bytes") " )", fsize, usize, lsize);
-    else
-        snprintf(retStr, sizeof(buf), "0x%02X ( " _GREEN_("%d bytes") " )", fsize, lsize);
-    return buf;
-}
-
-static char *getProtocolStr(uint8_t id, bool hw) {
-
-    static char buf[64] = {0x00};
-    char *retStr = buf;
-
-    if (id == 0x04) {
-        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("ISO 14443-3 MIFARE, 14443-4") " )", id);
-    } else if (id == 0x05) {
-        if (hw)
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("ISO 14443-2, 14443-3") " )", id);
-        else
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("ISO 14443-3, 14443-4") " )", id);
-    } else if (id == 0x20) {
-        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("I2C") " )", id);
-    } else if (id == 0x25) {
-        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("I2C and ISO/IEC 14443-4") " )", id);
-    } else {
-        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Unknown") " )", id);
-    }
-    return buf;
-}
-
-static char *getVersionStr(uint8_t type, uint8_t major, uint8_t minor) {
-
-    static char buf[40] = {0x00};
-    char *retStr = buf;
-
-    if (type == 0x01 && major == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire MF3ICD40") " )", major, minor);
-    else if (major == 0x10 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("NTAG413DNA") " )", major, minor);
-    else if (type == 0x01 && major == 0x01 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV1") " )", major, minor);
-    else if (type == 0x01 && major == 0x12 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV2") " )", major, minor);
-    else if (type == 0x01 && major == 0x22 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV2 XL") " )", major, minor);
-    else if (type == 0x01 && major == 0x42 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV2") " )", major, minor);
-    else if (type == 0x01 && major == 0x33 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV3") " )", major, minor);
-    else if (type == 0x01 && major == 0x30 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire Light") " )", major, minor);
-    else if (type == 0x02 && major == 0x11 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("Plus EV1") " )", major, minor);
-    else if (type == 0x02 && major == 0x22 && minor == 0x00)
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("Plus EV2") " )", major, minor);
-    else
-        snprintf(retStr, sizeof(buf), "%x.%x ( " _YELLOW_("Unknown") " )", major, minor);
-    return buf;
-}
-
-static char *getTypeStr(uint8_t type) {
-
-    static char buf[40] = {0x00};
-    char *retStr = buf;
-
-    switch (type) {
-        case 0x01:
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("DESFire") " )", type);
-            break;
-        case 0x02:
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Plus") " )", type);
-            break;
-        case 0x03:
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Ultralight") " )", type);
-            break;
-        case 0x04:
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("NTAG") " )", type);
-            break;
-        case 0x81:
-            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Smartcard") " )", type);
-            break;
-        default:
-            break;
-    }
-    return buf;
-}
 
 // --- GET SIGNATURE
 static int plus_print_signature(uint8_t *uid, uint8_t uidlen, uint8_t *signature, int signature_len) {
@@ -188,20 +88,20 @@ static int plus_print_version(uint8_t *version) {
     PrintAndLogEx(INFO, "--- " _CYAN_("Hardware Information"));
     PrintAndLogEx(INFO, "          Raw : %s", sprint_hex(version, 7));
     PrintAndLogEx(INFO, "     Vendor Id: " _YELLOW_("%s"), getTagInfo(version[0]));
-    PrintAndLogEx(INFO, "          Type: %s", getTypeStr(version[1]));
+    PrintAndLogEx(INFO, "          Type: %s", mifare_prime_get_type_str(version[1]));
     PrintAndLogEx(INFO, "       Subtype: " _YELLOW_("0x%02X"), version[2]);
-    PrintAndLogEx(INFO, "       Version: %s", getVersionStr(version[1], version[3], version[4]));
-    PrintAndLogEx(INFO, "  Storage size: %s", getCardSizeStr(version[5]));
-    PrintAndLogEx(INFO, "      Protocol: %s", getProtocolStr(version[6], true));
+    PrintAndLogEx(INFO, "       Version: %s", mifare_prime_get_version_str(version[1], version[3], version[4]));
+    PrintAndLogEx(INFO, "  Storage size: %s", mifare_prime_get_card_size_str(version[5]));
+    PrintAndLogEx(INFO, "      Protocol: %s", mifare_prime_get_protocol_str(version[6], true));
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "--- " _CYAN_("Software Information"));
     PrintAndLogEx(INFO, "          Raw : %s", sprint_hex(version + 7, 6));
     PrintAndLogEx(INFO, "     Vendor Id: " _YELLOW_("%s"), getTagInfo(version[7]));
-    PrintAndLogEx(INFO, "          Type: %s", getTypeStr(version[8]));
+    PrintAndLogEx(INFO, "          Type: %s", mifare_prime_get_type_str(version[8]));
     PrintAndLogEx(INFO, "       Subtype: " _YELLOW_("0x%02X"), version[9]);
     PrintAndLogEx(INFO, "       Version: " _YELLOW_("%d.%d"),  version[10], version[11]);
-    PrintAndLogEx(INFO, "  Storage size: %s", getCardSizeStr(version[12]));
-    PrintAndLogEx(INFO, "      Protocol: %s", getProtocolStr(version[13], false));
+    PrintAndLogEx(INFO, "  Storage size: %s", mifare_prime_get_card_size_str(version[12]));
+    PrintAndLogEx(INFO, "      Protocol: %s", mifare_prime_get_protocol_str(version[13], false));
     return PM3_SUCCESS;
 }
 

--- a/client/src/mifare/prime.c
+++ b/client/src/mifare/prime.c
@@ -1,0 +1,137 @@
+//-----------------------------------------------------------------------------
+// Copyright (C) Proxmark3 contributors. See AUTHORS.md for details.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// See LICENSE.txt for the text of the license.
+//-----------------------------------------------------------------------------
+// Shared MIFARE Prime helpers for ISO-DEP based MIFARE protocols
+//-----------------------------------------------------------------------------
+
+#include "mifare/prime.h"
+
+#include <stdio.h>
+#include "ui.h"
+
+/*
+  The 7 MSBits (= n) code the storage size itself based on 2^n,
+  the LSBit is set to '0' if the size is exactly 2^n
+    and set to '1' if the storage size is between 2^n and 2^(n+1).
+    For this version of DESFire the 7 MSBits are set to 0x0C (2^12 = 4096) and the LSBit is '0'.
+*/
+const char *mifare_prime_get_card_size_str(uint8_t fsize) {
+
+    static char buf[40] = {0x00};
+    char *retStr = buf;
+
+    uint16_t usize = 1U << (((uint16_t)fsize >> 1U) + 1U);
+    uint16_t lsize = 1U << ((uint16_t)fsize >> 1U);
+
+    // is LSB set?
+    if (fsize & 1U) {
+        snprintf(retStr, sizeof(buf), "0x%02X ( " _GREEN_("%d - %d bytes") " )", fsize, usize, lsize);
+    } else {
+        snprintf(retStr, sizeof(buf), "0x%02X ( " _GREEN_("%d bytes") " )", fsize, lsize);
+    }
+    return buf;
+}
+
+const char *mifare_prime_get_protocol_str(uint8_t id, bool hw) {
+
+    static char buf[64] = {0x00};
+    char *retStr = buf;
+
+    if (id == 0x04) {
+        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("ISO 14443-3 MIFARE, 14443-4") " )", id);
+    } else if (id == 0x05) {
+        if (hw) {
+            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("ISO 14443-2, 14443-3") " )", id);
+        } else {
+            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("ISO 14443-3, 14443-4") " )", id);
+        }
+    } else if (id == 0x20) {
+        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("I2C") " )", id);
+    } else if (id == 0x25) {
+        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("I2C and ISO/IEC 14443-4") " )", id);
+    } else {
+        snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Unknown") " )", id);
+    }
+    return buf;
+}
+
+const char *mifare_prime_get_version_str(uint8_t type, uint8_t major, uint8_t minor) {
+
+    static char buf[60] = {0x00};
+    char *retStr = buf;
+
+    if (type == 0x01 && major == 0x00) {
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire MF3ICD40") " )", major, minor);
+    } else if (major == 0x10 && minor == 0x00) {
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("NTAG413DNA") " )", major, minor);
+    } else if (type == 0x01 && major == 0x01 && minor == 0x00) {
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV1") " )", major, minor);
+    } else if (type == 0x01 && major == 0x12 && minor == 0x00) {
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV2") " )", major, minor);
+    } else if (type == 0x01 && major == 0x22 && minor == 0x00) {
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV2 XL") " )", major, minor);
+    } else if (type == 0x01 && major == 0x42 && minor == 0x00) {
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV2") " )", major, minor);
+    } else if (type == 0x01 && major == 0x33 && minor == 0x00) {
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV3") " )", major, minor);
+    } else if (type == 0x81 && major == 0x43 && minor == 0x01) {
+        // Swisskey iShield Key
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire EV3C implementation on P71D600") " )", major, minor);
+    } else if (type == 0x01 && major == 0x30 && minor == 0x00) {
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire Light") " )", major, minor);
+    } else if (type == 0x02 && major == 0x11 && minor == 0x00) {
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("Plus EV1") " )", major, minor);
+    } else if (type == 0x02 && major == 0x22 && minor == 0x00) {
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("Plus EV2") " )", major, minor);
+    } else if (type == 0x01 && major == 0xA0 && minor == 0x00) {
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DUOX") " )", major, minor);
+    } else if ((type & 0x08) == 0x08) {
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire Light") " )", major, minor);
+    } else {
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _YELLOW_("Unknown") " )", major, minor);
+    }
+    return buf;
+}
+
+const char *mifare_prime_get_type_str(uint8_t type) {
+
+    static char buf[40] = {0x00};
+    char *retStr = buf;
+
+    switch (type) {
+        case 0x01:
+            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("DESFire") " )", type);
+            break;
+        case 0x02:
+            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Plus") " )", type);
+            break;
+        case 0x03:
+            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Ultralight") " )", type);
+            break;
+        case 0x04:
+            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("NTAG") " )", type);
+            break;
+        case 0x81:
+            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Smartcard") " )", type);
+            break;
+        case 0x91:
+            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Applet") " )", type);
+            break;
+        default:
+            snprintf(retStr, sizeof(buf), "0x%02X", type);
+            break;
+    }
+    return buf;
+}

--- a/client/src/mifare/prime.h
+++ b/client/src/mifare/prime.h
@@ -1,0 +1,29 @@
+//-----------------------------------------------------------------------------
+// Copyright (C) Proxmark3 contributors. See AUTHORS.md for details.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// See LICENSE.txt for the text of the license.
+//-----------------------------------------------------------------------------
+// Shared MIFARE Prime helpers for ISO-DEP based MIFARE protocols
+//-----------------------------------------------------------------------------
+
+#ifndef MIFARE_PRIME_H
+#define MIFARE_PRIME_H
+
+#include "common.h"
+
+const char *mifare_prime_get_card_size_str(uint8_t fsize);
+const char *mifare_prime_get_protocol_str(uint8_t id, bool hw);
+const char *mifare_prime_get_version_str(uint8_t type, uint8_t major, uint8_t minor);
+const char *mifare_prime_get_type_str(uint8_t type);
+
+#endif // MIFARE_PRIME_H


### PR DESCRIPTION
This PR makes the following changes:
* Migrate 99% identical GetVersion command helpers for Mifare Plus and DESFire to a common "Mifare Prime" module. This name was chosen as it is used by NXP internally inside of their Android apps as a common denominator for ISO-DEP based Mifare cards.
* Improve parsing of ProtocolType byte in GetVersion, detecting support for declared I2C protocol, as specified by NXP in public [AN14223  - MIFARE DUOX for EV charging](https://www.nxp.com/docs/en/application-note/AN14223.pdf) document.
* Add VDE EV charging AID values to respective AID list files.


```log
[+]   Production date: week 40 / 2025
[+]      Product type: MIFARE DESFire native IC (physical card)

[=] --- Hardware Information
[=]    raw: 040101A0001625
[=]      Vendor Id: NXP Semiconductors Germany
[=]           Type: 0x01 ( DESFire )
[=]        Subtype: 0x01
[=]        Version: a0.0 ( DUOX )
[=]   Storage size: 0x16 ( 2048 bytes )
[=]       Protocol: 0x25 ( I2C and ISO/IEC 14443-4 )

[=] --- Software Information
[=]    raw: 04010700011625
[=]      Vendor Id: NXP Semiconductors Germany
[=]           Type: 0x01 ( DESFire )
[=]        Subtype: 0x07
[=]        Version: 0.1
[=]   Storage size: 0x16 ( 2048 bytes )
[=]       Protocol: 0x25 ( I2C and ISO/IEC 14443-4 )

[+] --------------------------------- Applications list ---------------------------------
[+] Application ID....... 0x1010F6
[+]    ISO id............ 0x00DF
[+]    DF name........... ? ( A0000008450000000000000000000001 )
[=]   DF AID Function... 1010F6  : VDE EV charging [VDE]
[+] Auth commands
[+]    Auth.............. NO
[+]    Auth ISO.......... NO
[+]    Auth AES.......... NO
[+]    Auth Ev2.......... YES
[+]    Auth ISO Native... NO
[+]    Auth LRP.......... NO
[+] 

```