### PR TITLE
Include dynamic memory contents in `hf topaz dump`

### DIFF
--- a/client/src/cmdhftopaz.c
+++ b/client/src/cmdhftopaz.c
@@ -913,10 +913,14 @@ static int CmdHFTopazDump(const char *Cmd) {
         FillFileNameByUID(filename, topaz_tag.uid, "-dump", sizeof(topaz_tag.uid));
     }
 
-    if (topaz_tag.size)
-        pm3_save_dump(filename, (uint8_t *)&topaz_tag, sizeof(topaz_tag_t) + topaz_tag.size, jsfTopaz);
-    else
+    if (topaz_tag.size > TOPAZ_STATIC_MEMORY) {
+        uint8_t mem[TOPAZ_MAX_SIZE];
+        memcpy(mem, topaz_tag.data_blocks, TOPAZ_STATIC_MEMORY);
+        memcpy(mem + TOPAZ_STATIC_MEMORY, topaz_tag.dynamic_memory, topaz_tag.size - TOPAZ_STATIC_MEMORY);
+        pm3_save_dump(filename, mem, topaz_tag.size, jsfTopaz);
+    } else {
         pm3_save_dump(filename, (uint8_t *)&topaz_tag, sizeof(topaz_tag_t), jsfTopaz);
+    }
 
     if (set_dynamic) {
         free(topaz_tag.dynamic_memory);


### PR DESCRIPTION
The pointer in the struct wasn't being dereferenced inside pm3_save_dump (never meant to), and random memory was being dumped.  This fixes that so the binary dump of a tag with dynamic memory is more like the topaz as described in the datasheet.  it semi-breaks some other stuff, but mostly stuff already problematic (json reader/json writer, bin reader which would have been reading bad data anyways)

There are alternatives versions of the fix that would have changed up the struct to not have a pointer, but I felt a small diff was better just to get this a little improved.