### PR TITLE
Fix MFC sector trailer ACL bug

### DIFF
--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -1021,7 +1021,7 @@ static int mfc_read_tag(iso14a_card_select_t *card, uint8_t *carddata, uint8_t n
             bool received = false;
             current_key = MF_KEY_A;
             uint8_t data_area = (sectorNo < 32) ? blockNo : blockNo / 5;
-            if (rights[sectorNo][data_area] == 0x07) {                                     // no key would work
+            if (!mfIsSectorTrailerBasedOnBlocks(sectorNo, blockNo) && rights[sectorNo][data_area] == 0x07) {                                     // no key would work
                 PrintAndLogEx(WARNING, "Access rights prevent reading sector... " _YELLOW_("%2d") " block... " _YELLOW_("%3d") " ( skip )", sectorNo, blockNo);
                 continue;
             }


### PR DESCRIPTION
When reading a Mifare Classic credential, if the sector trailer's ACL bits are set to 0b111, it would fail to dump with the error "Access rights prevent reading sector". There is no combination of ACL bits to completely block reading the sector trailer, so this check should be skipped on the trailer.