### PR TITLE
Fix NULL dereference (#3347) in emv_pki_decode_message

### DIFF
--- a/client/src/emv/emv_pki.c
+++ b/client/src/emv/emv_pki.c
@@ -75,10 +75,11 @@ static unsigned char *emv_pki_decode_message(const struct emv_pk *enc_pk,
     data = crypto_pk_encrypt(kcp, cert_tlv->value, cert_tlv->len, &data_len);
     crypto_pk_close(kcp);
 
-    /*  if (true){
-            PrintAndLogEx(SUCCESS, "Recovered data:\n");
-            print_buffer(data, data_len, 1);
-        }*/
+    if (data == NULL || data_len < 3) {
+        PrintAndLogEx(WARNING, "ERROR: Certificate decrypt failed");
+        free(data);
+        return NULL;
+    }
 
     if (data[data_len - 1] != 0xbc || data[0] != 0x6a || data[1] != msgtype) {
         PrintAndLogEx(WARNING, "ERROR: Certificate format");


### PR DESCRIPTION
This patch corrects the NULL dereference vulnerability in `emv_pki_decode_message` that was described in issue #3347.