### PR TITLE
More umc pack updates

### DIFF
--- a/client/luascripts/hf_mf_ultimatecard.lua
+++ b/client/luascripts/hf_mf_ultimatecard.lua
@@ -15,7 +15,7 @@ local _ug4_version = ''
 local _packpage = 'E6'
 copyright = ''
 author = 'Nathan Glaser'
-version = 'v1.0.6'
+version = 'v1.0.7'
 date = 'Created - Jan 2022'
 desc = 'This script enables easy programming of an Ultimate Mifare Magic card'
 example = [[
@@ -184,23 +184,24 @@ end
 ---
 -- Probe UMC revision robustly. CF<key>CC occasionally returns a truncated
 -- frame (e.g. 3F/7F), so retry until we get a well-formed 5-byte version.
--- New "UG4" replies 00 00 00 06 A0 -> PACK page 0x13; clean non-06A0 reads
+-- Some (06A0, 6666) UMC versions -> PACK page 0x13; others are assumed fine
 -- and an unprobeable card fall back to page 0xE6.
 local function detect_packpage()
     if _ug4_version ~= '' then return end          -- already classified this run
     for i = 1, 5 do
-        local v = (send("CF".._key.."CC") or ''):sub(1,10)
-        if #v == 10 and v:find('^%x+$') then        -- exactly 5 hex bytes
+        local v = (send("CF".._key.."CC") or ''):sub(1,-5):sub(-4)
+        if v:find('^%x+$') then        -- exactly 5 hex bytes
             _ug4_version = v:upper()
+            print("Detected UMC version: ".._ug4_version)
             break
         end
     end
-    if _ug4_version == '00000006A0' then
+    if _ug4_version == '06A0' or _ug4_version == '6666' then
         _packpage = '13'
     else
         _packpage = 'E6'
         if _ug4_version == '' then
-            print('[!] Warning: could not confirm UMC revision (CC probe corrupted); using PACK page 0xE6')
+            print("[!] Warning: unable to confirm config (".._ug4_version .."); using PACK page 0xE6")
         end
     end
 end

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -8830,7 +8830,7 @@ static int CmdHF14AGen4Info(const char *cmd) {
     uint8_t uid_len = resp[1];
 
     res = mfG4GetFactoryTest(pwd, resp, &resplen, false);
-    if (res == PM3_SUCCESS && resplen > 2) {
+    if (res == PM3_SUCCESS && resplen >= 2) {
 
         PrintAndLogEx(INFO, "");
         PrintAndLogEx(INFO, _CYAN_("Factory test"));
@@ -8839,19 +8839,19 @@ static int CmdHF14AGen4Info(const char *cmd) {
         }
 
         if (memcmp(resp + resplen - 2, "\x66\x66", 2) == 0) {
-            PrintAndLogEx(INFO, "Card type... Generic");
+            PrintAndLogEx(INFO, "Card type... Generic (%02X%02X)", resp[resplen - 2], resp[resplen - 1]);
 
         } else if (memcmp(resp + resplen - 2, "\x02\xAA", 2) == 0) {
-            PrintAndLogEx(INFO, "Card type... " _RED_("Limited functionality"));
+            PrintAndLogEx(INFO, "Card type... " _RED_("Limited functionality (%02X%02X)"), resp[resplen - 2], resp[resplen - 1]);
 
         } else if (memcmp(resp + resplen - 2, "\x03\xA0", 2) == 0) {
-            PrintAndLogEx(INFO, "Card type... Old card version");
+            PrintAndLogEx(INFO, "Card type... Old card version (%02X%02X)", resp[resplen - 2], resp[resplen - 1]);
 
         } else if (memcmp(resp + resplen - 2, "\x06\xA0", 2) == 0) {
-            PrintAndLogEx(INFO, "Card type... " _GREEN_("New card version"));
+            PrintAndLogEx(INFO, "Card type... " _GREEN_("New card version (%02X%02X)"), resp[resplen - 2], resp[resplen - 1]);
 
         } else {
-            PrintAndLogEx(INFO, "Card type... " _RED_("unknown %02X%02X"), resp[resplen - 2], resp[resplen - 1]);
+            PrintAndLogEx(INFO, "Card type... " _RED_("unknown (%02X%02X)"), resp[resplen - 2], resp[resplen - 1]);
         }
     }
 

--- a/client/src/cmdhfmfu.c
+++ b/client/src/cmdhfmfu.c
@@ -3502,7 +3502,9 @@ static int CmdHF14AMfUDump(const char *Cmd) {
                   "hf mfu dump -k AABBCCDD      -> dump whole tag using pwd AABBCCDD\n"
                   "hf mfu dump -p 10            -> start at page 10 and dump rest of blocks\n"
                   "hf mfu dump -p 10 -q 2       -> start at page 10 and dump two blocks\n"
-                  "hf mfu dump --key 00112233445566778899AABBCCDDEEFF"
+                  "hf mfu dump --key 00112233445566778899AABBCCDDEEFF\n"
+                  "\n"
+                  "Note: Dumping a NTAG/UL tag to a UMC will likely result in incorrect PWD and PACK\n"
                  );
 
     void *argtable[] = {
@@ -4006,7 +4008,9 @@ static int CmdHF14AMfURestore(const char *Cmd) {
                   "Restore MIFARE Ultralight/NTAG dump file (bin/eml/json) to tag.\n",
                   "hf mfu restore -f myfile -s                 -> special write\n"
                   "hf mfu restore -f myfile -k AABBCCDD -s     -> special write, use key\n"
-                  "hf mfu restore -f myfile -k AABBCCDD -ser   -> special write, use key, write dump pwd, ..."
+                  "hf mfu restore -f myfile -k AABBCCDD -ser   -> special write, use key, write dump pwd, ...\n"
+                  "\n"
+                  "Note: Restoring a NTAG/UL dump to a UMC will likely result in incorrect PWD and PACK\n"
                  );
 
     void *argtable[] = {

--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -2837,6 +2837,8 @@ The CF..CC command is commonly considered to be a way of determining UMC version
 - 6666 "Card type generic"
 - 02AA "Card type limited functionality"
 
+**NOTE**: Some versions (eg, 6666) return just the version + crc (4-bytes) others (eg, 06A0) return a zero padded version + crc (7-bytes).
+
 ### Proxmark3 commands
 
 ^[Top](#top) ^^[Gen4](#g4top)

--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -3083,10 +3083,9 @@ hf 14a raw -s -c -t 1000 CF000000006B3F
 
 ^[Top](#top) ^^[Gen4](#g4top)
 
-**For UMC 06A0**
+**For UMC 06A0 and 6666**
 
-Despite varying memory structures on their specs, the UMC derives things like the
-PWD and PACK from fixed pages. The PWD is stored at E5 which matches the NTAG216/I2C transponders while the PACK is stored at 13 like an NTAG210.
+Despite varying memory structures on their specs, the UMC derives things like the PWD and PACK from fixed pages. The PWD is stored at E5 which matches the NTAG216/I2C transponders while the PACK is stored at 13 like an NTAG210 or an Ultralight EV1.
 
 #### Set NTAG PWD
 
@@ -3103,11 +3102,15 @@ script run hf_mf_ultimatecard -p <new 4-byte PWD>
 ```
 #### Set NTAG PACK
 ```
-hf mfu wrbl -b 13 -d <2-byte PACK>00
+hf mfu wrbl -b 13 -d <2-byte PACK>0000
 ```
 or
 ```
 hf 14a -s -c -t 1000 a213<2-byte PACK>0000
+```
+or
+```
+script run hf_mf_ultimatecard -a <2-byte PACK>
 ```
 
 ### Set shadow mode (GTU)


### PR DESCRIPTION
Added note to the hf mfu dump/restore commands re: password/pack on the UMC. There was also an issue with UMC version detection in ginfo (it couldn't detect version 6666) and the lua script (UMC version seems to be either 5 or 2-bytes with the leading bytes zero'd.