### PR TITLE
Fix a few more ways to lose emulator data

### DIFF
--- a/armsrc/Standalone/hf_iceclass.c
+++ b/armsrc/Standalone/hf_iceclass.c
@@ -217,7 +217,7 @@ static int fullsim_mode(void) {
         Dbprintf("loaded " _GREEN_(HF_ICLASS_FULLSIM_ORIG_BIN) " (%u bytes)", fsize);
     }
 
-    iclass_simulate(ICLASS_SIM_MODE_FULL, 0, false, NULL, NULL, NULL);
+    iclass_simulate(ICLASS_SIM_MODE_FULL, 0, false, false, NULL, NULL, NULL);
 
     LED_B_ON();
     rdv40_spiffs_lazy_mount();
@@ -240,7 +240,7 @@ static int reader_attack_mode(void) {
     uint16_t mac_response_len = 0;
     uint8_t *mac_responses = BigBuf_calloc(MAC_RESPONSES_SIZE);
 
-    iclass_simulate(ICLASS_SIM_MODE_READER_ATTACK, NUM_CSNS, false, csns, mac_responses, &mac_response_len);
+    iclass_simulate(ICLASS_SIM_MODE_READER_ATTACK, NUM_CSNS, false, false, csns, mac_responses, &mac_response_len);
 
     if (mac_response_len > 0) {
 
@@ -584,7 +584,7 @@ static int dump_sim_mode(void) {
     }
 
     Dbprintf("simming " _GREEN_(HF_ICALSSS_READSIM_TEMP_BIN));
-    iclass_simulate(ICLASS_SIM_MODE_FULL, 0, false, NULL, NULL, NULL);
+    iclass_simulate(ICLASS_SIM_MODE_FULL, 0, false, false, NULL, NULL, NULL);
 
     LED_B_ON();
     rdv40_spiffs_lazy_mount();
@@ -614,7 +614,7 @@ static int config_sim_mode(void) {
 
         if (res == SPIFFS_OK) {
             Dbprintf("loaded " _GREEN_("%s") " (%u bytes) to emulator memory", cc_files[i], fsize);
-            iclass_simulate(ICLASS_SIM_MODE_FULL, 0, false, NULL, NULL, NULL);
+            iclass_simulate(ICLASS_SIM_MODE_FULL, 0, false, false, NULL, NULL, NULL);
         }
     }
 

--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -137,10 +137,10 @@ static void CodeIClassTagSOF(void) {
  */
 // turn off afterwards
 void SimulateIClass(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_t *datain) {
-    iclass_simulate(arg0, arg1, arg2, datain, NULL, NULL);
+    iclass_simulate(arg0, arg1, arg2, true, datain, NULL, NULL);
 }
 
-void iclass_simulate(uint8_t sim_type, uint8_t num_csns, bool send_reply, uint8_t *datain, uint8_t *dataout, uint16_t *dataoutlen) {
+void iclass_simulate(uint8_t sim_type, uint8_t num_csns, bool send_reply, bool trace, uint8_t *datain, uint8_t *dataout, uint16_t *dataoutlen) {
 
     LEDsoff();
 
@@ -148,8 +148,7 @@ void iclass_simulate(uint8_t sim_type, uint8_t num_csns, bool send_reply, uint8_
 
     clear_trace();
 
-    // only logg if we are called from the client.
-    set_tracing(send_reply);
+    set_tracing(trace);
 
     //Use the emulator memory for SIM
     uint8_t *emulator = BigBuf_get_EM_addr();
@@ -292,10 +291,15 @@ out:
  */
 int do_iclass_simulation(int simulationMode, uint8_t *reader_mac_buf) {
 
-    // FULL_LIVE = FULL + per-byte USB poll so the client can push live emul
-    // updates (see hf iclass tagsim). Unfold the flag and continue as FULL
-    // so all existing FULL-mode checks below work unchanged.
-    const bool allow_usb_interrupt = (simulationMode == ICLASS_SIM_MODE_FULL_LIVE);
+    // FULL_LIVE = FULL + inline EML_MEMSET handling so the client can push live
+    // emul updates (see hf iclass tagsim). All full sim modes still need USB
+    // polling so commands like hw break or eview can stop the ARM-side loop.
+    const bool handle_live_updates = (simulationMode == ICLASS_SIM_MODE_FULL_LIVE);
+    const bool allow_usb_interrupt =
+        simulationMode == ICLASS_SIM_MODE_FULL ||
+        simulationMode == ICLASS_SIM_MODE_FULL_GLITCH ||
+        simulationMode == ICLASS_SIM_MODE_FULL_GLITCH_KEY ||
+        handle_live_updates;
     if (simulationMode == ICLASS_SIM_MODE_FULL_LIVE) {
         simulationMode = ICLASS_SIM_MODE_FULL;
     }
@@ -509,6 +513,11 @@ int do_iclass_simulation(int simulationMode, uint8_t *reader_mac_buf) {
         uint32_t reader_eof_time = 0;
         len = GetIso15693CommandFromReader(receivedCmd, MAX_FRAME_SIZE, &reader_eof_time, allow_usb_interrupt);
         if (len == -2) {
+            if (handle_live_updates == false) {
+                exit_loop = true;
+                continue;
+            }
+
             // USB data arrived while waiting for RF — drain all pending EML_MEMSET
             // commands inline (without FpgaDownloadAndGo) so live tag updates work.
             PacketCommandNG rx;
@@ -523,6 +532,8 @@ int do_iclass_simulation(int simulationMode, uint8_t *reader_mac_buf) {
                     struct p *payload = (struct p *) rx.data.asBytes;
                     emlSet(payload->data, payload->offset, payload->plen);
                 } else {
+                    // LIVE mode owns this packet; non-EML traffic (break or stray
+                    // commands) is treated as an abort and is not redispatched.
                     exit_loop = true;
                     break;
                 }
@@ -1126,7 +1137,13 @@ int do_iclass_simulation_nonsec(void) {
         WDT_HIT();
 
         uint32_t reader_eof_time = 0;
-        len = GetIso15693CommandFromReader(receivedCmd, MAX_FRAME_SIZE, &reader_eof_time, false);
+        len = GetIso15693CommandFromReader(receivedCmd, MAX_FRAME_SIZE, &reader_eof_time, true);
+        if (len == -2) {
+            // Non-secure simulation has no live reload/update path; any USB
+            // command interrupts the sim and is handled by the main dispatcher.
+            exit_loop = true;
+            continue;
+        }
         if (len < 0) {
             button_pressed = true;
             exit_loop = true;

--- a/armsrc/iclass.h
+++ b/armsrc/iclass.h
@@ -58,7 +58,7 @@ void iClass_Restore(iclass_restore_req_t *msg);
 int do_iclass_simulation_nonsec(void);
 int do_iclass_simulation(int simulationMode, uint8_t *reader_mac_buf);
 void SimulateIClass(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_t *datain);
-void iclass_simulate(uint8_t sim_type, uint8_t num_csns, bool send_reply, uint8_t *datain, uint8_t *dataout,  uint16_t *dataoutlen);
+void iclass_simulate(uint8_t sim_type, uint8_t num_csns, bool send_reply, bool trace, uint8_t *datain, uint8_t *dataout,  uint16_t *dataoutlen);
 
 void iClass_Authentication_fast(iclass_chk_t *p);
 bool iclass_auth(iclass_auth_req_t *payload, uint8_t *out);

--- a/armsrc/iso15693.c
+++ b/armsrc/iso15693.c
@@ -2134,7 +2134,7 @@ void ReaderIso15693(iso15_card_select_t *p_card) {
 // When SIM: initialize the Proxmark3 as ISO15693 tag
 void Iso15693InitTag(void) {
 
-    FpgaDownloadAndGo(FPGA_BITSTREAM_HF_15);
+    FpgaDownloadAndGo_keep_EM(FPGA_BITSTREAM_HF_15);
 
     // Start from off (no field generated)
     FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
@@ -2180,7 +2180,8 @@ void SimTagIso15693(const uint8_t *uid, uint8_t block_size) {
         // User supplied not empty?
         if (memcmp(uid, empty, 8)) {
             // Set default values if user supplied a UID.
-            // Assume emulator memory is empty
+            memset(tag, 0, sizeof(*tag));
+
             tag->uid[0] = uid[7]; // always E0
             tag->uid[1] = uid[6]; // IC Manufacturer code
             tag->uid[2] = uid[5];

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -520,8 +520,12 @@ static tagsim_key_t tagsim_poll_key(void) {
 
 static struct termios tagsim_saved_termios;
 static bool tagsim_rawmode_active = false;
+static bool tagsim_stdin_is_tty = false;
 
 static void tagsim_rawmode_enter(void) {
+    tagsim_stdin_is_tty = isatty(STDIN_FILENO);
+    if (tagsim_stdin_is_tty == false) return;
+
     if (tcgetattr(STDIN_FILENO, &tagsim_saved_termios) < 0) return;
     struct termios raw = tagsim_saved_termios;
     raw.c_lflag &= ~(uint32_t)(ICANON | ECHO);
@@ -541,6 +545,7 @@ static void tagsim_rawmode_exit(void) {
 static tagsim_key_t tagsim_poll_key(void) {
     char buf[8] = {0};
     int n = (int)read(STDIN_FILENO, buf, sizeof(buf));
+    if (n == 0 && tagsim_stdin_is_tty == false) return TAGSIM_KEY_ABORT;
     if (n <= 0) return TAGSIM_KEY_NONE;
     if (n == 1) {
         if (buf[0] == '\n' || buf[0] == '\r' || buf[0] == 0x1B)
@@ -1254,7 +1259,7 @@ static int CmdHFiClassSim(const char *Cmd) {
             PrintAndLogEx(INFO, "Press " _GREEN_("`pm3 button`") " to abort");
             uint8_t numberOfCSNs = 0;
             clearCommandBuffer();
-            SendCommandMIX(CMD_HF_ICLASS_SIMULATE, sim_type, numberOfCSNs, 1, csn, 8);
+            SendCommandMIX(CMD_HF_ICLASS_SIMULATE, sim_type, numberOfCSNs, 0, csn, 8);
 
             if (sim_type == ICLASS_SIM_MODE_FULL || sim_type ==  ICLASS_SIM_MODE_FULL_GLITCH || sim_type ==  ICLASS_SIM_MODE_FULL_GLITCH_KEY)
                 PrintAndLogEx(HINT, "Hint: Try `" _YELLOW_("hf iclass esave -h") "` to save the emulator memory to file");
@@ -1602,14 +1607,15 @@ static int CmdHFiClassTagSim(const char *Cmd) {
     clearCommandBuffer();
     SendCommandMIX(CMD_HF_ICLASS_SIMULATE, ICLASS_SIM_MODE_FULL_LIVE, 0, 1, csn, 8);
 
+    PacketResponseNG resp;
+    bool running = true;
+    bool arm_ended = false;  // true when ARM sent its own CMD_ACK (e.g. button press)
+
     // --- live FC/CN navigation (wiegand mode only; binary mode has no FC/CN to adjust)
     if (bin_len == 0) {
         int format_idx = HIDFindCardFormat(format);
 
         tagsim_rawmode_enter();
-        PacketResponseNG resp;
-        bool running = true;
-        bool arm_ended = false;  // true when ARM sent its own CMD_ACK (e.g. button press)
 
         while (running) {
             // A non-zero-timeout poll lets us detect when the ARM ends the sim
@@ -1717,14 +1723,30 @@ static int CmdHFiClassTagSim(const char *Cmd) {
         }
 
         tagsim_rawmode_exit();
+    } else {
+        tagsim_rawmode_enter();
 
-        if (!arm_ended) {
-            // Client exited the loop (Enter/Esc) but the ARM is still simulating.
-            // Tell it to stop and consume the resulting CMD_ACK so the ARM is
-            // cleanly back in the main loop before we return.
-            SendCommandNG(CMD_BREAK_LOOP, NULL, 0);
-            WaitForResponseTimeout(CMD_ACK, &resp, 2000);
+        while (running) {
+            if (WaitForResponseTimeout(CMD_ACK, &resp, 100)) {
+                arm_ended = true;
+                running = false;
+                break;
+            }
+            if (tagsim_poll_key() == TAGSIM_KEY_ABORT) {
+                running = false;
+                break;
+            }
         }
+
+        tagsim_rawmode_exit();
+    }
+
+    if (!arm_ended) {
+        // Client exited the loop (Enter/Esc) but the ARM is still simulating.
+        // Tell it to stop and consume the resulting CMD_ACK so the ARM is
+        // cleanly back in the main loop before we return.
+        SendCommandNG(CMD_BREAK_LOOP, NULL, 0);
+        WaitForResponseTimeout(CMD_ACK, &resp, 2000);
     }
 
     PrintAndLogEx(HINT, "Hint: Try `" _YELLOW_("hf iclass esave -h") "` to save the emulator memory to file");

--- a/tools/pm3_online_tests.sh
+++ b/tools/pm3_online_tests.sh
@@ -427,22 +427,27 @@ while true; do
     if $TESTICLASSEMU; then
       echo -e "\n${C_BLUE}Testing iCLASS emulator memory${C_NC} ${PM3BIN:=./pm3}"
       if ! CheckFileExist "pm3 exists"               "$PM3BIN"; then break; fi
-      if ! CheckExecute "hf iclass esetblk preserves emu" "$PM3BIN -c 'hf iclass eload -f traces/iclass/hf-iclass-dump.json; hw fpgaoff; hf iclass esetblk --blk 7 -d A55AC33C9669F00F; hf iclass eview -s 64' 2>&1 | LC_ALL=C tr -cd '\11\12\15\40-\176' | tr '\n' ' '" "0/0x00.*6D C2 5B 15 FE FF 12 E0.*7/0x07.*A5 5A C3 3C 96 69 F0 0F"; then break; fi
+      PM3CMD="$PM3BIN"
+      if [ -n "${PM3PORT:-}" ]; then
+        PM3CMD="$PM3CMD -p $PM3PORT"
+      fi
+      if ! CheckExecute "hf iclass esetblk preserves emu" "$PM3CMD -c 'hf iclass eload -f traces/iclass/hf-iclass-dump.json; hw fpgaoff; hf iclass esetblk --blk 7 -d A55AC33C9669F00F; hf iclass eview -s 64' 2>&1 | LC_ALL=C tr -cd '\11\12\15\40-\176' | tr '\n' ' '" "0/0x00.*6D C2 5B 15 FE FF 12 E0.*7/0x07.*A5 5A C3 3C 96 69 F0 0F"; then break; fi
+      if ! CheckExecute "hf iclass sim preserves emu" "$PM3CMD -c 'hf iclass eload -f traces/iclass/hf-iclass-dump.json; hf iclass sim -t 3; hf iclass eview -s 64' 2>&1 | LC_ALL=C tr -cd '\11\12\15\40-\176' | tr '\n' ' '" "6D C2 5B 15 FE FF 12 E0.*03 03 03 03 00 03 E0 17"; then break; fi
+      if ! CheckExecute "hf iclass sim break preserves emu" "$PM3CMD -c 'hf iclass eload -f traces/iclass/hf-iclass-dump.json; hf iclass sim -t 3; hw break; hf iclass eview -s 64' 2>&1 | LC_ALL=C tr -cd '\11\12\15\40-\176' | tr '\n' ' '" "6D C2 5B 15 FE FF 12 E0.*03 03 03 03 00 03 E0 17"; then break; fi
+      if ! CheckExecute "hf iclass tagsim bin exits cleanly" "printf '\n' | $PM3CMD -c 'hf iclass tagsim --bin 10001111100000001010100011 --enc none; hf iclass eview -s 80' 2>&1 | LC_ALL=C tr -cd '\11\12\15\40-\176' | tr '\n' ' '" "Uploaded .* bytes to emulator memory.*0/0x00.*6/0x06.*03 03 03 03 00 03 E0 14.*7/0x07.*00 00 00 00 06 3E 02 A3"; then break; fi
+      if ! CheckExecute "hf iclass tagsim bin back-to-back updates" "timeout 25 $PM3CMD -c 'hf iclass tagsim --bin 10001111100000001010100011 --enc none; hf iclass tagsim --bin 01010101010101010101010101010101 --enc none; hf iclass eview -s 80' 2>&1 | LC_ALL=C tr -cd '\11\12\15\40-\176' | tr '\n' ' '" "7/0x07.*00 00 00 01 55 55 55 55"; then break; fi
+      if ! CheckExecute "hf iclass tagsim live update exits cleanly" "printf '\033[C' | $PM3CMD -c 'hf iclass tagsim -w H10301 --fc 31 --cn 337 --enc none; hf iclass eview -s 80' 2>&1 | LC_ALL=C tr -cd '\11\12\15\40-\176' | tr '\n' ' '" "CN: 338.*0/0x00.*BD 0F 60 10 F7 FF 12 E0"; then break; fi
+      if ! CheckExecute "hf 15 uid sim resets emu state" "timeout 15 $PM3CMD -c 'hf 15 sim -u E011223344556677 -t 100; hf 15 eview' 2>&1 | LC_ALL=C tr -cd '\11\12\15\40-\176' | tr '\n' ' '" "UID.*E0 11 22 33 44 55 66 77.*4 bytes / blocks x 64 blocks"; then break; fi
     fi
 
     if $TESTICLASSREADER; then
       echo -e "\n${C_BLUE}Testing iCLASS reader verification${C_NC} ${PM3BIN:=./pm3}"
       if ! CheckFileExist "pm3 exists"               "$PM3BIN"; then break; fi
-      if [ -z "${PM3PORT:-}" ]; then
-        PM3PORT="$(ls /dev/cu.usbmodem* 2>/dev/null | head -n 1 || true)"
-      fi
-      if [ -z "${PM3PORT:-}" ]; then
-        echo "Error: No Proxmark3 serial port found. Pass --pm3port /dev/tty..."
-        break
-      fi
-      echo "Using PM3 port: $PM3PORT"
       PM3CMD="$PM3BIN"
-      PM3CMD="$PM3CMD $PM3PORT"
+      if [ -n "${PM3PORT:-}" ]; then
+        echo "Using PM3 port: $PM3PORT"
+        PM3CMD="$PM3CMD -p $PM3PORT"
+      fi
 
       WaitForEnter "PRESS ENTER TO START ICLASS PLAIN SIM, PRESENT THE PM3 TO ANOTHER READER, CONFIRM: iCLASS H10301 FC 31 CN 337, THEN PRESS THE PM3 BUTTON TO STOP SIM"
       if ! CheckExecute "hf iclass emu reader plain"  "$PM3CMD -c 'hf iclass tagsim -w H10301 --fc 31 --cn 337 --enc none' 2>&1" "Uploaded .* bytes to emulator memory"; then break; fi
@@ -450,6 +455,7 @@ while true; do
       if ! CheckExecute "hf iclass emu reader des"    "$PM3CMD -c 'hf iclass tagsim -w H10301 --fc 31 --cn 337 --enc des' 2>&1" "Uploaded .* bytes to emulator memory"; then break; fi
       WaitForEnter "PRESS ENTER TO START ICLASS 2K3DES SIM, PRESENT THE PM3 TO ANOTHER READER, CONFIRM: iCLASS H10301 FC 31 CN 337, THEN PRESS THE PM3 BUTTON TO STOP SIM"
       if ! CheckExecute "hf iclass emu reader 2k3des" "$PM3CMD -c 'hf iclass tagsim -w H10301 --fc 31 --cn 337 --enc 2k3des' 2>&1" "Uploaded .* bytes to emulator memory"; then break; fi
+      if ! CheckExecute "hf iclass sim preserves emu" "$PM3CMD -c 'hf iclass eview -s 80' 2>&1 | LC_ALL=C tr -cd '\11\12\15\40-\176' | tr '\n' ' '" "0/0x00.*BD 0C 60 10 F7 FF 12 E0.*6/0x06.*03 03 03 03 00 03 E0 17.*7/0x07.*10 A1 45 91 9E D1 6F 50"; then break; fi
     fi
   
   echo -e "\n------------------------------------------------------------"


### PR DESCRIPTION
Found a few more ways to wipe out the emulator memory.  This hardens handling and makes it easier to test.

  Changes:

  - Preserve emulator memory during iCLASS/ISO15693 FPGA setup.
  - Let plain hf iclass sim be interrupted cleanly by follow-up client commands such as eview or hw break.
  - Keep binary hf iclass tagsim --bin from returning while the ARM simulation loop is still running.
  - Keep live tagsim -w ... cleanup working for scripted stdin/EOF.
  - Decouple tracing from reply handling so plain simulation does not accidentally disable trace capture.
  - Avoid stale ACK handling for fire-and-return sim commands.

  Testing:

  - Added online tests for:
      - esetblk preserving emulator memory
      - sim preserving memory when interrupted by eview
      - sim preserving memory when interrupted by hw break
      - binary tagsim exiting cleanly
      - live tagsim scripted update exiting cleanly
      - back to back tagsim functionality
      - simulating uid only clears out the emulator