### PR TITLE
Fix buffer over-read in MADCardHolderInfoDecode

### DIFF
--- a/client/src/mifare/mad.c
+++ b/client/src/mifare/mad.c
@@ -289,12 +289,14 @@ int MADCardHolderInfoDecode(uint8_t *data, size_t datalen, bool verbose) {
         uint8_t len = data[idx] & 0x3f;
         uint8_t type = data[idx] >> 6;
         idx++;
-        if (len > 0) {
-            PrintAndLogEx(INFO, "%14s " _GREEN_("%.*s"), holder_info_type[type], len, &data[idx]);
-            idx += len;
-        } else {
+        if (len == 0)
+            break;
+        if (idx + len > datalen) {
+            PrintAndLogEx(WARNING, "Card holder info truncated (need %u bytes, %zu available)", len, datalen - idx);
             break;
         }
+        PrintAndLogEx(INFO, "%14s " _GREEN_("%.*s"), holder_info_type[type], len, &data[idx]);
+        idx += len;
     }
     return PM3_SUCCESS;
 }


### PR DESCRIPTION
# Buffer over-read in MADCardHolderInfoDecode

## Location

`client/src/mifare/mad.c:296` in `MADCardHolderInfoDecode()`

## Description

The cardholder info decoder parses TLV-encoded records from card data. Each
record has a 1-byte header where the lower 6 bits encode the length (0-63)
and the upper 2 bits encode the type (surname, given name, sex, other).

The parsing loop checked `idx < datalen` before reading the header byte, but
did not verify that `idx + len <= datalen` before reading `len` bytes of
payload. A crafted card could set `len = 63` in the last valid byte, causing
a 63-byte over-read past the buffer into adjacent stack or heap memory.

The data is then passed to `PrintAndLogEx` with `%.*s`, which prints the
over-read bytes to the terminal and leaks information.

## Fix

Add `if (idx + len > datalen)` after extracting the length field.
When the payload's size exceeds the buffer's, parsing stops with a warning
message indicating the truncation.

## Impact

Information leak: adjacent memory contents printed to the user's terminal.
Reachable from any crafted MIFARE Classic card or dump file via `hf mf mad`
(both the dump-file path and the live-card path) and `hf mfp mad`.
