### PR TITLE
Fix Mifare Plus dumping (and misc functions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `mfpReadSector` function to decrypt received data, fixing commands like `hf mfp dump` (@team-orangeBlue) 
 - Added `hf mfdes intauth` command (@kormax)
 - Improved `hf iclass legbrute` throughput: added a 64-wide bitsliced MAC1 sweep that tests 64 key candidates in parallel per cipher tick. Thanks @chick3nman (@antiklesys)
 - Improved `hf iclass legbrute` throughput further: added wider SIMD backends (128-lane NEON, 256-lane AVX2, 512-lane AVX-512F) with a runtime dispatcher that picks the widest one the CPU supports. Thanks @chick3nman (@antiklesys)

--- a/client/src/mifare/mifare4.c
+++ b/client/src/mifare/mifare4.c
@@ -21,6 +21,7 @@
 #include "commonutil.h"  // ARRAYLEN
 #include "comms.h" // DropField
 #include "cmdhf14a.h"
+#include "cmdhfmfp.h" // mfp_data_crypt
 #include "ui.h"
 #include "crypto/libpcrypto.h"
 
@@ -532,6 +533,9 @@ int mfpReadSector(uint8_t sectorNo, uint8_t keyType, uint8_t *key, uint8_t *data
             DropField();
             return 6;
         }
+        
+        // Encrypted mode is always used. Doing an if to check will waste instructions
+        mfp_data_crypt(&_session, &data[1], &data[1], true);
 
         memcpy(&dataout[(n - firstBlockNo) * 16], &data[1], 16);
 


### PR DESCRIPTION
Looks like either I, or someone else, or something - has never made `mfpReadSector` in mifare4 decrypt the data it receives.

This obviously wasn't an issue since nobody does MAD on Mifare Plus, and that was the only function that used that (and nobody cared...). But now that the last release added `hf mfp dump` using this function, this happened:

```
[ . . . ]
[=]   # | sector 14 / 0x0E                                | ascii
[=] ----+-------------------------------------------------+-----------------
[=]  56 | 4F DA 2A 82 18 6B 06 87 9A B4 8C E4 60 30 B7 55 | O.*..k......`0.U 
[=]  57 | A0 E7 20 2F 27 CC 94 62 23 D6 E4 A1 3C D7 45 E4 | .. /'..b#...<.E. 
[=]  58 | 5B 8F 2A 6F DD 01 50 31 73 23 87 6C 61 C0 CF 6C | [.*o..P1s#.la..l 
[=]  59 | 56 65 06 46 94 D2 08 11 7B 4C A8 7A B7 54 6E 8F | Ve.F....{L.z.Tn.

[=]   # | sector 15 / 0x0F                                | ascii
[=] ----+-------------------------------------------------+-----------------
[=]  60 | BA 06 3A D9 2D 1E C5 1D 2D D7 0C 38 42 B0 F9 0D | ..:.-...-..8B... 
[=]  61 | 95 78 26 44 9D 32 FA 42 0A B2 C3 85 46 52 E8 54 | .x&D.2.B....FR.T 
[=]  62 | 1B 8F BF E2 C6 D4 35 EC B0 D0 4D 71 A8 13 C5 59 | ......5...Mq...Y 
[=]  63 | F5 61 F3 AF 2E E7 D2 9E 36 D5 A0 8B C2 89 E4 42 | .a......6......B

[+] Saved 2048 bytes to binary file `/home/obguy/proxmark3/tagDumps/hf-mfp-042E597A777980-dump.bin`
[!] ⚠️  Invalid dump. UID/SAK/ATQA not found
[+] Saved to json file /home/obguy/proxmark3/tagDumps/hf-mfp-042E597A777980-dump.json
[?] Partial dump: 16 of 32 sectors read
[?] Hint: use `hf mfp chk --dump` and/or `hf mf chk` to find more keys
[usb] pm3 --> hf mfp list
[+] Recorded activity ( 587 bytes )
[=] start = start of start frame. end = end of frame. src = source of transfer.
[=] ISO14443A - all times are in carrier periods (1/13.56MHz)

      Start |        End | Src | Data (! denotes parity error)                                           | CRC | Annotation
------------+------------+-----+-------------------------------------------------------------------------+-----+--------------------
          0 |        992 | Rdr |52(7)                                                                    |     | WUPA
       2116 |       4484 | Tag |44  00                                                                   |     | 
       7040 |       9504 | Rdr |93  20                                                                   |     | ANTICOLL
      10564 |      16452 | Tag |88  04  2E  59  FB                                                       |     | 
      19584 |      30112 | Rdr |93  70  88  04  2E  59  FB  96  25                                       |  ok | SELECT_UID
      31172 |      34692 | Tag |04  DA  17                                                               |  ok | 
      35968 |      38432 | Rdr |95  20                                                                   |     | ANTICOLL-2
      39492 |      45380 | Tag |7A  77  79  80  F4                                                       |     | 
      48384 |      58912 | Rdr |95  70  7A  77  79  80  F4  CF  F4                                       |  ok | SELECT_UID-2
      59972 |      63556 | Tag |20  FC  70                                                               |  ok | 
      65024 |      69792 | Rdr |E0  80  31  73                                                           |  ok | RATS - FSDI=8 (FSD=256), CID=0
      70852 |      87108 | Tag |0C  75  77  80  02  C1  05  21  30  00  77  C1  60  D3                   |  ok | 
     390400 |     399776 | Rdr |0A  00  70  1E  40  00  10  97                                           |  ok | FIRST AUTH (Keynr 0x401E: A sector 15)
     440644 |     464964 | Tag |0A  00  90  71  3F  87  67  0A  0D  D6  28  FD  F3  C6  DD  18  25  A9   |     | 
            |            |     |F8  E0  7F                                                               |  ok | 
     774784 |     817504 | Rdr |0B  00  72  66  E6  44  BF  E7  6C  63  75  F2  7B  3A  88  FD  DC  13   |     | 
            |            |     |CB  38  7B  78  19  19  C0  8E  2A  B0  08  B2  B7  03  1B  DF  09  CA   |     | 
            |            |     |18                                                                       |  ok | SECOND AUTH STEP
     838468 |     881156 | Tag |0B  00  90  72  94  6B  7C  D6  8E  99  13  5D  B5  27  10  56  68  87   |     | 
            |            |     |A6  43  A9  A7  1F  19  C0  9F  CE  44  73  28  71  0A  24  2B  04  AB   |     | 
            |            |     |A5                                                                       |  ok | 
    1185024 |    1203552 | Rdr |0A  00  31  3C  00  01  44  C0  9A  25  AD  BB  38  F8  B1  BB           |  ok | READ ENCRYPTED(60) MAC_MACed
    1221188 |    1254660 | Tag |0A  00  90  BA  06  3A  D9  2D  1E  C5  1D  2D  D7  0C  38  42  B0  F9   |     | 
            |            |     |0D  D0  36  19  64  9E  2C  7A  56  34  35                               |  ok | 
    1556992 |    1575584 | Rdr |0B  00  31  3D  00  01  86  FF  66  3F  19  24  EB  3D  8B  C7           |  ok | READ ENCRYPTED(61) MAC_MACed
    1592772 |    1626244 | Tag |0B  00  90  95  78  26  44  9D  32  FA  42  0A  B2  C3  85  46  52  E8   |     | 
            |            |     |54  83  30  73  83  1A  93  6C  F3  CC  99                               |  ok | 
    1936768 |    1955360 | Rdr |0A  00  31  3E  00  01  76  E5  E4  66  4B  B4  30  F9  87  2F           |  ok | READ ENCRYPTED(62) MAC_MACed
    1972420 |    2005956 | Tag |0A  00  90  1B  8F  BF  E2  C6  D4  35  EC  B0  D0  4D  71  A8  13  C5   |     | 
            |            |     |59  4F  71  49  4E  9D  0A  8A  A9  8D  86                               |  ok | 
    2316416 |    2335008 | Rdr |0B  00  31  3F  00  01  B4  F3  24  AC  C0  74  AC  29  B9  CD           |  ok | READ ENCRYPTED(63) MAC_MACed
    2351684 |    2385156 | Tag |0B  00  90  F5  61  F3  AF  2E  E7  D2  9E  36  D5  A0  8B  C2  89  E4   |     | 
            |            |     |42  1B  43  76  41  3B  CE  1F  9A  A7  FA                               |  ok | 

```

As you can see, the function copy-pasted encrypted outputs from the tag.
Without the keys+trace, the dump is pointless.

Using `mfp_data_crypt` in the sector reader fixes this:
```
[usb] pm3 --> hf mfp dump --ns
[=] --- Tag Information ---------------------------
[=] UID......... 04 2E 59 7A 77 79 80 
[=] ATQA........ 00 44
[=] SAK......... 20

[+] Loaded 32 AES keys from key file

[=] Successfully read 16 / 32 sectors  (SL3: 16, SL1: 0)

[=] -----+----+----------------------------------+----------------------------------
[=]  Sec | SL | key A                            | key B
[=] -----+----+----------------------------------+----------------------------------
[=]  000 | 3  | FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF | FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
[=]  001 | 3  | FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF | FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
[ . . . ]
[=]  015 | 3  | FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF | FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
[=]  016 | ?  | -------------------------------- | --------------------------------
[ . . . ]
[=] -----+----+----------------------------------+----------------------------------

[=]   # | sector 00 / 0x00                                | ascii
[=] ----+-------------------------------------------------+-----------------
[=]   0 | 04 2E 59 7A 77 79 80 08 44 00 01 01 11 00 18 23 | ..Yzwy..D......#
[=]   1 | 04 35 4D B2 33 7B 80 00 00 00 00 00 00 00 00 00 | .5M.3{.......... 
[=]   2 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................ 
[=]   3 | 00 00 00 00 00 0F 7F 07 88 69 00 00 00 00 00 00 | .........i......
[ . . . ]
```

This is obviously a bodge.

A cleaner, and maybe more sensible way would be instead to move `mfp_data_crypt` to `mifare4.c` and declare it there.
However I won't decide. After all that function is in fact only useful for mifare plus chips, so I find it OK to invoke.