### PR TITLE
Add 2 keys for Mifare Plus SE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Added two Mifare Classic keys into extensive dictionary which are hardcoded into Mifare Plus SE (@team-orangeBlue)
 - Fixed `hf mfp rdbl` when using "read multiple" blocks by decrypting the entire buffer instead of one block only (@team-orangeBlue)
 - Improved `hf mfp dump` execution speed by removing crypto+card restarts, approx. 40% faster (@team-orangeBlue)
 - Added support for non-first authentication in Mifare Plus (@team-orangeBlue)

--- a/client/dictionaries/mfc_default_keys.dic
+++ b/client/dictionaries/mfc_default_keys.dic
@@ -32,6 +32,12 @@ D01AFEEB890A
 # 17 B
 4B791BEA7BCC
 #
+# Mifare Plus SE post-1K blocks
+# Key A
+4823741386AB
+# Key B
+326587C3D17F
+#
 # QL88 keys
 # 17 A/B
 2612C6DE84CA


### PR DESCRIPTION
Used by the chip in SL1 for all sectors after 15.

Useful in the case that someone decides to use Mifare Plus SE as S50 chips - this enables the use of hardnested on a fully custom-keyed tag.