### PR TITLE
Fix MADDecode off-by-one (#3346): mad[] sized for 39 entries but 40 written when MAD2 present

### DIFF
--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -6956,7 +6956,7 @@ static int CmdHF14AMfMAD(const char *Cmd) {
         }
 
         if (aidlen == 2 || decodeholder) {
-            uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
+            uint16_t mad[MAD_MAX_AID_ENTRIES] = {0};
             size_t madlen = 0;
             if (MADDecode(dump, dump + (0x10 * MIFARE_1K_MAXBLOCK), mad, &madlen, swapmad, override)) {
                 PrintAndLogEx(ERR, "can't decode MAD");
@@ -7041,7 +7041,7 @@ static int CmdHF14AMfMAD(const char *Cmd) {
     }
 
     if (aidlen == 2 || decodeholder) {
-        uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
+        uint16_t mad[MAD_MAX_AID_ENTRIES] = {0};
         size_t madlen = 0;
         if (MADDecode(sector0, sector10, mad, &madlen, swapmad, override)) {
             PrintAndLogEx(ERR, "can't decode MAD");
@@ -7218,7 +7218,7 @@ int CmdHFMFNDEFRead(const char *Cmd) {
             return res;
     }
 
-    uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
+    uint16_t mad[MAD_MAX_AID_ENTRIES] = {0};
     size_t madlen = 0;
     res = MADDecode(sector0, sector10, mad, &madlen, false, override);
     if (res != PM3_SUCCESS) {
@@ -7648,7 +7648,7 @@ int CmdHFMFNDEFWrite(const char *Cmd) {
     }
 
     // decode MAD v1
-    uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
+    uint16_t mad[MAD_MAX_AID_ENTRIES] = {0};
     size_t madlen = 0;
     res = MADDecode(sector0, sector10, mad, &madlen, false, false);
     if (res != PM3_SUCCESS) {
@@ -8528,7 +8528,7 @@ static int CmdHF14AMfView(const char *Cmd) {
         PrintAndLogEx(INFO, _CYAN_("VIGIK PACS detected"));
 
         // decode MAD v1
-        uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
+        uint16_t mad[MAD_MAX_AID_ENTRIES] = {0};
         size_t madlen = 0;
         res = MADDecode(dump, NULL, mad, &madlen, false, true);
         if (res != PM3_SUCCESS) {

--- a/client/src/cmdhfmfp.c
+++ b/client/src/cmdhfmfp.c
@@ -2623,7 +2623,7 @@ static int CmdHFMFPMAD(const char *Cmd) {
     }
 
     if (aidlen == 2 || decodeholder) {
-        uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
+        uint16_t mad[MAD_MAX_AID_ENTRIES] = {0};
         size_t madlen = 0;
         if (MADDecode(sector0, sector16, mad, &madlen, swapmad, override)) {
             PrintAndLogEx(ERR, "can't decode MAD");
@@ -2809,7 +2809,7 @@ int CmdHFMFPNDEFRead(const char *Cmd) {
         }
     }
 
-    uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
+    uint16_t mad[MAD_MAX_AID_ENTRIES] = {0};
     size_t madlen = 0;
     res = MADDecode(sector0, (haveMAD2 ? sector16 : NULL), mad, &madlen, false, override);
     if (res != PM3_SUCCESS) {

--- a/client/src/mifare/mad.c
+++ b/client/src/mifare/mad.c
@@ -500,7 +500,7 @@ int convert_mad_to_arr(uint8_t *in, uint16_t ilen, uint8_t *out, uint16_t *olen,
         memcpy(sector16, in + (MF_MAD2_SECTOR * 4 * MFBLOCK_SIZE), sizeof(sector16));
     }
 
-    uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
+    uint16_t mad[MAD_MAX_AID_ENTRIES] = {0};
     size_t madlen = 0;
     if (MADDecode(sector0, sector16, mad, &madlen, false, override)) {
         PrintAndLogEx(ERR, "can't decode MAD");

--- a/client/src/mifare/mad.h
+++ b/client/src/mifare/mad.h
@@ -21,6 +21,9 @@
 
 #include "common.h"
 
+// 16 MAD1 AIDs + 1 MAD2 marker (0x0005) + 23 MAD2 AIDs = 40
+#define MAD_MAX_AID_ENTRIES 40
+
 int MADCheck(uint8_t *sector0, uint8_t *sector16, bool verbose, bool *haveMAD2);
 int MADDecode(uint8_t *sector0, uint8_t *sector16, uint16_t *mad, size_t *madlen, bool swapmad, bool override);
 int MAD1DecodeAndPrint(uint8_t *sector, bool swapmad, bool verbose, bool *haveMAD2);


### PR DESCRIPTION
This patch corrects the off-by-one vulnerability that was described in issue #3346.