### PR TITLE
Update mifaredesfire.c to support DESELECT response

### DIFF
--- a/armsrc/mifaredesfire.c
+++ b/armsrc/mifaredesfire.c
@@ -756,11 +756,19 @@ size_t CreateAPDU(uint8_t *datain, size_t len, uint8_t *dataout) {
 // uint32_t crc = crc_finish(&desfire_crc32);
 
 void OnSuccess(void) {
+    size_t len = 0;
+    uint8_t resp[MAX_FRAME_SIZE];
+    uint8_t par[MAX_PARITY_SIZE];
+
     pcb_blocknum = 0;
     ReaderTransmit(deselect_cmd, 3, NULL);
-    if (mifare_ultra_halt()) {
-        if (g_dbglevel >= DBG_ERROR) Dbprintf("Halt error");
+    len = ReaderReceive(resp, sizeof(resp), par);
+    if (len == 0) {
+        if (mifare_ultra_halt()) {
+            if (g_dbglevel >= DBG_ERROR) Dbprintf("Halt error");
+        }
     }
+
     switch_off();
 }
 


### PR DESCRIPTION
Even if I don't see any reason to have the `GetVersion` command in `ARM` codebase (no time sensitive - can be moved in the client part), this PR fix the incorrect `HLTA` command sent during `Deselect` reponse

We had:
![](https://github.com/user-attachments/assets/8d71788c-0ee4-4ed4-9aef-bd72935e115d)
_`HLTA` command sent during `Deselect` reponse_

After the fix:
![](https://github.com/user-attachments/assets/486dab4b-c100-451f-86bd-8ac683dd4733)
_Only `Deselect` response, as `HLTA` is not needed_