### PR TITLE
Don't check for MFC Mini if Plus detected

### DIFF
--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -3158,7 +3158,7 @@ static int CmdHF14AMfAutoPWN(const char *Cmd) {
         PrintAndLogEx(INFO, "MIFARE Plus card detected.  Using limited set of attacks");
     }
 
-    if (isMifareMini && sector_cnt != MIFARE_MINI_MAXSECTOR) {
+    if (!isMifarePlus && isMifareMini && sector_cnt != MIFARE_MINI_MAXSECTOR) {
         PrintAndLogEx(WARNING, "MIFARE Mini S20 card detected. Changing sector count to %u", MIFARE_MINI_MAXSECTOR);
         sector_cnt = MIFARE_MINI_MAXSECTOR;
     }


### PR DESCRIPTION
~~A user in the Discord server had a Mifare Mini card misidentified as a Mifare Classic EV1 due to the signature check. This PR skips that check for Mifare Mini and Mifare Plus tags, to prevent the detected memory size from being overwritten.~~ I added a check to prevent re-detecting Mifare Plus cards as Mifare Mini.