### PR TITLE
legic: parse DCF argument as hex in migrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `hf legic migrate` failing to parse the optional DCF argument as hex (@IdanHo)
 - Add support for parsing Finnish Helsinki Regional Transport (HRT) travel cards (@sanduuz)
 - Added standalone mode `HF_DOEGOX_COMMIT`: DESFire suspended commit without relay (@doegox)
 - Added support for Innovatron protocol detection to `hf 14b info` (@kormax)

--- a/client/src/cmdhflegic.c
+++ b/client/src/cmdhflegic.c
@@ -211,7 +211,7 @@ static int CmdLegicMigrate(const char *Cmd) {
     int dcf_len = 0;
     uint8_t dcf[2] = {0};
     if (arg_get_str(ctx, 2) != NULL) {
-        CLIParamStrToBuf(arg_get_str(ctx, 2), dcf, sizeof(dcf), &dcf_len);
+        CLIParamHexToBuf(arg_get_str(ctx, 2), dcf, sizeof(dcf), &dcf_len);
         if (dcf_len != 2) {
             PrintAndLogEx(WARNING, "DCF must be exactly two bytes");
             CLIParserFree(ctx);


### PR DESCRIPTION
In the `hf legic migrate` command, the optional `--dcf` argument allows specifying two DCF bytes to write after cloning, and the command help describes it as a hex string (e.g., `--dcf 60EA`).

However, the argument was being parsed using `CLIParamStrToBuf` instead of `CLIParamHexToBuf`. This caused the input to be read as raw ASCII characters rather than converted from hexadecimal representations, failing the byte length checks and/or being parsed incorrectly.