### PR TITLE
Process ATTRIB RR response

### DIFF
--- a/armsrc/iso14443b.c
+++ b/armsrc/iso14443b.c
@@ -1975,9 +1975,6 @@ static int iso14443b_select_prime_card(iso14b_prime_card_select_t *card) {
             card->config = r_repgen[offset++];
             if ((card->config & ISO14443B_PRIME_CONFIG_ATR_PRESENT) && repgen_len > offset) {
                 uint16_t atr_len = repgen_len - offset;
-                if (atr_len >= 2 && r_repgen[repgen_len - 2] == 0x90 && r_repgen[repgen_len - 1] == 0x00) {
-                    atr_len -= 2;
-                }
                 card->atr_len = (uint8_t)MIN(atr_len, ISO14B_PRIME_ATR_MAX_LEN);
                 memcpy(card->atr, r_repgen + offset, card->atr_len);
             }

--- a/armsrc/iso14443b.c
+++ b/armsrc/iso14443b.c
@@ -1998,6 +1998,25 @@ static int iso14443b_select_prime_card(iso14b_prime_card_select_t *card) {
     start_time = eof_time + ISO14B_TR2;
     CodeAndTransmit14443bAsReader(attrib, sizeof(attrib), &start_time, &eof_time, true);
 
+    uint8_t r_rr[4] = { 0x00 };
+    eof_time += DELAY_ISO14443B_PCD_TO_PICC_READER;
+    retlen = 0;
+    if (Get14443bAnswerFromTag(r_rr, sizeof(r_rr), s_iso14b_timeout, &eof_time, &retlen) != PM3_SUCCESS) {
+        return PM3_ECARDEXCHANGE;
+    }
+
+    if (retlen != sizeof(r_rr)) {
+        return PM3_ELENGTH;
+    }
+
+    if (check_crc(CRC_14443_B, r_rr, retlen) == false) {
+        return PM3_ECRC;
+    }
+
+    if (r_rr[0] != r_repgen[0] || r_rr[1] != ISO14443B_PRIME_CMD_RR) {
+        return PM3_EWRONGANSWER;
+    }
+
     s_iso14b_pcb_blocknum = 0;
     return PM3_SUCCESS;
 }

--- a/client/src/cmdhf14b.c
+++ b/client/src/cmdhf14b.c
@@ -1400,16 +1400,16 @@ int select_card_14443b_prime(bool disconnect, iso14b_prime_card_select_t *card, 
             return PM3_SUCCESS;
         }
         case PM3_ELENGTH:
-            if (verbose) PrintAndLogEx(FAILED, "ISO 14443-B' REPGEN wrong length");
+            if (verbose) PrintAndLogEx(FAILED, "ISO 14443-B' activation response wrong length");
             break;
         case PM3_ECRC:
-            if (verbose) PrintAndLogEx(FAILED, "ISO 14443-B' REPGEN CRC fail");
+            if (verbose) PrintAndLogEx(FAILED, "ISO 14443-B' activation response CRC fail");
             break;
         case PM3_EWRONGANSWER:
-            if (verbose) PrintAndLogEx(FAILED, "ISO 14443-B' REPGEN wrong answer");
+            if (verbose) PrintAndLogEx(FAILED, "ISO 14443-B' activation response wrong answer");
             break;
         default:
-            if (verbose) PrintAndLogEx(FAILED, "ISO 14443-B' APGEN failed");
+            if (verbose) PrintAndLogEx(FAILED, "ISO 14443-B' activation failed");
             break;
     }
 


### PR DESCRIPTION
When adding Innovatron protocol implementation initially, I, for some reason, was unable to get my PM3 to receive the response to `ATTRIB`/`DISC`, called `RR`, so I ignored the response when activating the target.

I tried looking into that issue again, and for some reason it does work now without any changes to `hf 14b raw` command, so  I've re-enabled the check.
The response to ATTRIB can also be now seen in logs:

```log
[usb] pm3 --> hf 14b info

[=] --- Type B' / Innovatron ---------------------
[+]  V&T Ad : 01 (card 0, coupler 1)
[+]  DIV    : AA BB CC DD 
[+]  VerLog : FF (long REPGEN, software version 15)
[+]  Config : C0 (WAIT supported, ATR present)
[+]  ATR    : 3B 6F 00 00 80 5A 08 03 04 00 02 00 AA BB CC DD 82 90 00

[usb] pm3 --> hf calypso list
[+] Recorded activity ( 86 bytes )
[=] start = start of start frame. end = end of frame. src = source of transfer.
[=] Calypso - Timings n/a

      Start |        End | Src | Data (! denotes parity error)                                           | CRC | Annotation
------------+------------+-----+-------------------------------------------------------------------------+-----+--------------------
          0 |       2560 | Rdr |01  0B  3F  80                                                           | B ok| APGEN(OccuPar=3F, Config=80)
       5788 |      15772 | Tag |01  07  AA  BB  CC  DD  FF  C0  3B  6F  00  00  80  5A  08  03  04  00   |     | 
            |            |     |02  00  AA  BB  CC  DD  82  90  00                                       | B ok| REPGEN(DIV=AABBCCDD, VERLOG=FF, CONFIG=C0)
      16992 |      20064 | Rdr |01  0F  AA  BB  CC  DD                                                   | B ok| ATTRIB(DIV=AABBCCDD)
      22109 |      24093 | Tag |01  01                                                                   | B ok| RR
[usb] pm3 --> 
```


Also, on my card, 2 last bytes of ATR ended in `90 00`, which looked like an SW, so I truncated them.
Having taken a second look, second byte of ATR indicates that length of historical data is 15 bytes, which encompasses those two last bytes, meaning that they were truncated in an error.