### PR TITLE
Auto detect Makefile.platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ originalitysig.csv
 Makefile.platform
 Makefile.platform.*
 !Makefile.platform.sample
+!Makefile.platform.autodetect
 
 # Cache for detecting platform def changes
 .Makefile.options.cache

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Makefile.platform
 Makefile.platform.*
 !Makefile.platform.sample
 !Makefile.platform.autodetect
+.Makefile.platform.autodetect.cache
 
 # Cache for detecting platform def changes
 .Makefile.options.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Added `hw platformconfig` command and `Makefile.platform.autodetect` to auto-detect platform config from a connected device (@nemanjan00)
 - Added secure channel operations to `hf iclass sam` and fixed/improved I2C bus operations (@antiklesys)
 - Added `hf calypso list` command (@kormax)
 - Added `hf mfd verifycert` command (@kormax)

--- a/Makefile.platform.autodetect
+++ b/Makefile.platform.autodetect
@@ -2,16 +2,23 @@
 # Copy this file as Makefile.platform to use auto-detection.
 # Requires a connected Proxmark3 device and a pre-built client.
 #
-# Set PM3_PORT to your device, e.g.:
-#   make PM3_PORT=/dev/ttyACM0
+# Device is auto-detected via ./pm3. To select a specific device
+# when multiple are connected, set PM3_PORT:
+#   make PM3_PORT=/dev/ttyACM1
 #
-PM3_PORT ?= /dev/ttyACM0
 
 _AUTODETECT_CACHE := .Makefile.platform.autodetect.cache
-_AUTODETECT_DONE := $(shell client/proxmark3 $(PM3_PORT) -c "hw platformconfig" 2>/dev/null | grep -E '^[A-Z_]+=' > $(_AUTODETECT_CACHE) && echo ok)
+
+ifdef PM3_PORT
+_AUTODETECT_CMD := ./pm3 -p $(PM3_PORT) -c "hw platformconfig"
+else
+_AUTODETECT_CMD := ./pm3 -c "hw platformconfig"
+endif
+
+_AUTODETECT_DONE := $(shell $(_AUTODETECT_CMD) 2>/dev/null | grep -E '^[A-Z_]+=' > $(_AUTODETECT_CACHE) && echo ok)
 
 ifeq ($(_AUTODETECT_DONE),ok)
     include $(_AUTODETECT_CACHE)
 else
-    $(warning Auto-detection failed. Is the device connected on $(PM3_PORT)?)
+    $(warning Auto-detection failed. Is a Proxmark3 device connected?)
 endif

--- a/Makefile.platform.autodetect
+++ b/Makefile.platform.autodetect
@@ -2,6 +2,10 @@
 # Copy this file as Makefile.platform to use auto-detection.
 # Requires a connected Proxmark3 device and a pre-built client.
 #
+# PLATFORM and PLATFORM_EXTRAS are auto-detected from the device.
+# Everything below the auto-detection block can be edited to
+# override or add settings (standalone mode, skip flags, etc.)
+#
 # Device is auto-detected via ./pm3. To select a specific device
 # when multiple are connected, set PM3_PORT:
 #   make PM3_PORT=/dev/ttyACM1
@@ -22,3 +26,24 @@ ifeq ($(_AUTODETECT_DONE),ok)
 else
     $(warning Auto-detection failed. Is a Proxmark3 device connected?)
 endif
+
+# --- Manual overrides below this line ---
+# Uncomment and edit as needed:
+
+#STANDALONE=
+#SKIP_LF=1
+#SKIP_HITAG=1
+#SKIP_EM4x50=1
+#SKIP_EM4x70=1
+#SKIP_ZX8211=1
+#SKIP_HF=1
+#SKIP_ISO15693=1
+#SKIP_LEGICRF=1
+#SKIP_ISO14443b=1
+#SKIP_ISO14443a=1
+#SKIP_ICLASS=1
+#SKIP_SEOS=1
+#SKIP_FELICA=1
+#SKIP_NFCBARCODE=1
+#SKIP_HFSNIFF=1
+#SKIP_HFPLOT=1

--- a/Makefile.platform.autodetect
+++ b/Makefile.platform.autodetect
@@ -1,0 +1,17 @@
+# Auto-detect platform config from connected device
+# Copy this file as Makefile.platform to use auto-detection.
+# Requires a connected Proxmark3 device and a pre-built client.
+#
+# Set PM3_PORT to your device, e.g.:
+#   make PM3_PORT=/dev/ttyACM0
+#
+PM3_PORT ?= /dev/ttyACM0
+
+_AUTODETECT_CACHE := .Makefile.platform.autodetect.cache
+_AUTODETECT_DONE := $(shell client/proxmark3 $(PM3_PORT) -c "hw platformconfig" 2>/dev/null | grep -E '^[A-Z_]+=' > $(_AUTODETECT_CACHE) && echo ok)
+
+ifeq ($(_AUTODETECT_DONE),ok)
+    include $(_AUTODETECT_CACHE)
+else
+    $(warning Auto-detection failed. Is the device connected on $(PM3_PORT)?)
+endif

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -749,6 +749,110 @@ static void SendCapabilities(void) {
     reply_ng(CMD_CAPABILITIES, PM3_SUCCESS, (uint8_t *)&capabilities, sizeof(capabilities));
 }
 
+static void SendBuildConfig(void) {
+    build_config_t config;
+    memset(&config, 0, sizeof(config));
+    config.version = BUILD_CONFIG_VERSION;
+
+    // Platform
+#if defined(ICOPYX)
+    config.platform = BUILD_PLATFORM_ICOPYX;
+#elif defined(XC2S50)
+    config.platform = BUILD_PLATFORM_ULTIMATE;
+#elif defined(RDV4)
+    config.platform = BUILD_PLATFORM_RDV4;
+#else
+    config.platform = BUILD_PLATFORM_GENERIC;
+#endif
+
+    // LED order
+#if defined(LED_ORDER_PM3EASY)
+    config.led_order = 1;
+#else
+    config.led_order = 0;
+#endif
+
+    // Platform extras
+#ifdef WITH_FLASH
+    config.has_flash = true;
+#endif
+#ifdef WITH_SMARTCARD
+    config.has_smartcard = true;
+#endif
+#ifdef WITH_FPC_USART_HOST
+    config.has_btaddon = true;
+#endif
+#ifdef WITH_FPC_USART_DEV
+    config.has_fpc_usart_dev = true;
+#endif
+
+    // Feature flags (true = compiled in)
+#ifdef WITH_LF
+    config.with_lf = true;
+#endif
+#ifdef WITH_HITAG
+    config.with_hitag = true;
+#endif
+#ifdef WITH_EM4x50
+    config.with_em4x50 = true;
+#endif
+#ifdef WITH_EM4x70
+    config.with_em4x70 = true;
+#endif
+#ifdef WITH_ZX8211
+    config.with_zx8211 = true;
+#endif
+#ifdef WITH_GENERAL_HF
+    config.with_hf = true;
+#endif
+#ifdef WITH_ISO15693
+    config.with_iso15693 = true;
+#endif
+#ifdef WITH_LEGICRF
+    config.with_legicrf = true;
+#endif
+#ifdef WITH_ISO14443b
+    config.with_iso14443b = true;
+#endif
+#ifdef WITH_ISO14443a
+    config.with_iso14443a = true;
+#endif
+#ifdef WITH_ICLASS
+    config.with_iclass = true;
+#endif
+#ifdef WITH_SEOS
+    config.with_seos = true;
+#endif
+#ifdef WITH_FELICA
+    config.with_felica = true;
+#endif
+#ifdef WITH_NFCBARCODE
+    config.with_nfcbarcode = true;
+#endif
+#ifdef WITH_HFSNIFF
+    config.with_hfsniff = true;
+#endif
+#ifdef WITH_HFPLOT
+    config.with_hfplot = true;
+#endif
+#ifdef WITH_COMPRESSION
+    config.with_compression = true;
+#endif
+#ifdef WITH_LCD
+    config.with_lcd = true;
+#endif
+
+    // Standalone mode name
+#ifdef STANDALONE_NAME
+    strncpy(config.standalone, STANDALONE_NAME, sizeof(config.standalone) - 1);
+    config.standalone[sizeof(config.standalone) - 1] = '\0';
+#else
+    config.standalone[0] = '\0';
+#endif
+
+    reply_ng(CMD_BUILD_CONFIG, PM3_SUCCESS, (uint8_t *)&config, sizeof(config));
+}
+
 // Show some leds in a pattern to identify StandAlone mod is running
 void StandAloneMode(void) {
     DbpString("");
@@ -3257,6 +3361,10 @@ static void PacketReceived(PacketCommandNG *packet) {
         }
         case CMD_CAPABILITIES: {
             SendCapabilities();
+            break;
+        }
+        case CMD_BUILD_CONFIG: {
+            SendBuildConfig();
             break;
         }
         case CMD_PING: {

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -746,6 +746,8 @@ static void SendCapabilities(void) {
     capabilities.compiled_with_zx8211 = false;
 #endif
 
+    capabilities.has_build_config = true;
+
     reply_ng(CMD_CAPABILITIES, PM3_SUCCESS, (uint8_t *)&capabilities, sizeof(capabilities));
 }
 
@@ -770,76 +772,6 @@ static void SendBuildConfig(void) {
     config.led_order = 1;
 #else
     config.led_order = 0;
-#endif
-
-    // Platform extras
-#ifdef WITH_FLASH
-    config.has_flash = true;
-#endif
-#ifdef WITH_SMARTCARD
-    config.has_smartcard = true;
-#endif
-#ifdef WITH_FPC_USART_HOST
-    config.has_btaddon = true;
-#endif
-#ifdef WITH_FPC_USART_DEV
-    config.has_fpc_usart_dev = true;
-#endif
-
-    // Feature flags (true = compiled in)
-#ifdef WITH_LF
-    config.with_lf = true;
-#endif
-#ifdef WITH_HITAG
-    config.with_hitag = true;
-#endif
-#ifdef WITH_EM4x50
-    config.with_em4x50 = true;
-#endif
-#ifdef WITH_EM4x70
-    config.with_em4x70 = true;
-#endif
-#ifdef WITH_ZX8211
-    config.with_zx8211 = true;
-#endif
-#ifdef WITH_GENERAL_HF
-    config.with_hf = true;
-#endif
-#ifdef WITH_ISO15693
-    config.with_iso15693 = true;
-#endif
-#ifdef WITH_LEGICRF
-    config.with_legicrf = true;
-#endif
-#ifdef WITH_ISO14443b
-    config.with_iso14443b = true;
-#endif
-#ifdef WITH_ISO14443a
-    config.with_iso14443a = true;
-#endif
-#ifdef WITH_ICLASS
-    config.with_iclass = true;
-#endif
-#ifdef WITH_SEOS
-    config.with_seos = true;
-#endif
-#ifdef WITH_FELICA
-    config.with_felica = true;
-#endif
-#ifdef WITH_NFCBARCODE
-    config.with_nfcbarcode = true;
-#endif
-#ifdef WITH_HFSNIFF
-    config.with_hfsniff = true;
-#endif
-#ifdef WITH_HFPLOT
-    config.with_hfplot = true;
-#endif
-#ifdef WITH_COMPRESSION
-    config.with_compression = true;
-#endif
-#ifdef WITH_LCD
-    config.with_lcd = true;
 #endif
 
     // Standalone mode name

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -774,14 +774,6 @@ static void SendBuildConfig(void) {
     config.led_order = 0;
 #endif
 
-    // Standalone mode name
-#ifdef STANDALONE_NAME
-    strncpy(config.standalone, STANDALONE_NAME, sizeof(config.standalone) - 1);
-    config.standalone[sizeof(config.standalone) - 1] = '\0';
-#else
-    config.standalone[0] = '\0';
-#endif
-
     reply_ng(CMD_BUILD_CONFIG, PM3_SUCCESS, (uint8_t *)&config, sizeof(config));
 }
 

--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -1809,8 +1809,8 @@ static int CmdPlatformConfig(const char *Cmd) {
     if (!g_pm3_capabilities.compiled_with_hfplot)
         PrintAndLogEx(NORMAL, "SKIP_HFPLOT=1");
 
-    // Standalone placeholder (cannot be determined from capabilities alone)
-    PrintAndLogEx(NORMAL, "#STANDALONE=");
+    // Standalone (cannot be determined from capabilities alone, leave empty)
+    PrintAndLogEx(NORMAL, "STANDALONE=");
 
     return PM3_SUCCESS;
 }

--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -1701,6 +1701,120 @@ int set_fpga_mode(uint8_t mode) {
     return resp.status;
 }
 
+static int CmdPlatformConfig(const char *Cmd) {
+    CLIParserContext *ctx;
+    CLIParserInit(&ctx, "hw platformconfig",
+                  "Query connected device capabilities and print Makefile.platform content\n"
+                  "that matches the device's build configuration.",
+                  "hw platformconfig"
+                 );
+
+    void *argtable[] = {
+        arg_param_begin,
+        arg_param_end
+    };
+    CLIExecWithReturn(ctx, Cmd, argtable, true);
+    CLIParserFree(ctx);
+
+    if (g_session.pm3_present == false) {
+        PrintAndLogEx(ERR, "No Proxmark3 device connected");
+        return PM3_ENOTTY;
+    }
+
+    // Determine platform from version string (FPGA bitstream names)
+    const char *platform = "PM3GENERIC";
+
+    clearCommandBuffer();
+    SendCommandNG(CMD_VERSION, NULL, 0);
+    PacketResponseNG resp;
+    if (WaitForResponseTimeout(CMD_VERSION, &resp, 1000)) {
+        struct p {
+            uint32_t id;
+            uint32_t section_size;
+            uint32_t versionstr_len;
+            char versionstr[PM3_CMD_DATA_SIZE - 12];
+        } PACKED;
+        struct p *payload = (struct p *)&resp.data.asBytes;
+
+        if (strstr(payload->versionstr, "fpga_icopyx")) {
+            platform = "PM3ICOPYX";
+        } else if (strstr(payload->versionstr, "fpga_pm3_ult")) {
+            platform = "PM3ULTIMATE";
+        } else if (g_pm3_capabilities.is_rdv4) {
+            platform = "PM3RDV4";
+        }
+    } else if (g_pm3_capabilities.is_rdv4) {
+        platform = "PM3RDV4";
+    }
+
+    // Print PLATFORM
+    PrintAndLogEx(NORMAL, "PLATFORM=%s", platform);
+
+    // Reconstruct PLATFORM_EXTRAS from capability flags
+    char extras[128] = {0};
+    if (g_pm3_capabilities.compiled_with_fpc_usart_host) {
+        if (extras[0]) strncat(extras, " ", sizeof(extras) - strlen(extras) - 1);
+        strncat(extras, "BTADDON", sizeof(extras) - strlen(extras) - 1);
+    }
+    // FLASH and SMARTCARD are implicit for RDV4, only emit for other platforms
+    if (strcmp(platform, "PM3RDV4") != 0) {
+        if (g_pm3_capabilities.compiled_with_flash) {
+            if (extras[0]) strncat(extras, " ", sizeof(extras) - strlen(extras) - 1);
+            strncat(extras, "FLASH", sizeof(extras) - strlen(extras) - 1);
+        }
+        if (g_pm3_capabilities.compiled_with_smartcard) {
+            if (extras[0]) strncat(extras, " ", sizeof(extras) - strlen(extras) - 1);
+            strncat(extras, "SMARTCARD", sizeof(extras) - strlen(extras) - 1);
+        }
+    }
+    if (g_pm3_capabilities.compiled_with_fpc_usart_dev) {
+        if (extras[0]) strncat(extras, " ", sizeof(extras) - strlen(extras) - 1);
+        strncat(extras, "FPC_USART_DEV", sizeof(extras) - strlen(extras) - 1);
+    }
+
+    if (extras[0]) {
+        PrintAndLogEx(NORMAL, "PLATFORM_EXTRAS=%s", extras);
+    }
+
+    // Reconstruct SKIP_* from negation of compiled_with_* flags
+    // Only print lines for features that are actually skipped (disabled)
+    if (!g_pm3_capabilities.compiled_with_lf)
+        PrintAndLogEx(NORMAL, "SKIP_LF=1");
+    if (!g_pm3_capabilities.compiled_with_hitag)
+        PrintAndLogEx(NORMAL, "SKIP_HITAG=1");
+    if (!g_pm3_capabilities.compiled_with_em4x50)
+        PrintAndLogEx(NORMAL, "SKIP_EM4x50=1");
+    if (!g_pm3_capabilities.compiled_with_em4x70)
+        PrintAndLogEx(NORMAL, "SKIP_EM4x70=1");
+    if (!g_pm3_capabilities.compiled_with_zx8211)
+        PrintAndLogEx(NORMAL, "SKIP_ZX8211=1");
+    if (!g_pm3_capabilities.compiled_with_iso15693)
+        PrintAndLogEx(NORMAL, "SKIP_ISO15693=1");
+    if (!g_pm3_capabilities.compiled_with_legicrf)
+        PrintAndLogEx(NORMAL, "SKIP_LEGICRF=1");
+    if (!g_pm3_capabilities.compiled_with_iso14443b)
+        PrintAndLogEx(NORMAL, "SKIP_ISO14443b=1");
+    if (!g_pm3_capabilities.compiled_with_iso14443a)
+        PrintAndLogEx(NORMAL, "SKIP_ISO14443a=1");
+    if (!g_pm3_capabilities.compiled_with_iclass)
+        PrintAndLogEx(NORMAL, "SKIP_ICLASS=1");
+    if (!g_pm3_capabilities.compiled_with_seos)
+        PrintAndLogEx(NORMAL, "SKIP_SEOS=1");
+    if (!g_pm3_capabilities.compiled_with_felica)
+        PrintAndLogEx(NORMAL, "SKIP_FELICA=1");
+    if (!g_pm3_capabilities.compiled_with_nfcbarcode)
+        PrintAndLogEx(NORMAL, "SKIP_NFCBARCODE=1");
+    if (!g_pm3_capabilities.compiled_with_hfsniff)
+        PrintAndLogEx(NORMAL, "SKIP_HFSNIFF=1");
+    if (!g_pm3_capabilities.compiled_with_hfplot)
+        PrintAndLogEx(NORMAL, "SKIP_HFPLOT=1");
+
+    // Standalone placeholder (cannot be determined from capabilities alone)
+    PrintAndLogEx(NORMAL, "#STANDALONE=");
+
+    return PM3_SUCCESS;
+}
+
 static command_t CommandTable[] = {
     {"help", CmdHelp, AlwaysAvailable, "This help"},
     {"-------------", CmdHelp, AlwaysAvailable, "----------------------- " _CYAN_("Operation") " -----------------------"},
@@ -1718,6 +1832,7 @@ static command_t CommandTable[] = {
     {"lcd", CmdLCD, IfPm3Lcd, "Send command/data to LCD"},
     {"lcdreset", CmdLCDReset, IfPm3Lcd, "Hardware reset LCD"},
     {"ping", CmdPing, IfPm3Present, "Test if the Proxmark3 is responsive"},
+    {"platformconfig", CmdPlatformConfig, IfPm3Present, "Generate Makefile.platform from connected device"},
     {"readmem", CmdReadmem, IfPm3Present, "Read from MCU flash"},
     {"reset", CmdReset, IfPm3Present, "Reset the device"},
     {"setlfdivisor", CmdSetDivisor, IfPm3Lf, "Drive LF antenna at 12MHz / (divisor + 1)"},

--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -1732,7 +1732,6 @@ static int CmdPlatformConfig(const char *Cmd) {
         PacketResponseNG resp;
         if (WaitForResponseTimeout(CMD_BUILD_CONFIG, &resp, 1000) && resp.status == PM3_SUCCESS) {
             memcpy(&bc, resp.data.asBytes, sizeof(bc));
-            bc.standalone[sizeof(bc.standalone) - 1] = '\0';
             has_build_config = true;
 
             const char *platform_names[] = {"PM3RDV4", "PM3GENERIC", "PM3ICOPYX", "PM3ULTIMATE"};

--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -1721,42 +1721,60 @@ static int CmdPlatformConfig(const char *Cmd) {
         return PM3_ENOTTY;
     }
 
-    // Determine platform from version string (FPGA bitstream names)
+    // Try CMD_BUILD_CONFIG for full structured data
     const char *platform = "PM3GENERIC";
+    build_config_t bc;
+    bool has_build_config = false;
 
-    clearCommandBuffer();
-    SendCommandNG(CMD_VERSION, NULL, 0);
-    PacketResponseNG resp;
-    if (WaitForResponseTimeout(CMD_VERSION, &resp, 1000)) {
-        struct p {
-            uint32_t id;
-            uint32_t section_size;
-            uint32_t versionstr_len;
-            char versionstr[PM3_CMD_DATA_SIZE - 12];
-        } PACKED;
-        struct p *payload = (struct p *)&resp.data.asBytes;
+    if (g_pm3_capabilities.has_build_config) {
+        clearCommandBuffer();
+        SendCommandNG(CMD_BUILD_CONFIG, NULL, 0);
+        PacketResponseNG resp;
+        if (WaitForResponseTimeout(CMD_BUILD_CONFIG, &resp, 1000) && resp.status == PM3_SUCCESS) {
+            memcpy(&bc, resp.data.asBytes, sizeof(bc));
+            bc.standalone[sizeof(bc.standalone) - 1] = '\0';
+            has_build_config = true;
 
-        if (strstr(payload->versionstr, "fpga_icopyx")) {
-            platform = "PM3ICOPYX";
-        } else if (strstr(payload->versionstr, "fpga_pm3_ult")) {
-            platform = "PM3ULTIMATE";
+            const char *platform_names[] = {"PM3RDV4", "PM3GENERIC", "PM3ICOPYX", "PM3ULTIMATE"};
+            if (bc.platform < 4)
+                platform = platform_names[bc.platform];
+        }
+    }
+
+    // Fallback: heuristic platform detection from version string
+    if (!has_build_config) {
+        clearCommandBuffer();
+        SendCommandNG(CMD_VERSION, NULL, 0);
+        PacketResponseNG resp;
+        if (WaitForResponseTimeout(CMD_VERSION, &resp, 1000)) {
+            struct p {
+                uint32_t id;
+                uint32_t section_size;
+                uint32_t versionstr_len;
+                char versionstr[PM3_CMD_DATA_SIZE - 12];
+            } PACKED;
+            struct p *payload = (struct p *)&resp.data.asBytes;
+
+            if (strstr(payload->versionstr, "fpga_icopyx")) {
+                platform = "PM3ICOPYX";
+            } else if (strstr(payload->versionstr, "fpga_pm3_ult")) {
+                platform = "PM3ULTIMATE";
+            } else if (g_pm3_capabilities.is_rdv4) {
+                platform = "PM3RDV4";
+            }
         } else if (g_pm3_capabilities.is_rdv4) {
             platform = "PM3RDV4";
         }
-    } else if (g_pm3_capabilities.is_rdv4) {
-        platform = "PM3RDV4";
     }
 
-    // Print PLATFORM
+    // --- Output ---
+
     PrintAndLogEx(NORMAL, "PLATFORM=%s", platform);
 
-    // Reconstruct PLATFORM_EXTRAS from capability flags
+    // PLATFORM_EXTRAS from capabilities (these flags are stable across versions)
     char extras[128] = {0};
-    if (g_pm3_capabilities.compiled_with_fpc_usart_host) {
-        if (extras[0]) strncat(extras, " ", sizeof(extras) - strlen(extras) - 1);
+    if (g_pm3_capabilities.compiled_with_fpc_usart_host)
         strncat(extras, "BTADDON", sizeof(extras) - strlen(extras) - 1);
-    }
-    // FLASH and SMARTCARD are implicit for RDV4, only emit for other platforms
     if (strcmp(platform, "PM3RDV4") != 0) {
         if (g_pm3_capabilities.compiled_with_flash) {
             if (extras[0]) strncat(extras, " ", sizeof(extras) - strlen(extras) - 1);
@@ -1771,46 +1789,8 @@ static int CmdPlatformConfig(const char *Cmd) {
         if (extras[0]) strncat(extras, " ", sizeof(extras) - strlen(extras) - 1);
         strncat(extras, "FPC_USART_DEV", sizeof(extras) - strlen(extras) - 1);
     }
-
-    if (extras[0]) {
+    if (extras[0])
         PrintAndLogEx(NORMAL, "PLATFORM_EXTRAS=%s", extras);
-    }
-
-    // Reconstruct SKIP_* from negation of compiled_with_* flags
-    // Only print lines for features that are actually skipped (disabled)
-    if (!g_pm3_capabilities.compiled_with_lf)
-        PrintAndLogEx(NORMAL, "SKIP_LF=1");
-    if (!g_pm3_capabilities.compiled_with_hitag)
-        PrintAndLogEx(NORMAL, "SKIP_HITAG=1");
-    if (!g_pm3_capabilities.compiled_with_em4x50)
-        PrintAndLogEx(NORMAL, "SKIP_EM4x50=1");
-    if (!g_pm3_capabilities.compiled_with_em4x70)
-        PrintAndLogEx(NORMAL, "SKIP_EM4x70=1");
-    if (!g_pm3_capabilities.compiled_with_zx8211)
-        PrintAndLogEx(NORMAL, "SKIP_ZX8211=1");
-    if (!g_pm3_capabilities.compiled_with_iso15693)
-        PrintAndLogEx(NORMAL, "SKIP_ISO15693=1");
-    if (!g_pm3_capabilities.compiled_with_legicrf)
-        PrintAndLogEx(NORMAL, "SKIP_LEGICRF=1");
-    if (!g_pm3_capabilities.compiled_with_iso14443b)
-        PrintAndLogEx(NORMAL, "SKIP_ISO14443b=1");
-    if (!g_pm3_capabilities.compiled_with_iso14443a)
-        PrintAndLogEx(NORMAL, "SKIP_ISO14443a=1");
-    if (!g_pm3_capabilities.compiled_with_iclass)
-        PrintAndLogEx(NORMAL, "SKIP_ICLASS=1");
-    if (!g_pm3_capabilities.compiled_with_seos)
-        PrintAndLogEx(NORMAL, "SKIP_SEOS=1");
-    if (!g_pm3_capabilities.compiled_with_felica)
-        PrintAndLogEx(NORMAL, "SKIP_FELICA=1");
-    if (!g_pm3_capabilities.compiled_with_nfcbarcode)
-        PrintAndLogEx(NORMAL, "SKIP_NFCBARCODE=1");
-    if (!g_pm3_capabilities.compiled_with_hfsniff)
-        PrintAndLogEx(NORMAL, "SKIP_HFSNIFF=1");
-    if (!g_pm3_capabilities.compiled_with_hfplot)
-        PrintAndLogEx(NORMAL, "SKIP_HFPLOT=1");
-
-    // Standalone (cannot be determined from capabilities alone, leave empty)
-    PrintAndLogEx(NORMAL, "STANDALONE=");
 
     return PM3_SUCCESS;
 }

--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -1732,11 +1732,15 @@ static int CmdPlatformConfig(const char *Cmd) {
         PacketResponseNG resp;
         if (WaitForResponseTimeout(CMD_BUILD_CONFIG, &resp, 1000) && resp.status == PM3_SUCCESS) {
             memcpy(&bc, resp.data.asBytes, sizeof(bc));
-            has_build_config = true;
+            if (bc.version == BUILD_CONFIG_VERSION) {
+                has_build_config = true;
 
-            const char *platform_names[] = {"PM3RDV4", "PM3GENERIC", "PM3ICOPYX", "PM3ULTIMATE"};
-            if (bc.platform < 4)
-                platform = platform_names[bc.platform];
+                const char *platform_names[] = {"PM3RDV4", "PM3GENERIC", "PM3ICOPYX", "PM3ULTIMATE"};
+                if (bc.platform < 4)
+                    platform = platform_names[bc.platform];
+            } else {
+                PrintAndLogEx(WARNING, "Build config version mismatch (device=%u, client=%u), falling back to heuristic detection", bc.version, BUILD_CONFIG_VERSION);
+            }
         }
     }
 

--- a/common_arm/Makefile.hal
+++ b/common_arm/Makefile.hal
@@ -286,6 +286,11 @@ ifneq (,$(word 2, $(PLATFORM_DEFS_INFO_STANDALONE)))
     $(error You must choose only one Standalone mode!: $(PLATFORM_DEFS_INFO_STANDALONE))
 endif
 
+# Pass standalone mode name as a string to firmware for CMD_BUILD_CONFIG
+ifneq (,$(STANDALONE))
+    PLATFORM_DEFS += -DSTANDALONE_NAME=\"$(STANDALONE)\"
+endif
+
 PLATFORM_EXTRAS_INFO = $(PLATFORM_EXTRAS)
 # info when no extra
 ifeq (,$(PLATFORM_EXTRAS_INFO))

--- a/common_arm/Makefile.hal
+++ b/common_arm/Makefile.hal
@@ -286,11 +286,6 @@ ifneq (,$(word 2, $(PLATFORM_DEFS_INFO_STANDALONE)))
     $(error You must choose only one Standalone mode!: $(PLATFORM_DEFS_INFO_STANDALONE))
 endif
 
-# Pass standalone mode name as a string to firmware for CMD_BUILD_CONFIG
-ifneq (,$(STANDALONE))
-    PLATFORM_DEFS += -DSTANDALONE_NAME=\"$(STANDALONE)\"
-endif
-
 PLATFORM_EXTRAS_INFO = $(PLATFORM_EXTRAS)
 # info when no extra
 ifeq (,$(PLATFORM_EXTRAS_INFO))

--- a/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md
+++ b/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md
@@ -223,8 +223,9 @@ Example output for an iCopy-X:
 ```
 PLATFORM=PM3ICOPYX
 PLATFORM_EXTRAS=FLASH
-STANDALONE=
 ```
+
+Only `PLATFORM` and `PLATFORM_EXTRAS` are auto-detected. Other settings (standalone mode, skip flags) must be configured manually.
 
 ### Using `Makefile.platform.autodetect`
 
@@ -240,7 +241,7 @@ The `./pm3` script handles device auto-detection automatically. If you have mult
 make PM3_PORT=/dev/ttyACM1
 ```
 
-Note: the `STANDALONE` mode cannot be determined from the device alone. If you use a standalone mode, edit `Makefile.platform` after copying to set `STANDALONE=` to your desired value.
+The file includes a manual overrides section at the bottom where you can uncomment and set `STANDALONE`, `SKIP_*` flags, and other options. These take effect alongside the auto-detected `PLATFORM` and `PLATFORM_EXTRAS`.
 
 ## Next step
 ^[Top](#top)

--- a/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md
+++ b/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md
@@ -11,6 +11,7 @@
   - [PLATFORM\_EXTRAS](#platform_extras)
   - [STANDALONE](#standalone)
   - [256KB versions](#256kb-versions)
+  - [Auto-detecting platform from a connected device](#auto-detecting-platform-from-a-connected-device)
   - [Next step](#next-step)
 
 
@@ -204,6 +205,42 @@ SKIP_FELICA=1
 Situation might change when the firmware is growing of course, requiring to skip more elements.
 
 Last note: if you skip a tech, be careful not to use a standalone mode which requires that same tech, else the firmware size reduction won't be much.
+
+## Auto-detecting platform from a connected device
+^[Top](#top)
+
+If you have a Proxmark3 device connected and a working client, you can auto-generate the platform configuration instead of writing `Makefile.platform` by hand.
+
+### Using the CLI command
+
+The `hw platformconfig` command queries the connected device and prints valid `Makefile.platform` content:
+
+```
+./pm3 -c "hw platformconfig"
+```
+
+Example output for an iCopy-X:
+```
+PLATFORM=PM3ICOPYX
+PLATFORM_EXTRAS=FLASH
+STANDALONE=
+```
+
+### Using `Makefile.platform.autodetect`
+
+A ready-made `Makefile.platform.autodetect` file is provided that probes the device at build time. To use it, simply copy it as your `Makefile.platform`:
+
+```
+cp Makefile.platform.autodetect Makefile.platform
+```
+
+The `./pm3` script handles device auto-detection automatically. If you have multiple devices connected, specify which one to probe:
+
+```
+make PM3_PORT=/dev/ttyACM1
+```
+
+Note: the `STANDALONE` mode cannot be determined from the device alone. If you use a standalone mode, edit `Makefile.platform` after copying to set `STANDALONE=` to your desired value.
 
 ## Next step
 ^[Top](#top)

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -247,6 +247,47 @@ typedef struct {
 #define CAPABILITIES_VERSION 7
 extern capabilities_t g_pm3_capabilities;
 
+// Platform enum values for build_config_t.platform
+#define BUILD_PLATFORM_RDV4     0
+#define BUILD_PLATFORM_GENERIC  1
+#define BUILD_PLATFORM_ICOPYX   2
+#define BUILD_PLATFORM_ULTIMATE 3
+
+// Build configuration struct — reports exact build settings as structured data
+typedef struct {
+    uint8_t version;
+    uint8_t platform;        // BUILD_PLATFORM_* enum
+    uint8_t led_order;       // 0=default, 1=PM3EASY
+    // platform extras (bitfield)
+    bool has_flash : 1;
+    bool has_smartcard : 1;
+    bool has_btaddon : 1;
+    bool has_fpc_usart_dev : 1;
+    // skip flags (true = feature IS compiled in, matching capabilities convention)
+    bool with_lf : 1;
+    bool with_hitag : 1;
+    bool with_em4x50 : 1;
+    bool with_em4x70 : 1;
+    bool with_zx8211 : 1;
+    bool with_hf : 1;
+    bool with_iso15693 : 1;
+    bool with_legicrf : 1;
+    bool with_iso14443b : 1;
+    bool with_iso14443a : 1;
+    bool with_iclass : 1;
+    bool with_seos : 1;
+    bool with_felica : 1;
+    bool with_nfcbarcode : 1;
+    bool with_hfsniff : 1;
+    bool with_hfplot : 1;
+    bool with_compression : 1;
+    bool with_lcd : 1;
+    // standalone mode name (e.g., "HF_UNISNIFF" or empty string if none)
+    char standalone[32];
+} PACKED build_config_t;
+
+#define BUILD_CONFIG_VERSION 1
+
 typedef struct {
     uint16_t stabilize_ms;
     uint16_t measure_us;
@@ -525,6 +566,7 @@ typedef struct {
 #define CMD_DOWNLOAD_EML_BIGBUF 0x0110
 #define CMD_DOWNLOADED_EML_BIGBUF 0x0111
 #define CMD_CAPABILITIES 0x0112
+#define CMD_BUILD_CONFIG 0x011B
 #define CMD_QUIT_SESSION 0x0113
 #define CMD_SET_DBGMODE 0x0114
 #define CMD_STANDALONE 0x0115

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -261,8 +261,6 @@ typedef struct {
     uint8_t version;
     uint8_t platform;        // BUILD_PLATFORM_* enum
     uint8_t led_order;       // 0=default, 1=PM3EASY
-    // standalone mode name (e.g., "HF_UNISNIFF" or empty string if none)
-    char standalone[32];
 } PACKED build_config_t;
 
 #define BUILD_CONFIG_VERSION 1

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -243,6 +243,8 @@ typedef struct {
     bool hw_available_flash : 1;
     bool hw_available_smartcard : 1;
     bool is_rdv4 : 1;
+    // build config support
+    bool has_build_config : 1;
 } PACKED capabilities_t;
 #define CAPABILITIES_VERSION 7
 extern capabilities_t g_pm3_capabilities;
@@ -253,35 +255,12 @@ extern capabilities_t g_pm3_capabilities;
 #define BUILD_PLATFORM_ICOPYX   2
 #define BUILD_PLATFORM_ULTIMATE 3
 
-// Build configuration struct — reports exact build settings as structured data
+// Build configuration struct — reports settings not available in capabilities_t.
+// Platform extras and feature flags are read from capabilities_t instead.
 typedef struct {
     uint8_t version;
     uint8_t platform;        // BUILD_PLATFORM_* enum
     uint8_t led_order;       // 0=default, 1=PM3EASY
-    // platform extras (bitfield)
-    bool has_flash : 1;
-    bool has_smartcard : 1;
-    bool has_btaddon : 1;
-    bool has_fpc_usart_dev : 1;
-    // skip flags (true = feature IS compiled in, matching capabilities convention)
-    bool with_lf : 1;
-    bool with_hitag : 1;
-    bool with_em4x50 : 1;
-    bool with_em4x70 : 1;
-    bool with_zx8211 : 1;
-    bool with_hf : 1;
-    bool with_iso15693 : 1;
-    bool with_legicrf : 1;
-    bool with_iso14443b : 1;
-    bool with_iso14443a : 1;
-    bool with_iclass : 1;
-    bool with_seos : 1;
-    bool with_felica : 1;
-    bool with_nfcbarcode : 1;
-    bool with_hfsniff : 1;
-    bool with_hfplot : 1;
-    bool with_compression : 1;
-    bool with_lcd : 1;
     // standalone mode name (e.g., "HF_UNISNIFF" or empty string if none)
     char standalone[32];
 } PACKED build_config_t;


### PR DESCRIPTION
## Auto-discover platform config from connected device

### Problem

Users currently must manually create `Makefile.platform` with the correct `PLATFORM` and `PLATFORM_EXTRAS` settings. Getting these wrong leads to firmware that doesn't match the hardware, or missing features. The firmware already reports nearly all of this information via `CMD_CAPABILITIES` and `CMD_VERSION`, but there's no way to turn that into a build config automatically.

### Solution

**New CLI command: `hw platformconfig`**

Connects to the device, queries capabilities and version info, and prints valid `Makefile.platform` content to stdout:

```
$ ./pm3 -c "hw platformconfig"
PLATFORM=PM3ICOPYX
PLATFORM_EXTRAS=FLASH
```

Only `PLATFORM` and `PLATFORM_EXTRAS` are auto-detected. Other settings (standalone mode, skip flags, LED order) are left for manual configuration.

Works with existing firmware (no flash needed) by using heuristics:
- FPGA bitstream names in the version string identify the platform (`fpga_icopyx_*` → PM3ICOPYX, `fpga_pm3_ult_*` → PM3ULTIMATE, `is_rdv4` → PM3RDV4, else PM3GENERIC)
- `compiled_with_*` capability flags reconstruct `PLATFORM_EXTRAS` (FLASH, SMARTCARD, BTADDON)

**New firmware command: `CMD_BUILD_CONFIG`**

Reports build configuration as structured data (`build_config_t`) with platform type and LED order. The client auto-detects support via a `has_build_config` bit in `capabilities_t` (uses existing padding — no struct size change). When available, the client uses this instead of heuristics for exact platform identification. On version mismatch, warns and falls back to heuristic detection.

**New file: `Makefile.platform.autodetect`**

Drop-in replacement for `Makefile.platform` that probes the device at build time:

```
cp Makefile.platform.autodetect Makefile.platform
make
```

Uses `./pm3` for auto-detection. Supports `PM3_PORT=` for multi-device setups. Includes a manual overrides section for standalone mode, skip flags, and other options.

### Files changed

- `include/pm3_cmd.h` — `CMD_BUILD_CONFIG` (0x011B), `build_config_t` struct, `has_build_config` capability bit
- `armsrc/appmain.c` — `SendBuildConfig()` handler + dispatch
- `client/src/cmdhw.c` — `CmdPlatformConfig()` with structured path + heuristic fallback
- `Makefile.platform.autodetect` — Auto-detecting Makefile.platform drop-in
- `.gitignore` — Ignore autodetect cache file
- `doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md` — Documentation
- `CHANGELOG.md` — Changelog entry

### Testing

Tested against a PM3 Easy Max (PM3ICOPYX) with existing (pre-patch) firmware:
- `hw platformconfig` correctly outputs `PLATFORM=PM3ICOPYX` + `PLATFORM_EXTRAS=FLASH` via the heuristic fallback path
- `Makefile.platform.autodetect` correctly sets build variables at make time
- Output matches the device's actual `Makefile.platform`
