### PR TITLE
Raise simaid selectaid_response cap to 256

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1911,7 +1911,7 @@ static void PacketReceived(PacketCommandNG *packet) {
                 uint8_t uid[10];
                 uint8_t ats[20];
                 uint8_t aid[30];
-                uint8_t selectaid_response[100];
+                uint8_t selectaid_response[256];
                 uint8_t getdata_response[100];
                 uint32_t ats_len;
                 uint32_t aid_len;

--- a/client/src/cmdhf14a.c
+++ b/client/src/cmdhf14a.c
@@ -4393,7 +4393,7 @@ int CmdHF14AAIDSim(const char *Cmd) {
         arg_str0("u", "uid", "<hex>", "<4|7|10> hex bytes UID"),
         arg_str0("r", "ats", "<hex>", "<0-20> hex bytes ATS"),
         arg_str0("a", "aid", "<hex>", "<0-30> hex bytes for AID to respond to (Default: A000000000000000000000)"),
-        arg_str0("e", "selectaid_response", "<hex>", "<0-100> hex bytes for APDU Response to AID Select (Default: 9000)"),
+        arg_str0("e", "selectaid_response", "<hex>", "<0-256> hex bytes for APDU Response to AID Select (Default: 9000)"),
         arg_str0("p", "getdata_response", "<hex>", "<0-100> hex bytes for APDU Response to Get Data request after AID (Default: 9000)"),
         arg_lit0("x", "enumerate", "Enumerate all AID values via returning Not Found and print them to console "),
         arg_param_end
@@ -4410,7 +4410,7 @@ int CmdHF14AAIDSim(const char *Cmd) {
     uint8_t ats[20] = {0};
     uint8_t aid[30] = {0xA0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     uint8_t default_aid_len = 11;
-    uint8_t selectaid_response[100] = {0x90, 0x00};
+    uint8_t selectaid_response[256] = {0x90, 0x00};
     uint8_t default_selectaid_response_len = 2;
     uint8_t getdata_response[100] = {0x90, 0x00};
     uint8_t default_getdata_response_len = 2;
@@ -4492,7 +4492,7 @@ int CmdHF14AAIDSim(const char *Cmd) {
         uint8_t uid[10];
         uint8_t ats[20];
         uint8_t aid[30];
-        uint8_t selectaid_response[100];
+        uint8_t selectaid_response[256];
         uint8_t getdata_response[100];
         uint32_t ats_len;
         uint32_t aid_len;


### PR DESCRIPTION
The selectaid_response buffer in `hf 14a simaid` was capped at 100 bytes, which is well below the ISO 14443A frame maximum of 256 bytes and prevents users from emulating tags whose SELECT AID response is larger than a trivial status word.

This bumps selectaid_response from 100 to 256 in all three locations (ARM packet handler, client locals, client payload struct) along with the argparse help text. getdata_response is left at 100. The payload struct overlays PM3_CMD_DATA_SIZE (512) via packet->data.asBytes; with the new sizes it totals 435 bytes, so it still fits.

Pairs with the earlier tosend bounds check / DYNAMIC_MODULATION_BUFFER2 fix, which raised the actual transmit ceiling to the 256-byte frame limit — this change lets callers supply a response up to that limit.