### PR TITLE
MAD revamp to harden the parser with typed structs and to fix memory safety bugs

### DIFF
--- a/client/src/cmdhfgallagher.c
+++ b/client/src/cmdhfgallagher.c
@@ -999,20 +999,19 @@ static int hfgal_update_mad(uint8_t cred_sector, uint8_t cad_sector,
         return res;
     }
 
+    mad1_sector_t *m = (mad1_sector_t *)sector0;
+
     // Set AID for credential sector (0x4812)
     if (cred_sector >= 1 && cred_sector <= 15) {
-        sector0[16 + 2 + (cred_sector - 1) * 2]     = CLASSIC_CRED_AID & 0xFF;
-        sector0[16 + 2 + (cred_sector - 1) * 2 + 1]  = (CLASSIC_CRED_AID >> 8) & 0xFF;
+        mad_aid_set(&m->aid[cred_sector - 1], CLASSIC_CRED_AID);
     }
 
     // Set AID for CAD sector (0x4811)
     if (cad_sector >= 1 && cad_sector <= 15) {
-        sector0[16 + 2 + (cad_sector - 1) * 2]     = CLASSIC_CAD_AID & 0xFF;
-        sector0[16 + 2 + (cad_sector - 1) * 2 + 1]  = (CLASSIC_CAD_AID >> 8) & 0xFF;
+        mad_aid_set(&m->aid[cad_sector - 1], CLASSIC_CAD_AID);
     }
 
-    // Recalculate CRC over bytes 17..47 (info byte + 15 AID entries)
-    sector0[16] = CRC8Mad(&sector0[16 + 1], 15 + 16);
+    m->crc = MADComputeCRC(m);
 
     // Write blocks 1 and 2 of sector 0 back (block 0 is manufacturer block, don't touch)
     res = mf_write_block(1, mad_key_type, mad_key, &sector0[MFBLOCK_SIZE]);

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -703,7 +703,8 @@ void mf_print_blocks(uint16_t n, uint8_t *d, bool verbose) {
     }
 
     // MAD detection
-    if (HasMADKey(d)) {
+    mad_sector_t mad_sec = {d, n * MFBLOCK_SIZE};
+    if (HasMADKey(&mad_sec)) {
         PrintAndLogEx(HINT, "Hint: MAD key detected. Try `" _YELLOW_("hf mf mad") "` for more details");
     }
     PrintAndLogEx(NORMAL, "");
@@ -6902,7 +6903,8 @@ static int CmdHF14AMfMAD(const char *Cmd) {
         }
 
         // MAD detection
-        if ((HasMADKey(dump) == false) && (force == false)) {
+        mad_sector_t dump_sec = {dump, bytes_read};
+        if ((HasMADKey(&dump_sec) == false) && (force == false)) {
             PrintAndLogEx(FAILED, "No MAD key was detected in the dump file");
             free(dump);
             return PM3_ESOFT;
@@ -6910,9 +6912,9 @@ static int CmdHF14AMfMAD(const char *Cmd) {
 
         MADPrintHeader();
         bool haveMAD2 = false;
-        MAD1DecodeAndPrint(dump, swapmad, verbose, &haveMAD2);
+        MAD1DecodeAndPrint(&dump_sec, swapmad, verbose, &haveMAD2);
 
-        int sector = DetectHID(dump, 0x484d);
+        int sector = DetectHID(&dump_sec, 0x484d);
         if (sector > -1) {
 
             // decode it
@@ -6921,7 +6923,7 @@ static int CmdHF14AMfMAD(const char *Cmd) {
             PrintAndLogEx(INFO, _CYAN_("HID PACS detected"));
 
             uint8_t pacs_sector[MFBLOCK_SIZE * 3] = {0};
-            memcpy(pacs_sector, dump + (sector * 4 * 16), sizeof(pacs_sector));
+            memcpy(pacs_sector, dump + (sector * 4 * MFBLOCK_SIZE), sizeof(pacs_sector));
 
             if (pacs_sector[16] == 0x02) {
 
@@ -6944,7 +6946,7 @@ static int CmdHF14AMfMAD(const char *Cmd) {
             }
         }
 
-        sector = DetectHID(dump, 0x4910);
+        sector = DetectHID(&dump_sec, 0x4910);
         if (sector > -1) {
             // decode it
             PrintAndLogEx(INFO, "");
@@ -6952,13 +6954,18 @@ static int CmdHF14AMfMAD(const char *Cmd) {
         }
 
         if (haveMAD2) {
-            MAD2DecodeAndPrint(dump + (MIFARE_1K_MAXBLOCK * MF_MAD2_SECTOR), swapmad, verbose);
+            size_t mad2_off = MIFARE_1K_MAXBLOCK * MF_MAD2_SECTOR;
+            size_t mad2_len = (bytes_read > mad2_off) ? bytes_read - mad2_off : 0;
+            mad_sector_t mad2_sec = {dump + mad2_off, mad2_len};
+            MAD2DecodeAndPrint(&mad2_sec, swapmad, verbose);
         }
 
         if (aidlen == 2 || decodeholder) {
-            uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
-            size_t madlen = 0;
-            if (MADDecode(dump, dump + (0x10 * MIFARE_1K_MAXBLOCK), mad, &madlen, swapmad, override)) {
+            size_t sector16_off = 0x10 * MIFARE_1K_MAXBLOCK;
+            size_t sector16_len = (bytes_read > sector16_off) ? bytes_read - sector16_off : 0;
+            mad_sector_t s16 = {dump + sector16_off, sector16_len};
+            mad_t mad = {0};
+            if (MADDecode(&dump_sec, &s16, &mad, swapmad, override) != PM3_SUCCESS) {
                 PrintAndLogEx(ERR, "can't decode MAD");
                 free(dump);
                 return PM3_ESOFT;
@@ -6972,7 +6979,42 @@ static int CmdHF14AMfMAD(const char *Cmd) {
             PrintAndLogEx(NORMAL, "");
             PrintAndLogEx(INFO, "-------- " _CYAN_("Card Holder Info 0x%04x") " --------", aaid);
 
-            MADCardHolderInfoDecode(dump, bytes_read, verbose);
+            uint8_t chdata[MIFARE_4K_MAX_BYTES] = {0};
+            int chdatalen = 0;
+
+            for (size_t i = 0; i < mad.count; i++) {
+                if (aaid != mad.entries[i])
+                    continue;
+
+                uint8_t sectorNo = i + 1;
+                size_t sec_off = mfFirstBlockOfSector(sectorNo) * MFBLOCK_SIZE;
+                uint8_t nblocks = mfNumBlocksPerSector(sectorNo);
+                size_t sec_size = nblocks * MFBLOCK_SIZE;
+
+                if (sec_off + sec_size > bytes_read)
+                    continue;
+
+                if (aidlen == 2) {
+                    for (int j = 0; j < (verbose ? nblocks : nblocks - 1); j++)
+                        PrintAndLogEx(INFO, " [%03d] %s", (int)(mfFirstBlockOfSector(sectorNo) + j), sprint_hex(&dump[sec_off + j * MFBLOCK_SIZE], MFBLOCK_SIZE));
+                }
+
+                if (decodeholder) {
+                    size_t data_size = (nblocks - 1) * MFBLOCK_SIZE;
+                    if (chdatalen + data_size > sizeof(chdata))
+                        break;
+                    memcpy(&chdata[chdatalen], dump + sec_off, data_size);
+                    chdatalen += data_size;
+                }
+            }
+
+            if (decodeholder) {
+                if (chdatalen == 0) {
+                    PrintAndLogEx(WARNING, "no Card Holder Info data");
+                } else {
+                    MADCardHolderInfoDecode(chdata, chdatalen, verbose);
+                }
+            }
         }
         free(dump);
         return PM3_SUCCESS;
@@ -7034,16 +7076,18 @@ static int CmdHF14AMfMAD(const char *Cmd) {
     MADPrintHeader();
 
     bool haveMAD2 = false;
-    MAD1DecodeAndPrint(sector0, swapmad, verbose, &haveMAD2);
+    mad_sector_t s0 = {sector0, sizeof(sector0)};
+    MAD1DecodeAndPrint(&s0, swapmad, verbose, &haveMAD2);
 
     if (haveMAD2) {
-        MAD2DecodeAndPrint(sector10, swapmad, verbose);
+        mad_sector_t s10 = {sector10, sizeof(sector10)};
+        MAD2DecodeAndPrint(&s10, swapmad, verbose);
     }
 
     if (aidlen == 2 || decodeholder) {
-        uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
-        size_t madlen = 0;
-        if (MADDecode(sector0, sector10, mad, &madlen, swapmad, override)) {
+        mad_sector_t s10 = {sector10, sizeof(sector10)};
+        mad_t mad = {0};
+        if (MADDecode(&s0, &s10, &mad, swapmad, override) != PM3_SUCCESS) {
             PrintAndLogEx(ERR, "can't decode MAD");
             return PM3_ESOFT;
         }
@@ -7065,17 +7109,17 @@ static int CmdHF14AMfMAD(const char *Cmd) {
             PrintAndLogEx(NORMAL, "");
             PrintAndLogEx(INFO, "-------------- " _CYAN_("AID 0x%04x") " ---------------", aaid);
 
-            for (int i = 0; i < madlen; i++) {
-                if (aaid == mad[i]) {
+            for (size_t i = 0; i < mad.count; i++) {
+                if (aaid == mad.entries[i]) {
                     uint8_t vsector[MFBLOCK_SIZE * 4] = {0};
                     if (mf_read_sector(i + 1, keyB ? MF_KEY_B : MF_KEY_A, akey, vsector)) {
                         PrintAndLogEx(NORMAL, "");
-                        PrintAndLogEx(ERR, "error, read sector %d", i + 1);
+                        PrintAndLogEx(ERR, "error, read sector %d", (int)(i + 1));
                         return PM3_ESOFT;
                     }
 
                     for (int j = 0; j < (verbose ? 4 : 3); j ++)
-                        PrintAndLogEx(NORMAL, " [%03d] %s", (i + 1) * 4 + j, sprint_hex(&vsector[j * MFBLOCK_SIZE], MFBLOCK_SIZE));
+                        PrintAndLogEx(NORMAL, " [%03d] %s", (int)((i + 1) * 4 + j), sprint_hex(&vsector[j * MFBLOCK_SIZE], MFBLOCK_SIZE));
                 }
             }
         }
@@ -7088,17 +7132,18 @@ static int CmdHF14AMfMAD(const char *Cmd) {
             uint8_t data[MIFARE_4K_MAX_BYTES] = {0};
             int datalen = 0;
 
-            for (int i = 0; i < madlen; i++) {
-                if (aaid == mad[i]) {
+            for (size_t i = 0; i < mad.count; i++) {
+                if (aaid == mad.entries[i]) {
 
                     uint8_t vsector[MFBLOCK_SIZE * 4] = {0};
                     if (mf_read_sector(i + 1, keyB ? MF_KEY_B : MF_KEY_A, akey, vsector)) {
                         PrintAndLogEx(NORMAL, "");
-                        PrintAndLogEx(ERR, "error, read sector %d", i + 1);
+                        PrintAndLogEx(ERR, "error, read sector %d", (int)(i + 1));
                         return PM3_ESOFT;
                     }
 
-                    // skip ST block hence only 3 blocks copy
+                    if (datalen + MFBLOCK_SIZE * 3 > (int)sizeof(data))
+                        break;
                     memcpy(&data[datalen], vsector, MFBLOCK_SIZE * 3);
                     datalen += MFBLOCK_SIZE * 3;
                 }
@@ -7209,7 +7254,9 @@ int CmdHFMFNDEFRead(const char *Cmd) {
     }
 
     bool haveMAD2 = false;
-    int res = MADCheck(sector0, sector10, verbose, &haveMAD2);
+    mad_sector_t s0 = {sector0, sizeof(sector0)};
+    mad_sector_t s10 = {sector10, sizeof(sector10)};
+    int res = MADCheck(&s0, &s10, verbose, &haveMAD2);
     if (res != PM3_SUCCESS) {
         PrintAndLogEx(ERR, "MAD error %d", res);
         if (override)
@@ -7218,17 +7265,16 @@ int CmdHFMFNDEFRead(const char *Cmd) {
             return res;
     }
 
-    uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
-    size_t madlen = 0;
-    res = MADDecode(sector0, sector10, mad, &madlen, false, override);
+    mad_t mad = {0};
+    res = MADDecode(&s0, &s10, &mad, false, override);
     if (res != PM3_SUCCESS) {
         PrintAndLogEx(ERR, "can't decode MAD");
         return res;
     }
 
     PrintAndLogEx(INFO, "reading data from tag");
-    for (int i = 0; i < madlen; i++) {
-        if (ndef_aid == mad[i]) {
+    for (size_t i = 0; i < mad.count; i++) {
+        if (ndef_aid == mad.entries[i]) {
             uint8_t vsector[MFBLOCK_SIZE * 4] = {0};
             if (mf_read_sector(i + 1, keyB ? MF_KEY_B : MF_KEY_A, ndefkey, vsector)) {
                 PrintAndLogEx(ERR, "error, reading sector %d ", i + 1);
@@ -7648,9 +7694,10 @@ int CmdHFMFNDEFWrite(const char *Cmd) {
     }
 
     // decode MAD v1
-    uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
-    size_t madlen = 0;
-    res = MADDecode(sector0, sector10, mad, &madlen, false, false);
+    mad_sector_t s0 = {sector0, sizeof(sector0)};
+    mad_sector_t s10 = {sector10, sizeof(sector10)};
+    mad_t mad = {0};
+    res = MADDecode(&s0, &s10, &mad, false, false);
     if (res != PM3_SUCCESS) {
         PrintAndLogEx(ERR, "can't decode MAD");
         return res;
@@ -7661,9 +7708,9 @@ int CmdHFMFNDEFWrite(const char *Cmd) {
     uint8_t freemem[MIFARE_4K_MAXSECTOR] = {0};
     uint16_t sum = 0;
     uint8_t block_no = 0;
-    for (uint8_t i = 1; i < (madlen & 0xFF); i++) {
+    for (uint8_t i = 1; i < (mad.count & 0xFF); i++) {
 
-        freemem[i] = (mad[i] == NDEF_MFC_AID);
+        freemem[i] = (mad.entries[i] == NDEF_MFC_AID);
 
         if (freemem[i]) {
 
@@ -8521,16 +8568,16 @@ static int CmdHF14AMfView(const char *Cmd) {
         mf_save_keys_from_arr(block_cnt, dump);
     }
 
-    int sector = DetectHID(dump, 0x4910);
+    mad_sector_t dump_sec = {dump, bytes_read};
+    int sector = DetectHID(&dump_sec, 0x4910);
     if (sector > -1) {
         // decode it
         PrintAndLogEx(INFO, "");
         PrintAndLogEx(INFO, _CYAN_("VIGIK PACS detected"));
 
         // decode MAD v1
-        uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
-        size_t madlen = 0;
-        res = MADDecode(dump, NULL, mad, &madlen, false, true);
+        mad_t mad = {0};
+        res = MADDecode(&dump_sec, NULL, &mad, false, true);
         if (res != PM3_SUCCESS) {
             PrintAndLogEx(ERR, "can't decode MAD");
             return res;
@@ -8557,8 +8604,8 @@ static int CmdHF14AMfView(const char *Cmd) {
         pdump += (MFBLOCK_SIZE * 4);  // skip sectortrailer
 
         // extract memory from MAD sectors
-        for (int i = 0; i <= madlen; i++) {
-            if (0x4910 == mad[i] || 0x4916 == mad[i]) {
+        for (size_t i = 0; i < mad.count; i++) {
+            if (0x4910 == mad.entries[i] || 0x4916 == mad.entries[i]) {
                 memcpy(d.bytes + dlen, pdump, MFBLOCK_SIZE * 3);
                 dlen += MFBLOCK_SIZE * 3;
             }

--- a/client/src/cmdhfmfp.c
+++ b/client/src/cmdhfmfp.c
@@ -2610,7 +2610,8 @@ static int CmdHFMFPMAD(const char *Cmd) {
     }
 
     bool haveMAD2 = false;
-    MAD1DecodeAndPrint(sector0, swapmad, verbose, &haveMAD2);
+    mad_sector_t s0 = {sector0, sizeof(sector0)};
+    MAD1DecodeAndPrint(&s0, swapmad, verbose, &haveMAD2);
 
     if (haveMAD2) {
         if (mfpReadSector(MF_MAD2_SECTOR, MF_KEY_A, (uint8_t *)g_mifarep_mad_key, sector16, verbose)) {
@@ -2619,13 +2620,14 @@ static int CmdHFMFPMAD(const char *Cmd) {
             return PM3_ESOFT;
         }
 
-        MAD2DecodeAndPrint(sector16, swapmad, verbose);
+        mad_sector_t s16 = {sector16, sizeof(sector16)};
+        MAD2DecodeAndPrint(&s16, swapmad, verbose);
     }
 
     if (aidlen == 2 || decodeholder) {
-        uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
-        size_t madlen = 0;
-        if (MADDecode(sector0, sector16, mad, &madlen, swapmad, override)) {
+        mad_sector_t s16 = {sector16, sizeof(sector16)};
+        mad_t mad = {0};
+        if (MADDecode(&s0, &s16, &mad, swapmad, override) != PM3_SUCCESS) {
             PrintAndLogEx(ERR, "can't decode MAD");
             return PM3_EWRONGANSWER;
         }
@@ -2645,17 +2647,17 @@ static int CmdHFMFPMAD(const char *Cmd) {
             PrintAndLogEx(NORMAL, "");
             PrintAndLogEx(INFO, "-------------- " _CYAN_("AID 0x%04x") " ---------------", aaid);
 
-            for (int i = 0; i < madlen; i++) {
-                if (aaid == mad[i]) {
+            for (size_t i = 0; i < mad.count; i++) {
+                if (aaid == mad.entries[i]) {
                     uint8_t vsector[16 * 4] = {0};
                     if (mfpReadSector(i + 1, keyB ? MF_KEY_B : MF_KEY_A, akey, vsector, false)) {
                         PrintAndLogEx(NORMAL, "");
-                        PrintAndLogEx(ERR, "error, read sector %d error", i + 1);
+                        PrintAndLogEx(ERR, "error, read sector %d error", (int)(i + 1));
                         return PM3_ESOFT;
                     }
 
                     for (int j = 0; j < (verbose ? 4 : 3); j ++)
-                        PrintAndLogEx(NORMAL, " [%03d] %s", (i + 1) * 4 + j, sprint_hex(&vsector[j * 16], 16));
+                        PrintAndLogEx(NORMAL, " [%03d] %s", (int)((i + 1) * 4 + j), sprint_hex(&vsector[j * 16], 16));
                 }
             }
         }
@@ -2668,18 +2670,20 @@ static int CmdHFMFPMAD(const char *Cmd) {
             uint8_t data[4096] = {0};
             int datalen = 0;
 
-            for (int i = 0; i < madlen; i++) {
-                if (aaid == mad[i]) {
+            for (size_t i = 0; i < mad.count; i++) {
+                if (aaid == mad.entries[i]) {
 
                     uint8_t vsector[16 * 4] = {0};
                     if (mf_read_sector(i + 1, keyB ? MF_KEY_B : MF_KEY_A, akey, vsector)) {
                         PrintAndLogEx(NORMAL, "");
-                        PrintAndLogEx(ERR, "error, read sector %d", i + 1);
+                        PrintAndLogEx(ERR, "error, read sector %d", (int)(i + 1));
                         return PM3_ESOFT;
                     }
 
-                    memcpy(&data[datalen], vsector, 16 * 3);
-                    datalen += 16 * 3;
+                    if (datalen + MFBLOCK_SIZE * 3 > (int)sizeof(data))
+                        break;
+                    memcpy(&data[datalen], vsector, MFBLOCK_SIZE * 3);
+                    datalen += MFBLOCK_SIZE * 3;
                 }
             }
 
@@ -2788,7 +2792,8 @@ int CmdHFMFPNDEFRead(const char *Cmd) {
     }
 
     bool haveMAD2 = false;
-    int res = MADCheck(sector0, NULL, verbose, &haveMAD2);
+    mad_sector_t s0 = {sector0, sizeof(sector0)};
+    int res = MADCheck(&s0, NULL, verbose, &haveMAD2);
     if (res != PM3_SUCCESS) {
         PrintAndLogEx(ERR, "MAD error %d", res);
         if (override)
@@ -2809,17 +2814,21 @@ int CmdHFMFPNDEFRead(const char *Cmd) {
         }
     }
 
-    uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
-    size_t madlen = 0;
-    res = MADDecode(sector0, (haveMAD2 ? sector16 : NULL), mad, &madlen, false, override);
+    mad_sector_t s16 = {0};
+    if (haveMAD2) {
+        s16.data = sector16;
+        s16.len = sizeof(sector16);
+    }
+    mad_t mad = {0};
+    res = MADDecode(&s0, haveMAD2 ? &s16 : NULL, &mad, false, override);
     if (res != PM3_SUCCESS) {
         PrintAndLogEx(ERR, "can't decode MAD");
         return res;
     }
 
     PrintAndLogEx(INFO, "reading data from tag");
-    for (int i = 0; i < madlen; i++) {
-        if (ndefAID == mad[i]) {
+    for (size_t i = 0; i < mad.count; i++) {
+        if (ndefAID == mad.entries[i]) {
             uint8_t vsector[MIFARE_1K_MAXBLOCK] = {0};
             if (mfpReadSector(i + 1, keyB ? MF_KEY_B : MF_KEY_A, ndefkey, vsector, false)) {
                 PrintAndLogEx(ERR, "error, reading sector %d", i + 1);

--- a/client/src/cmdnfc.c
+++ b/client/src/cmdnfc.c
@@ -138,12 +138,13 @@ static int CmdNfcDecode(const char *Cmd) {
         } else  {
 
             // convert from MFC dump file to a pure NDEF byte array
-            if (HasMADKey(tmp)) {
+            mad_sector_t s = {tmp, bytes_read};
+            if (HasMADKey(&s)) {
                 PrintAndLogEx(SUCCESS, "MFC dump file detected. Converting...");
                 uint8_t ndef[4096] = {0};
-                uint16_t ndeflen = 0;
+                size_t ndeflen = 0;
 
-                if (convert_mad_to_arr(tmp, bytes_read, ndef, &ndeflen, override) != PM3_SUCCESS) {
+                if (convert_mad_to_arr(tmp, bytes_read, ndef, &ndeflen, sizeof(ndef), override) != PM3_SUCCESS) {
                     PrintAndLogEx(FAILED, "Failed converting, aborting...");
                     free(dump);
                     return PM3_ESOFT;

--- a/client/src/mifare/gallaghertest.c
+++ b/client/src/mifare/gallaghertest.c
@@ -4,6 +4,7 @@
 #include <string.h>      // memcpy memset
 #include "ui.h"
 #include "crc.h"
+#include "mad.h"
 
 #include "mifare/gallaghercore.h"
 
@@ -137,9 +138,9 @@ static bool test_mad_crc(void) {
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x78, 0x77, 0x88, 0xC1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     };
 
-    // MAD v1 CRC: computed over sector0[17..47] (info byte + 15 AID pairs = 31 bytes)
-    uint8_t expected_crc = sector0[16]; // 0xBD
-    uint8_t computed_crc = CRC8Mad(&sector0[16 + 1], 15 + 16);
+    const mad1_sector_t *m = (const mad1_sector_t *)sector0;
+    uint8_t expected_crc = m->crc;
+    uint8_t computed_crc = MADComputeCRC(m);
     if (computed_crc != expected_crc) {
         PrintAndLogEx(INFO, "MAD CRC test failed: expected 0x%02X, got 0x%02X", expected_crc, computed_crc);
         return false;

--- a/client/src/mifare/mad.c
+++ b/client/src/mifare/mad.c
@@ -25,6 +25,11 @@
 #include "fileutils.h"
 #include "jansson.h"
 #include "mifaredefault.h"
+#include "mifare4.h"
+
+// Compile-time size sanity checks (force a build error if the structs don't match a 4-block sector).
+typedef char mad_assert_mad1[sizeof(mad1_sector_t) == MFBLOCK_SIZE * 4 ? 1 : -1];
+typedef char mad_assert_mad2[sizeof(mad2_sector_t) == MFBLOCK_SIZE * 4 ? 1 : -1];
 
 // https://www.nxp.com/docs/en/application-note/AN10787.pdf
 static json_t *mad_known_aids = NULL;
@@ -45,8 +50,11 @@ static const char *aid_admin[] = {
     "not applicable"
 };
 
-static int open_mad_file(json_t **root, bool verbose) {
+// ---------------------------------------------------------------------------
+// JSON helpers
+// ---------------------------------------------------------------------------
 
+static int open_mad_file(json_t **root, bool verbose) {
     char *path;
     int res = searchFile(&path, RESOURCES_SUBDIR, "mad", ".json", true);
     if (res != PM3_SUCCESS) {
@@ -87,7 +95,6 @@ static int close_mad_file(json_t *root) {
 }
 
 static const char *mad_json_get_str(json_t *data, const char *name) {
-
     json_t *jstr = json_object_get(data, name);
     if (jstr == NULL)
         return NULL;
@@ -105,6 +112,10 @@ static const char *mad_json_get_str(json_t *data, const char *name) {
 }
 
 static int print_aid_description(json_t *root, uint16_t aid, char *fmt, bool verbose) {
+    if (root == NULL || fmt == NULL) {
+        return PM3_EINVARG;
+    }
+
     char lmad[7] = {0};
     snprintf(lmad, sizeof(lmad), "0x%04x", aid); // must be lowercase
 
@@ -113,12 +124,15 @@ static int print_aid_description(json_t *root, uint16_t aid, char *fmt, bool ver
     for (uint32_t idx = 0; idx < json_array_size(root); idx++) {
         json_t *data = json_array_get(root, idx);
         if (!json_is_object(data)) {
-            PrintAndLogEx(ERR, "data [%d] is not an object\n", idx);
+            PrintAndLogEx(ERR, "data [%u] is not an object", idx);
             continue;
         }
         const char *fmad = mad_json_get_str(data, "mad");
-        char lfmad[strlen(fmad) + 1];
-        strcpy(lfmad, fmad);
+        if (fmad == NULL)
+            continue;
+        char lfmad[16];
+        strncpy(lfmad, fmad, sizeof(lfmad) - 1);
+        lfmad[sizeof(lfmad) - 1] = '\0';
         str_lower(lfmad);
         if (strcmp(lmad, lfmad) == 0) {
             elm = data;
@@ -138,14 +152,13 @@ static int print_aid_description(json_t *root, uint16_t aid, char *fmt, bool ver
     const char *integrator = mad_json_get_str(elm, "system_integrator");
 
     if (application && company) {
-        size_t result_len = 6 + strlen(application) + strlen(company);
-        char result[result_len];
-        snprintf(result, result_len, " %s [%s]", application, company);
+        char result[512];
+        snprintf(result, sizeof(result), " %s [%s]", application, company);
         PrintAndLogEx(INFO, fmt, result);
     }
 
     if (verbose) {
-        PrintAndLogEx(SUCCESS, "     MAD................. %s", vmad);
+        PrintAndLogEx(SUCCESS, "     MAD................. %s", vmad ? vmad : "n/a");
         if (application) {
             PrintAndLogEx(SUCCESS, "     Application......... %s", application);
         }
@@ -162,42 +175,102 @@ static int print_aid_description(json_t *root, uint16_t aid, char *fmt, bool ver
     return PM3_SUCCESS;
 }
 
-static int madCRCCheck(uint8_t *sector, bool verbose, int MADver) {
-    if (MADver == 1) {
-        uint8_t crc = CRC8Mad(&sector[16 + 1], 15 + 16);
-        if (crc != sector[16]) {
-            PrintAndLogEx(WARNING, _RED_("Wrong MAD %d CRC") " calculated: 0x%02x != 0x%02x", MADver, crc, sector[16]);
+// ---------------------------------------------------------------------------
+// Low-level MAD sector parsing
+// ---------------------------------------------------------------------------
+
+static bool mad_sector_valid(const mad_sector_t *sector) {
+    return sector != NULL && sector->data != NULL && sector->len >= sizeof(mad1_sector_t);
+}
+
+static int madCRCCheck(const mad_sector_t *sector, int mad_ver) {
+    if (!mad_sector_valid(sector)) {
+        return PM3_EINVARG;
+    }
+
+    if (mad_ver == 1) {
+        const mad1_sector_t *m = (const mad1_sector_t *)sector->data;
+        uint8_t crc = MADComputeCRC(m);
+        if (crc != m->crc) {
+            PrintAndLogEx(WARNING, _RED_("Wrong MAD %d CRC") " calculated: 0x%02x != 0x%02x", mad_ver, crc, m->crc);
             return PM3_ESOFT;
-        };
+        }
     } else {
-        uint8_t crc = CRC8Mad(&sector[1], 15 + 16 + 16);
-        if (crc != sector[0]) {
-            PrintAndLogEx(WARNING,  _RED_("Wrong MAD %d CRC") " calculated: 0x%02x != 0x%02x", MADver, crc, sector[0]);
+        const mad2_sector_t *m = (const mad2_sector_t *)sector->data;
+        uint8_t crc = MADComputeCRC(m);
+        if (crc != m->crc) {
+            PrintAndLogEx(WARNING,  _RED_("Wrong MAD %d CRC") " calculated: 0x%02x != 0x%02x", mad_ver, crc, m->crc);
             return PM3_ESOFT;
-        };
+        }
     }
     return PM3_SUCCESS;
 }
 
-static uint16_t madGetAID(const uint8_t *sector, bool swapmad, int MADver, int sectorNo) {
-    uint16_t mad;
-    if (MADver == 1)
-        mad = (sector[16 + 2 + (sectorNo - 1) * 2 + 1] << 8) + (sector[16 + 2 + (sectorNo - 1) * 2]);
-    else
-        mad = (sector[2 + (sectorNo - 1) * 2 + 1] << 8) + (sector[2 + (sectorNo - 1) * 2]);
-    if (swapmad) {
-        return BSWAP_16(mad);
-    } else {
-        return mad;
+static uint16_t madGetAID(const mad_sector_t *sector, bool swapmad, int mad_ver, int sector_no) {
+    if (!mad_sector_valid(sector)) {
+        return 0;
     }
+
+    const mad_aid_t *aid = NULL;
+
+    if (mad_ver == 1) {
+        const mad1_sector_t *m = (const mad1_sector_t *)sector->data;
+        if (sector_no >= 1 && sector_no <= 15)
+            aid = &m->aid[sector_no - 1];
+        else
+            return 0;
+    } else {
+        const mad2_sector_t *m = (const mad2_sector_t *)sector->data;
+        if (sector_no >= 1 && sector_no <= 23)
+            aid = &m->aid[sector_no - 1];
+        else
+            return 0;
+    }
+
+    uint16_t val = mad_aid_get(aid);
+    return swapmad ? BSWAP_16(val) : val;
 }
 
-int MADCheck(uint8_t *sector0, uint8_t *sector16, bool verbose, bool *haveMAD2) {
-
-    if (sector0 == NULL)
+static int MADInfoByteDecode(const mad_sector_t *sector, int mad_ver, bool verbose) {
+    if (!mad_sector_valid(sector)) {
         return PM3_EINVARG;
+    }
 
-    uint8_t GPB = sector0[(3 * 16) + 9];
+    uint8_t info;
+    if (mad_ver == 1) {
+        const mad1_sector_t *m = (const mad1_sector_t *)sector->data;
+        info = m->info & 0x3f;
+        if (info >= 0x10) {
+            PrintAndLogEx(WARNING, "Invalid Info byte (MAD1) value " _YELLOW_("0x%02x"), info);
+            if (verbose) {
+                PrintAndLogEx(WARNING, "MAD1 Info byte points outside of MAD1 sector space (0x%02x), report a bug?", info);
+            }
+            return PM3_ESOFT;
+        }
+    } else {
+        const mad2_sector_t *m = (const mad2_sector_t *)sector->data;
+        info = m->info & 0x3f;
+        if (info == 0x10 || info >= 0x28) {
+            PrintAndLogEx(WARNING, "Invalid Info byte (MAD2) value " _YELLOW_("0x%02x"), info);
+            return PM3_ESOFT;
+        }
+    }
+
+    return info;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+int MADCheck(const mad_sector_t *sector0, const mad_sector_t *sector16, bool verbose, bool *haveMAD2) {
+    if (!mad_sector_valid(sector0)) {
+        return PM3_EINVARG;
+    }
+
+    const mad1_sector_t *m1 = (const mad1_sector_t *)sector0->data;
+    uint8_t GPB = m1->gpb;
+
     if (verbose) {
         PrintAndLogEx(SUCCESS, "GPB....... " _GREEN_("0x%02X"), GPB);
     }
@@ -212,29 +285,30 @@ int MADCheck(uint8_t *sector0, uint8_t *sector16, bool verbose, bool *haveMAD2) 
     if (verbose)
         PrintAndLogEx(SUCCESS, "Version... " _GREEN_("%d"), mad_ver);
 
-    //  MAD version
+    // MAD version
     if ((mad_ver != 0x01) && (mad_ver != 0x02)) {
         PrintAndLogEx(ERR, "Wrong MAD version " _RED_("0x%02X"), mad_ver);
         return PM3_ESOFT;
-    };
+    }
 
+    bool mad2_available = (mad_ver == 2) && mad_sector_valid(sector16);
     if (haveMAD2) {
-        *haveMAD2 = (mad_ver == 2);
+        *haveMAD2 = mad2_available;
     }
 
-    int res = madCRCCheck(sector0, true, 1);
+    int res = madCRCCheck(sector0, 1);
     if (verbose && res == PM3_SUCCESS) {
-        PrintAndLogEx(SUCCESS, "CRC8...... 0x%02X ( %s )", sector0[16], _GREEN_("ok"));
+        PrintAndLogEx(SUCCESS, "CRC8...... 0x%02X ( %s )", m1->crc, _GREEN_("ok"));
     }
 
-    if (mad_ver == 2 && sector16) {
-        int res2 = madCRCCheck(sector16, true, 2);
+    if (mad2_available) {
+        int res2 = madCRCCheck(sector16, 2);
         if (res == PM3_SUCCESS) {
             res = res2;
         }
-
-        if (verbose && !res2) {
-            PrintAndLogEx(SUCCESS, "CRC8...... 0x%02X ( %s )", sector16[0], _GREEN_("ok"));
+        if (verbose && res2 == PM3_SUCCESS) {
+            const mad2_sector_t *m2 = (const mad2_sector_t *)sector16->data;
+            PrintAndLogEx(SUCCESS, "CRC8...... 0x%02X ( %s )", m2->crc, _GREEN_("ok"));
         }
     }
 
@@ -248,10 +322,21 @@ int MADCheck(uint8_t *sector0, uint8_t *sector16, bool verbose, bool *haveMAD2) 
     return res;
 }
 
-int MADDecode(uint8_t *sector0, uint8_t *sector16, uint16_t *mad, size_t *madlen, bool swapmad, bool override) {
-    *madlen = 0;
+int MADDecode(const mad_sector_t *sector0, const mad_sector_t *sector16, mad_t *out, bool swapmad, bool override) {
+    if (out == NULL) {
+        return PM3_EINVARG;
+    }
+
+    memset(out, 0, sizeof(mad_t));
+
     bool haveMAD2 = false;
     int res = MADCheck(sector0, sector16, false, &haveMAD2);
+    out->has_mad2 = haveMAD2;
+
+    if (mad_sector_valid(sector0)) {
+        const mad1_sector_t *m1 = (const mad1_sector_t *)sector0->data;
+        out->gpb = m1->gpb;
+    }
 
     if (res != PM3_SUCCESS && override == false) {
         PrintAndLogEx(WARNING, "Not a valid MAD");
@@ -262,64 +347,57 @@ int MADDecode(uint8_t *sector0, uint8_t *sector16, uint16_t *mad, size_t *madlen
         PrintAndLogEx(INFO, "overriding crc check");
     }
 
-    // 7 + 8 == 15
-    for (int i = 1; i <= 16; i++) {
-        mad[*madlen] = madGetAID(sector0, swapmad, 1, i);
-        (*madlen)++;
+    out->crc1_ok = (madCRCCheck(sector0, 1) == PM3_SUCCESS);
+
+    for (int i = 1; i <= MAD1_AID_COUNT; i++) {
+        if (out->count >= MAD_MAX_AID_ENTRIES)
+            break;
+        out->entries[out->count++] = madGetAID(sector0, swapmad, 1, i);
     }
 
     if (haveMAD2) {
-        // mad2 sector (0x10 == 16) here
-        mad[*madlen] = 0x0005;
-        (*madlen)++;
+        out->crc2_ok = (madCRCCheck(sector16, 2) == PM3_SUCCESS);
 
-        // 7 + 8 + 8  == 23
-        for (int i = 1; i < 24; i++) {
-            mad[*madlen] = madGetAID(sector16, swapmad, 2, i);
+        if (out->count >= MAD_MAX_AID_ENTRIES)
+            return PM3_ESOFT;
 
-            (*madlen)++;
+        // MAD2 sector marker
+        out->entries[out->count++] = 0x0005;
+
+        for (int i = 1; i <= MAD2_AID_COUNT; i++) {
+            if (out->count >= MAD_MAX_AID_ENTRIES)
+                break;
+            out->entries[out->count++] = madGetAID(sector16, swapmad, 2, i);
         }
     }
     return PM3_SUCCESS;
 }
 
-int MADCardHolderInfoDecode(uint8_t *data, size_t datalen, bool verbose) {
+int MADCardHolderInfoDecode(const uint8_t *data, size_t datalen, bool verbose) {
+    if (data == NULL) {
+        return PM3_EINVARG;
+    }
+
     size_t idx = 0;
     while (idx < datalen) {
         uint8_t len = data[idx] & 0x3f;
         uint8_t type = data[idx] >> 6;
         idx++;
-        if (len > 0) {
-            PrintAndLogEx(INFO, "%14s " _GREEN_("%.*s"), holder_info_type[type], len, &data[idx]);
-            idx += len;
-        } else {
+        if (len == 0)
+            break;
+        if (idx + len > datalen) {
+            PrintAndLogEx(WARNING, "Card holder info truncated (need %u bytes, %zu available)", len, datalen - idx);
             break;
         }
+        if (type >= ARRAYLEN(holder_info_type)) {
+            PrintAndLogEx(WARNING, "Unknown card holder info type %u", type);
+            idx += len;
+            continue;
+        }
+        PrintAndLogEx(INFO, "%14s " _GREEN_("%.*s"), holder_info_type[type], len, &data[idx]);
+        idx += len;
     }
     return PM3_SUCCESS;
-}
-
-static int MADInfoByteDecode(const uint8_t *sector, bool swapmad, int mad_ver, bool verbose) {
-    uint8_t info;
-    if (mad_ver == 1) {
-        info = sector[16 + 1] & 0x3f;
-        if (info >= 0xF) {
-            PrintAndLogEx(WARNING, "Invalid Info byte (MAD1) value " _YELLOW_("0x%02x"), info);
-            if (verbose) {
-                // I understand the spec in a way that MAD1 InfoByte should not point into MAD2 sectors, @lukaskuzmiak
-                PrintAndLogEx(WARNING, "MAD1 Info byte points outside of MAD1 sector space (0x%02x), report a bug?", info);
-            }
-            return PM3_ESOFT;
-        }
-    } else {
-        info = sector[1] & 0x3f;
-        if (info == 0x10 || info >= 0x28) {
-            PrintAndLogEx(WARNING, "Invalid Info byte (MAD2) value " _YELLOW_("0x%02x"), info);
-            return PM3_ESOFT;
-        }
-    }
-
-    return info;
 }
 
 void MADPrintHeader(void) {
@@ -327,8 +405,15 @@ void MADPrintHeader(void) {
     PrintAndLogEx(INFO, "--- " _CYAN_("MIFARE App Directory Information") " ----------------");
 }
 
-int MAD1DecodeAndPrint(uint8_t *sector, bool swapmad, bool verbose, bool *haveMAD2) {
-    open_mad_file(&mad_known_aids, verbose);
+int MAD1DecodeAndPrint(const mad_sector_t *sector, bool swapmad, bool verbose, bool *haveMAD2) {
+    if (!mad_sector_valid(sector)) {
+        return PM3_EINVARG;
+    }
+
+    int res = open_mad_file(&mad_known_aids, verbose);
+    if (res != PM3_SUCCESS) {
+        mad_known_aids = NULL;
+    }
 
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "------------ " _CYAN_("MAD v1 details") " -------------");
@@ -336,7 +421,12 @@ int MAD1DecodeAndPrint(uint8_t *sector, bool swapmad, bool verbose, bool *haveMA
     // check MAD1 only
     MADCheck(sector, NULL, verbose, haveMAD2);
 
-    int ibs = MADInfoByteDecode(sector, swapmad, 1, verbose);
+    int ibs = MADInfoByteDecode(sector, 1, verbose);
+    if (ibs < 0) {
+        close_mad_file(mad_known_aids);
+        mad_known_aids = NULL;
+        return ibs;
+    }
 
     if (ibs > 0) {
         PrintAndLogEx(SUCCESS, "Card publisher sector " _MAGENTA_("0x%02X"), ibs);
@@ -349,9 +439,9 @@ int MAD1DecodeAndPrint(uint8_t *sector, bool swapmad, bool verbose, bool *haveMA
 
     PrintAndLogEx(INFO, " 00 MAD v1");
     uint32_t prev_aid = 0xFFFFFFFF;
-    for (int i = 1; i < 16; i++) {
+    for (int i = 1; i <= MAD1_AID_COUNT; i++) {
         uint16_t aid = madGetAID(sector, swapmad, 1, i);
-        if (aid < 6) {
+        if (aid < ARRAYLEN(aid_admin)) {
             PrintAndLogEx(INFO,
                           (ibs == i) ? _MAGENTA_(" %02d [%04X] %s") : " %02d [" _GREEN_("%04X") "] %s",
                           i,
@@ -381,24 +471,39 @@ int MAD1DecodeAndPrint(uint8_t *sector, bool swapmad, bool verbose, bool *haveMA
         }
     }
     close_mad_file(mad_known_aids);
+    mad_known_aids = NULL;
     return PM3_SUCCESS;
 }
 
-int MAD2DecodeAndPrint(uint8_t *sector, bool swapmad, bool verbose) {
-    open_mad_file(&mad_known_aids, false);
+int MAD2DecodeAndPrint(const mad_sector_t *sector, bool swapmad, bool verbose) {
+    if (!mad_sector_valid(sector)) {
+        return PM3_EINVARG;
+    }
+
+    int res = open_mad_file(&mad_known_aids, false);
+    if (res != PM3_SUCCESS) {
+        mad_known_aids = NULL;
+    }
 
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "------------ " _CYAN_("MAD v2 details") " -------------");
 
-    int res = madCRCCheck(sector, true, 2);
+    int crc_res = madCRCCheck(sector, 2);
     if (verbose) {
-        if (res == PM3_SUCCESS)
-            PrintAndLogEx(SUCCESS, "CRC8...... 0x%02X ( " _GREEN_("%s") " )", sector[0], "ok");
+        const mad2_sector_t *m2 = (const mad2_sector_t *)sector->data;
+        if (crc_res == PM3_SUCCESS)
+            PrintAndLogEx(SUCCESS, "CRC8...... 0x%02X ( " _GREEN_("%s") " )", m2->crc, "ok");
         else
-            PrintAndLogEx(SUCCESS, "CRC8...... 0x%02X ( " _RED_("%s") " )", sector[0], "fail");
+            PrintAndLogEx(SUCCESS, "CRC8...... 0x%02X ( " _RED_("%s") " )", m2->crc, "fail");
     }
 
-    int ibs = MADInfoByteDecode(sector, swapmad, 2, verbose);
+    int ibs = MADInfoByteDecode(sector, 2, verbose);
+    if (ibs < 0) {
+        close_mad_file(mad_known_aids);
+        mad_known_aids = NULL;
+        return ibs;
+    }
+
     if (ibs > 0) {
         PrintAndLogEx(SUCCESS, "Card publisher sector " _MAGENTA_("0x%02X"), ibs);
     } else {
@@ -411,9 +516,9 @@ int MAD2DecodeAndPrint(uint8_t *sector, bool swapmad, bool verbose) {
     PrintAndLogEx(INFO, " 16 MAD v2");
 
     uint32_t prev_aid = 0xFFFFFFFF;
-    for (int i = 1; i < 8 + 8 + 7 + 1; i++) {
+    for (int i = 1; i <= MAD2_AID_COUNT; i++) {
         uint16_t aid = madGetAID(sector, swapmad, 2, i);
-        if (aid < 6) {
+        if (aid < ARRAYLEN(aid_admin)) {
             PrintAndLogEx(INFO,
                           (ibs == i + 16) ? _MAGENTA_(" %02d [%04X] %s") : " %02d [" _GREEN_("%04X") "] %s",
                           i + 16,
@@ -442,36 +547,45 @@ int MAD2DecodeAndPrint(uint8_t *sector, bool swapmad, bool verbose) {
         }
     }
     close_mad_file(mad_known_aids);
+    mad_known_aids = NULL;
 
     return PM3_SUCCESS;
 }
 
 int MADDFDecodeAndPrint(uint32_t short_aid, bool verbose) {
-    open_mad_file(&mad_known_aids, false);
+    int res = open_mad_file(&mad_known_aids, false);
+    if (res != PM3_SUCCESS) {
+        mad_known_aids = NULL;
+    }
 
     char fmt[128];
     snprintf(fmt, sizeof(fmt), "   MAD AID Function 0x%04X... " _YELLOW_("%s"), short_aid, "%s");
     print_aid_description(mad_known_aids, short_aid, fmt, verbose);
     close_mad_file(mad_known_aids);
+    mad_known_aids = NULL;
     return PM3_SUCCESS;
 }
 
-bool HasMADKey(uint8_t *d) {
-    if (d == NULL) {
+bool HasMADKey(const mad_sector_t *sector) {
+    if (sector == NULL || sector->data == NULL) {
         return false;
     }
 
-    return (memcmp(d + (3 * MFBLOCK_SIZE), g_mifare_mad_key, sizeof(g_mifare_mad_key)) == 0);
+    if (sector->len < sizeof(mad1_sector_t)) {
+        return false;
+    }
+
+    const mad1_sector_t *m = (const mad1_sector_t *)sector->data;
+    return (memcmp(m->key_a, g_mifare_mad_key, sizeof(g_mifare_mad_key)) == 0);
 }
 
-int DetectHID(uint8_t *d, uint16_t manufacture) {
-    if (d == NULL) {
+int DetectHID(const mad_sector_t *sector, uint16_t manufacture) {
+    if (!mad_sector_valid(sector)) {
         return -1;
     }
 
-    // find HID
-    for (int i = 1; i < 16; i++) {
-        uint16_t aid = madGetAID(d, false, 1, i);
+    for (int i = 1; i <= MAD1_AID_COUNT; i++) {
+        uint16_t aid = madGetAID(sector, false, 1, i);
         if (aid == manufacture) {
             return i;
         }
@@ -480,49 +594,63 @@ int DetectHID(uint8_t *d, uint16_t manufacture) {
     return -1;
 }
 
-int convert_mad_to_arr(uint8_t *in, uint16_t ilen, uint8_t *out, uint16_t *olen, bool override) {
-
-    if (in == NULL || out == NULL || ilen == 0) {
+int convert_mad_to_arr(const uint8_t *in, size_t ilen, uint8_t *out, size_t *olen, size_t olen_max, bool override) {
+    if (in == NULL || out == NULL || olen == NULL || ilen == 0 || olen_max == 0) {
         return PM3_EINVARG;
     }
 
-    // MAD detection
-    if (HasMADKey(in) == false) {
+    *olen = 0;
+
+    mad_sector_t dump = { in, ilen };
+    if (HasMADKey(&dump) == false) {
         PrintAndLogEx(FAILED, "No MAD key was detected in the dump file");
         return PM3_ESOFT;
     }
 
-    uint8_t sector0[MFBLOCK_SIZE * 4] = {0};
-    uint8_t sector16[MFBLOCK_SIZE * 4] = {0};
+    uint8_t sector0_buf[MFBLOCK_SIZE * 4] = {0};
+    uint8_t sector16_buf[MFBLOCK_SIZE * 4] = {0};
 
-    memcpy(sector0, in, sizeof(sector0));
-    if (ilen == MIFARE_4K_MAX_BYTES) {
-        memcpy(sector16, in + (MF_MAD2_SECTOR * 4 * MFBLOCK_SIZE), sizeof(sector16));
+    memcpy(sector0_buf, in, MIN(sizeof(sector0_buf), ilen));
+
+    mad_sector_t sector16 = { NULL, 0 };
+    size_t sector16_offset = MF_MAD2_SECTOR * 4 * MFBLOCK_SIZE;
+    if (ilen >= sector16_offset + sizeof(sector16_buf)) {
+        memcpy(sector16_buf, in + sector16_offset, sizeof(sector16_buf));
+        sector16.data = sector16_buf;
+        sector16.len = sizeof(sector16_buf);
     }
 
-    uint16_t mad[7 + 8 + 8 + 8 + 8] = {0};
-    size_t madlen = 0;
-    if (MADDecode(sector0, sector16, mad, &madlen, false, override)) {
+    mad_sector_t sector0 = { sector0_buf, sizeof(sector0_buf) };
+    mad_t mad = {0};
+    int res = MADDecode(&sector0, &sector16, &mad, false, override);
+    if (res != PM3_SUCCESS) {
         PrintAndLogEx(ERR, "can't decode MAD");
         return PM3_ESOFT;
     }
 
     uint16_t ndef_aid = 0xE103;
-    for (int i = 0; i < madlen; i++) {
-        if (ndef_aid == mad[i]) {
-            uint8_t tmp[MFBLOCK_SIZE * 4] = {0};
-            memset(tmp, 0x00, sizeof(tmp));
+    for (size_t i = 0; i < mad.count; i++) {
+        if (ndef_aid == mad.entries[i]) {
+            uint8_t sectorNo = i + 1;
+            uint16_t first_block = mfFirstBlockOfSector(sectorNo);
+            uint8_t num_blocks = mfNumBlocksPerSector(sectorNo);
+            uint32_t offset = first_block * MFBLOCK_SIZE;
+            uint16_t sector_size = num_blocks * MFBLOCK_SIZE;
 
-            // sector i dump (skip first sector +1)
-            memcpy(tmp, in + (i + 1) * sizeof(tmp), sizeof(tmp));
+            if (offset + sector_size > ilen) {
+                PrintAndLogEx(WARNING, "NDEF sector %u exceeds input bounds", sectorNo);
+                break;
+            }
 
-            // debug print
-            // print_hex_noascii_break(tmp, sizeof(tmp) - MFBLOCK_SIZE, MFBLOCK_SIZE);
+            uint16_t data_size = sector_size - MFBLOCK_SIZE;
+            if (*olen + data_size > olen_max) {
+                PrintAndLogEx(WARNING, "NDEF output buffer full");
+                return PM3_ESOFT;
+            }
 
-            // copy to out (skip ST)
-            memcpy(out, tmp, sizeof(tmp) - MFBLOCK_SIZE);
-            out += sizeof(tmp) - MFBLOCK_SIZE;
-            *olen += sizeof(tmp) - MFBLOCK_SIZE;
+            memcpy(out, in + offset, data_size);
+            out += data_size;
+            *olen += data_size;
         }
     }
     return PM3_SUCCESS;

--- a/client/src/mifare/mad.h
+++ b/client/src/mifare/mad.h
@@ -21,14 +21,87 @@
 
 #include "common.h"
 
-int MADCheck(uint8_t *sector0, uint8_t *sector16, bool verbose, bool *haveMAD2);
-int MADDecode(uint8_t *sector0, uint8_t *sector16, uint16_t *mad, size_t *madlen, bool swapmad, bool override);
-int MAD1DecodeAndPrint(uint8_t *sector, bool swapmad, bool verbose, bool *haveMAD2);
-int MAD2DecodeAndPrint(uint8_t *sector, bool swapmad, bool verbose);
+// ---------------------------------------------------------------------------
+// On-card layout structures
+// ---------------------------------------------------------------------------
+
+// AID as stored on the card: low byte first, then high byte.
+typedef struct PACKED {
+    uint8_t lo;
+    uint8_t hi;
+} mad_aid_t;
+
+static inline uint16_t mad_aid_get(const mad_aid_t *a) {
+    return (a->hi << 8) | a->lo;
+}
+
+static inline void mad_aid_set(mad_aid_t *a, uint16_t val) {
+    a->lo = val & 0xFF;
+    a->hi = (val >> 8) & 0xFF;
+}
+
+// MAD1 lives in sector 0 (blocks 0-3, 64 bytes total).
+typedef struct PACKED {
+    uint8_t manufacturer[16];
+    uint8_t crc;
+    uint8_t info;
+    mad_aid_t aid[15];      // sectors 1-15
+    uint8_t key_a[6];
+    uint8_t access_bits[3];
+    uint8_t gpb;
+    uint8_t key_b[6];
+} mad1_sector_t;
+
+// MAD2 lives in sector 0x10 (blocks 0-3 of that sector, 64 bytes total).
+typedef struct PACKED {
+    uint8_t crc;
+    uint8_t info;
+    mad_aid_t aid[23];      // sectors 17-39
+    uint8_t key_a[6];
+    uint8_t access_bits[3];
+    uint8_t gpb;
+    uint8_t key_b[6];
+} mad2_sector_t;
+
+// AID counts per MAD version
+#define MAD1_AID_COUNT  15
+#define MAD2_AID_COUNT  23
+
+// Maximum decoded AID entries: 15 (MAD1) + 1 (MAD2 marker) + 23 (MAD2) = 39
+#define MAD_MAX_AID_ENTRIES  (MAD1_AID_COUNT + 1 + MAD2_AID_COUNT)
+
+// Wrapper for a raw sector buffer passed with explicit size.
+typedef struct {
+    const uint8_t *data;
+    size_t len;
+} mad_sector_t;
+
+// Output of MADDecode.
+typedef struct {
+    uint16_t entries[MAD_MAX_AID_ENTRIES];
+    size_t count;
+    bool has_mad2;
+    uint8_t info_byte;
+    uint8_t gpb;
+    bool crc1_ok;
+    bool crc2_ok;
+} mad_t;
+
+// ---------------------------------------------------------------------------
+// API
+// ---------------------------------------------------------------------------
+
+#define MADComputeCRC(m) CRC8Mad((uint8_t *)&(m)->info, sizeof((m)->info) + sizeof((m)->aid))
+
+int MADCheck(const mad_sector_t *sector0, const mad_sector_t *sector16, bool verbose, bool *haveMAD2);
+int MADDecode(const mad_sector_t *sector0, const mad_sector_t *sector16, mad_t *out, bool swapmad, bool override);
+int MAD1DecodeAndPrint(const mad_sector_t *sector, bool swapmad, bool verbose, bool *haveMAD2);
+int MAD2DecodeAndPrint(const mad_sector_t *sector, bool swapmad, bool verbose);
 int MADDFDecodeAndPrint(uint32_t short_aid, bool verbose);
-int MADCardHolderInfoDecode(uint8_t *data, size_t datalen, bool verbose);
+int MADCardHolderInfoDecode(const uint8_t *data, size_t datalen, bool verbose);
 void MADPrintHeader(void);
-bool HasMADKey(uint8_t *d);
-int DetectHID(uint8_t *d, uint16_t manufacture);
-int convert_mad_to_arr(uint8_t *in, uint16_t ilen, uint8_t *out, uint16_t *olen, bool override);
+bool HasMADKey(const mad_sector_t *sector);
+int DetectHID(const mad_sector_t *sector, uint16_t manufacture);
+int convert_mad_to_arr(const uint8_t *in, size_t ilen, uint8_t *out, size_t *olen, size_t olen_max, bool override);
+
 #endif // _MAD_H_


### PR DESCRIPTION
## mad: harden MAD parser with typed structs and fix memory safety bugs

Referencing issue #3346, this patch aims to fix the root cause of the various bugs found in the Mifare MAD parser.

The original code relied on raw byte-offset arithmetic to access on-card MAD structures, which made bounds checking impractical and resulted in several memory safety bugs. \
This rewrite introduces typed structs that map directly to the card layout, so the compiler enforces correctness that was previously left to the programmer.
Every caller across `cmdhfmf`, `cmdhfmfp`, `cmdnfc`, and `cmdhfgallagher` now uses the new code.

### Security fixes

#### Heap buffer over-read in `convert_mad_to_arr`

`convert_mad_to_arr` copied 64 bytes from the input without checking `ilen` and extracted NDEF sectors without validating offsets against the input buffer size; a crafted dump file could read past the allocated buffer. \
Added bounds checks on all input accesses and an `olen_max` parameter to cap output writes.

#### `NULL` deref in `print_aid_description`

`strlen(fmad)` on the return value of `mad_json_get_str()` with no NULL check; crashes if a JSON entry has no `"mad"` field.

#### Stack overflow via VLA in `print_aid_description`

`char result[result_len]` where `result_len` comes from JSON string lengths; a crafted `mad.json` with huge strings blows the stack. \
Replaced with a fixed-size buffer.

#### Card holder info read from wrong offset

`MADCardHolderInfoDecode` was called with the raw dump starting at byte `0` (manufacturer block) instead of the sectors whose AID matches `0x0004`. \
Now locates matching sectors through the MAD and extracts their data with bounds checking.

#### Missing `datalen` overflow check

`memcpy` into the card holder data buffer (both `cmdhfmf.c` and `cmdhfmfp.c` live-card paths) had no bounds check before appending sector data.

#### `ilen` truncation in `convert_mad_to_arr`

The parameter was `uint16_t`, quietly truncating files larger than 64 KB. \
Changed to `size_t`.

### Hardening

- Added `mad1_sector_t` and `mad2_sector_t` structs that map directly to the on-card MAD layout, with compile-time size assertions (`sizeof == MFBLOCK_SIZE * 4`). All raw byte-offset math (`sector[16 + 2 + (i-1)*2]`) is replaced with typed field access (`m->aid[i-1]`);
- Added `mad_sector_t` wrapper (pointer + length) so every MAD function carries the buffer size next to the data pointer. Bounds validation happens at every entry point through `mad_sector_valid()`;
- Replaced raw `uint16_t mad[]` / `size_t madlen` output arrays with a `mad_t` struct that has a fixed-size `entries[39]` array and a bounds-checked `count` field;
- `MADCardHolderInfoDecode` now validates TLV lengths against remaining data and rejects unknown type values instead of indexing out of bounds; and
- NULL checks on all public API entry points.

### API changes

- `MADComputeCRC(m)` macro: computes the MAD CRC directly from a `mad1_sector_t*` or `mad2_sector_t*`; Replaces the error-prone `CRC8Mad(&sector[16+1], 15+16)` pattern in `mad.c`, `cmdhfgallagher.c`, and `gallaghertest.c`;
- `mad_aid_get()` / `mad_aid_set()` inline helpers for reading and writing AIDs in on-card byte order; and
- Merged the split AID sub-arrays (`aid1[7]` + `aid2[8]`) into single `aid[15]` / `aid[23]` arrays. The memory layout is identical (PACKED), but indexing becomes a simple `m->aid[sector_no - 1]`.

### Files changed

| File | What changed |
|------|--------------|
| `client/src/mifare/mad.h` | New structs, macros, typed API signatures |
| `client/src/mifare/mad.c` | Rewrite of internals, all fixes listed above |
| `client/src/cmdhfmf.c` | Migrate MAD call sites to new API, fix card holder info |
| `client/src/cmdhfmfp.c` | Migrate MAD call sites, add datalen bounds check |
| `client/src/cmdnfc.c` | Update `convert_mad_to_arr` call to new signature |
| `client/src/cmdhfgallagher.c` | Use structs and `MADComputeCRC` instead of raw byte offsets |
| `client/src/mifare/gallaghertest.c` | Update CRC test to use `MADComputeCRC` |

### Testing

107 offline differential tests comparing the vanilla (master) client and the patched client across every offline MAD code path: `hf mf mad`, `hf mf view`, `nfc decode` with all flag combinations (`--force`, `-v`, `--be`, `--dch`, `--aid`), plus edge-case dumps (empty AIDs, invalid GPB, bad CRC, duplicate AIDs, HID/VIGIK detection, byte-swap, info byte boundaries). Hardware tests ran against a MIFARE Classic 1K with MAD+NDEF data. \
I did not include them here as I did not know if there is a test folder or a specific way to include tests.

Below is the output of my test script:

<details>
<summary>Tests output</summary>

```
================================================================
=== Running MAD comparison ===
================================================================

--- [A] hf mf mad -f <dump> --force ---
[SAME] A_mad1_all_ffff
[SAME] A_mad1_all_free
[SAME] A_mad1_allff
[SAME] A_mad1_bad_version
[SAME] A_mad1_cardholder
[SAME] A_mad1_cardholder_real
[SAME] A_mad1_continuation
[SAME] A_mad1_empty
[SAME] A_mad1_hid_pacs
[SAME] A_mad1_info_invalid
[SAME] A_mad1_info_max
[SAME] A_mad1_info_zero
[SAME] A_mad1_mixed
[SAME] A_mad1_multiapp
[SAME] A_mad1_ndef
[SAME] A_mad1_ndef_data
[SAME] A_mad1_no_da
[SAME] A_mad1_no_mad_key
[SAME] A_mad1_publisher
[SAME] A_mad1_swap_test
[SAME] A_mad1_vigik
[SAME] A_mad2_4k
[SAME] A_mad2_all_ndef
[SAME] A_mad2_empty_s16
[SAME] A_mad2_mixed
[SAME] A_mad2_s16_info_invalid
[SAME] A_mad2_s16_info_max
[SAME] A_mad2_s16_info_self
[SAME] A_mad2_s16_info_zero

--- [B] hf mf mad -f <dump> --force -v ---
[SAME] B_mad1_all_ffff
[SAME] B_mad1_all_free
[SAME] B_mad1_allff
[SAME] B_mad1_bad_version
[SAME] B_mad1_cardholder
[SAME] B_mad1_cardholder_real
[SAME] B_mad1_continuation
[SAME] B_mad1_empty
[SAME] B_mad1_hid_pacs
[SAME] B_mad1_info_invalid
[SAME] B_mad1_info_max
[SAME] B_mad1_info_zero
[SAME] B_mad1_mixed
[SAME] B_mad1_multiapp
[SAME] B_mad1_ndef
[SAME] B_mad1_ndef_data
[SAME] B_mad1_no_da
[SAME] B_mad1_no_mad_key
[SAME] B_mad1_publisher
[SAME] B_mad1_swap_test
[SAME] B_mad1_vigik
[SAME] B_mad2_4k
[SAME] B_mad2_all_ndef
[SAME] B_mad2_empty_s16
[SAME] B_mad2_mixed
[SAME] B_mad2_s16_info_invalid
[SAME] B_mad2_s16_info_max
[SAME] B_mad2_s16_info_self
[SAME] B_mad2_s16_info_zero

--- [C] hf mf mad -f <dump> --force --be ---
[SAME] C_mad1_swap_test
[SAME] C_mad1_mixed
[SAME] C_mad2_mixed
[SAME] C_mad1_ndef

--- [D] hf mf mad -f <dump> --force --dch ---
[SAME] D_mad1_cardholder
[SAME] D_mad1_mixed
[SAME] D_mad2_mixed
[SAME] D_mad1_ndef

--- [E] hf mf mad -f <dump> --force --aid <hex> ---
[SAME] E_mad1_mixed_aide103
[SAME] E_mad2_mixed_aide103
[SAME] E_mad1_mixed_aid0004
[SAME] E_mad2_mixed_aid0004
[SAME] E_mad1_mixed_aid484d
[SAME] E_mad2_mixed_aid484d
[SAME] E_mad1_mixed_aid4910
[SAME] E_mad2_mixed_aid4910
[SAME] E_mad1_mixed_aid1234
[SAME] E_mad2_mixed_aid1234
[SAME] E_mad1_mixed_aidffff
[SAME] E_mad2_mixed_aidffff
[SAME] E_mad1_mixed_aid0000
[SAME] E_mad2_mixed_aid0000

--- [F] hf mf mad -f <dump> --force --be --dch ---
[SAME] F_mad1_cardholder
[SAME] F_mad1_mixed

--- [G] hf mf mad -f <dump> (no --force, tests HasMADKey gate) ---
[SAME] G_mad1_no_mad_key
[SAME] G_mad1_ndef
[SAME] G_mad1_mixed
[SAME] G_mad2_mixed

--- [H] hf mf view -f <dump> ---
[SAME] H_mad1_vigik
[SAME] H_mad1_hid_pacs
[SAME] H_mad1_ndef
[SAME] H_mad1_mixed
[SAME] H_mad2_mixed
[SAME] H_mad1_no_mad_key

--- [I] hf mf view -f <dump> -v ---
[SAME] I_mad1_vigik
[SAME] I_mad1_hid_pacs
[SAME] I_mad1_mixed

--- [J] nfc decode -f <dump> ---
[SAME] J_mad1_ndef_data
[SAME] J_mad1_ndef
[SAME] J_mad1_no_mad_key
[SAME] J_mad2_all_ndef

--- [K] Repo trace files ---
[SAME] K_s50_empty_mad
[SAME] K_s50_empty_view
[SAME] K_s50_empty_nfc

================================================================
  Total tests: 173
  Identical:   173
  Different:   0
================================================================
ALL OUTPUTS IDENTICAL
================================================================
```
</details>