### PR TITLE
The fob with raw 00000000000009xxxxxxxxx9 cannot be written with lf hid clone -r

### DIFF
--- a/client/src/cmdlfhid.c
+++ b/client/src/cmdlfhid.c
@@ -76,8 +76,8 @@ static int lf_hid_validate_packed_transport(const wiegand_input_t *input, const 
         return PM3_SUCCESS;
     }
 
-    if (input->packed.Length > 37) {
-        PrintAndLogEx(ERR, "%s supports only packed credentials up to 37 bits", command_name);
+    if (input->packed.Length > 48) {
+        PrintAndLogEx(ERR, "%s supports only packed credentials up to 48 bits", command_name);
         return PM3_EINVARG;
     }
 


### PR DESCRIPTION
The following use case is not working as it was working before:
```
[usb] pm3 --> lf search

[=] Note: False Positives ARE possible
[=] 
[=] Checking for known tags...
[=] 
[=] Trying with a preamble bit...
[+] DemodBuffer:
[+] 1DXXXXXXXXXXXXXXXXXXXXXX6

[=] raw: 00000000000009XXXXXXXXX9

```
When one tries to write with --raw it fails with message: `"... supports only packed credentials up to 37 bits"`

The current implementation also contradicts with help  samples (lf hid clone --help):
```
    lf hid clone -r 01f0760643c3                         -> write raw value for T55x7 tag (HID P10001 40 bit)
    lf hid clone -r 01400076000c86                       -> write raw value for T55x7 tag (HID Corporate 48 bit)
```

The suggested change fixes this (limit 48 bits)