### PR TITLE
mad: gate diagnostic prints behind verbose flag to quiet test output

### DIFF
--- a/client/src/mifare/mad.c
+++ b/client/src/mifare/mad.c
@@ -173,7 +173,8 @@ static void mad_print_aid_verbose(json_t *elm) {
 static int mad1CRCCheck(const mad1_t *mad1, bool verbose) {
     uint8_t crc = CRC8Mad((uint8_t *)&mad1->info, sizeof(mad1_t) - 1);
     if (crc != mad1->crc) {
-        PrintAndLogEx(WARNING, _RED_("Wrong MAD 1 CRC") " calculated: 0x%02x != 0x%02x", crc, mad1->crc);
+        if (verbose)
+            PrintAndLogEx(WARNING, _RED_("Wrong MAD 1 CRC") " calculated: 0x%02x != 0x%02x", crc, mad1->crc);
         return PM3_ESOFT;
     }
     return PM3_SUCCESS;
@@ -182,7 +183,8 @@ static int mad1CRCCheck(const mad1_t *mad1, bool verbose) {
 static int mad2CRCCheck(const mad2_t *mad2, bool verbose) {
     uint8_t crc = CRC8Mad((uint8_t *)&mad2->info, sizeof(mad2_t) - 1);
     if (crc != mad2->crc) {
-        PrintAndLogEx(WARNING, _RED_("Wrong MAD 2 CRC") " calculated: 0x%02x != 0x%02x", crc, mad2->crc);
+        if (verbose)
+            PrintAndLogEx(WARNING, _RED_("Wrong MAD 2 CRC") " calculated: 0x%02x != 0x%02x", crc, mad2->crc);
         return PM3_ESOFT;
     }
     return PM3_SUCCESS;
@@ -231,13 +233,13 @@ int MADCheck(const mad1_sector_t *sector0, const mad2_sector_t *mad2, bool verbo
         *haveMAD2 = (mad_ver == 2);
     }
 
-    int res = mad1CRCCheck(&sector0->mad, true);
+    int res = mad1CRCCheck(&sector0->mad, verbose);
     if (verbose && res == PM3_SUCCESS) {
         PrintAndLogEx(SUCCESS, "CRC8...... 0x%02X ( %s )", sector0->mad.crc, _GREEN_("ok"));
     }
 
     if (mad_ver == 2 && mad2) {
-        int res2 = mad2CRCCheck(&mad2->mad, true);
+        int res2 = mad2CRCCheck(&mad2->mad, verbose);
         if (res == PM3_SUCCESS) {
             res = res2;
         }
@@ -570,7 +572,7 @@ int mad_app_read(const mad_ops_t *ops, uint16_t aid, bool swapmad, bool override
             PrintAndLogEx(INFO, "read sector %u, %zu data bytes", sno, nbytes);
     }
 
-    if (*out_len == 0)
+    if (*out_len == 0 && ops->verbose)
         PrintAndLogEx(WARNING, "no sectors found for AID 0x%04X", aid);
 
     return PM3_SUCCESS;
@@ -590,8 +592,9 @@ int mad_app_write(const mad_ops_t *ops, uint16_t aid, bool swapmad, bool overrid
     }
 
     if (data_len > capacity) {
-        PrintAndLogEx(ERR, "data (%zu bytes) exceeds capacity (%zu bytes) for AID 0x%04X",
-                      data_len, capacity, aid);
+        if (ops->verbose)
+            PrintAndLogEx(ERR, "data (%zu bytes) exceeds capacity (%zu bytes) for AID 0x%04X",
+                          data_len, capacity, aid);
         return PM3_EINVARG;
     }
 
@@ -641,12 +644,14 @@ int mad_app_verify(const mad_ops_t *ops, uint16_t aid, bool swapmad, bool overri
 
     size_t cmp_len = readback_len < expected_len ? readback_len : expected_len;
     if (memcmp(expected, readback, cmp_len) != 0) {
-        PrintAndLogEx(ERR, "Verify " _RED_("FAILED") ": data mismatch");
-        for (size_t j = 0; j < cmp_len; j++) {
-            if (expected[j] != readback[j]) {
-                PrintAndLogEx(ERR, "first difference at offset %zu: expected %02X, got %02X",
-                              j, expected[j], readback[j]);
-                break;
+        if (ops->verbose) {
+            PrintAndLogEx(ERR, "Verify " _RED_("FAILED") ": data mismatch");
+            for (size_t j = 0; j < cmp_len; j++) {
+                if (expected[j] != readback[j]) {
+                    PrintAndLogEx(ERR, "first difference at offset %zu: expected %02X, got %02X",
+                                  j, expected[j], readback[j]);
+                    break;
+                }
             }
         }
         return PM3_ESOFT;

--- a/client/src/mifare/mad_test.c
+++ b/client/src/mifare/mad_test.c
@@ -211,7 +211,7 @@ static bool test_mad1_crc_corrupt(bool verbose) {
 
     bool haveMAD2 = false;
 
-    int res = MADCheck(&s, NULL, false, &haveMAD2);
+    int res = MADCheck(&s, NULL, verbose, &haveMAD2);
 
     ASSERT_TRUE("MADCheck should fail on corrupt CRC", res != PM3_SUCCESS);
 
@@ -493,6 +493,7 @@ static bool test_verify_mismatch(bool verbose) {
     PrintAndLogEx(INFO, "  verify mismatch...");
     mock_card_init();
     mad_ops_t ops = make_mock_ops();
+    ops.verbose = verbose;
 
     // write known data
     uint8_t wdata[240];
@@ -522,6 +523,7 @@ static bool test_write_overflow(bool verbose) {
     PrintAndLogEx(INFO, "  write overflow...");
     mock_card_init();
     mad_ops_t ops = make_mock_ops();
+    ops.verbose = verbose;
 
     uint8_t wdata[241];
     memset(wdata, 0xAA, sizeof(wdata));
@@ -538,6 +540,7 @@ static bool test_aid_not_found(bool verbose) {
     PrintAndLogEx(INFO, "  AID not found...");
     mock_card_init();
     mad_ops_t ops = make_mock_ops();
+    ops.verbose = verbose;
 
     uint8_t data[256] = {0};
     size_t datalen = 99;
@@ -741,7 +744,7 @@ static bool test_mad2_crc_independent(bool verbose) {
 
     // valid: both CRCs pass
     bool haveMAD2 = false;
-    int res = MADCheck(&s0, &s16, false, &haveMAD2);
+    int res = MADCheck(&s0, &s16, verbose, &haveMAD2);
     ASSERT_EQ("both valid", PM3_SUCCESS, res);
     ASSERT_EQ("MAD2 present", true, haveMAD2);
 
@@ -750,7 +753,7 @@ static bool test_mad2_crc_independent(bool verbose) {
     memcpy(&s16_bad, &s16, sizeof(s16_bad));
     s16_bad.mad.crc ^= 0xFF;
 
-    res = MADCheck(&s0, &s16_bad, false, &haveMAD2);
+    res = MADCheck(&s0, &s16_bad, verbose, &haveMAD2);
     ASSERT_TRUE("should fail with corrupt MAD2 CRC", res != PM3_SUCCESS);
 
     // corrupt MAD1 CRC only, MAD2 stays valid
@@ -758,7 +761,7 @@ static bool test_mad2_crc_independent(bool verbose) {
     memcpy(&s0_bad, &s0, sizeof(s0_bad));
     s0_bad.mad.crc ^= 0xFF;
 
-    res = MADCheck(&s0_bad, &s16, false, &haveMAD2);
+    res = MADCheck(&s0_bad, &s16, verbose, &haveMAD2);
     ASSERT_TRUE("should fail with corrupt MAD1 CRC", res != PM3_SUCCESS);
 
     if (verbose) PrintAndLogEx(SUCCESS, "    " _GREEN_("passed"));


### PR DESCRIPTION
Following [this message](https://github.com/RfidResearchGroup/proxmark3/issues/3356#issuecomment-4698256106) in issue #3356, I've moved the `mad test` prints behind the verbose flag, so that they won't pollute the test logs.

Here is the new output:
```
hf gst test                             [ OK ] ✔ 
mad test                                [ OK ] ✔
hf waveshare load                       [ OK ] ✔
```

Instead of:
```
mad test                                [!!] Verify FAILED: data mismatch
[!!] first difference at offset 72: expected 27, got D8
[!!] data (241 bytes) exceeds capacity (240 bytes) for AID 0xE103
[ OK ] ✔
```

The verbose test outputs the following:
```
[offline|script] pm3 --> mad test -v
[=] --- MAD regression tests ---
[=]   struct sizes...
[+]     passed
[=]   MAD1 CRC valid...
[+]     passed
[=]   MAD1 CRC corrupt...
[+] GPB....... 0x82
[+] Version... 2
[!] ⚠  Wrong MAD 1 CRC calculated: 0xef != 0x10
[+] Single application card
[+]     passed
[=]   MAD1 decode entries...
[+]     passed
[=]   MAD2 decode with MAD1 v2...
[+]     passed
[=]   read AID spanning MAD1+MAD2...
[+]     passed
[=]   read full AID content...
[+]     passed
[=]   read single-sector AID...
[+]     passed
[=]   write full round-trip...
[+] wrote 240 bytes to AID 0xE103
[+]     passed
[=]   write partial zero-pads remainder...
[+] wrote 50 bytes to AID 0xE103
[+]     passed
[=]   verify match...
[+] wrote 240 bytes to AID 0xE103
[+] Verify OK (240 bytes)
[+]     passed
[=]   verify mismatch...
[=] wrote sector 1, 48 bytes
[=] wrote sector 2, 48 bytes
[=] wrote sector 3, 48 bytes
[=] wrote sector 17, 48 bytes
[=] wrote sector 18, 48 bytes
[+] wrote 240 bytes to AID 0xE103
[=] read sector 1, 48 data bytes
[=] read sector 2, 48 data bytes
[=] read sector 3, 48 data bytes
[=] read sector 17, 48 data bytes
[=] read sector 18, 48 data bytes
[!!] 🚨 Verify FAILED: data mismatch
[!!] 🚨 first difference at offset 72: expected 27, got D8
[+]     passed
[=]   write overflow...
[!!] 🚨 data (241 bytes) exceeds capacity (240 bytes) for AID 0xE103
[+]     passed
[=]   AID not found...
[!] ⚠  no sectors found for AID 0xBEEF
[+]     passed
[=]   write does not touch trailer...
[+] wrote 48 bytes to AID 0xE103
[+]     passed
[=]   MAD sector untouched after write...
[+] wrote 240 bytes to AID 0xE103
[+]     passed
[=]   encode-decode round-trip...
[+]     passed
[=]   encode-decode MAD2 round-trip...
[+]     passed
[=]   MAD2 CRC independent...
[+] GPB....... 0x82
[+] Version... 2
[+] CRC8...... 0xEF ( ok )
[+] CRC8...... 0x42 ( ok )
[+] Single application card
[+] GPB....... 0x82
[+] Version... 2
[+] CRC8...... 0xEF ( ok )
[!] ⚠  Wrong MAD 2 CRC calculated: 0x42 != 0xbd
[+] Single application card
[+] GPB....... 0x82
[+] Version... 2
[!] ⚠  Wrong MAD 1 CRC calculated: 0xef != 0x10
[+] CRC8...... 0x42 ( ok )
[+] Single application card
[+]     passed
[=]   encode GPB version...
[+]     passed
[=]   encode sector overlap detection...
[+]     passed
[=] ----------------------------
[+] Tests ( ok )
```

whereas the non-verbose only outputs this:
```
[offline|script] pm3 --> mad test
[=] --- MAD regression tests ---
[=]   struct sizes...
[=]   MAD1 CRC valid...
[=]   MAD1 CRC corrupt...
[=]   MAD1 decode entries...
[=]   MAD2 decode with MAD1 v2...
[=]   read AID spanning MAD1+MAD2...
[=]   read full AID content...
[=]   read single-sector AID...
[=]   write full round-trip...
[+] wrote 240 bytes to AID 0xE103
[=]   write partial zero-pads remainder...
[+] wrote 50 bytes to AID 0xE103
[=]   verify match...
[+] wrote 240 bytes to AID 0xE103
[+] Verify OK (240 bytes)
[=]   verify mismatch...
[+] wrote 240 bytes to AID 0xE103
[=]   write overflow...
[=]   AID not found...
[=]   write does not touch trailer...
[+] wrote 48 bytes to AID 0xE103
[=]   MAD sector untouched after write...
[+] wrote 240 bytes to AID 0xE103
[=]   encode-decode round-trip...
[=]   encode-decode MAD2 round-trip...
[=]   MAD2 CRC independent...
[=]   encode GPB version...
[=]   encode sector overlap detection...
[=] ----------------------------
[+] Tests ( ok )
```