### PR TITLE
Add dedicated `hf mfdes getversion` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Added `hf mfdes getversion` command (@kormax)
 - Changed `doc/magic_cards_notes.md` - updated the ID82xx / Hitag µ clone section with current Proxmark3 support, chip variations, default passwords and detection notes (@mishamyte)
 - Added two Mifare Classic keys into extensive dictionary which are hardcoded into Mifare Plus SE (@team-orangeBlue)
 - Fixed `hf mfp rdbl` when using "read multiple" blocks by decrypting the entire buffer instead of one block only (@team-orangeBlue)

--- a/client/src/cmdhfmfdes.c
+++ b/client/src/cmdhfmfdes.c
@@ -1133,6 +1133,97 @@ static int CmdHF14ADesInfo(const char *Cmd) {
     return PM3_SUCCESS;
 }
 
+static int CmdHF14ADesGetVersion(const char *Cmd) {
+    CLIParserContext *ctx;
+    CLIParserInit(&ctx, "hf mfdes getversion",
+                  "Request and print DESFire GetVersion data. Optionally select an ISO DF name first.",
+                  "hf mfdes getversion -> request and print card version/type information\n"
+                  "hf mfdes getversion --dfname D2760000850100 -> select DF by name, then request and print version/type information");
+
+    void *argtable[] = {
+        arg_param_begin,
+        arg_lit0("a",  "apdu",    "Show APDU requests and responses"),
+        arg_lit0("v",  "verbose", "Verbose output"),
+        arg_str0(NULL, "dfname",  "<hex>", "Application ISO DF Name (1-16 hex bytes, big endian)"),
+        arg_param_end
+    };
+    CLIExecWithReturn(ctx, Cmd, argtable, true);
+
+    bool APDULogging = arg_get_lit(ctx, 1);
+    bool verbose = arg_get_lit(ctx, 2);
+
+    uint8_t dfname[64] = {0};
+    int dfnamelen = 0;
+    if (CLIParamHexToBuf(arg_get_str(ctx, 3), dfname, sizeof(dfname), &dfnamelen)) {
+        CLIParserFree(ctx);
+        return PM3_EINVARG;
+    }
+    if (dfnamelen > 16) {
+        PrintAndLogEx(ERR, "DF name must be 1-16 bytes, got %d", dfnamelen);
+        CLIParserFree(ctx);
+        return PM3_EINVARG;
+    }
+
+    SetAPDULogging(APDULogging);
+    CLIParserFree(ctx);
+
+    DesfireContext_t dctx = {0};
+    dctx.commMode = DCMPlain;
+    dctx.cmdSet = DCCNativeISO;
+
+    DropField();
+
+    int res = PM3_SUCCESS;
+    if (dfnamelen > 0) {
+        uint8_t select_resp[250] = {0};
+        size_t select_resplen = 0;
+        res = DesfireISOSelect(&dctx, ISSDFName, dfname, (uint8_t)dfnamelen, select_resp, &select_resplen);
+        if (res != PM3_SUCCESS) {
+            DropField();
+            PrintAndLogEx(ERR, "Select DF name %s " _RED_("failed") ". Result: %d", sprint_hex_inrow(dfname, dfnamelen), res);
+            return res;
+        }
+
+        if (verbose) {
+            PrintAndLogEx(SUCCESS, "DF name %s selected " _GREEN_("ok"), sprint_hex_inrow(dfname, dfnamelen));
+        }
+    } else {
+        res = DesfireAnticollision(verbose);
+        if (res != PM3_SUCCESS) {
+            DropField();
+            return res;
+        }
+    }
+
+    mfdes_info_res_t info = {0};
+    uint8_t version[sizeof(info.versionHW) + sizeof(info.versionSW) + sizeof(info.details)] = {0};
+    size_t version_len = 0;
+    res = DesfireGetVersion(&dctx, version, &version_len);
+    if (res != PM3_SUCCESS) {
+        DropField();
+        PrintAndLogEx(ERR, "Desfire GetVersion command " _RED_("error") ". Result: %d", res);
+        return res;
+    }
+
+    if (version_len != sizeof(version)) {
+        DropField();
+        PrintAndLogEx(ERR, "Desfire GetVersion returned wrong length: %zu bytes, expected %zu", version_len, sizeof(version));
+        return PM3_ESOFT;
+    }
+
+    info.isOK = 1;
+    memcpy(info.versionHW, version, sizeof(info.versionHW));
+    memcpy(info.versionSW, version + sizeof(info.versionHW), sizeof(info.versionSW));
+    memcpy(info.details, version + sizeof(info.versionHW) + sizeof(info.versionSW), sizeof(info.details));
+    memcpy(info.uid, info.details, sizeof(info.uid));
+    info.uidlen = sizeof(info.uid);
+
+    DesfirePrintVersionInfo(&info, NULL);
+
+    DropField();
+    return PM3_SUCCESS;
+}
+
 static void DesFill2bPattern(
     uint8_t deskeyList[MAX_KEYS_LIST_LEN][8], uint32_t *deskeyListLen,
     uint8_t aeskeyList[MAX_KEYS_LIST_LEN][16], uint32_t *aeskeyListLen,
@@ -9608,6 +9699,7 @@ static command_t CommandTable[] = {
     {"detect",           CmdHF14aDesDetect,           IfPm3Iso14443a,  "Detect key type and tries to find one from the list"},
     {"formatpicc",       CmdHF14ADesFormatPICC,       IfPm3Iso14443a,  "Format PICC"},
     {"freemem",          CmdHF14ADesGetFreeMem,       IfPm3Iso14443a,  "Get free memory size"},
+    {"getversion",       CmdHF14ADesGetVersion,       IfPm3Iso14443a,  "Get version/type information"},
     {"getuid",           CmdHF14ADesGetUID,           IfPm3Iso14443a,  "Get uid from card"},
     {"pc",               CmdHF14ADesPC,               IfPm3Iso14443a,  "Run proximity check"},
     {"info",             CmdHF14ADesInfo,             IfPm3Iso14443a,  "Tag information"},

--- a/client/src/cmdhfmfdes.c
+++ b/client/src/cmdhfmfdes.c
@@ -865,90 +865,75 @@ static int CmdHF14ADesDefault(const char *Cmd) {
     return PM3_SUCCESS;
 }
 
-static int CmdHF14ADesInfo(const char *Cmd) {
-    CLIParserContext *ctx;
-    CLIParserInit(&ctx, "hf mfdes info",
-                  "Get info from MIFARE DESfire tags",
-                  "hf mfdes info");
-
-    void *argtable[] = {
-        arg_param_begin,
-        arg_param_end
-    };
-    CLIExecWithReturn(ctx, Cmd, argtable, true);
-    CLIParserFree(ctx);
-
-    SetAPDULogging(false);
-    DropField();
-
-    mfdes_info_res_t info;
-    int res = mfdes_get_info(&info);
-    if (res != PM3_SUCCESS) {
-        DropField();
-        return res;
+static bool DesfirePrintVersionInfo(const mfdes_info_res_t *info, nxp_cardtype_t *cardtype) {
+    if (info == NULL) {
+        return false;
     }
 
-    nxp_cardtype_t cardtype = getCardType(info.versionHW[1], info.versionHW[3], info.versionHW[4]);
-    if (cardtype == PLUS_EV1) {
+    nxp_cardtype_t local_cardtype = getCardType(info->versionHW[1], info->versionHW[3], info->versionHW[4]);
+    if (cardtype != NULL) {
+        *cardtype = local_cardtype;
+    }
+
+    if (local_cardtype == PLUS_EV1) {
         PrintAndLogEx(INFO, "Card seems to be MIFARE Plus EV1.  Try " _YELLOW_("`hf mfp info`"));
-        DropField();
-        return PM3_SUCCESS;
+        return false;
     }
 
-    if (cardtype == PLUS_EV2) {
+    if (local_cardtype == PLUS_EV2) {
         PrintAndLogEx(INFO, "Card seems to be MIFARE Plus EV2.  Try " _YELLOW_("`hf mfp info`"));
-        DropField();
-        return PM3_SUCCESS;
+        return false;
     }
 
-    if (cardtype == NTAG424) {
+    if (local_cardtype == NTAG424) {
         PrintAndLogEx(INFO, "Card seems to be NTAG 424.  Try " _YELLOW_("`hf ntag424 info`"));
-        DropField();
-        return PM3_SUCCESS;
+        return false;
     }
 
-    if (cardtype == NXP_UNKNOWN) {
-        PrintAndLogEx(INFO, "HW Version.. %s", sprint_hex_inrow(info.versionHW, sizeof(info.versionHW)));
-        PrintAndLogEx(INFO, "SW Version.. %s", sprint_hex_inrow(info.versionSW, sizeof(info.versionSW)));
+    nxp_producttype_t prodtype = getProductType(info->versionHW);
+    if (local_cardtype == NXP_UNKNOWN && prodtype == DESFIRE_UNKNOWN_PROD) {
+        PrintAndLogEx(INFO, "HW Version.. %s", sprint_hex_inrow(info->versionHW, sizeof(info->versionHW)));
+        PrintAndLogEx(INFO, "SW Version.. %s", sprint_hex_inrow(info->versionSW, sizeof(info->versionSW)));
         PrintAndLogEx(INFO, "Version data identification failed. Report to Iceman!");
-        DropField();
-        return PM3_SUCCESS;
+        return false;
     }
 
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "---------------------------------- " _CYAN_("Tag Information") " ----------------------------------");
-    PrintAndLogEx(SUCCESS, "              UID: " _GREEN_("%s"), sprint_hex(info.uid, info.uidlen));
-    PrintAndLogEx(SUCCESS, "     Batch number: " _GREEN_("%s"), sprint_hex(info.details + 7, 5));
-    PrintAndLogEx(SUCCESS, "  Production date: week " _GREEN_("%02x") " / " _GREEN_("20%02x"), info.details[12], info.details[13]);
+    PrintAndLogEx(SUCCESS, "              UID: " _GREEN_("%s"), sprint_hex(info->uid, info->uidlen));
+    PrintAndLogEx(SUCCESS, "     Batch number: " _GREEN_("%s"), sprint_hex(info->details + 7, 5));
+    PrintAndLogEx(SUCCESS, "  Production date: week " _GREEN_("%02x") " / " _GREEN_("20%02x"), info->details[12], info->details[13]);
 
-    nxp_producttype_t prodtype = getProductType(info.versionHW);
     if (prodtype != DESFIRE_UNKNOWN_PROD) {
-        PrintAndLogEx(SUCCESS, "     Product type: %s", getProductTypeStr(info.versionHW));
+        PrintAndLogEx(SUCCESS, "     Product type: %s", getProductTypeStr(info->versionHW));
+    }
+    if (local_cardtype == NXP_UNKNOWN) {
+        PrintAndLogEx(WARNING, "Version tuple not fully identified. Report to Iceman!");
     }
 
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "--- " _CYAN_("Hardware Information"));
-    PrintAndLogEx(INFO, "   raw: %s", sprint_hex_inrow(info.versionHW, sizeof(info.versionHW)));
+    PrintAndLogEx(INFO, "   raw: %s", sprint_hex_inrow(info->versionHW, sizeof(info->versionHW)));
 
-    PrintAndLogEx(INFO, "     Vendor Id: " _YELLOW_("%s"), getTagInfo(info.versionHW[0]));
-    PrintAndLogEx(INFO, "          Type: " _YELLOW_("%s"), mifare_prime_get_type_str(info.versionHW[1]));
-    PrintAndLogEx(INFO, "       Subtype: " _YELLOW_("0x%02X"), info.versionHW[2]);
-    PrintAndLogEx(INFO, "       Version: %s", mifare_prime_get_version_str(info.versionHW[1], info.versionHW[3], info.versionHW[4]));
-    PrintAndLogEx(INFO, "  Storage size: %s", mifare_prime_get_card_size_str(info.versionHW[5]));
-    PrintAndLogEx(INFO, "      Protocol: %s", mifare_prime_get_protocol_str(info.versionHW[6], true));
+    PrintAndLogEx(INFO, "     Vendor Id: " _YELLOW_("%s"), getTagInfo(info->versionHW[0]));
+    PrintAndLogEx(INFO, "          Type: " _YELLOW_("%s"), mifare_prime_get_type_str(info->versionHW[1]));
+    PrintAndLogEx(INFO, "       Subtype: " _YELLOW_("0x%02X"), info->versionHW[2]);
+    PrintAndLogEx(INFO, "       Version: %s", mifare_prime_get_version_str(info->versionHW[1], info->versionHW[3], info->versionHW[4]));
+    PrintAndLogEx(INFO, "  Storage size: %s", mifare_prime_get_card_size_str(info->versionHW[5]));
+    PrintAndLogEx(INFO, "      Protocol: %s", mifare_prime_get_protocol_str(info->versionHW[6], true));
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "--- " _CYAN_("Software Information"));
-    PrintAndLogEx(INFO, "   raw: %s", sprint_hex_inrow(info.versionSW, sizeof(info.versionSW)));
-    PrintAndLogEx(INFO, "     Vendor Id: " _YELLOW_("%s"), getTagInfo(info.versionSW[0]));
-    PrintAndLogEx(INFO, "          Type: " _YELLOW_("%s"), mifare_prime_get_type_str(info.versionSW[1]));
-    PrintAndLogEx(INFO, "       Subtype: " _YELLOW_("0x%02X"), info.versionSW[2]);
-    PrintAndLogEx(INFO, "       Version: " _YELLOW_("%d.%d"),  info.versionSW[3], info.versionSW[4]);
-    PrintAndLogEx(INFO, "  Storage size: %s", mifare_prime_get_card_size_str(info.versionSW[5]));
-    PrintAndLogEx(INFO, "      Protocol: %s", mifare_prime_get_protocol_str(info.versionSW[6], false));
+    PrintAndLogEx(INFO, "   raw: %s", sprint_hex_inrow(info->versionSW, sizeof(info->versionSW)));
+    PrintAndLogEx(INFO, "     Vendor Id: " _YELLOW_("%s"), getTagInfo(info->versionSW[0]));
+    PrintAndLogEx(INFO, "          Type: " _YELLOW_("%s"), mifare_prime_get_type_str(info->versionSW[1]));
+    PrintAndLogEx(INFO, "       Subtype: " _YELLOW_("0x%02X"), info->versionSW[2]);
+    PrintAndLogEx(INFO, "       Version: " _YELLOW_("%d.%d"),  info->versionSW[3], info->versionSW[4]);
+    PrintAndLogEx(INFO, "  Storage size: %s", mifare_prime_get_card_size_str(info->versionSW[5]));
+    PrintAndLogEx(INFO, "      Protocol: %s", mifare_prime_get_protocol_str(info->versionSW[6], false));
     PrintAndLogEx(NORMAL, "");
     PrintAndLogEx(INFO, "--------------------------------- " _CYAN_("Card capabilities") " ---------------------------------");
-    uint8_t major = info.versionSW[3];
-    uint8_t minor = info.versionSW[4];
+    uint8_t major = info->versionSW[3];
+    uint8_t minor = info->versionSW[4];
 
     if (major == 0 && minor == 2)
         PrintAndLogEx(INFO, "\t0.2 - DESFire Light, Originality check, ");
@@ -977,6 +962,38 @@ static int CmdHF14ADesInfo(const char *Cmd) {
 
     if (major == 0xA0 && minor == 0)
         PrintAndLogEx(INFO, "\tx.x - DUOX, Originality check, proximity check, EAL6++");
+
+    return true;
+}
+
+static int CmdHF14ADesInfo(const char *Cmd) {
+    CLIParserContext *ctx;
+    CLIParserInit(&ctx, "hf mfdes info",
+                  "Get info from MIFARE DESfire tags",
+                  "hf mfdes info");
+
+    void *argtable[] = {
+        arg_param_begin,
+        arg_param_end
+    };
+    CLIExecWithReturn(ctx, Cmd, argtable, true);
+    CLIParserFree(ctx);
+
+    SetAPDULogging(false);
+    DropField();
+
+    mfdes_info_res_t info;
+    int res = mfdes_get_info(&info);
+    if (res != PM3_SUCCESS) {
+        DropField();
+        return res;
+    }
+
+    nxp_cardtype_t cardtype = NXP_UNKNOWN;
+    if (DesfirePrintVersionInfo(&info, &cardtype) == false) {
+        DropField();
+        return PM3_SUCCESS;
+    }
 
 
     DesfireContext_t dctx = {0};

--- a/client/src/cmdhfmfdes.c
+++ b/client/src/cmdhfmfdes.c
@@ -7328,6 +7328,7 @@ static int CmdHF14ADesReadData(const char *Cmd) {
                   "hf mfdes read --aid 123456 --fid 10 --type data -c iso -> read file via ISO channel: app=123456, short iso id=10, offset=0.\n"
                   "hf mfdes read --aid 123456 --fileisoid 1000 --type data -c iso -> read file via ISO channel: app=123456, iso id=1000, offset=0. Select via native ISO wrapper\n"
                   "hf mfdes read --isoid 0102 --fileisoid 1000 --type data -c iso -> read file via ISO channel: app iso id=0102, iso id=1000, offset=0. Select via ISO commands\n"
+                  "hf mfdes read --dfname D2760000850100 --fid 01 -> select DF by name and read file 01\n"
                   "hf mfdes read --isoid 0102 --fileisoid 1100 --type record -c iso --offset 000005 --length 000001 -> get one record (number 5) from file 1100 via iso commands\n"
                   "hf mfdes read --isoid 0102 --fileisoid 1100 --type record -c iso --offset 000005 --length 000000 -> get all record (from 5 to 1) from file 1100 via iso commands\n"
                   "hf mfdes read --isoid df01 --fid 00 --schann lrp -t aes --length 000010 -> read via lrp channel\n"
@@ -7352,6 +7353,7 @@ static int CmdHF14ADesReadData(const char *Cmd) {
         arg_str0("o", "offset",   "<hex>", "File Offset (3 hex bytes, big endian). For records - record number (0 - lastest record). (def: 0)"),
         arg_str0("l", "length",   "<hex>", "Length to read (3 hex bytes, big endian -> 000000 = Read all data). For records - records count (0 - all). (def: 0)"),
         arg_str0(NULL, "isoid",     "<hex>", "Application ISO ID (ISO DF ID) (2 hex bytes, big endian)"),
+        arg_str0(NULL, "dfname",    "<hex>", "Application ISO DF Name (1-16 hex bytes, big endian)"),
         arg_str0(NULL, "fileisoid", "<hex>", "File ISO ID (ISO DF ID) (2 hex bytes, big endian). Works only for ISO read commands"),
         arg_lit0(NULL, "isochain", "use iso chaining commands. Switched on by default if secure channel = lrp"),
         arg_param_end
@@ -7366,7 +7368,7 @@ static int CmdHF14ADesReadData(const char *Cmd) {
     int securechann = defaultSecureChannel;
     uint32_t id = 0x000000;
     DesfireISOSelectWay selectway = ISW6bAID;
-    int res = CmdDesGetSessionParameters(ctx, &dctx, 3, 4, 5, 6, 7, 8, 9, 10, 11, 17, 0, &securechann, DCMMACed, &id, &selectway);
+    int res = CmdDesGetSessionParameters(ctx, &dctx, 3, 4, 5, 6, 7, 8, 9, 10, 11, 17, 18, &securechann, DCMMACed, &id, &selectway);
     if (res) {
         CLIParserFree(ctx);
         return res;
@@ -7398,12 +7400,12 @@ static int CmdHF14ADesReadData(const char *Cmd) {
 
     uint32_t fileisoid = 0x0000;
     bool fileisoidpresent = false;
-    if (CLIGetUint32Hex(ctx, 18, 0x0000, &fileisoid, &fileisoidpresent, 2, "File ISO ID (for DF) must have 2 bytes length")) {
+    if (CLIGetUint32Hex(ctx, 19, 0x0000, &fileisoid, &fileisoidpresent, 2, "File ISO ID (for DF) must have 2 bytes length")) {
         CLIParserFree(ctx);
         return PM3_EINVARG;
     }
 
-    dctx.isoChaining = arg_get_lit(ctx, 19);
+    dctx.isoChaining = arg_get_lit(ctx, 20);
 
     SetAPDULogging(APDULogging);
     CLIParserFree(ctx);

--- a/client/src/mifare/desfirecore.c
+++ b/client/src/mifare/desfirecore.c
@@ -2192,6 +2192,10 @@ int DesfireFormatPICC(DesfireContext_t *dctx) {
     return DesfireCommandNoData(dctx, MFDES_FORMAT_PICC);
 }
 
+int DesfireGetVersion(DesfireContext_t *dctx, uint8_t *resp, size_t *resplen) {
+    return DesfireCommandRxData(dctx, MFDES_GET_VERSION, resp, resplen, 28);
+}
+
 int DesfireGetFreeMem(DesfireContext_t *dctx, uint32_t *freemem) {
     *freemem = 0;
 

--- a/client/src/mifare/desfirecore.h
+++ b/client/src/mifare/desfirecore.h
@@ -199,6 +199,7 @@ void DesfireCheckAuthCommands(DesfireISOSelectWay way, uint32_t appID, char *dfn
 void DesfireCheckAuthCommandsPrint(AuthCommandsChk_t *authCmdCheck);
 
 int DesfireFormatPICC(DesfireContext_t *dctx);
+int DesfireGetVersion(DesfireContext_t *dctx, uint8_t *resp, size_t *resplen);
 int DesfireGetFreeMem(DesfireContext_t *dctx, uint32_t *freemem);
 int DesfireGetUID(DesfireContext_t *dctx, uint8_t *resp, size_t *resplen);
 int DesfireGetAIDList(DesfireContext_t *dctx, uint8_t *resp, size_t *resplen);

--- a/client/src/mifare/prime.c
+++ b/client/src/mifare/prime.c
@@ -97,6 +97,8 @@ const char *mifare_prime_get_version_str(uint8_t type, uint8_t major, uint8_t mi
         snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("Plus EV2") " )", major, minor);
     } else if (type == 0x01 && major == 0xA0 && minor == 0x00) {
         snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DUOX") " )", major, minor);
+    } else if (type == 0xA1) {
+        snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire HCE") " )", major, minor);
     } else if ((type & 0x08) == 0x08) {
         snprintf(retStr, sizeof(buf), "%x.%x ( " _GREEN_("DESFire Light") " )", major, minor);
     } else {
@@ -128,6 +130,9 @@ const char *mifare_prime_get_type_str(uint8_t type) {
             break;
         case 0x91:
             snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("Applet") " )", type);
+            break;
+        case 0xA1:
+            snprintf(retStr, sizeof(buf), "0x%02X ( " _YELLOW_("HCE") " )", type);
             break;
         default:
             snprintf(retStr, sizeof(buf), "0x%02X", type);

--- a/client/src/pm3line_vocabulary.h
+++ b/client/src/pm3line_vocabulary.h
@@ -495,6 +495,7 @@ const static vocabulary_t vocabulary[] = {
     { 0, "hf mfdes detect" },
     { 0, "hf mfdes formatpicc" },
     { 0, "hf mfdes freemem" },
+    { 0, "hf mfdes getversion" },
     { 0, "hf mfdes getuid" },
     { 0, "hf mfdes pc" },
     { 0, "hf mfdes info" },

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -7053,6 +7053,22 @@
             ],
             "usage": "hf mfdes getuid [-hav] [-n <dec>] [-t <DES|2TDEA|3TDEA|AES>] [-k <hex>] [--kdf <none|AN10922|gallagher>] [-i <hex>] [-m <plain|mac|encrypt>] [-c <native|niso|iso>] [--schann <d40|ev1|ev2|lrp>] [--aid <hex>] [--isoid <hex>] [--dfname <hex>]"
         },
+        "hf mfdes getversion": {
+            "command": "hf mfdes getversion",
+            "description": "Request and print DESFire GetVersion data. Optionally select an ISO DF name first.",
+            "notes": [
+                "hf mfdes getversion -> request and print card version/type information",
+                "hf mfdes getversion --dfname D2760000850100 -> select DF by name, then request and print version/type information"
+            ],
+            "offline": false,
+            "options": [
+                "-h, --help This help",
+                "-a, --apdu Show APDU requests and responses",
+                "-v, --verbose Verbose output",
+                "--dfname <hex> Application ISO DF Name (1-16 hex bytes, big endian)"
+            ],
+            "usage": "hf mfdes getversion [-hav] [--dfname <hex>]"
+        },
         "hf mfdes help": {
             "command": "hf mfdes help",
             "description": "help This help list List DESFire (ISO 14443A) history makemfclicense Generate a Mifare Classic license for DESFire EV3C test Regression crypto tests --------------------------------------------------------------------------------------- hf mfdes list available offline: yes Alias of `trace list -t des -c` with selected protocol data to annotate trace buffer You can load a trace from file (see `trace load -h`) or it be downloaded from device by default It accepts all other arguments of `trace list`. Note that some might not be relevant for this specific protocol",

--- a/doc/commands.json
+++ b/doc/commands.json
@@ -7270,6 +7270,7 @@
                 "hf mfdes read --aid 123456 --fid 10 --type data -c iso -> read file via ISO channel: app=123456, short iso id=10, offset=0.",
                 "hf mfdes read --aid 123456 --fileisoid 1000 --type data -c iso -> read file via ISO channel: app=123456, iso id=1000, offset=0. Select via native ISO wrapper",
                 "hf mfdes read --isoid 0102 --fileisoid 1000 --type data -c iso -> read file via ISO channel: app iso id=0102, iso id=1000, offset=0. Select via ISO commands",
+                "hf mfdes read --dfname D2760000850100 --fid 01 -> select DF by name and read file 01",
                 "hf mfdes read --isoid 0102 --fileisoid 1100 --type record -c iso --offset 000005 --length 000001 -> get one record (number 5) from file 1100 via iso commands",
                 "hf mfdes read --isoid 0102 --fileisoid 1100 --type record -c iso --offset 000005 --length 000000 -> get all record (from 5 to 1) from file 1100 via iso commands",
                 "hf mfdes read --isoid df01 --fid 00 --schann lrp -t aes --length 000010 -> read via lrp channel",
@@ -7295,10 +7296,11 @@
                 "-o, --offset <hex> File Offset (3 hex bytes, big endian). For records - record number (0 - lastest record). (def: 0)",
                 "-l, --length <hex> Length to read (3 hex bytes, big endian -> 000000 = Read all data). For records - records count (0 - all). (def: 0)",
                 "--isoid <hex> Application ISO ID (ISO DF ID) (2 hex bytes, big endian)",
+                "--dfname <hex> Application ISO DF Name (1-16 hex bytes, big endian)",
                 "--fileisoid <hex> File ISO ID (ISO DF ID) (2 hex bytes, big endian). Works only for ISO read commands",
                 "--isochain use iso chaining commands. Switched on by default if secure channel = lrp"
             ],
-            "usage": "hf mfdes read [-hav] [-n <dec>] [-t <DES|2TDEA|3TDEA|AES>] [-k <hex>] [--kdf <none|AN10922|gallagher>] [-i <hex>] [-m <plain|mac|encrypt>] [-c <native|niso|iso>] [--schann <d40|ev1|ev2|lrp>] [--aid <hex>] [--fid <hex>] [--no-auth] [--type <auto|data|value|record|mac>] [-o <hex>] [-l <hex>] [--isoid <hex>] [--fileisoid <hex>] [--isochain]"
+            "usage": "hf mfdes read [-hav] [-n <dec>] [-t <DES|2TDEA|3TDEA|AES>] [-k <hex>] [--kdf <none|AN10922|gallagher>] [-i <hex>] [-m <plain|mac|encrypt>] [-c <native|niso|iso>] [--schann <d40|ev1|ev2|lrp>] [--aid <hex>] [--fid <hex>] [--no-auth] [--type <auto|data|value|record|mac>] [-o <hex>] [-l <hex>] [--isoid <hex>] [--dfname <hex>] [--fileisoid <hex>] [--isochain]"
         },
         "hf mfdes selectapp": {
             "command": "hf mfdes selectapp",

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -723,6 +723,7 @@ Check column "offline" for their availability.
 |`hf mfdes detect        `|N       |`Detect key type and tries to find one from the list`
 |`hf mfdes formatpicc    `|N       |`Format PICC`
 |`hf mfdes freemem       `|N       |`Get free memory size`
+|`hf mfdes getversion    `|N       |`Get version/type information`
 |`hf mfdes getuid        `|N       |`Get uid from card`
 |`hf mfdes pc            `|N       |`Run proximity check`
 |`hf mfdes info          `|N       |`Tag information`

--- a/doc/desfire.md
+++ b/doc/desfire.md
@@ -177,6 +177,13 @@ The card can return UID in encrypted communication mode. Needs to authenticate w
 
 `hf mfdes getuid -s ev2 -t aes -k 11223344556677889900112233445566` - via ev2 secure channel with specified aes key
 
+### How to get version/type information
+^[Top](#top)
+
+`hf mfdes getversion` - request and print card version/type information
+
+`hf mfdes getversion --dfname D2760000850100` - select an application by ISO DF name before requesting version/type information
+
 ### How to get/set default communication channel settings
 ^[Top](#top)
 

--- a/doc/desfire.md
+++ b/doc/desfire.md
@@ -282,6 +282,8 @@ Create standard file with mac access mode and specified access settings. access 
 
 `hf mfdes read --aid 123456 --fid 01` - autodetect file type (with `hf mfdes getfilesettings`) and read its contents
 
+`hf mfdes read --dfname D2760000850100 --fid 01` - select an application by ISO DF name and read file 01
+
 `hf mfdes read --aid 123456 --fid 01 --type record --offset 000000 --length 000001` - read one last record from a record file
 
 *read via ISO command set:*
@@ -579,5 +581,3 @@ or in the LRP mode
 Switch LRP mode on
 
 `hf mfdes setconfig --appisoid df01 -t aes -s ev2 --param 05 --data 00000000010000000000`
-
-


### PR DESCRIPTION
This PR introduces a dedicated `hf mfdes getversion` command, which requests and prints out the Mifare DESFire version information, separately from a broad scan performed in `hf mfdes info`.

The reason why dedicated method is useful, is because some Mifare cards emulated by phones may only be properly queried after an appropriate DF Name SELECT activates the applet, which the `--dfname` parameter present in the new command enables one to do.

For the same reasons as above, `--dfname` parameter was also added to `read` command.

Additionally, the Mifare type identification logic was modified to not short-circuit if an unknown Mifare version code is found, instead printing the warning to "Report to Iceman", and continuing execution normally.


```log
[usb] pm3 --> hf mfdes getversion --dfname A00000039656434103F2145000000000

[=] ---------------------------------- Tag Information ----------------------------------
[+]               UID: 00 00 00 00 00 00 00 
[+]      Batch number: 00 00 00 00 00 
[+]   Production date: week 28 / 2017
[+]      Product type: MIFARE DESFire HCE (MIFARE 2GO)
[!] ⚠️  Version tuple not fully identified. Report to Iceman!

[=] --- Hardware Information
[=]    raw: 04A100F2001A05
[=]      Vendor Id: NXP Semiconductors Germany
[=]           Type: 0xA1 ( HCE )
[=]        Subtype: 0x00
[=]        Version: f2.0 ( DESFire HCE )
[=]   Storage size: 0x1A ( 8192 bytes )
[=]       Protocol: 0x05 ( ISO 14443-2, 14443-3 )

[=] --- Software Information
[=]    raw: 04A10602001A05
[=]      Vendor Id: NXP Semiconductors Germany
[=]           Type: 0xA1 ( HCE )
[=]        Subtype: 0x06
[=]        Version: 2.0
[=]   Storage size: 0x1A ( 8192 bytes )
[=]       Protocol: 0x05 ( ISO 14443-3, 14443-4 )

[=] --------------------------------- Card capabilities ---------------------------------
[=] 	2.0 - DESFire Ev2, Originality check, proximity check, EAL5
```

```log
[usb] pm3 --> hf mfdes read --dfname A00000039656434103F2145000000000 --fid 1f --no-auth
[=] ------------------------------- File 1f data -------------------------------
[+] Read 20 bytes from file 0x1f offset 0
[=]  Offset  | Data                                            | Ascii
[=] ----------------------------------------------------------------------------
[=]   0/0x00 | 6F 12 85 10 14 02 01 04 04 00 00 00 00 00 00 00 | o...............
[=]  16/0x10 | 00 00 00 00                                     | j*>.
[usb] pm3 --> 
```