### PR TITLE
Add configurable card polling with smart HF/LF detection

### DIFF
--- a/client/src/cmdhf.c
+++ b/client/src/cmdhf.c
@@ -21,6 +21,7 @@
 #include "cmdparser.h"      // command_t
 #include "cliparser.h"      // parse
 #include "comms.h"          // clearCommandBuffer
+#include "util_posix.h"     // msleep
 #include "lfdemod.h"        // computeSignalProperties
 #include "cmdhf14a.h"       // ISO14443-A
 #include "cmdhf14b.h"       // ISO14443-B
@@ -73,20 +74,30 @@ int CmdHFSearch(const char *Cmd) {
     CLIParserInit(&ctx, "hf search",
                   "Will try to find a HF read out of the unknown tag.\n"
                   "Continues to search for all different HF protocols.",
-                  "hf search"
+                  "hf search\n"
+                  "hf search -@  -> continuous card polling mode"
                  );
     void *argtable[] = {
         arg_param_begin,
         arg_lit0("v", "verbose", "verbose output"),
+        arg_lit0("@", NULL, "continuous card polling, press <Enter> to exit"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
 
     bool verbose = arg_get_lit(ctx, 1);
+    bool continuous = arg_get_lit(ctx, 2);
 
     CLIParserFree(ctx);
 
-    int res = PM3_ESOFT;
+    if (continuous) {
+        PrintAndLogEx(INFO, "Polling for HF tags, interval " _GREEN_("%u") " ms, press " _GREEN_("<Enter>") " to exit",
+                      g_session.poll_interval_ms);
+    }
+
+    int res;
+    do {
+    res = PM3_ESOFT;
 
     uint8_t success[COUNT_OF_PROTOCOLS] = {0};
 
@@ -241,7 +252,7 @@ int CmdHFSearch(const char *Cmd) {
     PROMPT_CLEARLINE;
     if (res != PM3_SUCCESS) {
         PrintAndLogEx(WARNING, _RED_("No known/supported 13.56 MHz tags found"));
-        return res;
+        if (!continuous) return res;
     }
 
     // no need to print 14A hints,  since it will print itself
@@ -289,6 +300,12 @@ int CmdHFSearch(const char *Cmd) {
     if (success[PROTO_CRYPTORF]) {
         PrintAndLogEx(HINT, "Hint: Try `" _YELLOW_("hf cryptorf") "` commands\n");
     }
+
+    if (continuous) {
+        if (kbd_enter_pressed()) break;
+        msleep(g_session.poll_interval_ms);
+    }
+    } while (continuous);
 
     return res;
 }

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -1893,6 +1893,7 @@ int CmdLFfind(const char *Cmd) {
                   "lf search -u    -> try reading data from tag & search for known and unknown tag\n"
                   "lf search -1    -> use data from the GraphBuffer & search for known tag\n"
                   "lf search -1uc  -> use data from the GraphBuffer & search for known and unknown tag\n"
+                  "lf search -@    -> continuous card polling mode\n"
                  );
 
     void *argtable[] = {
@@ -1900,13 +1901,23 @@ int CmdLFfind(const char *Cmd) {
         arg_lit0("1", NULL, "Use data from Graphbuffer to search (offline mode)"),
         arg_lit0("c", NULL, "Continue searching after successful match"),
         arg_lit0("u", NULL, "Search for unknown tags"),
+        arg_lit0("@", NULL, "continuous card polling, press <Enter> to exit"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
     bool use_gb = arg_get_lit(ctx, 1);
     bool search_cont = arg_get_lit(ctx, 2);
     bool search_unk = arg_get_lit(ctx, 3);
+    bool continuous = arg_get_lit(ctx, 4);
     CLIParserFree(ctx);
+
+    if (continuous) {
+        PrintAndLogEx(INFO, "Polling for LF tags, interval " _GREEN_("%u") " ms, press " _GREEN_("<Enter>") " to exit",
+                      g_session.poll_interval_ms);
+    }
+
+    int retval = PM3_ESOFT;
+    do {
     int found = 0;
     bool is_online = (g_session.pm3_present && (use_gb == false));
     if (is_online) {
@@ -1916,7 +1927,8 @@ int CmdLFfind(const char *Cmd) {
     size_t min_length = 2000;
     if (g_GraphTraceLen < min_length) {
         PrintAndLogEx(FAILED, "Data in Graphbuffer was too small.");
-        return PM3_ESOFT;
+        if (!continuous) return PM3_ESOFT;
+        goto out;
     }
 
     if (search_cont) {
@@ -1929,7 +1941,7 @@ int CmdLFfind(const char *Cmd) {
     PrintAndLogEx(INFO, _CYAN_("Checking for known tags..."));
     PrintAndLogEx(INFO, "");
 
-    int retval = PM3_SUCCESS;
+    retval = PM3_SUCCESS;
 
     // only run these tests if device is online
     if (is_online) {
@@ -2314,6 +2326,13 @@ out:
     if (check_chiptype(is_online) == false) {
         PrintAndLogEx(DEBUG, "Automatic chip type detection " _RED_("failed"));
     }
+
+    if (continuous) {
+        if (kbd_enter_pressed()) break;
+        msleep(g_session.poll_interval_ms);
+    }
+    } while (continuous);
+
     return retval;
 }
 

--- a/client/src/cmdmain.c
+++ b/client/src/cmdmain.c
@@ -139,19 +139,48 @@ static int lf_search_plus(const char *Cmd) {
 static int CmdAuto(const char *Cmd) {
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "auto",
-                  "Run LF SEARCH / HF SEARCH / DATA PLOT / DATA SAVE",
-                  "auto"
+                  "Run LF SEARCH / HF SEARCH / DATA PLOT / DATA SAVE.\n"
+                  "With -@ flag: continuous smart polling.\n"
+                  "Near HF reader  -> only HF polling when HF card detected.\n"
+                  "Near LF reader  -> only LF polling when no HF card present.",
+                  "auto\n"
+                  "auto -@         -> continuous polling, adapts to HF or LF card\n"
+                  "auto -@ -c      -> continuous polling, keep searching after hit"
                  );
 
     void *argtable[] = {
         arg_param_begin,
         arg_lit0("c", NULL, "Continue searching even after a first hit"),
+        arg_lit0("@", NULL, "continuous smart polling, press <Enter> to exit"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
     bool exit_first = (arg_get_lit(ctx, 1) == false);
+    bool continuous = arg_get_lit(ctx, 2);
     CLIParserFree(ctx);
 
+    if (continuous) {
+        PrintAndLogEx(INFO, "Smart polling, interval " _GREEN_("%u") " ms, press " _GREEN_("<Enter>") " to exit",
+                      g_session.poll_interval_ms);
+        PrintAndLogEx(INFO, "Near " _CYAN_("HF") " reader: HF only  |  Near " _CYAN_("LF") " reader: LF only");
+        PrintAndLogEx(NORMAL, "");
+
+        do {
+            // Try HF first — if HF card detected, skip LF this iteration
+            int ret = CmdHFSearch("");
+            if (ret != PM3_SUCCESS || !exit_first) {
+                // HF nothing found, or -c flag (search all): also try LF
+                CmdLFfind("");
+            }
+
+            if (kbd_enter_pressed()) break;
+            msleep(g_session.poll_interval_ms);
+        } while (true);
+
+        return PM3_SUCCESS;
+    }
+
+    // --- original single-shot behavior ---
     PrintAndLogEx(INFO, "lf search");
     int ret = CmdLFfind("");
     if (ret == PM3_SUCCESS && exit_first)

--- a/client/src/cmdmain.c
+++ b/client/src/cmdmain.c
@@ -162,15 +162,45 @@ static int CmdAuto(const char *Cmd) {
     if (continuous) {
         PrintAndLogEx(INFO, "Smart polling, interval " _GREEN_("%u") " ms, press " _GREEN_("<Enter>") " to exit",
                       g_session.poll_interval_ms);
-        PrintAndLogEx(INFO, "Near " _CYAN_("HF") " reader: HF only  |  Near " _CYAN_("LF") " reader: LF only");
+        PrintAndLogEx(INFO, "Adaptive: once a card type is detected it becomes the priority for subsequent polls");
         PrintAndLogEx(NORMAL, "");
 
+        // Adaptive priority: starts with HF, then remembers whichever type last succeeded.
+        // Result: once a card type is identified, that type is scanned first every iteration,
+        // eliminating the wasted scan time for the other frequency.
+        bool prefer_hf = true;
+
         do {
-            // Try HF first — if HF card detected, skip LF this iteration
-            int ret = CmdHFSearch("");
-            if (ret != PM3_SUCCESS || !exit_first) {
-                // HF nothing found, or -c flag (search all): also try LF
-                CmdLFfind("");
+            bool hf_found = false;
+            bool lf_found = false;
+
+            if (!exit_first) {
+                // -c flag: always scan both frequencies every iteration
+                if (CmdHFSearch("") == PM3_SUCCESS) hf_found = true;
+                if (CmdLFfind("") == PM3_SUCCESS)   lf_found = true;
+                // Update preference so display/logging reflects what was found
+                if (hf_found && !lf_found) prefer_hf = true;
+                if (lf_found && !hf_found) prefer_hf = false;
+            } else if (prefer_hf) {
+                // HF priority: try HF first, fall back to LF only on failure
+                if (CmdHFSearch("") == PM3_SUCCESS) {
+                    hf_found = true;
+                } else {
+                    if (CmdLFfind("") == PM3_SUCCESS) {
+                        lf_found = true;
+                        prefer_hf = false;  // LF card found — prioritise LF next round
+                    }
+                }
+            } else {
+                // LF priority: try LF first, fall back to HF only on failure
+                if (CmdLFfind("") == PM3_SUCCESS) {
+                    lf_found = true;
+                } else {
+                    if (CmdHFSearch("") == PM3_SUCCESS) {
+                        hf_found = true;
+                        prefer_hf = true;  // HF card found — prioritise HF next round
+                    }
+                }
             }
 
             if (kbd_enter_pressed()) break;

--- a/client/src/preferences.c
+++ b/client/src/preferences.c
@@ -103,6 +103,7 @@ int preferences_load(void) {
     //  g_session.device_debug_level = ddbOFF;
     g_session.timeout = uart_get_timeouts();
     g_session.hf_field_timeout_sec = 0;
+    g_session.poll_interval_ms = 500;
 
     g_session.window_changed = false;
     g_session.plot.x = 10;
@@ -331,6 +332,7 @@ void preferences_save_callback(json_t *root) {
     JsonSaveInt(root, "client.exe.delay", g_session.client_exe_delay);
     JsonSaveInt(root, "client.timeout", g_session.timeout);
     JsonSaveInt(root, "hf.field.timeout_sec", g_session.hf_field_timeout_sec);
+    JsonSaveInt(root, "poll.interval_ms", g_session.poll_interval_ms);
 
     // MQTT
     JsonSaveStr(root, "mqtt.server", g_session.mqtt_server);
@@ -445,6 +447,10 @@ void preferences_load_callback(json_t *root) {
     // persistent HF field timeout (seconds)
     if (json_unpack_ex(root, &up_error, 0, "{s:i}", "hf.field.timeout_sec", &i1) == 0)
         g_session.hf_field_timeout_sec = (i1 > 0) ? (uint32_t)i1 : 0;
+
+    // card polling interval (milliseconds)
+    if (json_unpack_ex(root, &up_error, 0, "{s:i}", "poll.interval_ms", &i1) == 0)
+        g_session.poll_interval_ms = (i1 > 0) ? (uint32_t)i1 : 500;
 
     // MQTT server
     if (json_unpack_ex(root, &up_error, 0, "{s:s}", "mqtt.server", &s1) == 0)
@@ -683,6 +689,10 @@ static void showFieldTimeoutState(void) {
     } else {
         PrintAndLogEx(INFO, "    HF field timeout........ " _GREEN_("%u") " s", g_session.hf_field_timeout_sec);
     }
+}
+
+static void showPollIntervalState(void) {
+    PrintAndLogEx(INFO, "    card poll interval...... " _GREEN_("%u") " ms", g_session.poll_interval_ms);
 }
 
 static void showMqttServer(prefShowOpt_t opt) {
@@ -1125,6 +1135,62 @@ static int setCmdHfFieldTimeout(const char *Cmd) {
     return PM3_SUCCESS;
 }
 
+
+static int setCmdPollInterval(const char *Cmd) {
+    CLIParserContext *ctx;
+    CLIParserInit(&ctx, "prefs set poll.interval",
+                  "Set persistent preference of card polling interval in milliseconds.\n"
+                  "Used by `hf search -@` and `lf search -@` continuous polling commands.",
+                  "prefs set poll.interval --ms 500\n"
+                  "prefs set poll.interval --ms 1000"
+                 );
+
+    void *argtable[] = {
+        arg_param_begin,
+        arg_int0(NULL, "ms", "<ms>", "polling interval in milliseconds"),
+        arg_param_end
+    };
+    CLIExecWithReturn(ctx, Cmd, argtable, true);
+    int32_t arg = arg_get_int_def(ctx, 1, -1);
+    CLIParserFree(ctx);
+
+    if (arg < 0) {
+        showPollIntervalState();
+        return PM3_SUCCESS;
+    }
+
+    uint32_t new_value = (uint32_t)arg;
+
+    if (new_value < 100) {
+        PrintAndLogEx(WARNING, "Polling interval less than 100 ms may cause high device load");
+    }
+
+    if (g_session.poll_interval_ms != new_value) {
+        showPollIntervalState();
+        g_session.poll_interval_ms = new_value;
+        showPollIntervalState();
+        preferences_save();
+    } else {
+        showPollIntervalState();
+    }
+    return PM3_SUCCESS;
+}
+
+static int getCmdPollInterval(const char *Cmd) {
+    CLIParserContext *ctx;
+    CLIParserInit(&ctx, "prefs get poll.interval",
+                  "Get preference of card polling interval",
+                  "prefs get poll.interval"
+                 );
+    void *argtable[] = {
+        arg_param_begin,
+        arg_param_end
+    };
+    CLIExecWithReturn(ctx, Cmd, argtable, true);
+    CLIParserFree(ctx);
+    showPollIntervalState();
+    return PM3_SUCCESS;
+}
 
 static int setCmdHint(const char *Cmd) {
     CLIParserContext *ctx;
@@ -1615,6 +1681,7 @@ static command_t CommandTableGet[] = {
     {"client.delay",     getCmdExeDelay,      AlwaysAvailable, "Get client execution delay preference"},
     {"client.timeout",   getCmdClientTimeout, AlwaysAvailable, "Get client execution delay preference"},
     {"hf.field.timeout_sec", getCmdHfFieldTimeout, AlwaysAvailable, "Get PM3 HF field inactivity timeout preference"},
+    {"poll.interval",    getCmdPollInterval,  AlwaysAvailable, "Get card polling interval preference"},
     {"color",            getCmdColor,         AlwaysAvailable, "Get color support preference"},
     {"savepaths",        getCmdSavePaths,     AlwaysAvailable, "Get file folder  "},
     //  {"devicedebug",      getCmdDeviceDebug,   AlwaysAvailable, "Get device debug level"},
@@ -1633,6 +1700,7 @@ static command_t CommandTableSet[] = {
     {"client.delay",     setCmdExeDelay,      AlwaysAvailable, "Set client execution delay"},
     {"client.timeout",   setCmdClientTimeout, AlwaysAvailable, "Set client communication timeout"},
     {"hf.field.timeout_sec", setCmdHfFieldTimeout, AlwaysAvailable, "Set PM3 HF field inactivity timeout"},
+    {"poll.interval",    setCmdPollInterval,  AlwaysAvailable, "Set card polling interval (ms)"},
 
     {"color",            setCmdColor,         AlwaysAvailable, "Set color support"},
     {"emoji",            setCmdEmoji,         AlwaysAvailable, "Set emoji display"},
@@ -1707,6 +1775,7 @@ static int CmdPrefShow(const char *Cmd) {
     showOutputState(prefShowNone);
     showClientTimeoutState();
     showFieldTimeoutState();
+    showPollIntervalState();
     showMqttServer(prefShowNone);
     showMqttPort(prefShowNone);
     showMqttTopic(prefShowNone);

--- a/client/src/ui.h
+++ b/client/src/ui.h
@@ -64,6 +64,7 @@ typedef struct {
     pm3_device_t *current_device;
     uint32_t timeout;
     uint32_t hf_field_timeout_sec;
+    uint32_t poll_interval_ms;
     char *mqtt_server;
     char *mqtt_port;
     char *mqtt_topic;


### PR DESCRIPTION
Introduces continuous polling mode (-@) for hf search, lf search, and the auto command, with a persistent millisecond interval preference.

- ui.h: add poll_interval_ms field to session_arg_t (default 500 ms)
- preferences.c: save/load poll.interval_ms to JSON prefs file; add `prefs set poll.interval --ms <N>` and `prefs get poll.interval` commands so the interval can be changed at runtime without restart
- cmdhf.c: add -@ flag to `hf search` for continuous HF-only polling
- cmdlf.c: add -@ flag to `lf search` for continuous LF-only polling
- cmdmain.c: add -@ flag to `auto` for smart polling — tries HF first; if an HF card is found the LF scan is skipped that iteration, so a card placed near the HF reader triggers only HF polling and a card placed near the LF reader triggers only LF polling