### PR TITLE
Added signal passing to stop capture

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1857,13 +1857,13 @@ static void PacketReceived(PacketCommandNG *packet) {
             break;
         }
         case CMD_HF_ISO14443A_SNIFF: {
-            SniffIso14443a(packet->data.asBytes[0]);
-            reply_ng(CMD_HF_ISO14443A_SNIFF, PM3_SUCCESS, NULL, 0);
+            int retval = SniffIso14443a(packet->data.asBytes[0]);
+            reply_ng(CMD_HF_ISO14443A_SNIFF, retval, NULL, 0);
             break;
         }
         case CMD_HF_HIDCONFIG_SNIFF: {
-            SniffHIDConfigCard((const hid_sniff_payload_t *)packet->data.asBytes);
-            reply_ng(CMD_HF_HIDCONFIG_SNIFF, PM3_SUCCESS, NULL, 0);
+            int retval = SniffHIDConfigCard((const hid_sniff_payload_t *)packet->data.asBytes);
+            reply_ng(CMD_HF_HIDCONFIG_SNIFF, retval, NULL, 0);
             break;
         }
         case CMD_HF_ISO14443A_READER: {

--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -803,7 +803,7 @@ static int ManchesterDecoding_Thinfilm(uint8_t bit) {
 // near the reader.
 // "hf 14a sniff"
 //-----------------------------------------------------------------------------
-void RAMFUNC SniffIso14443a(uint8_t param) {
+int RAMFUNC SniffIso14443a(uint8_t param) {
     LEDsoff();
     // param:
     // bit 0 - trigger from first card answer
@@ -846,7 +846,8 @@ void RAMFUNC SniffIso14443a(uint8_t param) {
     // Setup and start DMA.
     if (FpgaSetupSscDma((uint8_t *) dma->buf, DMA_BUFFER_SIZE) == false) {
         if (g_dbglevel > DBG_ERROR) Dbprintf("FpgaSetupSscDma failed. Exiting");
-        return;
+        switch_off();
+        return PM3_EINIT;
     }
 
     // We won't start recording the frames that we acquire until we trigger;
@@ -860,6 +861,7 @@ void RAMFUNC SniffIso14443a(uint8_t param) {
     uint32_t dma_stalls = 0;
 
     uint16_t checker = 12000;
+    int retval = PM3_SUCCESS;
 
     // loop and listen
     while (BUTTON_PRESS() == false) {
@@ -868,6 +870,7 @@ void RAMFUNC SniffIso14443a(uint8_t param) {
 
         if (checker-- == 0) {
             if (data_available()) {
+                retval = PM3_EOPABORTED;
                 break;
             }
             checker = 12000;
@@ -948,6 +951,7 @@ void RAMFUNC SniffIso14443a(uint8_t param) {
                                       Uart.endTime * 16 - DELAY_READER_AIR2ARM_AS_SNIFFER,
                                       Uart.parity,
                                       true)) {
+                            retval = PM3_SUCCESS;
                             break;
                         }
                     }
@@ -980,7 +984,10 @@ void RAMFUNC SniffIso14443a(uint8_t param) {
                                   Demod.startTime * 16 - DELAY_TAG_AIR2ARM_AS_SNIFFER,
                                   Demod.endTime * 16 - DELAY_TAG_AIR2ARM_AS_SNIFFER,
                                   Demod.parity,
-                                  false)) break;
+                                  false)) {
+                        retval = PM3_SUCCESS;
+                        break;
+                    }
 
                     if ((!triggered) && (param & 0x01)) {
                         triggered = true;
@@ -1005,6 +1012,10 @@ void RAMFUNC SniffIso14443a(uint8_t param) {
         }
     } // end main loop
 
+    if (retval == PM3_SUCCESS && BUTTON_PRESS()) {
+        retval = PM3_EOPABORTED;
+    }
+
     FpgaDisableTracing();
 
     if (g_dbglevel >= DBG_ERROR) {
@@ -1015,6 +1026,7 @@ void RAMFUNC SniffIso14443a(uint8_t param) {
         }
     }
     switch_off();
+    return retval;
 }
 
 //-----------------------------------------------------------------------------

--- a/armsrc/iso14443a.h
+++ b/armsrc/iso14443a.h
@@ -141,7 +141,7 @@ void Uart14aInit(uint8_t *d, uint16_t n, uint8_t *par);
 RAMFUNC bool MillerDecoding(uint8_t bit, uint32_t non_real_time);
 RAMFUNC int ManchesterDecoding(uint8_t bit, uint16_t offset, uint32_t non_real_time);
 
-void RAMFUNC SniffIso14443a(uint8_t param);
+int RAMFUNC SniffIso14443a(uint8_t param);
 void SimulateIso14443aTag(uint8_t tagType, uint16_t flags, uint8_t *useruid, uint8_t exitAfterNReads);
 
 void SimulateIso14443aTagEx(uint8_t tagType, uint16_t flags, uint8_t *useruid, uint8_t exitAfterNReads,

--- a/armsrc/secc.c
+++ b/armsrc/secc.c
@@ -619,7 +619,7 @@ void SimulateHIDConfigCard(const hid_sim_payload_t *payload) {
 // HID Config Card sniff with optional A0 D4 jamming
 // ---------------------------------------------------------------------------
 
-void SniffHIDConfigCard(const hid_sniff_payload_t *payload) {
+int SniffHIDConfigCard(const hid_sniff_payload_t *payload) {
     // Configure jam pattern and response before entering the sniff loop.
     if (payload->apdu_len > 0 && payload->apdu_len <= HID_JAM_MAX_APDU) {
         memcpy(s_jam_apdu, payload->apdu, payload->apdu_len);
@@ -636,5 +636,5 @@ void SniffHIDConfigCard(const hid_sniff_payload_t *payload) {
     // Delegate to SniffIso14443a.
     // When param bit 0x04 is set, SniffIso14443a calls hid_config_card_jam()
     // inline after each decoded reader frame (see iso14443a.c).
-    SniffIso14443a(payload->param);
+    return SniffIso14443a(payload->param);
 }

--- a/armsrc/secc.h
+++ b/armsrc/secc.h
@@ -97,7 +97,7 @@ void SimulateHIDConfigCard(const hid_sim_payload_t *payload);
 // Sniff ISO 14443-A with optional jamming (param bit 0x04).
 // When apdu_len > 0 the supplied APDU pattern overrides the default A0 D4 00 00 00.
 // When resp_len > 0 the supplied response overrides the default 00 00 90 00.
-void SniffHIDConfigCard(const hid_sniff_payload_t *payload);
+int SniffHIDConfigCard(const hid_sniff_payload_t *payload);
 
 // Handle an I-block received during HID Config Card (tagType=16) simulation.
 // Fills dynamic_response_info with the appropriate response payload (without CRC).

--- a/client/src/cmdhf14a.c
+++ b/client/src/cmdhf14a.c
@@ -1079,29 +1079,61 @@ int CmdHF14ASniff(const char *Cmd) {
     CLIParserInit(&ctx, "hf 14a sniff",
                   "Sniff the communication between reader and tag\n"
                   "Use `hf 14a list` to view collected data.",
-                  " hf 14a sniff -c -r"
+                  " hf 14a sniff -c -r\n"
+                  " hf 14a sniff --stop"
                  );
     void *argtable[] = {
         arg_param_begin,
         arg_lit0("c", "card", "triggered by first data from card"),
         arg_lit0("r", "reader", "triggered by first 7-bit request from reader (REQ, WUP)"),
         arg_lit0("i", "interactive", "Console will not be returned until sniff finishes or is aborted"),
+        arg_lit0(NULL, "stop", "stop an active ISO 14443-a sniffer"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
 
+    bool card_trigger = arg_get_lit(ctx, 1);
+    bool reader_trigger = arg_get_lit(ctx, 2);
+    bool interactive = arg_get_lit(ctx, 3);
+    bool stop = arg_get_lit(ctx, 4);
+
+    if (stop && (card_trigger || reader_trigger || interactive)) {
+        CLIParserFree(ctx);
+        PrintAndLogEx(ERR, "`--stop` cannot be used with `--card`, `--reader`, or `--interactive`");
+        return PM3_EINVARG;
+    }
+
     uint8_t param = 0;
 
-    if (arg_get_lit(ctx, 1)) {
+    if (card_trigger) {
         param |= 0x01;
     }
 
-    if (arg_get_lit(ctx, 2)) {
+    if (reader_trigger) {
         param |= 0x02;
     }
 
-    bool interactive = arg_get_lit(ctx, 3);
     CLIParserFree(ctx);
+
+    if (stop) {
+        SendCommandNG(CMD_BREAK_LOOP, NULL, 0);
+
+        PacketResponseNG resp;
+        if (WaitForResponseTimeout(CMD_HF_ISO14443A_SNIFF, &resp, 2000) == false) {
+            PrintAndLogEx(WARNING, "timeout while waiting for sniffer to stop");
+            return PM3_ETIMEOUT;
+        }
+
+        if (resp.status != PM3_SUCCESS && resp.status != PM3_EOPABORTED) {
+            PrintAndLogEx(WARNING, "sniffer stopped with status %d", resp.status);
+            return resp.status;
+        }
+
+        PrintAndLogEx(INFO, "Done!");
+        PrintAndLogEx(HINT, "Hint: Try `" _YELLOW_("hf 14a list")"` to view captured tracelog");
+        PrintAndLogEx(HINT, "Hint: Try `" _YELLOW_("trace save -h") "` to save tracelog for later analysing");
+        return PM3_SUCCESS;
+    }
 
     clearCommandBuffer();
     SendCommandNG(CMD_HF_ISO14443A_SNIFF, (uint8_t *)&param, sizeof(uint8_t));
@@ -1124,6 +1156,11 @@ int CmdHF14ASniff(const char *Cmd) {
             // inform device to break the sim loop since client has exited
             SendCommandNG(CMD_BREAK_LOOP, NULL, 0);
             WaitForResponse(CMD_HF_ISO14443A_SNIFF, &resp);
+        }
+
+        if (resp.status != PM3_SUCCESS && resp.status != PM3_EOPABORTED) {
+            PrintAndLogEx(WARNING, "sniffer stopped with status %d", resp.status);
+            return resp.status;
         }
 
         PrintAndLogEx(INFO, "Done!");


### PR DESCRIPTION
Right now PM3 requires physical press to stop capturing.

This adjustment to CLI and firmware add proper signaling that lets CLI to send signal to Proxmark to stop capture, acting same as a physical button press.

This is really useful for automated testing flows.