### PR TITLE
Fix build issues with Android NDK

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -825,7 +825,7 @@ if ((NOT SKIPQT EQUAL 1) AND Qt6_FOUND)
     target_include_directories(proxmark3 PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
-target_compile_options(proxmark3 PUBLIC -Wall -Werror -O3)
+target_compile_options(proxmark3 PUBLIC -Wall -Werror -Wno-missing-braces -O3)
 if (EMBED_READLINE)
     if (NOT SKIPREADLINE EQUAL 1)
         add_dependencies(proxmark3 ncurses readline)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -500,6 +500,14 @@ set (TARGET_SOURCES
         ${CMAKE_BINARY_DIR}/version_pm3.c
         )
 
+# Enable AVX2 support for x86/x64
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|i.86")
+    set_source_files_properties(
+        src/loclass/cipher_bs_avx2.c
+        PROPERTIES COMPILE_OPTIONS "-mavx2"
+    )
+endif()
+
 add_custom_command(
     OUTPUT  ${CMAKE_BINARY_DIR}/version_pm3.c
     COMMAND sh ${PM3_ROOT}/tools/mkversion.sh ${CMAKE_BINARY_DIR}/version_pm3.c || ${CMAKE_COMMAND} -E copy ${PM3_ROOT}/common/default_version_pm3.c ${CMAKE_BINARY_DIR}/version_pm3.c

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -508,6 +508,14 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|i.86")
     )
 endif()
 
+# Enable AVX 512 support for x64
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+	set_source_files_properties(
+        src/loclass/cipher_bs_avx512.c
+        PROPERTIES COMPILE_OPTIONS "-mavx512f"
+    )
+endif()
+
 add_custom_command(
     OUTPUT  ${CMAKE_BINARY_DIR}/version_pm3.c
     COMMAND sh ${PM3_ROOT}/tools/mkversion.sh ${CMAKE_BINARY_DIR}/version_pm3.c || ${CMAKE_COMMAND} -E copy ${PM3_ROOT}/common/default_version_pm3.c ${CMAKE_BINARY_DIR}/version_pm3.c

--- a/client/deps/amiibo.cmake
+++ b/client/deps/amiibo.cmake
@@ -19,7 +19,7 @@ target_link_libraries(pm3rrg_rdv4_amiibo PRIVATE
         m
         pm3rrg_rdv4_mbedtls)
 
-target_compile_options(pm3rrg_rdv4_amiibo PRIVATE -Wall -Werror -O3)
+target_compile_options(pm3rrg_rdv4_amiibo PRIVATE -Wall -Werror -Wno-missing-braces -O3)
 set_property(TARGET pm3rrg_rdv4_amiibo PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(pm3rrg_rdv4_amiibo PRIVATE amiitool

--- a/client/deps/id48lib.cmake
+++ b/client/deps/id48lib.cmake
@@ -5,7 +5,7 @@ add_library(pm3rrg_rdv4_id48 STATIC
         id48/src/id48_generator.c
         id48/src/id48_recover.c
 )
-target_compile_options(    pm3rrg_rdv4_id48 PRIVATE   -Wpedantic -Wall -Werror -O3 -Wno-unknown-pragmas -Wno-inline -Wno-unused-function -DID48_NO_STDIO)
+target_compile_options(    pm3rrg_rdv4_id48 PRIVATE   -Wpedantic -Wall -Werror -O3 -Wno-unknown-pragmas -Wno-inline -Wno-unused-function -Wno-missing-braces -DID48_NO_STDIO)
 target_include_directories(pm3rrg_rdv4_id48 PRIVATE   id48/public)
 target_include_directories(pm3rrg_rdv4_id48 INTERFACE id48/public)
 set_property(TARGET        pm3rrg_rdv4_id48 PROPERTY  POSITION_INDEPENDENT_CODE ON)

--- a/client/deps/lua.cmake
+++ b/client/deps/lua.cmake
@@ -52,5 +52,5 @@ if (NOT MINGW)
 endif (NOT MINGW)
 
 target_include_directories(pm3rrg_rdv4_lua INTERFACE liblua)
-target_compile_options(pm3rrg_rdv4_lua PRIVATE -Wall -Werror -O3)
+target_compile_options(pm3rrg_rdv4_lua PRIVATE -Wall -Werror -Wno-missing-braces -O3)
 set_property(TARGET pm3rrg_rdv4_lua PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/client/deps/lua.cmake
+++ b/client/deps/lua.cmake
@@ -52,5 +52,5 @@ if (NOT MINGW)
 endif (NOT MINGW)
 
 target_include_directories(pm3rrg_rdv4_lua INTERFACE liblua)
-target_compile_options(pm3rrg_rdv4_lua PRIVATE -Wall -Werror -Wno-missing-braces -O3)
+target_compile_options(pm3rrg_rdv4_lua PRIVATE -Wall -Werror -Wno-missing-braces -Wno-deprecated-declarations -O3)
 set_property(TARGET pm3rrg_rdv4_lua PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/client/src/cmdparser.c
+++ b/client/src/cmdparser.c
@@ -30,6 +30,24 @@
 # include "pthread_spin_lock_shim.h"  // spinlock shim for OSX ..
 #endif
 
+#ifdef __ANDROID__
+//Spinlock patch for building with Android NDK
+
+typedef pthread_mutex_t pthread_spinlock_t;
+
+#define pthread_spin_init(lock, pshared) \
+    pthread_mutex_init(lock, NULL)
+
+#define pthread_spin_lock(lock) \
+    pthread_mutex_lock(lock)
+
+#define pthread_spin_unlock(lock) \
+    pthread_mutex_unlock(lock)
+
+#define pthread_spin_destroy(lock) \
+    pthread_mutex_destroy(lock)
+#endif
+
 #define MAX_PM3_INPUT_ARGS_LENGTH    4096
 
 bool AlwaysAvailable(void) {

--- a/client/src/loclass/cipher_bs_avx2.c
+++ b/client/src/loclass/cipher_bs_avx2.c
@@ -18,7 +18,7 @@
 
 #include <immintrin.h>
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__ANDROID__)
 #pragma GCC push_options
 #pragma GCC target("avx2")
 #endif
@@ -263,14 +263,14 @@ void doMAC_brute_match256(const uint64_t y_bits_bs[96 * BS256_WORDS],
     _mm256_storeu_si256((__m256i *)match_out, mac_match);
 }
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__ANDROID__)
 #pragma GCC pop_options
 #endif
 
 bool bs_avx2_supported(void) {
     static int cached = -1;
     if (cached < 0) {
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__ANDROID__)
         __builtin_cpu_init();
         cached = __builtin_cpu_supports("avx2") ? 1 : 0;
 #else

--- a/client/src/loclass/cipher_bs_avx512.c
+++ b/client/src/loclass/cipher_bs_avx512.c
@@ -19,7 +19,7 @@
 
 #include <immintrin.h>
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__ANDROID__)
 #pragma GCC push_options
 #pragma GCC target("avx512f")
 #endif
@@ -291,14 +291,14 @@ void doMAC_brute_match512(const uint64_t y_bits_bs[96 * BS512_WORDS],
     _mm512_storeu_si512((void *)match_out, mac_match);
 }
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__ANDROID__)
 #pragma GCC pop_options
 #endif
 
 bool bs_avx512_supported(void) {
     static int cached = -1;
     if (cached < 0) {
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__ANDROID__)
         __builtin_cpu_init();
         cached = __builtin_cpu_supports("avx512f") ? 1 : 0;
 #else


### PR DESCRIPTION
Cross compilation using the Android NDK (for the RFID tools app) has several problems on master
1. Clang throws errors on implicit zero inizialization of structs using `{0}` because we build with `-WError`
2. The Android NDK deprecates tempnam for lua, thus causing a deprecated declarations error
3. Android does not have spinlocks but only mutexes which causes errors where spinlocks are used
4. The Android NDK (maybe clang in general?) does not understand GCC pragmas

This PR fixes the issues as follows
1. Ignore the warnings by providing `-Wno-missing-braces` where required  
   The compiler suggests to use more brackets for deep initialization: `{{0}}`, `{{{0}}}`, ... but this becomes quite unreadable and causes `missing-field-initializers` errors on nested structs with length of more than one when building natively. To fix this, the initializations would have to look e.g. like this `{{{0},{0},{0}}}` which seems unnecessarily complex.
2. Ignore the deprecation warning  
   Alternatively, we could build with `-DLUA_USE_POSIX` but this only works for POSIX based systems, causing build errors for some arches. There seems to be no alternative to tempnam on non-POSIX systems with the current dependencies.
3. Replace spinlock with mutexes when building for Android  
4. Replace GCC pragmas with cmake definitions for Android  
   This actually makes the pragma definitions obsolete when building with cmake. The build successfully completes even with the pragmas removed. However when building with `make` only (`cd client && make`), the cmake definitions are not used which causes errors due to missing AVX2 support. To maintain compatibility with `make`, the pragmas were not removed.