### PR TITLE
Fix lf em 4x05 dump writing corrupted (byte-swapped) dump files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 
 ## [unreleased][unreleased]
 
+- Fixed `lf em 4x05 dump` writing byte-swapped (corrupted) block data to the saved dump file (@munzzyy)
 - Added `hf 14b dump` support for Standard ISO14443-B tags (@thisiscamk)
 - Added `hf 14b ctrdbl` and `hf 14b ctdump` commands for interacting with ASK CTS tags (@kormax)
 - Fixed `hf legic migrate` failing to parse the optional DCF argument as hex (@IdanHo)

--- a/client/src/cmdlfem4x05.c
+++ b/client/src/cmdlfem4x05.c
@@ -934,14 +934,20 @@ static void em4x05_print_footer(void) {
     PrintAndLogEx(NORMAL, "");
 }
 
-static void em4x05_print_blocks(em_tech_type_t cardtype, uint8_t *data, uint8_t dlen) {
+static void em4x05_print_blocks(em_tech_type_t cardtype, const uint8_t *src, uint8_t dlen) {
 
     // must have 4 byte alignment
-    if ((data == NULL) || (dlen % EM4X05_BLOCK_SIZE) != 0) {
+    if ((src == NULL) || (dlen % EM4X05_BLOCK_SIZE) != 0) {
         return;
     }
 
-    uint32_t *d = (void *)data;
+    // Work on a private copy. This routine byte-swaps the buffer for display,
+    // and callers such as CmdEM4x05Dump() still need the original bytes
+    // afterwards to save an uncorrupted dump to file (issue #3403).
+    // dlen is a uint8_t, so 64 words is enough to hold any valid input.
+    uint32_t d[64] = {0};
+    memcpy(d, src, dlen);
+    uint8_t *data = (uint8_t *)d;
 
     uint8_t i;
     for (i = 0; i < (dlen >> 2); i++) {


### PR DESCRIPTION
## What

`lf em 4x05 dump` writes a corrupted dump file. Every 32-bit block in the saved `.bin`/`.json` comes out byte-reversed, so reloading it (with `lf em 4x05 view` or anything else) gives the wrong data.

## Why

`em4x05_print_blocks()` byte-swaps its buffer in place to print the blocks:

```c
uint32_t *d = (void *)data;
for (i = 0; i < (dlen >> 2); i++)
    d[i] = BSWAP_32(d[i]);
```

In `CmdEM4x05Dump()` that print call runs *before* `pm3_save_dump()`. The read loop stores each word as `data[addr] = BSWAP_32(word)`, which is the order the loader in `CmdEM4x05View()` expects — it reads blocks MSB-first via `bytes_to_num()`. The extra in-place swap in the print routine undoes that right before the save, so the file lands in the wrong byte order.

It also corrupts the auto-generated filename, which is built from `BSWAP_32(data[1])` after the print call.

Symmetric words like `0x00000000` survive a byte-swap unchanged, which is why this is easy to miss at a glance.

## Fix

Give `em4x05_print_blocks()` a private copy to swap and print, and take the input as `const` so it can't mutate the caller's buffer. On-screen output is byte-for-byte identical; the dump path now saves the untouched buffer. Both call sites stay correct — `view` frees its buffer right after and never relied on the mutation.

## Checking it

Modelling the exact transforms (`BSWAP_32`, the little-endian save, and the loader's MSB-first `bytes_to_num`) and round-tripping a full 16-block tag:

| block | tag word | reloads before | reloads after |
|------:|:--------:|:--------------:|:-------------:|
| 1 | `01020304` | `04030201` ✗ | `01020304` ✓ |
| 4 | `DEADBEEF` | `EFBEADDE` ✗ | `DEADBEEF` ✓ |
| 8 | `00000000` | `00000000` ✓ | `00000000` ✓ |

Before the fix the saved dump reloads byte-swapped; after, it round-trips cleanly.

## Possible follow-up (not part of this change)

While in here I noticed `CmdEM4x05View()` passes a `size_t bytes_read` into the `uint8_t dlen` parameter, which silently truncates on an oversized or malformed dump file. That's pre-existing and untouched by this PR — flagging it as a separate hardening item so it doesn't look overlooked.

Fixes #3403
