### PR TITLE
Fix NULL dereference in MAD print_aid_description

### DIFF
--- a/client/src/mifare/mad.c
+++ b/client/src/mifare/mad.c
@@ -117,6 +117,8 @@ static int print_aid_description(json_t *root, uint16_t aid, char *fmt, bool ver
             continue;
         }
         const char *fmad = mad_json_get_str(data, "mad");
+        if (fmad == NULL)
+            continue;
         char lfmad[strlen(fmad) + 1];
         strcpy(lfmad, fmad);
         str_lower(lfmad);


### PR DESCRIPTION
# NULL dereference in print_aid_description

## Context

This PR follows issue #3346.

## Location

`client/src/mifare/mad.c:120` in `print_aid_description()`

## Description

`mad_json_get_str(data, "mad")` returns NULL when a JSON entry in `mad.json`
is missing the `"mad"` key, has it as a non-string type, or has an empty string
value. The return value was passed directly to `strlen()` and `strcpy()` without
a NULL check, causing a crash.

## Fix

Added `if (fmad == NULL) continue;` before the `strlen(fmad)` call. Entries
without a valid `"mad"` field are now silently skipped during AID lookup.

## Impact

Crash (`SIGSEGV`) when loading a malformed or corrupt `mad.json` resource file.
Reachable from any command that prints AID descriptions: `hf mf mad`, `nfc decode`,
`hf mfp mad`.