### PR TITLE
Add prime.c to experimental client lib CMakeLists.txt

### DIFF
--- a/client/experimental_lib/CMakeLists.txt
+++ b/client/experimental_lib/CMakeLists.txt
@@ -287,6 +287,7 @@ set (TARGET_SOURCES
         ${PM3_ROOT}/client/src/mifare/desfiretest.c
         ${PM3_ROOT}/client/src/mifare/gallaghercore.c
         ${PM3_ROOT}/client/src/mifare/gallaghertest.c
+        ${PM3_ROOT}/client/src/mifare/prime.c
         ${PM3_ROOT}/client/src/nfc/ndef.c
         ${PM3_ROOT}/client/src/qrcode/qrcode.c
         ${PM3_ROOT}/client/src/relay/relay_posix.c


### PR DESCRIPTION
The experimental_lib CMakeLists.txt file is missing prime.c, which includes symbols for e.g. `mifare_prime_get_version_str`. The lib builds without errors, but when trying to use it for example in python an error is presented:
`undefined symbol: mifare_prime_get_version_str`.

This is fixed by adding the prime.c to CMakeLists.txt.
