### PR TITLE
Fix heap out-of-bounds read in hf iclass view on short dump files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 
 ## [unreleased][unreleased]
 
+- Fixed `hf iclass view` reading past the end of dump files smaller than a picopass header, causing a heap out-of-bounds read and garbage/leaked heap data being printed as tag content (@munzzyy)
 - Fixed `wiegand decode` returning facility code 16777339 instead of the encoded value for the IR56 (Inner Range 56-bit) format by masking the header sentinel bit off the facility code (@munzzyy)
 - Fixed `lf em 4x05 dump` writing byte-swapped (corrupted) block data to the saved dump file (@munzzyy)
 - Added `hf 14b dump` support for Standard ISO14443-B tags (@thisiscamk)

--- a/client/src/cmdhficlass.c
+++ b/client/src/cmdhficlass.c
@@ -5306,7 +5306,10 @@ void printIclassDumpContents(uint8_t *iclass_dump, uint8_t startblock, uint8_t e
         endblock = maxmemcount;
 
     // remember endblock needs to relate to zero-index arrays.
-    if (endblock > filemaxblock - 1)
+    // filemaxblock is 0 when filesize < 8, so filemaxblock - 1 would underflow.
+    if (filemaxblock == 0)
+        endblock = 0;
+    else if (endblock > filemaxblock - 1)
         endblock = filemaxblock - 1;
 
     /*
@@ -5513,6 +5516,12 @@ static int CmdHFiClassView(const char *Cmd) {
     int res = pm3_load_dump(filename, (void **)&dump, &bytes_read, 2048);
     if (res != PM3_SUCCESS) {
         return res;
+    }
+
+    if (bytes_read < sizeof(picopass_hdr_t)) {
+        PrintAndLogEx(FAILED, "Error, dump file is too small to be a valid iCLASS dump - bytes: %zu, expected at least: %zu", bytes_read, sizeof(picopass_hdr_t));
+        free(dump);
+        return PM3_EFILE;
     }
 
     if (verbose) {


### PR DESCRIPTION
`hf iclass view` casts the loaded dump buffer straight to `picopass_hdr_t *` (48 bytes) with no check that the file is actually that big first:

```c
int res = pm3_load_dump(filename, (void **)&dump, &bytes_read, 2048);
...
print_picopass_header((picopass_hdr_t *) dump);
print_picopass_info((picopass_hdr_t *) dump);
```

For `.bin`/`.eml`/`.mct` dumps, `pm3_load_dump()` sizes the buffer to the actual file content, so a dump file shorter than 48 bytes turns that cast into a heap over-read. `hf 15 view` and `hf mf view` both guard this already (`bytes_read != sizeof(iso15_tag_t)`, etc.) - `hf iclass view` is just missing the same check.

Confirmed with an ASan build (`make client SANITIZE=1`) against an 8-byte dump (`hf iclass view -f tiny.bin`):

```
==ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 1
    #0 hex_to_buffer src/util.c:257
    #2 sprint_hex src/util.c:449
    #3 print_picopass_header src/cmdhficlass.c:987
    #4 CmdHFiClassView src/cmdhficlass.c:5524
```

On a plain release build (no sanitizer) it doesn't crash, it just prints whatever's sitting in adjacent heap memory as if it were tag data, labeled as CSN/config/debit key/etc. So this can leak unrelated heap contents to the terminal, not only crash.

Fix: add the same length guard the other `view` commands use, before the struct cast. While I was in there I also fixed `printIclassDumpContents()`'s `uint8_t filemaxblock = filesize / 8`, which underflows to 255 when `filesize < 8` and defeats the `endblock` clamp - it's a second, independent way to hit an oversized read in the same function even if the first guard gets loosened later, so I guarded that too.

Verified:
- Reproduced the ASan crash above on current master with an 8-byte dump.
- Applied the fix, rebuilt with `SANITIZE=1`, ran the same command against the same file - no more heap-buffer-overflow, just a clean "dump file is too small" message and no output.
- Also ran it against a 48-byte file (exactly `sizeof(picopass_hdr_t)`) to make sure the boundary case still works normally - prints the header fine, no crash.
- Didn't have `astyle` installed to run `make style`, matched the surrounding code's spacing/brace style by hand instead.
