### PR TITLE
Fix IR56 wiegand decode leaking header sentinel bit into facility code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 
 ## [unreleased][unreleased]
 
+- Fixed `wiegand decode` returning facility code 16777339 instead of the encoded value for the IR56 (Inner Range 56-bit) format by masking the header sentinel bit off the facility code (@munzzyy)
 - Fixed `lf em 4x05 dump` writing byte-swapped (corrupted) block data to the saved dump file (@munzzyy)
 - Added `hf 14b dump` support for Standard ISO14443-B tags (@thisiscamk)
 - Added `hf 14b ctrdbl` and `hf 14b ctdump` commands for interacting with ASK CTS tags (@kormax)

--- a/client/src/wiegand_formats.c
+++ b/client/src/wiegand_formats.c
@@ -1472,7 +1472,9 @@ static bool Unpack_IR56(wiegand_message_t *packed, wiegand_card_t *card) {
 
     if (packed->Length != 56) return false;
 
-    card->FacilityCode = packed->Mid;
+    // Mask off the header/sentinel bit that add_HID_header sets at position 56
+    // (Mid |= 1 << 24) so it doesn't leak into the 24-bit facility code.
+    card->FacilityCode = packed->Mid & 0x00FFFFFF;
     card->CardNumber = packed->Bot;
     return true;
 }

--- a/tools/pm3_tests.sh
+++ b/tools/pm3_tests.sh
@@ -506,6 +506,8 @@ while true; do
       if ! CheckExecute "wiegand Verkada40 decode test 2" "$CLIENTBIN -c 'wiegand decode --raw 86400007D9'" "Verkada40.*FC: 50  CN: 1004  parity \( ok \)"; then break; fi
       if ! CheckExecute "wiegand Verkada40 encode test 3" "$CLIENTBIN -c 'wiegand encode -w Verkada40 --fc 81 --cn 5008'" "8A20002721"; then break; fi
       if ! CheckExecute "wiegand Verkada40 decode test 3" "$CLIENTBIN -c 'wiegand decode --raw 8A20002721'" "Verkada40.*FC: 81  CN: 5008  parity \( ok \)"; then break; fi
+      if ! CheckExecute "wiegand IR56 encode roundtrip"   "$CLIENTBIN -c 'wiegand encode -w IR56 --fc 123 --cn 123 --pre'" "9E000000100007B0000007B"; then break; fi
+      if ! CheckExecute "wiegand IR56 decode roundtrip"   "$CLIENTBIN -c 'wiegand decode --raw 9E000000100007B0000007B'" "IR56.*FC: 123  CN: 123"; then break; fi
 
       echo -e "\n${C_BLUE}Testing LF:${C_NC}"
       if ! CheckExecute "lf hitag2 test"             "$CLIENTBIN -c 'lf hitag test'" "Tests \( ok"; then break; fi


### PR DESCRIPTION
Fixes #2975.

## The bug

Encoding an IR56 (Inner Range 56-bit) card and decoding it back doesn't round-trip. The facility code comes out wrong:

```
[usb] pm3 --> wiegand encode -w IR56 --fc 123 --cn 123 --pre
[+] Wiegand: 9E000000100007B0000007B

[usb] pm3 --> wiegand decode --raw 9E000000100007B0000007B
[+] [IR56    ] Inner Range 56-bit               FC: 16777339  CN: 123
```

FC 123 goes in, FC 16777339 comes out.

## Why

`Pack_IR56` stores the facility code in `packed->Mid`, then `add_HID_header` sets the length sentinel bit at position 56 (`Mid |= 1 << 24`). So for FC 123 the Mid word ends up as `0x0100007B`.

`Unpack_IR56` copied `packed->Mid` straight into `card->FacilityCode` without masking, so that sentinel bit leaked into the value: `0x0100007B` = 16777339, which is exactly the wrong number in the report.

This is a regression from #2772, which swapped the old masked linear-field accessors for a raw `packed->Mid` assignment.

## The fix

Mask the facility code to its 24-bit field on unpack:

```c
card->FacilityCode = packed->Mid & 0x00FFFFFF;
```

`0x00FFFFFF` is the format's own declared MaxFC in the descriptor table, and the sibling `Unpack_C1k48s` masks its facility code the same way. The sentinel lives at bit 24, above the field, so the mask drops it without touching any legitimate FC value.

## Verification

Built the client on Linux and checked the round-trip offline (no hardware needed, since this is pure client-side bit logic):

- Before the fix, `wiegand decode --raw 9E000000100007B0000007B` returns FC 16777339.
- After the fix it returns FC 123, matching what was encoded.
- A facility code near the top of the range (16777000) still round-trips exactly, so the mask isn't clipping valid values.

Added two cases to `tools/pm3_tests.sh` (an IR56 encode and a decode round-trip) next to the existing Verkada40 wiegand tests. I confirmed the decode case fails on current HEAD and passes with the fix by stashing the change and rebuilding.

I could not test against a real Inner Range reader/tag; the check is client-side encode/decode only.
