### PR TITLE
Fix `WRITEBLOCK` read out-of-bounds

### DIFF
--- a/client/src/cmdhflist.c
+++ b/client/src/cmdhflist.c
@@ -424,7 +424,7 @@ int applyIso14443a(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize, bool i
             case MIFARE_ULC_WRITE : {
                 if (cmd[1] < 0x21)
                     snprintf(exp, size, "WRITEBLOCK(" _MAGENTA_("%d") ")", cmd[1]);
-                else
+                else if (cmdsize >= 6)
                     // outside limits, useful for some tags...
                     snprintf(exp, size, "WRITEBLOCK(" _MAGENTA_("%d") ") (%s)", cmd[1], sprint_hex_inrow(cmd + 2, 4));
                 break;


### PR DESCRIPTION
Fixes a minor bug, the `hf * list` output can show `WRITEBLOCK(...)` even when there's not enough data, causing it to read out-of-bounds.