### PR TITLE
Fix for issue https://github.com/RfidResearchGroup/proxmark3/issues/3250

### DIFF
--- a/client/src/loclass/cipher_bs_avx512.c
+++ b/client/src/loclass/cipher_bs_avx512.c
@@ -222,7 +222,14 @@ void doMAC_brute_match512(const uint64_t y_bits_bs[96 * BS512_WORDS],
     __m512i mac_match = BS_ONES;
     for (int tick = 0; tick < 32; tick++) {
         const __m512i diff = _mm512_xor_si512(r[2], _mm512_loadu_si512((const void *)&target_mac_bs[tick * BS512_WORDS]));
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
         mac_match = _mm512_andnot_si512(diff, mac_match);
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
         if ((tick == 7 || tick == 15 || tick == 23) &&
                 _mm512_test_epi64_mask(mac_match, mac_match) == 0) {


### PR DESCRIPTION
The root cause: a GCC intrinsic macro uses an uninitialized variable by design Intel's AVX-512 intrinsics in GCC are implemented as inline wrappers around __builtin_ia32_* builtins. Some of those builtins take a "merge source" operand that the user-facing intrinsic doesn't expose. For _mm512_andnot_si512, GCC's implementation in avx512fintrin.h looks like:

return (__m512i) __builtin_ia32_pandnd512_mask ((__v16si) __A,
                                                 (__v16si) __B,
                                                 (__v16si) _mm512_undefined_epi32 (),
                                                 (__mmask16) -1);
The mask is -1 (all lanes written), so the "merge source" is discarded — that's why GCC passes _mm512_undefined_epi32(), which is literally defined as:

__m512i __Y = __Y;   // intentionally self-initialized, value is "don't care"
return __Y;

----------------

The line __m512i __Y = __Y; lives in GCC's own header:

/usr/lib/gcc/x86_64-linux-gnu/12/include/avx512fintrin.h That file belongs to the distro's gcc-12 package. Editing it would:

Only fix this one developer's machine.
Get silently reverted the next time apt upgrade runs. Cause divergence from every other build host / CI runner. Not help anyone else who clones the repo.
So patching the header in-place is a non-starter for a committed fix.

-----------------------
Implemented solution:

Silence only the false positive around the call — add a diagnostic pragma right at the intrinsic site so the rest of the file keeps full warnings.