### PR TITLE
Fix (limit) 'lf cotag demod' custom clock argument

### DIFF
--- a/client/src/cmdlfcotag.c
+++ b/client/src/cmdlfcotag.c
@@ -428,6 +428,10 @@ end:
 
 int demodCOTAG(bool verbose, int clock, int threshold) {
     int clk = (clock > 0) ? clock : LF_COTAG_CLOCK;
+    if (clk < 32) {
+        PrintAndLogEx(FAILED, "custom clock must be >= 32, got " _RED_("%d"), clk);
+        return PM3_EINVARG;
+    }
     return demod_cotag(g_GraphBuffer, (int)g_GraphTraceLen, clk, -1, threshold, verbose);
 }
 


### PR DESCRIPTION
Fix (limit) `lf cotag demod` custom clock argument

No checks for the custom clock argument were done, and providing `--clk 1` caused a divison by zero exception. 

Limit `--clk` argument of`'lf cotag demod` to some sane value (still low for cotag though, but let's be flexible).