### PR TITLE
Fix MAD1 off-by-one in MADDecode: loop read Key A as 16th AID

### DIFF
--- a/client/src/mifare/mad.c
+++ b/client/src/mifare/mad.c
@@ -262,8 +262,7 @@ int MADDecode(uint8_t *sector0, uint8_t *sector16, uint16_t *mad, size_t *madlen
         PrintAndLogEx(INFO, "overriding crc check");
     }
 
-    // 7 + 8 == 15
-    for (int i = 1; i <= 16; i++) {
+    for (int i = 1; i < 16; i++) {
         mad[*madlen] = madGetAID(sector0, swapmad, 1, i);
         (*madlen)++;
     }

--- a/client/src/mifare/mad.h
+++ b/client/src/mifare/mad.h
@@ -21,8 +21,8 @@
 
 #include "common.h"
 
-// 16 MAD1 AIDs + 1 MAD2 marker (0x0005) + 23 MAD2 AIDs = 40
-#define MAD_MAX_AID_ENTRIES 40
+// 15 MAD1 AIDs (sectors 1-15) + 1 MAD2 marker (0x0005) + 23 MAD2 AIDs (sectors 17-39) = 39
+#define MAD_MAX_AID_ENTRIES 39
 
 int MADCheck(uint8_t *sector0, uint8_t *sector16, bool verbose, bool *haveMAD2);
 int MADDecode(uint8_t *sector0, uint8_t *sector16, uint16_t *mad, size_t *madlen, bool swapmad, bool override);


### PR DESCRIPTION
# MAD1 off-by-one: loop reads Key A as AID, wrong MAD_MAX_AID_ENTRIES

## Context

This PR follows issue #3346.

## Locations

- `client/src/mifare/mad.c:268` in `MADDecode()`, MAD1 loop bound
- `client/src/mifare/mad.h:25`, the `MAD_MAX_AID_ENTRIES` constant

## Description

The MAD1 loop in `MADDecode()` used `for (int i = 1; i <= 16; i++)`, iterating
16 times. MAD1 in sector 0 only stores 15 AIDs (sectors 1-15):

- Block 1 (bytes 16-31): CRC at `sector[16]`, info byte at `sector[17]`,
  7 AIDs at `sector[18..31]`
- Block 2 (bytes 32-47): 8 AIDs at `sector[32..47]`
- Block 3 (bytes 48-63): sector trailer (Key A, access bits, Key B)

On the 16th iteration, `madGetAID(sector0, swapmad, 1, 16)` reads
`sector[48..49]`, which are the first two bytes of Key A from the sector trailer.
With the default MAD key `A0 A1 A2 A3 A4 A5`, this produces a bogus AID
of `0xA1A0`.

This bogus entry had two consequences:

1. The `mad[]` array stored 16 + 1 + 23 = 40 entries when MAD2 was present.
   The previous BOF-001 fix (commit d4c4ab30c) resized the array to 40 to
   prevent the overflow, but didn't fix the root cause.

2. The `i + 1` sector mapping used by `convert_mad_to_arr` and callers in
   `cmdhfmf.c` was off by one for all MAD2 entries. The marker at `mad[16]`
   should represent sector 16, but with 16 MAD1 entries it was pushed to
   `mad[17]`, misaligning every subsequent sector lookup.

## Fix

- Changed loop bound to `i < 16` (15 iterations, sectors 1-15).
- Updated `MAD_MAX_AID_ENTRIES` from 40 to 39 (15 + 1 + 23).

The `mad[]` index-to-sector mapping is now correct: `mad[i]` corresponds to
sector `i + 1` for all entries, and the `0x0005` marker for sector 16 sits
at `mad[15]`.

## Impact

The bogus AID from Key A was stored in the array and passed to all callers
that iterate over decoded MAD entries. If the Key A bytes happened to match
a target AID (e.g. `0xE103` for NDEF), `convert_mad_to_arr` would compute
offset `16 * 64 = 1024` on a 1K dump, which is a 64-byte out-of-bounds read past
the end of the input buffer.