### PR TITLE
Feature: CI check for building client experimental lib

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -145,7 +145,33 @@ jobs:
       - name: Build experimental lib
         env:
           VERBOSE: 1
-        run: cmake --build client/experimental_lib/build -j$((`nproc` + 1))
+        run: |
+          set +e
+          cmake --build client/experimental_lib/build -j$((`nproc` + 1)) 2>&1 | tee experimental-lib-build.log
+          status=${PIPESTATUS[0]}
+
+          if [ "$status" -ne 0 ]; then
+            symbols="$(sed -n "s/.*undefined reference to [\`']\\([^'\`]*\\)['\`].*/\\1/p" experimental-lib-build.log | sort -u)"
+
+            if [ -n "$symbols" ]; then
+              {
+                echo "### Experimental lib unresolved symbols"
+                echo
+                echo "The experimental lib failed to link because these symbols are unresolved:"
+                echo
+                echo '```'
+                echo "$symbols"
+                echo '```'
+                echo
+                echo "Add the defining source file(s) to \`client/experimental_lib/CMakeLists.txt\` under \`TARGET_SOURCES\`."
+              } >> "$GITHUB_STEP_SUMMARY"
+
+              symbols_one_line="$(echo "$symbols" | tr '\n' ',' | sed 's/,$//; s/,/, /g')"
+              echo "::error title=Experimental lib has unresolved symbols::Undefined symbol(s): $symbols_one_line. Add the defining source file(s) to client/experimental_lib/CMakeLists.txt under TARGET_SOURCES."
+            fi
+
+            exit "$status"
+          fi
 
       - name: Import experimental Python module
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -119,3 +119,36 @@ jobs:
         env:
           CHECKARGS: "--clientbin ./client/build/proxmark3"
         run: make client/check
+
+  ubuntu-experimental-lib:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Update apt repos
+        run: sudo apt-get update
+
+      - name: Install dependencies
+        run: sudo apt-get install -yqq make build-essential ca-certificates pkg-config libreadline-dev gcc-arm-none-eabi libnewlib-dev qt6-base-dev libbz2-dev liblz4-dev libbluetooth-dev libpython3-dev python3 python3-dev libpython3-all-dev liblua5.4-dev liblua5.4-0 lua5.4 sed libssl-dev libgd-dev
+
+      - name: Install Python dependencies
+        run: pip install -r tools/requirements.txt
+
+      - name: Configure experimental lib
+        run: cmake -S client/experimental_lib -B client/experimental_lib/build
+
+      - name: Build experimental lib
+        env:
+          VERBOSE: 1
+        run: cmake --build client/experimental_lib/build -j$((`nproc` + 1))
+
+      - name: Import experimental Python module
+        run: |
+          ln -sf ../build/libpm3rrg_rdv4.so _pm3.so
+          PYTHONPATH=../../pyscripts:. python3 -c "import pm3"
+        working-directory: client/experimental_lib/example_py

--- a/client/experimental_lib/CMakeLists.txt
+++ b/client/experimental_lib/CMakeLists.txt
@@ -667,6 +667,12 @@ add_library(pm3rrg_rdv4 SHARED
 
 target_compile_definitions(pm3rrg_rdv4 PRIVATE LIBPM3)
 
+if (UNIX AND NOT APPLE)
+    # Fail the build if a client source file is missing from TARGET_SOURCES.
+    # Otherwise Linux may defer unresolved shared-library symbols until import.
+    set_property(TARGET pm3rrg_rdv4 APPEND_STRING PROPERTY LINK_FLAGS " -Wl,--no-undefined")
+endif()
+
 target_compile_options(pm3rrg_rdv4 PUBLIC -Wall -Werror -O3)
 if (EMBED_READLINE)
     if (NOT SKIPREADLINE EQUAL 1)


### PR DESCRIPTION
Added a CI check that tries to build the client experimental lib. Added linker option `-Wl,--no-undefined` to fail at compile-time if there are undefined symbols in the experimental client lib. Also added better error message for a failed check to improve developer experience. 