### PR TITLE
Fix -Werror=stringop-truncation build failure in fileutils.c

### DIFF
--- a/client/src/fileutils.c
+++ b/client/src/fileutils.c
@@ -3036,9 +3036,7 @@ static int filelist(const char *path, const char *ext, uint8_t last, bool tentat
     for (int i = 0; i < n; i++) {
 
         char tmp_fullpath[1024] = {0};
-        strncat(tmp_fullpath, path, sizeof(tmp_fullpath) - 1);
-        tmp_fullpath[1023] = 0x00;
-        strncat(tmp_fullpath, namelist[i]->d_name, strlen(tmp_fullpath) - 1);
+        snprintf(tmp_fullpath, sizeof(tmp_fullpath), "%s%s", path, namelist[i]->d_name);
 
         if (path_is_directory(tmp_fullpath)) {
 


### PR DESCRIPTION
`strncat(tmp_fullpath, path, sizeof(tmp_fullpath) - 1)` into a zero-initialized buffer triggers `-Wstringop-truncation` on newer GCC because the copy length equals the buffer size, so GCC flags it as potentially truncating.

Replaced the `strncat` chain with a single `snprintf` call, which also fixes a secondary bug on the old line 3041 where the third argument to `strncat` was `strlen(tmp_fullpath) - 1` (which is the current string length, not the remaining buffer space). In practice this means the append could overrun the buffer if `path` was short and `d_name` was long enough.

Before:
```c
char tmp_fullpath[1023] = {0};
strncat(tmp_fullpath, path, sizeof(tmp_fullpath) - 1);
tmp_fullpath[1023] = 0x00;
strncat(tmp_fullpath, namelist[i]->d_name, strlen(tmp_fullpath) - 1);
```

After:
```c
snprintf(tmp_fullpath, sizeof(tmp_fullpath), "%s%s", path, namelist[i]->d_name);
```
