### PR TITLE
Add new DFC qualifiers for FeliCa lite, print DFC in `hf felica info`

### DIFF
--- a/client/resources/felica_system_code_list.json
+++ b/client/resources/felica_system_code_list.json
@@ -393,32 +393,6 @@
     "description": "Default system code used by FeliCa Lite/Lite-S tags",
     "services": [
       {
-        "name": "Aime",
-        "type": "e-amusement",
-        "description": "AIME E-amusement",
-        "nodes": [
-          {
-            "code": "0b00",
-            "data": {
-              "0082": "^................0078............$"
-            }
-          }
-        ]
-      },
-      {
-        "name": "Bandai Namco Pasport",
-        "type": "e-amusement",
-        "description": "Bandai Namco Pasport E-amusement",
-        "nodes": [
-          {
-            "code": "0b00",
-            "data": {
-              "0082": "^................002A............$"
-            }
-          }
-        ]
-      },
-      {
         "name": "Konami",
         "type": "e-amusement",
         "description": "Konami E-amusement",
@@ -440,6 +414,58 @@
             "code": "0b00",
             "data": {
               "0082": "^................0077............$"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Aime",
+        "type": "e-amusement",
+        "description": "AIME E-amusement",
+        "nodes": [
+          {
+            "code": "0b00",
+            "data": {
+              "0082": "^................0078............$"
+            }
+          }
+        ]
+      },
+      {
+        "name": "NESiCA",
+        "type": "e-amusement",
+        "description": "NESiCA E-amusement",
+        "nodes": [
+          {
+            "code": "0b00",
+            "data": {
+              "0082": "^................0079............$"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Bandai Namco Pasport",
+        "type": "e-amusement",
+        "description": "Bandai Namco Pasport E-amusement",
+        "nodes": [
+          {
+            "code": "0b00",
+            "data": {
+              "0082": "^................002A............$"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Mobiry Days",
+        "type": "transit",
+        "description": "Mobiry Days transit service",
+        "nodes": [
+          {
+            "code": "0b00",
+            "data": {
+              "0082": "^................0093............$"
             }
           }
         ]

--- a/client/src/cmdhffelica.c
+++ b/client/src/cmdhffelica.c
@@ -1209,6 +1209,29 @@ static void felica_info_process_system(int level, uint8_t flags, const felica_di
     }
 
     if (system->has_idm) {
+        if (system->system_code == FELICA_SYSTEM_CODE_FELICA_LITE) {
+            static const uint8_t lite_id_block_list_element[] = {0x80U, FELICA_BLK_NUMBER_ID};
+            uint8_t lite_id_block[FELICA_BLK_SIZE] = {0};
+            size_t lite_id_block_len = 0;
+
+            if (felica_read_service_block_for_node(flags, system->idm, FELICA_PRESENCE_SERVICE_CODE_LE,
+                                                   lite_id_block_list_element, sizeof(lite_id_block_list_element),
+                                                   lite_id_block, sizeof(lite_id_block), &lite_id_block_len) == PM3_SUCCESS &&
+                    lite_id_block_len >= FELICA_BLK_SIZE) {
+                const uint8_t *lite_tail = lite_id_block + FELICA_BLK_HALF;
+                const uint16_t dfc = (uint16_t)((uint16_t)lite_tail[0] << 8) | lite_tail[1];
+                if (dfc == 0x0000U) {
+                    PrintAndLogEx(level, "    DFC............ " _YELLOW_("%02X%02X") " ( Unused )", lite_tail[0], lite_tail[1]);
+                } else {
+                    PrintAndLogEx(level, "    DFC............ " _YELLOW_("%02X%02X"), lite_tail[0], lite_tail[1]);
+                }
+                PrintAndLogEx(level, "    ARB............ " _YELLOW_("%s"), sprint_hex_inrow(lite_tail + 2, 6));
+            } else {
+                PrintAndLogEx(level, "    DFC............ " _RED_("N/A"));
+                PrintAndLogEx(level, "    ARB............ " _RED_("N/A"));
+            }
+        }
+
         felica_info_process_system_services(level, flags, system->system_code, system->idm, entry);
     }
 }


### PR DESCRIPTION
This PR adds two more detection qualifiers for FeliCa lite cards based on DFC, for Nesica (courtesy of @ry4000) and MOBIRY DAYS (courtesy of @frozenpandaman).

Additionally, the DFC and ARB values are now printed inside of `hf felica info` when FeliCa Lite system is detected.