### PR TITLE
Calypso AID handling improvements

### DIFF
--- a/client/resources/aidlist.json
+++ b/client/resources/aidlist.json
@@ -2966,6 +2966,18 @@
         ]
     },
     {
+        "AID": "315449432E49434132",
+        "Vendor": "Calypso Networks Association (CNA)",
+        "Country": "France",
+        "Name": "1TIC.ICA2",
+        "Description": "Compatibility AID. \"1TIC.ICA2\" in ISO/IEC 8859-1 coding.",
+        "Type": "transport",
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "2100"
+        }
+    },
+    {
         "AID": "304554502E494341",
         "Vendor": "Calypso Networks Association (CNA)",
         "Country": "France",
@@ -2990,25 +3002,34 @@
         "Name": "3MTR.ICA",
         "Description": "Legacy header dedicated to the Master File. \"3MTR.ICA\" in ISO/IEC 8859-1 coding.",
         "Type": "",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "3F00"
+        }
     },
     {
         "AID": "334D54522E494341D48401019001",
         "Vendor": "Secretaria de Movilidad (SEMOVI)",
         "Country": "Mexico",
         "Name": "Tarjeta de Movilidad Integrada",
-        "Description": "Master File AID observed on a Mexico City Tarjeta de Movilidad Integrada matching MF LID 3F00. \"3MTR.ICA\" in ISO/IEC 8859-1 coding.",
+        "Description": "Master File AID observed on a Mexico City Tarjeta de Movilidad Integrada. \"3MTR.ICA\" in ISO/IEC 8859-1 coding.",
         "Type": "",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "3F00"
+        }
     },
     {
         "AID": "334D54522E4943410000000000000000",
         "Vendor": "Lignes D'Azur",
         "Country": "France",
         "Name": "La Carte",
-        "Description": "Master File AID observed on La Carte matching MF LID 3F00. \"3MTR.ICA\" in ISO/IEC 8859-1 coding with a zero-padded suffix.",
+        "Description": "Master File AID observed on La Carte. \"3MTR.ICA\" in ISO/IEC 8859-1 coding with a zero-padded suffix.",
         "Type": "",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "3F00"
+        }
     },
     {
         "AID": "315449432E494341D4840101",
@@ -3024,9 +3045,12 @@
         "Vendor": "Secretaria de Movilidad (SEMOVI); Spirtech",
         "Country": "N/A",
         "Name": "Tarjeta de Movilidad Integrada | Mover Emilia Romagna",
-        "Description": "Calypso-based ticket for public transport in Mexico City or Emilia-Romagna. Observed matching Calypso DF LID 2000.",
+        "Description": "Calypso-based ticket for public transport in Mexico City or Emilia-Romagna.",
         "Type": "transport",
         "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "2000"
+        },
         "Sources": [
             "android://com.spirtech.emiliaromagna",
             "android://mx.gob.cdmx.adip.apps"
@@ -3037,18 +3061,24 @@
         "Vendor": "Secretaria de Movilidad (SEMOVI)",
         "Country": "Mexico",
         "Name": "Tarjeta de Movilidad Integrada",
-        "Description": "Calypso-based public transport application observed matching DF LID 3100.",
+        "Description": "Calypso-based public transport application.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "3100"
+        }
     },
     {
         "AID": "315449432E494341D05600019101",
         "Vendor": "MOBIB",
         "Country": "Belgium",
         "Name": "MOBIB",
-        "Description": "Calypso-based transit card used by Brussels public transport. Observed matching Calypso DF LID 2000.",
+        "Description": "Calypso-based transit card used by Brussels public transport.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "2000"
+        }
     },
     {
         "AID": "A000000291D62000029101",
@@ -3079,9 +3109,12 @@
         "Vendor": "Secretaria de Movilidad (SEMOVI)",
         "Country": "Mexico",
         "Name": "Tarjeta de Movilidad Integrada",
-        "Description": "Store value application observed on a Mexico City Tarjeta de Movilidad Integrada matching Calypso DF LID 1000.",
+        "Description": "Store value application observed on a Mexico City Tarjeta de Movilidad Integrada.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "1000"
+        }
     },
     {
         "AID": "A00000040401250901",
@@ -3101,18 +3134,24 @@
         "Vendor": "Ile-de-France Mobilites",
         "Country": "France",
         "Name": "Navigo",
-        "Description": "CALYPSO-based Navigo paper ticket application observed matching Calypso DF LID 2000.",
+        "Description": "CALYPSO-based Navigo paper ticket application.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "2000"
+        }
     },
     {
         "AID": "A0000004040125090101000000000000",
         "Vendor": "Ile-de-France Mobilites",
         "Country": "France",
         "Name": "Navigo",
-        "Description": "CALYPSO-based older Navigo plastic card application observed matching Calypso DF LID 2000.",
+        "Description": "CALYPSO-based older Navigo plastic card application.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "2000"
+        }
     },
     {
         "AID": "A00000040401250057F0",
@@ -3150,18 +3189,24 @@
         "Vendor": "Lignes D'Azur",
         "Country": "France",
         "Name": "La Carte",
-        "Description": "CALYPSO-based La Carte transit card application observed matching Calypso DF LID 2000.",
+        "Description": "CALYPSO-based La Carte transit card application.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "2000"
+        }
     },
     {
         "AID": "A000000291D25008009301",
         "Vendor": "Lignes D'Azur",
         "Country": "France",
         "Name": "La Carte",
-        "Description": "CALYPSO-based La Carte transit card application observed matching Calypso DF LID 3200.",
+        "Description": "CALYPSO-based La Carte transit card application.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "3200"
+        }
     },
     {
         "AID": "54494C414D4F32000000",
@@ -3190,72 +3235,96 @@
         "Vendor": "MOBIB",
         "Country": "Belgium",
         "Name": "MOBIB",
-        "Description": "Calypso-based transit card used by Brussels public transport. Observed matching Calypso MF LID 3F00.",
+        "Description": "Calypso-based transit card used by Brussels public transport.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "3F00"
+        }
     },
     {
         "AID": "A000000291D05600019201",
         "Vendor": "MOBIB",
         "Country": "Belgium",
         "Name": "MOBIB",
-        "Description": "Calypso-based transit card used by Brussels public transport. Observed matching Calypso DF LID 1000.",
+        "Description": "Calypso-based transit card used by Brussels public transport.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "1000"
+        }
     },
     {
         "AID": "A000000291A00000019102",
         "Vendor": "MOBIB",
         "Country": "Belgium",
         "Name": "MOBIB",
-        "Description": "Calypso-based transit card used by Brussels public transport. Observed matching Calypso DF LID 2100.",
+        "Description": "Calypso-based transit card used by Brussels public transport.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "2100"
+        }
     },
     {
         "AID": "A000000291D05600019301",
         "Vendor": "MOBIB",
         "Country": "Belgium",
         "Name": "MOBIB",
-        "Description": "Calypso-based transit card used by Brussels public transport. Observed matching Calypso DF LID 3100.",
+        "Description": "Calypso-based transit card used by Brussels public transport.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "3100"
+        }
     },
     {
         "AID": "A000000291D05600019302",
         "Vendor": "MOBIB",
         "Country": "Belgium",
         "Name": "MOBIB",
-        "Description": "Calypso-based transit card used by Brussels public transport. Observed matching Calypso DF LID 3200.",
+        "Description": "Calypso-based transit card used by Brussels public transport.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "3200"
+        }
     },
     {
         "AID": "A000000291D05600029302",
         "Vendor": "MOBIB",
         "Country": "Belgium",
         "Name": "MOBIB",
-        "Description": "Calypso-based transit card used by Brussels public transport. Observed matching Calypso DF LID 3300.",
+        "Description": "Calypso-based transit card used by Brussels public transport.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "3300"
+        }
     },
     {
         "AID": "A000000291D05600019303",
         "Vendor": "MOBIB",
         "Country": "Belgium",
         "Name": "MOBIB",
-        "Description": "Calypso-based transit card used by Brussels public transport. Observed matching Calypso DF LID 3400.",
+        "Description": "Calypso-based transit card used by Brussels public transport.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "3400"
+        }
     },
     {
         "AID": "A000000291D05600029401",
         "Vendor": "MOBIB",
         "Country": "Belgium",
         "Name": "MOBIB",
-        "Description": "Calypso-based transit card used by Brussels public transport. Observed matching Calypso DF LID 4100.",
+        "Description": "Calypso-based transit card used by Brussels public transport.",
         "Type": "transport",
-        "Protocol": "cna_calypso"
+        "Protocol": "cna_calypso",
+        "Extras": {
+            "LID": "4100"
+        }
     },
     {
         "AID": "A000000291D62000019101",

--- a/client/src/cmdhfcalypso.c
+++ b/client/src/cmdhfcalypso.c
@@ -673,6 +673,14 @@ static bool calypso_aid_is_generic(const uint8_t *aid, size_t aid_len) {
     return aid != NULL && aid_len > 0 && aid_len <= 8 && aid[0] >= 0x30 && aid[0] <= 0x34;
 }
 
+static size_t calypso_aid_len_without_trailing_zeroes(const uint8_t *aid, size_t aid_len) {
+    while (aid_len > 0 && aid[aid_len - 1] == 0x00) {
+        aid_len--;
+    }
+
+    return aid_len;
+}
+
 static int calypso_aid_specificity(bool prefix, bool generic, size_t aid_len) {
     if (prefix) {
         return (int)aid_len;
@@ -685,7 +693,7 @@ static int calypso_aid_specificity(bool prefix, bool generic, size_t aid_len) {
     return 2000 + (int)aid_len;
 }
 
-static void calypso_find_aid_match(json_t *root, const uint8_t *aid, size_t aid_len, const char *source, calypso_aid_match_t *match) {
+static void calypso_find_aid_match(json_t *root, const uint8_t *aid, size_t aid_len, const char *source, bool fci_aid, calypso_aid_match_t *match) {
     memset(match, 0, sizeof(*match));
     match->source = source;
 
@@ -693,6 +701,7 @@ static void calypso_find_aid_match(json_t *root, const uint8_t *aid, size_t aid_
         return;
     }
 
+    size_t prefix_aid_len = fci_aid ? calypso_aid_len_without_trailing_zeroes(aid, aid_len) : aid_len;
     for (size_t elmindx = 0; elmindx < json_array_size(root); elmindx++) {
         json_t *data = AIDSearchGetElm(root, elmindx);
         if (data == NULL || calypso_json_string_is(data, "Protocol", "cna_calypso") == false) {
@@ -705,14 +714,15 @@ static void calypso_find_aid_match(json_t *root, const uint8_t *aid, size_t aid_
             continue;
         }
 
-        if (aid_len < (size_t)entry_aid_len || memcmp(aid, entry_aid, (size_t)entry_aid_len) != 0) {
+        bool exact = fci_aid && aid_len == (size_t)entry_aid_len && memcmp(aid, entry_aid, aid_len) == 0;
+        if (exact == false && (prefix_aid_len < (size_t)entry_aid_len || memcmp(aid, entry_aid, (size_t)entry_aid_len) != 0)) {
             continue;
         }
 
         bool prefix = calypso_aid_is_prefix(entry_aid, (size_t)entry_aid_len);
         bool generic = calypso_aid_is_generic(entry_aid, (size_t)entry_aid_len);
         int score = calypso_aid_specificity(prefix, generic, (size_t)entry_aid_len);
-        if (match->found) {
+        if (match->found && exact == false) {
             int current_score = calypso_aid_specificity(match->prefix, match->generic, match->aid_len);
             if (current_score >= score) {
                 continue;
@@ -729,6 +739,9 @@ static void calypso_find_aid_match(json_t *root, const uint8_t *aid, size_t aid_
         match->prefix = prefix;
         match->generic = generic;
         match->aid_len = (size_t)entry_aid_len;
+        if (exact) {
+            return;
+        }
     }
 }
 
@@ -740,14 +753,12 @@ static int calypso_aid_match_score(const calypso_aid_match_t *match) {
     return calypso_aid_specificity(match->prefix, match->generic, match->aid_len);
 }
 
-static bool calypso_aid_match_is_specific(const calypso_aid_match_t *match) {
-    return match != NULL && match->found && match->prefix == false && match->generic == false;
-}
-
 static const calypso_aid_match_t *calypso_best_aid_match(const calypso_aid_match_t *selected, const calypso_aid_match_t *df_name) {
-    int selected_score = calypso_aid_match_score(selected);
-    int df_name_score = calypso_aid_match_score(df_name);
-    return df_name_score > selected_score ? df_name : selected;
+    if (df_name != NULL && df_name->found) {
+        return df_name;
+    }
+
+    return selected;
 }
 
 static void calypso_aid_attribution_init(const calypso_select_result_t *selected, bool verbose, calypso_aid_attribution_t *attribution) {
@@ -758,9 +769,9 @@ static void calypso_aid_attribution_init(const calypso_select_result_t *selected
         return;
     }
 
-    calypso_find_aid_match(attribution->root, selected->requested_aid, selected->requested_aid_len, selected->default_selection ? "default selection AID" : "selected AID", &attribution->selected_match);
+    calypso_find_aid_match(attribution->root, selected->requested_aid, selected->requested_aid_len, selected->default_selection ? "default selection AID" : "selected AID", false, &attribution->selected_match);
     if (selected->parsed.has_df_name) {
-        calypso_find_aid_match(attribution->root, selected->parsed.df_name, selected->parsed.df_name_len, "DF name", &attribution->df_name_match);
+        calypso_find_aid_match(attribution->root, selected->parsed.df_name, selected->parsed.df_name_len, "DF name", true, &attribution->df_name_match);
     }
 
     attribution->best = calypso_best_aid_match(&attribution->selected_match, &attribution->df_name_match);
@@ -826,14 +837,14 @@ static void calypso_print_aid_attribution_details(const calypso_aid_attribution_
     }
 }
 
-static bool calypso_df_name_matches_specific_aid(json_t *root, const calypso_select_result_t *selected) {
+static bool calypso_df_name_matches_known_aid(json_t *root, const calypso_select_result_t *selected) {
     if (selected->parsed.has_df_name == false) {
         return false;
     }
 
     calypso_aid_match_t df_name_match;
-    calypso_find_aid_match(root, selected->parsed.df_name, selected->parsed.df_name_len, "DF name", &df_name_match);
-    return calypso_aid_match_is_specific(&df_name_match);
+    calypso_find_aid_match(root, selected->parsed.df_name, selected->parsed.df_name_len, "DF name", true, &df_name_match);
+    return df_name_match.found;
 }
 
 static int calypso_select_attribution_score(json_t *root, const calypso_select_result_t *selected) {
@@ -841,9 +852,9 @@ static int calypso_select_attribution_score(json_t *root, const calypso_select_r
     calypso_aid_match_t df_name_match;
     memset(&df_name_match, 0, sizeof(df_name_match));
 
-    calypso_find_aid_match(root, selected->requested_aid, selected->requested_aid_len, "selected AID", &selected_match);
+    calypso_find_aid_match(root, selected->requested_aid, selected->requested_aid_len, "selected AID", false, &selected_match);
     if (selected->parsed.has_df_name) {
-        calypso_find_aid_match(root, selected->parsed.df_name, selected->parsed.df_name_len, "DF name", &df_name_match);
+        calypso_find_aid_match(root, selected->parsed.df_name, selected->parsed.df_name_len, "DF name", true, &df_name_match);
     }
 
     const calypso_aid_match_t *best = calypso_best_aid_match(&selected_match, &df_name_match);
@@ -935,7 +946,7 @@ static int calypso_scan_aidlist(const calypso_rf_info_t *rf, bool verbose, calyp
 
             if (*matched) {
                 if (prefix || generic) {
-                    if (calypso_df_name_matches_specific_aid(root, selected)) {
+                    if (calypso_df_name_matches_known_aid(root, selected)) {
                         AIDSearchFree(root);
                         return PM3_SUCCESS;
                     }

--- a/client/src/cmdhfcalypso.c
+++ b/client/src/cmdhfcalypso.c
@@ -41,6 +41,7 @@
 
 #define CALYPSO_SERIAL_LEN       8
 #define CALYPSO_STARTUP_LEN      7
+#define CALYPSO_MIN_AID_LEN      5
 #define CALYPSO_MAX_AID_LEN      16
 #define CALYPSO_ICC_RECORD_LEN   29
 #define CALYPSO_LEGACY_RECORD_LEN 0x1D
@@ -666,7 +667,7 @@ static const char *calypso_json_lookup_name(calypso_resource_t *resource, uint32
 }
 
 static bool calypso_aid_is_prefix(const uint8_t *aid, size_t aid_len) {
-    return aid != NULL && aid_len == 5;
+    return aid != NULL && aid_len == CALYPSO_MIN_AID_LEN;
 }
 
 static bool calypso_aid_is_generic(const uint8_t *aid, size_t aid_len) {
@@ -913,7 +914,7 @@ static int calypso_scan_aidlist(const calypso_rf_info_t *rf, bool verbose, calyp
     int probe_score = -1;
     calypso_select_result_t probe_selected = {0};
 
-    for (int scan_pass = 0; scan_pass < 3; scan_pass++) {
+    for (size_t scan_aid_len = CALYPSO_MIN_AID_LEN; scan_aid_len <= CALYPSO_MAX_AID_LEN; scan_aid_len++) {
         for (size_t elmindx = 0; elmindx < json_array_size(root); elmindx++) {
             json_t *data = AIDSearchGetElm(root, elmindx);
             if (data == NULL || calypso_json_string_is(data, "Protocol", "cna_calypso") == false) {
@@ -926,13 +927,12 @@ static int calypso_scan_aidlist(const calypso_rf_info_t *rf, bool verbose, calyp
                 continue;
             }
 
-            bool prefix = calypso_aid_is_prefix(aid, (size_t)aid_len);
-            bool generic = calypso_aid_is_generic(aid, (size_t)aid_len);
-            if ((scan_pass == 0 && prefix == false) ||
-                    (scan_pass == 1 && (prefix || generic == false)) ||
-                    (scan_pass == 2 && (prefix || generic))) {
+            if ((size_t)aid_len != scan_aid_len) {
                 continue;
             }
+
+            bool prefix = calypso_aid_is_prefix(aid, (size_t)aid_len);
+            bool generic = calypso_aid_is_generic(aid, (size_t)aid_len);
 
             if (AIDSeenBefore(root, aid, (size_t)aid_len, elmindx)) {
                 continue;
@@ -2751,7 +2751,7 @@ static int calypso_dump_all_declared_dfs(json_t *dfs, calypso_rf_info_t *rf, boo
     int first_error = PM3_SUCCESS;
     bool reactivate_before_next_probe = false;
 
-    for (int scan_pass = 0; scan_pass < 3 && first_error == PM3_SUCCESS; scan_pass++) {
+    for (size_t scan_aid_len = CALYPSO_MIN_AID_LEN; scan_aid_len <= CALYPSO_MAX_AID_LEN && first_error == PM3_SUCCESS; scan_aid_len++) {
         for (size_t elmindx = 0; elmindx < json_array_size(root); elmindx++) {
             json_t *data = AIDSearchGetElm(root, elmindx);
             if (data == NULL || calypso_json_string_is(data, "Protocol", "cna_calypso") == false) {
@@ -2764,11 +2764,7 @@ static int calypso_dump_all_declared_dfs(json_t *dfs, calypso_rf_info_t *rf, boo
                 continue;
             }
 
-            bool prefix = calypso_aid_is_prefix(aid, (size_t)aid_len);
-            bool generic = calypso_aid_is_generic(aid, (size_t)aid_len);
-            if ((scan_pass == 0 && prefix == false) ||
-                    (scan_pass == 1 && (prefix || generic == false)) ||
-                    (scan_pass == 2 && (prefix || generic))) {
+            if ((size_t)aid_len != scan_aid_len) {
                 continue;
             }
 

--- a/doc/aidlist.md
+++ b/doc/aidlist.md
@@ -42,6 +42,12 @@ Each entry in `client/resources/aidlist.json` must contain all of the fields bel
   - `stid_mobile_id`
   - `suprema_mobile`
   - `unifi_identity`
+- `Extras`: Object containing protocol-specific attributes for this entry, scoped based on `Protocol`. Use `Extras` only when the attribute applies to this exact AID entry; do not put exact-match metadata on broad prefix or wildcard entries.
+
+### Known `Extras` keys
+
+#### `cna_calypso`:
+- `LID`: Calypso Long Identifier as a 4-character uppercase hex string, no spaces or separators. Use this when a Calypso AID/DF Name is known to correspond to a specific MF or DF LID.
 
 ## Examples
 
@@ -84,5 +90,21 @@ Sources example:
         "android://com.lane.lane",
         "https://example.com/reference"
     ]
+}
+```
+
+Extras example:
+```json
+{
+    "AID": "A0000004040125090101",
+    "Vendor": "Ile-de-France Mobilites",
+    "Country": "France",
+    "Name": "Navigo",
+    "Description": "CALYPSO-based Navigo paper ticket application.",
+    "Type": "transport",
+    "Protocol": "cna_calypso",
+    "Extras": {
+        "LID": "2000"
+    }
 }
 ```


### PR DESCRIPTION
This PR makes the following changes:
* In `hf calypso info` and `hf calypso dump` - AID entry names are now matched exactly first, falling back to a most-common-prefix match only after that;
* When matching AID, zeroed-suffix part is stripped, as Calypso cards treat zeroes as a wildcard. I.E. SELECT for `33 4D 54 52 2E 49 43 41 00 00 00 00 00 00 00 00` will still make a card that has AID `33 4D 54 52 2E 49 43 41` respond;
* Ensure that in `hf calypso info` and `hf calypso dump`, AID probing starts with shorter prefixes before going to more concrete values;
* Add `Extras` field to `aidlist.json` to store any information which may not be shared with other entries;
* For Calypso cards, inside of `Extras` field, specify `LID`, Long File Identifier, of the DF that gets selected with this AID.