### PR TITLE
hf mf sen autopwn integration and GUI fixes

### DIFF
--- a/client/deps/hardnested/hardnested_bruteforce.c
+++ b/client/deps/hardnested/hardnested_bruteforce.c
@@ -175,12 +175,10 @@ crack_states_thread(void *x) {
                 __atomic_fetch_add(&keys_found, 1, __ATOMIC_SEQ_CST);
                 __atomic_fetch_add(&found_bs_key, key, __ATOMIC_SEQ_CST);
 
-                char progress_text[80];
                 char keystr[19];
                 snprintf(keystr, sizeof(keystr), "%012" PRIX64, key);
-                snprintf(progress_text, sizeof(progress_text), "Brute force phase completed.    Key found: " _GREEN_("%s"), keystr);
-                hardnested_print_progress(thread_arg->num_acquired_nonces, progress_text, 0.0, 0);
-                PrintAndLogEx(INFO, "---------+---------+---------------------------------------------------------+-----------------+-------");
+                hardnested_print_key_found_progress(thread_arg->num_acquired_nonces, keystr);
+                PrintAndLogEx(INFO, "---------+---------+---------------------------------------------------------+---------------------------+---------------");
                 break;
             } else if (keys_found) {
                 break;

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -66,6 +66,13 @@ typedef struct {
 
 static int CmdHelp(const char *Cmd);
 
+static int HFMFAutoPwnSEN(sector_t *e_sector, size_t sector_cnt) {
+    PrintAndLogEx(WARNING, "Static encrypted nonce card detected");
+    PrintAndLogEx(NORMAL, "");
+    DropField();
+    return HFMFSENRecover(false, false, false, false, 0, 0x1, true, e_sector, sector_cnt);
+}
+
 // Static array for Saflok key levels
 static const SaflokKeyLevel saflok_key_levels[] = {
     {1, "Guest Key"},
@@ -3259,6 +3266,13 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
         }
     }
 
+    if (has_staticnonce == NONCE_STATIC_ENC) {
+        int sen_res = HFMFAutoPwnSEN(e_sector, sector_cnt);
+        free(e_sector);
+        free(fptr);
+        return sen_res;
+    }
+
     // print parameters
     if (verbose) {
         PrintAndLogEx(INFO, "---- " _CYAN_("Command settings") " ------------------------------------------");
@@ -3388,6 +3402,7 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
 
     // Analyse the dictionary attack
     uint8_t num_found_keys = 0;
+    bool nested_attack_key_from_dictionary = false;
     for (int i = 0; i < sector_cnt; i++) {
         for (int j = MF_KEY_A; j <= MF_KEY_B; j++) {
 
@@ -3406,23 +3421,40 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
                 known_key = true;
                 sectorno = i;
                 keytype = j;
-                PrintAndLogEx(SUCCESS, "Target sector " _GREEN_("%3u") " key type " _GREEN_("%c") " -- found valid key [ " _GREEN_("%s") " ] (used for nested / hardnested attack)",
-                              i,
-                              (j == MF_KEY_B) ? 'B' : 'A',
-                              sprint_hex_inrow(tmp_key, sizeof(tmp_key))
-                             );
-            } else {
-                PrintAndLogEx(SUCCESS, "Target sector " _GREEN_("%3u") " key type " _GREEN_("%c") " -- found valid key [ " _GREEN_("%s") " ]",
-                              i,
-                              (j == MF_KEY_B) ? 'B' : 'A',
-                              sprint_hex_inrow(tmp_key, sizeof(tmp_key))
-                             );
+                nested_attack_key_from_dictionary = true;
             }
         }
     }
 
     if (num_found_keys == sector_cnt * 2) {
         goto all_found;
+    }
+
+    if (known_key && has_staticnonce == NONCE_NORMAL) {
+        has_staticnonce = detect_classic_static_encrypted_nonce(mfFirstBlockOfSector(sectorno), keytype, key);
+        if (has_staticnonce == NONCE_STATIC_ENC) {
+            int sen_res = HFMFAutoPwnSEN(e_sector, sector_cnt);
+            free(keyBlock);
+            free(e_sector);
+            free(fptr);
+            return sen_res;
+        }
+    }
+
+    for (int i = 0; i < sector_cnt; i++) {
+        for (int j = MF_KEY_A; j <= MF_KEY_B; j++) {
+            if (e_sector[i].foundKey[j] != 'D') {
+                continue;
+            }
+
+            num_to_bytes(e_sector[i].Key[j], MIFARE_KEY_SIZE, tmp_key);
+            PrintAndLogEx(SUCCESS, "Target sector " _GREEN_("%3u") " key type " _GREEN_("%c") " -- found valid key [ " _GREEN_("%s") " ]%s",
+                          i,
+                          (j == MF_KEY_B) ? 'B' : 'A',
+                          sprint_hex_inrow(tmp_key, sizeof(tmp_key)),
+                          (nested_attack_key_from_dictionary && i == sectorno && j == keytype) ? " (used for nested / hardnested attack)" : ""
+                         );
+        }
     }
 
     // Check if at least one sector key was found
@@ -3463,7 +3495,7 @@ noValidKeyFound:
 
             if (has_staticnonce == NONCE_STATIC_ENC) {
                 PrintAndLogEx(ERR, "Static encrypted nonce detected. Aborted\n");
-                PrintAndLogEx(HINT, "Hint: Try `" _YELLOW_("script run fm11rf08s_recovery.py") "`");
+                PrintAndLogEx(HINT, "Hint: Try `" _YELLOW_("hf mf sen") "`");
             }
 
             DropField();
@@ -3471,6 +3503,17 @@ noValidKeyFound:
             free(e_sector);
             free(fptr);
             return PM3_ESOFT;
+        }
+    }
+
+    if (known_key && has_staticnonce == NONCE_NORMAL) {
+        has_staticnonce = detect_classic_static_encrypted_nonce(mfFirstBlockOfSector(sectorno), keytype, key);
+        if (has_staticnonce == NONCE_STATIC_ENC) {
+            int sen_res = HFMFAutoPwnSEN(e_sector, sector_cnt);
+            free(keyBlock);
+            free(e_sector);
+            free(fptr);
+            return sen_res;
         }
     }
 
@@ -3625,17 +3668,12 @@ tryNested:
                                 break;
                             }
                             case PM3_ESTATIC_NONCE: {
-                                PrintAndLogEx(ERR, "Static encrypted nonce detected. Aborted\n");
-                                PrintAndLogEx(HINT, "Hint: Try `" _YELLOW_("script run fm11rf08s_recovery.py") "`");
-
                                 e_sector[current_sector_i].Key[current_key_type_i] = 0xffffffffffff;
                                 e_sector[current_sector_i].foundKey[current_key_type_i] = false;
-                                // Show the results to the user
-                                printKeyTable(sector_cnt, e_sector);
-                                PrintAndLogEx(NORMAL, "");
+                                int sen_res = HFMFAutoPwnSEN(e_sector, sector_cnt);
                                 free(e_sector);
                                 free(fptr);
-                                return isOK;
+                                return sen_res;
                             }
                             case PM3_SUCCESS: {
                                 calibrate = false;
@@ -3688,15 +3726,12 @@ tryHardnested: // If the nested attack fails then we try the hardnested attack
                                     break;
                                 }
                                 case PM3_ESTATIC_NONCE: {
-                                    PrintAndLogEx(ERR, "\nError: Static encrypted nonce detected. Aborted\n");
-
                                     e_sector[current_sector_i].Key[current_key_type_i] = 0xffffffffffff;
                                     e_sector[current_sector_i].foundKey[current_key_type_i] = false;
-
-                                    // Show the results to the user
-                                    printKeyTable(sector_cnt, e_sector);
-                                    PrintAndLogEx(NORMAL, "");
-                                    break;
+                                    int sen_res = HFMFAutoPwnSEN(e_sector, sector_cnt);
+                                    free(e_sector);
+                                    free(fptr);
+                                    return sen_res;
                                 }
                                 case PM3_EFAILED: {
                                     PrintAndLogEx(FAILED, "\nFailed to recover a key...");

--- a/client/src/cmdhfmfhard.c
+++ b/client/src/cmdhfmfhard.c
@@ -125,13 +125,45 @@ static void print_progress_header(void) {
     char progress_text[80];
     char instr_set[12] = "";
     get_SIMD_instruction_set(instr_set);
-    snprintf(progress_text, sizeof(progress_text), "Start using " _YELLOW_("%d") " threads and " _YELLOW_("%s") " SIMD core", num_CPUs(), instr_set);
+    snprintf(progress_text, sizeof(progress_text), "Start using %d threads and %s SIMD core", num_CPUs(), instr_set);
 
-    PrintAndLogEx(INFO, "---------+---------+---------------------------------------------------------+-----------------+-------");
-    PrintAndLogEx(INFO, "         |         |                                                         | Expected to brute force");
-    PrintAndLogEx(INFO, " Time    | #nonces | Activity                                                | #states         | time ");
-    PrintAndLogEx(INFO, "---------+---------+---------------------------------------------------------+-----------------+-------");
-    PrintAndLogEx(INFO, "       0 |       0 | %-73s |                 |", progress_text);
+    PrintAndLogEx(INFO, "---------+---------+---------------------------------------------------------+---------------------------+---------------");
+    PrintAndLogEx(INFO, "         |         |                                                         | Expected to brute force   | Estimated     ");
+    PrintAndLogEx(INFO, " Time    | #nonces | Activity                                                | #states                   | time for task ");
+    PrintAndLogEx(INFO, "---------+---------+---------------------------------------------------------+---------------------------+---------------");
+    PrintAndLogEx(INFO, "       0 |       0 | %-55.55s | %25s | %13s ", progress_text, "", "");
+}
+
+static void hardnested_format_activity(char *out, size_t out_len, const char *activity, size_t width) {
+    const char *src = activity ? activity : "";
+    size_t pos = 0;
+    size_t visible = 0;
+    bool copied_ansi = false;
+
+    while (*src && visible < width && pos + 1 < out_len) {
+        if (src[0] == '\x1b' && src[1] == '[') {
+            do {
+                if (pos + 1 >= out_len) {
+                    break;
+                }
+                out[pos++] = *src;
+            } while (*src && (*src++ < '@' || src[-1] > '~'));
+            copied_ansi = true;
+            continue;
+        }
+        out[pos++] = *src++;
+        visible++;
+    }
+
+    if (*src && copied_ansi && pos + strlen(AEND) < out_len) {
+        memcpy(out + pos, AEND, strlen(AEND));
+        pos += strlen(AEND);
+    }
+    while (visible < width && pos + 1 < out_len) {
+        out[pos++] = ' ';
+        visible++;
+    }
+    out[pos] = '\0';
 }
 
 void hardnested_print_progress(uint32_t nonces, const char *activity, float brute_force, uint64_t min_diff_print_time) {
@@ -155,24 +187,30 @@ void hardnested_print_progress(uint32_t nonces, const char *activity, float brut
             snprintf(brute_force_time_string, sizeof(brute_force_time_string), "%2.0fd", brute_force_time / (60 * 60 * 24));
         }
 
-        if (strlen(activity) > 67) {
-            PrintAndLogEx(INFO, " %7.0f | %7u | %-82s | %15.0f | %5s"
-                          , (float)total_time / 1000.0
-                          , nonces
-                          , activity
-                          , brute_force
-                          , brute_force_time_string
-                         );
-        } else {
-            PrintAndLogEx(INFO, " %7.0f | %7u | %-55s | %15.0f | %5s"
-                          , (float)total_time / 1000.0
-                          , nonces
-                          , activity
-                          , brute_force
-                          , brute_force_time_string
-                         );
-        }
+        char activity_col[128] = {0};
+        hardnested_format_activity(activity_col, sizeof(activity_col), activity, 55);
+
+        PrintAndLogEx(INFO, " %7.0f | %7u | %s | %25.0f | %13s "
+                      , (float)total_time / 1000.0
+                      , nonces
+                      , activity_col
+                      , brute_force
+                      , brute_force_time_string
+                     );
     }
+}
+
+void hardnested_print_key_found_progress(uint32_t nonces, const char *keystr) {
+    uint64_t total_time = msclock() - start_time;
+
+    PrintAndLogEx(INFO, " %7.0f | %7u | %-33s" _GREEN_("%22s") " | %25.0f | %13s "
+                  , (float)total_time / 1000.0
+                  , nonces
+                  , "Brute force completed. Key found:"
+                  , keystr ? keystr : ""
+                  , 0.0
+                  , "0s"
+                 );
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -508,7 +546,7 @@ static void init_bitflip_bitarrays(void) {
     {
         char progress_text[100];
         memset(progress_text, 0, sizeof(progress_text));
-        snprintf(progress_text, sizeof(progress_text), "Loaded " _YELLOW_("%u") " RAW / " _YELLOW_("%u") " LZ4 / " _YELLOW_("%u") " BZ2 in %4"PRIu64" ms"
+        snprintf(progress_text, sizeof(progress_text), "Loaded %u RAW / %u LZ4 / %u BZ2 in %4"PRIu64" ms"
                  , nraw
                  , nlz4
                  , nbz2
@@ -1267,7 +1305,7 @@ static int read_nonce_file(char *filename) {
         return PM3_EFILE;
     }
 
-    snprintf(progress_text, 80, "Reading nonces from file " _YELLOW_("%s"), filename);
+    snprintf(progress_text, 80, "Reading nonces from file %s", filename);
     hardnested_print_progress(0, progress_text, (float)(1LL << 47), 0);
     size_t bytes_read = fread(read_buf, 1, 6, fnonces);
     if (bytes_read != 6) {
@@ -1674,7 +1712,7 @@ static int acquire_nonces(uint8_t blockNo, uint8_t keyType, uint8_t *key, uint8_
                     return PM3_EFILE;
                 }
 
-                snprintf(progress_text, 80, "Writing acquired nonces to binary file " _YELLOW_("%s"), filename);
+                snprintf(progress_text, 80, "Writing acquired nonces to binary file %s", filename);
                 hardnested_print_progress(0, progress_text, (float)(1LL << 47), 0);
                 num_to_bytes(cuid, 4, write_buf);
                 fwrite(write_buf, 1, 4, fnonces);

--- a/client/src/cmdhfmfhard.h
+++ b/client/src/cmdhfmfhard.h
@@ -23,6 +23,6 @@
 
 int mfnestedhard(uint8_t blockNo, uint8_t keyType, uint8_t *key, uint8_t trgBlockNo, uint8_t trgKeyType, uint8_t *trgkey, bool nonce_file_read, bool nonce_file_write, bool slow, int tests, uint64_t *foundkey, char *filename);
 void hardnested_print_progress(uint32_t nonces, const char *activity, float brute_force, uint64_t min_diff_print_time);
+void hardnested_print_key_found_progress(uint32_t nonces, const char *keystr);
 
 #endif
-

--- a/client/src/cmdhfmfsen.c
+++ b/client/src/cmdhfmfsen.c
@@ -176,11 +176,11 @@ static void fm11_sen_format_eta(uint32_t seconds, char *out, size_t out_len) {
 
 static void fm11_sen_progress_header(void) {
     fm11_sen_start_time = msclock();
-    PrintAndLogEx(INFO, "---------+---------+---------------------------------------------------------+-----------------+-------");
-    PrintAndLogEx(INFO, "         |         |                                                         | Expected to verify      ");
-    PrintAndLogEx(INFO, " Time    | #nonces | Activity                                                | #keys/cands     | time  ");
-    PrintAndLogEx(INFO, "---------+---------+---------------------------------------------------------+-----------------+-------");
-    PrintAndLogEx(INFO, " " _YELLOW_("%7.0f") " | " _YELLOW_("%7u") " | %-55s | %15s | %5s ",
+    PrintAndLogEx(INFO, "---------+---------+---------------------------------------------------------+---------------------------+---------------");
+    PrintAndLogEx(INFO, "         |         |                                                         | Expected to verify        | Estimated     ");
+    PrintAndLogEx(INFO, " Time    | #nonces | Activity                                                | #keys/candidates          | time for task ");
+    PrintAndLogEx(INFO, "---------+---------+---------------------------------------------------------+---------------------------+---------------");
+    PrintAndLogEx(INFO, " " _YELLOW_("%7.0f") " | " _YELLOW_("%7u") " | %-55s | %25s | %13s ",
                   0.0, (uint32_t)0, "Start FM11RF08S static encrypted nonce recovery", "", "");
 }
 
@@ -197,7 +197,7 @@ static void fm11_sen_progress(uint32_t nonces, const char *activity, uint32_t st
 
     fm11_sen_last_nonces = nonces;
     uint64_t elapsed = fm11_sen_start_time ? (msclock() - fm11_sen_start_time) : 0;
-    PrintAndLogEx(INFO, " " _YELLOW_("%7.0f") " | " _YELLOW_("%7u") " | %-55.55s | " _YELLOW_("%15s") " | " _YELLOW_("%5s") " ",
+    PrintAndLogEx(INFO, " " _YELLOW_("%7.0f") " | " _YELLOW_("%7u") " | %-55.55s | " _YELLOW_("%25s") " | " _YELLOW_("%13s") " ",
                   (float)elapsed / 1000.0,
                   nonces,
                   activity_text,
@@ -275,7 +275,7 @@ static void fm11_sen_candidate_progress(uint8_t real_sec, uint8_t key_type, uint
 
     char row[256] = {0};
     snprintf(row, sizeof(row),
-             " " _YELLOW_("%7.0f") " | " _YELLOW_("%7u") " | sec " _CYAN_("%03u") " key " _GREEN_("%c") " [%s] " _YELLOW_("%6u") "/" _YELLOW_("%-6u") " " _YELLOW_("%3u%%") " | " _YELLOW_("%15u") " | %5s ",
+             " " _YELLOW_("%7.0f") " | " _YELLOW_("%7u") " | sec " _CYAN_("%03u") " key " _GREEN_("%c") " [%s] " _YELLOW_("%6u") "/" _YELLOW_("%-6u") " " _YELLOW_("%3u%%") " | " _YELLOW_("%25u") " | %13s ",
              (float)elapsed / 1000.0,
              fm11_sen_last_nonces,
              real_sec, key_type ? 'B' : 'A',
@@ -296,7 +296,7 @@ static void fm11_sen_keycheck_progress(const char *prefix, uint8_t real_sec, uin
 
     char row[256] = {0};
     snprintf(row, sizeof(row),
-             " " _YELLOW_("%7.0f") " | " _YELLOW_("%7u") " | %-3.3s " _CYAN_("%03u") " key " _GREEN_("%c") " [%s] " _YELLOW_("%6u") "/" _YELLOW_("%-6u") " " _YELLOW_("%3u%%") " | " _YELLOW_("%15u") " | %5s ",
+             " " _YELLOW_("%7.0f") " | " _YELLOW_("%7u") " | %-3.3s " _CYAN_("%03u") " key " _GREEN_("%c") " [%s] " _YELLOW_("%6u") "/" _YELLOW_("%-6u") " " _YELLOW_("%3u%%") " | " _YELLOW_("%25u") " | %13s ",
              (float)elapsed / 1000.0,
              fm11_sen_last_nonces,
              text, real_sec, key_type ? 'B' : 'A',
@@ -316,7 +316,7 @@ static void fm11_sen_compute_progress(const char *activity, uint32_t done, uint3
 
     char row[256] = {0};
     snprintf(row, sizeof(row),
-             " " _YELLOW_("%7.0f") " | " _YELLOW_("%7u") " | " _CYAN_("%-12.12s") " [%s] " _YELLOW_("%6u") "/" _YELLOW_("%-6u") " " _YELLOW_("%3u%%") "  | " _YELLOW_("%15u") " | %5s ",
+             " " _YELLOW_("%7.0f") " | " _YELLOW_("%7u") " | " _CYAN_("%-12.12s") " [%s] " _YELLOW_("%6u") "/" _YELLOW_("%-6u") " " _YELLOW_("%3u%%") "  | " _YELLOW_("%25u") " | %13s ",
              (float)elapsed / 1000.0,
              fm11_sen_last_nonces,
              text,
@@ -326,7 +326,7 @@ static void fm11_sen_compute_progress(const char *activity, uint32_t done, uint3
 }
 
 static void fm11_sen_progress_footer(void) {
-    PrintAndLogEx(INFO, "---------+---------+---------------------------------------------------------+-----------------+-------");
+    PrintAndLogEx(INFO, "---------+---------+---------------------------------------------------------+---------------------------+---------------");
 }
 
 static bool fm11_digest_reader_nonce(const nonces_t *data,
@@ -2166,7 +2166,7 @@ static void fm11_print_key_hit_row(uint32_t nonce_count, uint8_t sec, uint8_t kt
     PrintAndLogEx(SUCCESS,
                   " " _YELLOW_("%7.0f") " | " _YELLOW_("%7u") " |"
                   " Key sec " _YELLOW_("%03u") " key " _YELLOW_("%c") " = " _GREEN_("%012" PRIX64) "                        |"
-                  " " _YELLOW_("%15s") " | %5s ",
+                  " " _YELLOW_("%25s") " | %13s ",
                   (float)elapsed_key / 1000.0, nonce_count,
                   fm11_real_sector(sec), kt ? 'B' : 'A', key & 0xFFFFFFFFFFFFULL,
                   kcount, "");
@@ -2216,6 +2216,7 @@ static bool fm11_key_matches_nonce(uint32_t uid,
 static int fm11_collect_default_nonce_matches(uint32_t uid,
                                               const iso14a_fm11rf08s_nonces_with_data_t *nonces,
                                               const fm11_keylist_t *defaults,
+                                              const bool found_key[FM11RF08S_SECTORS][2],
                                               uint8_t parity_mask,
                                               fm11_keylist_t *matches) {
     if (nonces == NULL || defaults == NULL || matches == NULL) {
@@ -2225,11 +2226,24 @@ static int fm11_collect_default_nonce_matches(uint32_t uid,
         return PM3_SUCCESS;
     }
 
-    uint32_t total = defaults->count * FM11RF08S_SECTORS * 2;
+    uint32_t slots = 0;
+    for (uint8_t sec = 0; sec < FM11RF08S_SECTORS; sec++) {
+        for (uint8_t kt = 0; kt < 2; kt++) {
+            if (found_key != NULL && found_key[sec][kt]) {
+                continue;
+            }
+            slots++;
+        }
+    }
+
+    uint32_t total = defaults->count * slots;
     uint32_t done = 0;
     for (uint8_t sec = 0; sec < FM11RF08S_SECTORS; sec++) {
         uint8_t real_sec = fm11_real_sector(sec);
         for (uint8_t kt = 0; kt < 2; kt++) {
+            if (found_key != NULL && found_key[sec][kt]) {
+                continue;
+            }
             for (uint32_t i = 0; i < defaults->count; i++) {
                 if ((done & 0x3F) == 0) {
                     if (kbd_enter_pressed()) {
@@ -2262,7 +2276,7 @@ static int fm11_check_default_keys(uint32_t uid,
                                    uint64_t keys_found[FM11RF08S_SECTORS][2],
                                    bool found_key[FM11RF08S_SECTORS][2]) {
     fm11_keylist_t matches = {0};
-    int retval = fm11_collect_default_nonce_matches(uid, nonces, defaults, parity_mask, &matches);
+    int retval = fm11_collect_default_nonce_matches(uid, nonces, defaults, found_key, parity_mask, &matches);
     if (retval != PM3_SUCCESS) {
         fm11_keylist_free(&matches);
         return retval;
@@ -2848,49 +2862,7 @@ static int fm11_select_mifare_classic(iso14a_card_select_t *card_out) {
     return PM3_SUCCESS;
 }
 
-int CmdHF14AMfSEN(const char *Cmd) {
-    CLIParserContext *ctx;
-    CLIParserInit(&ctx, "hf mf sen",
-                  "Recover FM11RF08S keys using static encrypted nonce evidence in native client code",
-                  "hf mf sen\n"
-                  "hf mf sen --keep-nonces\n"
-                  "hf mf sen --no-oob\n"
-                  "hf mf sen --reader\n");
-    void *argtable[] = {
-        arg_param_begin,
-        arg_lit0(NULL, "keep-nonces", "save collected nonce/data JSON evidence"),
-        arg_lit0(NULL, "no-oob", "do not include FM11RF08S out-of-bounds sector 32 in key file"),
-        arg_lit0(NULL, "reader", "pre-pass: emulate this UID to a reader and digest recovered reader keys"),
-        arg_lit0(NULL, "offline-only", "stop after offline filtering, do not verify online"),
-        arg_lit0(NULL, "online-confirm", "only do online confirmation (skip generation if nonces loaded)"),
-        arg_int0(NULL, "max-online-candidates", "<n>", "abort online phase if total candidates exceed this limit"),
-        arg_str0(NULL, "parity-mask", "<hex>", "parity filter mask 1..F (default 1 = vetted staticnested_1nt behavior)"),
-        arg_param_end
-    };
-    CLIExecWithReturn(ctx, Cmd, argtable, true);
-    bool keep_nonces = arg_get_lit(ctx, 1);
-    bool no_oob = arg_get_lit(ctx, 2);
-    bool reader_mode = arg_get_lit(ctx, 3);
-    bool offline_only = arg_get_lit(ctx, 4);
-    bool online_confirm = arg_get_lit(ctx, 5);
-    int max_online_candidates = arg_get_int_def(ctx, 6, 0);
-    /* Only bit 0 (byte 0 parity) carries reliable data leakage from FM11RF08S.
-     * Bits 1-3 are not valid keystream leakage for this card variant — using
-     * them filters out correct keys.  Override via --parity-mask if needed. */
-    uint8_t parity_mask = 0x1;
-    {
-        int pm_len = 0;
-        char pm_str[8] = {0};
-        if (arg_get_str_len(ctx, 7) > 0) {
-            CLIGetStrWithReturn(ctx, 7, (uint8_t *)pm_str, &pm_len);
-            unsigned long pm_val = strtoul(pm_str, NULL, 16);
-            if (pm_val >= 1 && pm_val <= 0xF) {
-                parity_mask = (uint8_t)(pm_val & 0x0F);
-            }
-        }
-    }
-    (void)online_confirm;
-    CLIParserFree(ctx);
+int HFMFSENRecover(bool keep_nonces, bool no_oob, bool reader_mode, bool offline_only, int max_online_candidates, uint8_t parity_mask, bool skip_default_key_check, const sector_t *known_sectors, size_t known_sector_count) {
 
     iso14a_card_select_t card = {0};
     iso14a_fm11rf08s_nonces_with_data_t nonces = {0};
@@ -2968,6 +2940,24 @@ int CmdHF14AMfSEN(const char *Cmd) {
     fm11_keylist_t confirmed_reuse_keys = {0};
     int retval = PM3_SUCCESS;
 
+    uint32_t seeded_known = 0;
+    size_t seed_sector_count = MIN(known_sector_count, (size_t)FM11RF08S_NORMAL_SECTORS);
+    for (size_t sec = 0; sec < seed_sector_count; sec++) {
+        for (uint8_t kt = 0; kt < 2; kt++) {
+            if (known_sectors == NULL || known_sectors[sec].foundKey[kt] == 0) {
+                continue;
+            }
+            uint64_t known_key = known_sectors[sec].Key[kt] & 0xFFFFFFFFFFFFULL;
+            keys_found[sec][kt] = known_key;
+            found_key[sec][kt] = true;
+            seeded_known++;
+            (void)fm11_keylist_add_unique(&confirmed_reuse_keys, known_key);
+        }
+    }
+    if (seeded_known > 0) {
+        fm11_sen_progress(nonce_count, "Seed known keys from earlier autopwn stages", seeded_known, 0);
+    }
+
     if (reader_mode) {
         retval = fm11_collect_reader_material(&card, reader_keys, reader_found);
         if (retval != PM3_SUCCESS) {
@@ -2983,35 +2973,39 @@ int CmdHF14AMfSEN(const char *Cmd) {
         }
     }
 
-    fm11_sen_progress(nonce_count, "Check default-key dictionary against nonce evidence", default_keys.count, 0);
-    retval = fm11_check_default_keys(uid, nonce_count, &nonces, &default_keys, parity_mask, keys_found, found_key);
-    if (retval != PM3_SUCCESS) {
-        goto out;
-    }
-    for (uint8_t sec = 0; sec < FM11RF08S_SECTORS; sec++) {
-        for (uint8_t kt = 0; kt < 2; kt++) {
-            if (found_key[sec][kt] == false) {
-                continue;
-            }
-            uint64_t key = keys_found[sec][kt] & 0xFFFFFFFFFFFFULL;
-            if (fm11_keylist_has_key(&confirmed_reuse_keys, key)) {
-                continue;
-            }
-            retval = fm11_keylist_add_unique(&confirmed_reuse_keys, key);
-            if (retval != PM3_SUCCESS) {
-                goto out;
-            }
-            uint32_t reuse_found = fm11_propagate_key_reuse_online(nonce_count, key, keys_found, found_key);
-            if (reuse_found > 0) {
-                snprintf(activity, sizeof(activity), "Key re-use propagation confirmed %u additional key slots", reuse_found);
-                fm11_sen_progress(nonce_count, activity, reuse_found, 0);
+    if (skip_default_key_check) {
+        fm11_sen_progress(nonce_count, "Skip default-key dictionary check already done by autopwn", seeded_known, 0);
+    } else {
+        fm11_sen_progress(nonce_count, "Check default-key dictionary against nonce evidence", default_keys.count, 0);
+        retval = fm11_check_default_keys(uid, nonce_count, &nonces, &default_keys, parity_mask, keys_found, found_key);
+        if (retval != PM3_SUCCESS) {
+            goto out;
+        }
+        for (uint8_t sec = 0; sec < FM11RF08S_SECTORS; sec++) {
+            for (uint8_t kt = 0; kt < 2; kt++) {
+                if (found_key[sec][kt] == false) {
+                    continue;
+                }
+                uint64_t key = keys_found[sec][kt] & 0xFFFFFFFFFFFFULL;
+                if (fm11_keylist_has_key(&confirmed_reuse_keys, key)) {
+                    continue;
+                }
+                retval = fm11_keylist_add_unique(&confirmed_reuse_keys, key);
+                if (retval != PM3_SUCCESS) {
+                    goto out;
+                }
+                uint32_t reuse_found = fm11_propagate_key_reuse_online(nonce_count, key, keys_found, found_key);
+                if (reuse_found > 0) {
+                    snprintf(activity, sizeof(activity), "Key re-use propagation confirmed %u additional key slots", reuse_found);
+                    fm11_sen_progress(nonce_count, activity, reuse_found, 0);
+                }
             }
         }
-    }
-    uint32_t default_found = fm11_count_found_keys(found_key);
-    if (default_found > 0) {
-        snprintf(activity, sizeof(activity), "Default key check recovered %u key%s", default_found, (default_found == 1) ? "" : "s");
-        fm11_sen_progress(nonce_count, activity, default_found, 0);
+        uint32_t default_found = fm11_count_found_keys(found_key);
+        if (default_found > 0) {
+            snprintf(activity, sizeof(activity), "Default key check recovered %u key%s", default_found, (default_found == 1) ? "" : "s");
+            fm11_sen_progress(nonce_count, activity, default_found, 0);
+        }
     }
 
     fm11_sen_progress(nonce_count, "Generate first-pass candidates from nT/{nT}/parity", 0, 0);
@@ -3379,4 +3373,52 @@ out:
         fm11_keylist_free(&candidates[sec][1]);
     }
     return retval;
+}
+
+int CmdHF14AMfSEN(const char *Cmd) {
+    CLIParserContext *ctx;
+    CLIParserInit(&ctx, "hf mf sen",
+                  "Recover FM11RF08S keys using static encrypted nonce evidence in native client code",
+                  "hf mf sen\n"
+                  "hf mf sen --keep-nonces\n"
+                  "hf mf sen --no-oob\n"
+                  "hf mf sen --reader\n");
+    void *argtable[] = {
+        arg_param_begin,
+        arg_lit0(NULL, "keep-nonces", "save collected nonce/data JSON evidence"),
+        arg_lit0(NULL, "no-oob", "do not include FM11RF08S out-of-bounds sector 32 in key file"),
+        arg_lit0(NULL, "reader", "pre-pass: emulate this UID to a reader and digest recovered reader keys"),
+        arg_lit0(NULL, "offline-only", "stop after offline filtering, do not verify online"),
+        arg_lit0(NULL, "online-confirm", "only do online confirmation (skip generation if nonces loaded)"),
+        arg_int0(NULL, "max-online-candidates", "<n>", "abort online phase if total candidates exceed this limit"),
+        arg_str0(NULL, "parity-mask", "<hex>", "parity filter mask 1..F (default 1 = vetted staticnested_1nt behavior)"),
+        arg_param_end
+    };
+    CLIExecWithReturn(ctx, Cmd, argtable, true);
+    bool keep_nonces = arg_get_lit(ctx, 1);
+    bool no_oob = arg_get_lit(ctx, 2);
+    bool reader_mode = arg_get_lit(ctx, 3);
+    bool offline_only = arg_get_lit(ctx, 4);
+    bool online_confirm = arg_get_lit(ctx, 5);
+    int max_online_candidates = arg_get_int_def(ctx, 6, 0);
+    /* Only bit 0 (byte 0 parity) carries reliable data leakage from FM11RF08S.
+     * Bits 1-3 are not valid keystream leakage for this card variant - using
+     * them filters out correct keys.  Override via --parity-mask if needed for
+     * any weird chinese clones, normally you should never use this parameter. */
+    uint8_t parity_mask = 0x1;
+    {
+        int pm_len = 0;
+        char pm_str[8] = {0};
+        if (arg_get_str_len(ctx, 7) > 0) {
+            CLIGetStrWithReturn(ctx, 7, (uint8_t *)pm_str, &pm_len);
+            unsigned long pm_val = strtoul(pm_str, NULL, 16);
+            if (pm_val >= 1 && pm_val <= 0xF) {
+                parity_mask = (uint8_t)(pm_val & 0x0F);
+            }
+        }
+    }
+    (void)online_confirm;
+    CLIParserFree(ctx);
+
+    return HFMFSENRecover(keep_nonces, no_oob, reader_mode, offline_only, max_online_candidates, parity_mask, false, NULL, 0);
 }

--- a/client/src/cmdhfmfsen.h
+++ b/client/src/cmdhfmfsen.h
@@ -19,9 +19,12 @@
 #ifndef CMDHFMFSEN_H__
 #define CMDHFMFSEN_H__
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mifare.h"
 #include "mifare/mifaredefault.h"
+#include "mifare/mifarehost.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,6 +34,7 @@ extern "C" {
 extern const uint8_t fm11_backdoor_keys[FM11_BACKDOOR_KEY_COUNT][MIFARE_KEY_SIZE];
 
 int fm11_collect_nonces(const uint8_t *key, iso14a_card_select_t *card, iso14a_fm11rf08s_nonces_with_data_t *nonces);
+int HFMFSENRecover(bool keep_nonces, bool no_oob, bool reader_mode, bool offline_only, int max_online_candidates, uint8_t parity_mask, bool skip_default_key_check, const sector_t *known_sectors, size_t known_sector_count);
 int CmdHF14AMfSEN(const char *Cmd);
 
 #ifdef __cplusplus

--- a/client/src/mifare/mifarehost.c
+++ b/client/src/mifare/mifarehost.c
@@ -317,12 +317,14 @@ int mf_check_keys_fast_ex(uint8_t sectorsCnt, uint8_t firstChunk, uint8_t lastCh
                 e_sector[sector_no].foundKey[key_type] = true;
             }
 
-            PrintAndLogEx(NORMAL, "");
-            PrintAndLogEx(SUCCESS, "\nTarget block " _GREEN_("%4u") " key type " _GREEN_("%c") " -- found valid key [ " _GREEN_("%s") " ]",
-                          block_no,
-                          key_type ? 'B' : 'A',
-                          sprint_hex_inrow(resp.data.asBytes, MIFARE_KEY_SIZE)
-                         );
+            if (quiet == false) {
+                PrintAndLogEx(NORMAL, "");
+                PrintAndLogEx(SUCCESS, "Target block " _GREEN_("%4u") " key type " _GREEN_("%c") " -- found valid key [ " _GREEN_("%s") " ]",
+                              block_no,
+                              key_type ? 'B' : 'A',
+                              sprint_hex_inrow(resp.data.asBytes, MIFARE_KEY_SIZE)
+                             );
+            }
 
             return PM3_SUCCESS;
         }


### PR DESCRIPTION
Minor addition of hfmfsen to autopwn, fix for some GUI element alignment, hardnested and SEN specifically due to overlaps and vague text, and minor edits to hf mf sen to use default-dictionary keys. propagated to the internal SEN state to save time.