### PR TITLE
docs(emv): EMV terminal emulator planning bundle (1/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Added EMV terminal emulator operator guide (lab/research use only; not a certified payment terminal).
 
 - Added `hf mf gdmgetblk/gdmgethidblk/gdmsethidblk/gdmsetuid/gdmwipe/gdmsetsig` (@0x6r1an0y)
 - Changed `hf mf gdmparsecfg/gdmsetblk` (@0x6r1an0y)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The Proxmark3 is the swiss-army tool of RFID, allowing for interactions with the
 | Notes |||
 | ------------------- |:-------------------:| -------------------:|
 |[Notes on UART](/doc/uart_notes.md)|[Notes on Termux / Android](/doc/termux_notes.md)|[Notes on paths](/doc/path_notes.md)|
-|[Notes on frame format](/doc/new_frame_format.md)|[Notes on tracelog / wireshark](/doc/trace_notes.md)|[Notes on EMV](/doc/emv_notes.md)|
+|[Notes on frame format](/doc/new_frame_format.md)|[Notes on tracelog / wireshark](/doc/trace_notes.md)|[Notes on EMV](/doc/emv_notes.md) · [EMV terminal operator guide](/doc/planning/emv-terminal-emulator/OPERATOR-GUIDE.md)|
 |[Notes on external flash](/doc/ext_flash_notes.md)|[Notes on loclass](/doc/loclass_notes.md)|[Notes on Coverity Scan Config & Run](/doc/md/Development/Coverity-Scan-Config-and-Run.md)|
 |[Notes on file formats used with Proxmark3](/doc/extensions_notes.md)|[Notes on MFU binary format](/doc/mfu_binary_format_notes.md)|[Notes on FPGA & ARM](/doc/fpga_arm_notes.md)|
 |[Developing standalone mode](/armsrc/Standalone/readme.md)|[Wiki about standalone mode](https://github.com/RfidResearchGroup/proxmark3/wiki/Standalone-mode)|[Notes on Magic UID cards](/doc/magic_cards_notes.md)|

--- a/doc/emv_notes.md
+++ b/doc/emv_notes.md
@@ -30,15 +30,15 @@ Notes on EMV works on Proxmark3
 - Get records from AFL (`emv readrec`)
 - Make SDA (check records from GPO)
 - Make DDA (`emv challenge` `emv intauth`)
-- Check PIN (`not implemented`)
+- Check PIN (`not implemented` in `emv exec`; see `emv terminal pin`)
 - Fill CDOL1 and CDOL2 (look at next part)
-- Execute AC1 (with CDA support) (`emv genac`)
-- Check ARQC (bank part) (`not implemented`)
-- Make ARPC (bank part) (`not implemented`)
-- Execute external authenticate (`not implemented`)
-- Execute AC2 (with CDA support) (`not implemented`)
+- Execute AC1 (with CDA support) (`emv genac`, `emv terminal run`)
+- Check ARQC (bank part) (`emv terminal online` lab stub)
+- Make ARPC (bank part) (`emv terminal online --arpc` lab stub)
+- Execute external authenticate (`emv terminal online` lab stub)
+- Execute AC2 (with CDA support) (`emv terminal online`)
 - Check ARQC cryptogram (`not implemented`)
-- Issuer scripts processing (`not implemented`)
+- Issuer scripts processing (`emv terminal online` — tag 71 before AC2)
 
 ### Working parts of qVSDC
 ^[Top](#top)
@@ -123,6 +123,47 @@ All main commands are parts of EMV specification. Commands than not described th
 
 `emv test` - test all crypto code from emv part of proxmark.
 
+### EMV terminal emulator (`emv terminal`)
+^[Top](#top)
+
+> **FOR RESEARCH AND LAB USE ONLY — NO WARRANTY — PROVIDED AS-IS.**  
+> Not a certified payment terminal. Authorized EMV test cards only.  
+> Docs: [doc/planning/emv-terminal-emulator/README.md](planning/emv-terminal-emulator/README.md) · [OPERATOR-GUIDE.md](planning/emv-terminal-emulator/OPERATOR-GUIDE.md) · [SPEC-security-privacy.md](planning/emv-terminal-emulator/SPEC-security-privacy.md)
+
+Client-side terminal phase engine in `client/src/emv/terminal/`.
+
+```
+terminal run         Full phase loop (init → … → complete)
+terminal step        Single phase
+terminal online      Complete online path after ARQC
+terminal pin         Standalone VERIFY PIN
+terminal profile     print | validate
+terminal load        Import card TLV from prior emv scan JSON
+terminal session     print | merge | export
+terminal host        listen (TCP mock acquirer) | sim
+terminal host-sim    One-shot host-sim on session (alias)
+terminal export-sim  Export emv sim card patch from session
+terminal test        --golden | --fixture <name>  (no USB)
+terminal replay      Mock APDU replay (--from-phase / --to-phase)
+terminal capabilities Device and build capability list
+terminal help        Command help
+```
+
+Common flags on `run` / `step`: `-satj`, `-o session.json`, `--profile auto`, `--host-sim`, `--mock-apdu-file`, `--pcap-out`, `--timing-report`, `--exception-file`, `--no-redact`.
+
+Example:
+
+```
+emv terminal capabilities
+emv terminal run -satj -o /tmp/session.json --qvsdc --profile auto
+emv terminal run -j --host-sim -o /tmp/session.json
+emv terminal run --mock-apdu-file fixtures/foo/mock_apdu.json -j -o /tmp/s.json
+emv terminal replay mock_apdu.json --from-phase cvm --to-phase caa -o /tmp/s.json
+emv terminal online --session /tmp/session.json --host-sim
+emv terminal load card.json -o card_session.json
+emv terminal test --golden
+emv test
+```
 ### Useful links
 ^[Top](#top)
 

--- a/doc/emv_pcap_format.md
+++ b/doc/emv_pcap_format.md
@@ -1,0 +1,34 @@
+# Proxmark3 EMV ISO7816 PCAP format
+
+Link-layer type **265** (`EMV_PCAP_LINKTYPE`) for Wireshark USER0 / custom dissector import.
+
+## Global header
+
+Standard libpcap global header with `network = 265`.
+
+## Per-packet payload
+
+Each captured frame uses a pseudo-header compatible with the ISO14443 pcap convention.
+`text2pcap -l 265` may be used for text conversion.
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 0 | 1 | Version (`0x00`) |
+| 1 | 1 | Direction: `0xFE` = PMD→ICC (CAPDU), `0xFF` = ICC→PMD (RAPDU+SW) |
+| 2 | 2 | Payload length (big-endian, excludes pseudo-header) |
+| 4 | N | APDU bytes |
+| 4+N | 2 | Status word (ICC→PMD records only, appended after RAPDU body) |
+
+Timestamps are stored in the standard pcap record header (`ts_sec`, `ts_usec`), relative to the first APDU in the session.
+
+## PIN redaction
+
+When session redaction is enabled (default), VERIFY PIN (`INS=0x20`), VERIFY PIN enciphered (`0x24`), and related PIN-bearing CAPDUs have their command data field zeroed before write.
+
+## Companion metadata
+
+`--pcap-meta session.json` writes `<pcap>.meta.json` linking the trace file to the terminal session export for phase correlation.
+
+## Wireshark
+
+Register a USER0 dissector on linktype 265, or use `tshark -r trace.pcap -V` with a Lua post-dissector. Phase boundaries are available in the companion session JSON `Phases[]` array.

--- a/doc/planning/emv-terminal-emulator/OPERATOR-GUIDE.md
+++ b/doc/planning/emv-terminal-emulator/OPERATOR-GUIDE.md
@@ -1,0 +1,202 @@
+# EMV Terminal Emulator — Operator Guide
+
+> **FOR RESEARCH AND LAB USE ONLY — NO WARRANTY — PROVIDED AS-IS**
+>
+> This tool is **not** a certified payment terminal. It does not implement PCI PTS POI requirements and must **not** be used on live payment networks, at merchants, or against cards you do not own or lack written authorization to test.
+>
+> PIN handling: use `--pin` / `EMV_TEST_PIN` for automation; interactive prompt on TTY only. Session export redacts PAN/crypto by default (`--no-redact` is lab-only).
+
+---
+
+## What you need
+
+| Item | Notes |
+|------|--------|
+| Proxmark3 client | Built with `make client` (gcc recommended) |
+| PM3 device | Optional for mock/golden tests; required for live cards |
+| HF field voltage | RDV4 sim supplies **3.3 V** on the antenna; **5 V** legacy cards may not activate. Use 3.3 V lab cards or hardware that supports 5 V contactless if needed. |
+| Test cards | EMV lab / personal test cards only |
+| Terminal profile | `client/resources/emv_terminal_profile.json` or scheme profile (`--profile auto`) |
+
+Check hardware support (no device required):
+
+```bash
+./pm3 --offline -c 'emv terminal capabilities'
+```
+
+---
+
+## First run — legal acknowledgment
+
+The first time you run a live terminal command (`run`, `step`, `online`, `host-sim`), the client prints an authorized-use banner and writes a timestamp to:
+
+```text
+~/.proxmark3/emv_terminal_ack
+```
+
+To skip the banner in automation (CI only):
+
+```bash
+export EMV_TERMINAL_I_ACK=1
+```
+
+Mock and golden tests suppress the banner automatically (`--mock-apdu-file`, `emv terminal test --golden`).
+
+---
+
+## Common workflows
+
+### 1. Full contactless transaction (live card)
+
+```bash
+./pm3 -- emv terminal run -satj -o /tmp/session.json --qvsdc --profile auto
+```
+
+Flags:
+
+- `-s` — activate field and select card
+- `-a` — show APDUs (PIN data redacted by default)
+- `-t` — TLV decode
+- `-j` — load terminal profile JSON
+- `-o` — write session JSON
+
+### 2. Scheme-specific (Interac example)
+
+```bash
+./pm3 -- emv terminal run -j --profile interac --host-sim -o /tmp/session.json
+```
+
+### 3. Step-by-step debugging
+
+```bash
+./pm3 -- emv terminal step init -satj -o /tmp/session.json
+./pm3 -- emv terminal step cvm --session /tmp/session.json --pin 1234 -o /tmp/session.json
+./pm3 -- emv terminal step caa --session /tmp/session.json -o /tmp/session.json
+./pm3 -- emv terminal online --session /tmp/session.json --host-sim -o /tmp/session.json
+```
+
+### 4. Offline testing from scan JSON
+
+```bash
+./pm3 -- emv scan -at card.json
+./pm3 -- emv terminal load card.json -o card_session.json
+./pm3 -- emv terminal step taa --session card_session.json -o out.json
+```
+
+### 5. Mock APDU replay (no USB)
+
+```bash
+./pm3 --offline -c 'emv terminal run --mock-apdu-file fixtures/foo/mock_apdu.json -j -o /tmp/s.json'
+./pm3 --offline -c 'emv terminal replay fixtures/foo/mock_apdu.json --from-phase cvm --to-phase caa -o /tmp/s.json'
+```
+
+### 6. Host simulator (online completion)
+
+```bash
+# One-shot on existing session with ARQC
+./pm3 -- emv terminal host-sim --session /tmp/session.json
+
+# TCP mock acquirer (separate terminal)
+./pm3 --offline -c 'emv terminal host listen 8583'
+./pm3 -- emv terminal run -j --host-tcp 127.0.0.1:8583 -o /tmp/session.json
+```
+
+### 7. Session inspection and export
+
+```bash
+./pm3 --offline -c 'emv terminal session print /tmp/session.json'
+./pm3 --offline -c 'emv terminal session merge scan.json session.json -o merged.json'
+./pm3 --offline -c 'emv terminal export-sim session.json -o patch.json'
+```
+
+### 8. Trace and timing
+
+```bash
+./pm3 -- emv terminal run -satj --pcap-out /tmp/emv.pcap --timing-report -o /tmp/session.json
+```
+
+PCAP format: [doc/emv_pcap_format.md](../../doc/emv_pcap_format.md) (Wireshark linktype 265).
+
+---
+
+## PIN handling
+
+| Method | Command / env |
+|--------|----------------|
+| CLI flag | `--pin 1234` (avoid in shared shell history) |
+| Environment | `EMV_TEST_PIN=1234` (preferred for scripts) |
+| Interactive | `emv terminal pin --prompt` |
+| Skip online PIN CVM | `--cvm-skip-online` (sets TVR bit only) |
+
+PIN buffers are zeroized after use. Session JSON does not include raw PIN by default.
+
+---
+
+## Session JSON and redaction
+
+Default export **masks** PAN and **truncates** cryptograms. For lab-only full export:
+
+```bash
+./pm3 -- emv terminal run ... --no-redact --full-tlv -o session_full.json
+# or
+export EMV_TERMINAL_FULL_SESSION=1
+```
+
+Never commit unredacted session files with real card data to git.
+
+---
+
+## Regression testing (no hardware)
+
+```bash
+./pm3 --offline -c 'emv test'                      # unit tests incl. terminal crypto
+./pm3 --offline -c 'emv terminal test --golden'    # 6/6 golden fixtures
+./pm3 --offline -c 'emv terminal test --fixture taa_denial_expired'
+```
+
+Fixtures live in `client/src/emv/test/fixtures/`. See [fixtures README](../../client/src/emv/test/fixtures/README.md).
+
+---
+
+## Command reference (v2)
+
+```text
+emv terminal
+├── run              Full phase loop
+├── step             Single phase
+├── online           Complete online after ARQC
+├── pin              Standalone VERIFY PIN
+├── profile          print | validate
+├── load             Import card TLV from scan JSON
+├── session          print | merge | export
+├── host             listen (TCP) | sim (one-shot)
+├── host-sim         Alias for host sim one-shot
+├── export-sim       Card patch for emv sim research
+├── test             --golden | --fixture <name>
+├── replay           Mock APDU replay with phase range
+└── capabilities     Device / build capability list
+```
+
+Full CLI flags: `emv terminal help` and [SPEC-v2-cli-ux.md](./SPEC-v2-cli-ux.md).
+
+---
+
+## Troubleshooting
+
+| Symptom | Check |
+|---------|--------|
+| `No 14a tag spotted` | Card position, `-s` select, try `-w` for contact |
+| `SMARTCARD support` error | Contact path needs smartcard mod; use contactless or mock |
+| CVM / PIN failure | Wrong PIN, use test card docs; try `emv terminal pin --offline` |
+| ARQC online stuck | Pass `--host-sim`, `--host-tcp`, or `--arpc` |
+| Golden test fail | Run from repo root; `CC=gcc make -C client` |
+
+---
+
+## Related documentation
+
+- [README.md](./README.md) — overview and document map
+- [SPEC-security-privacy.md](./SPEC-security-privacy.md) — security requirements
+- [SPEC-v2-trace-replay.md](./SPEC-v2-trace-replay.md) — PCAP and replay
+- [doc/emv_notes.md](../../doc/emv_notes.md) — all EMV commands
+- [CHANGELOG.md](./CHANGELOG.md) — feature history

--- a/doc/planning/emv-terminal-emulator/README.md
+++ b/doc/planning/emv-terminal-emulator/README.md
@@ -1,0 +1,19 @@
+# EMV terminal emulator (lab use)
+
+> **FOR RESEARCH AND LAB USE ONLY — NO WARRANTY — PROVIDED AS-IS**
+>
+> This is **not** a certified payment terminal. Use only with authorized EMV test cards.
+
+## How to use
+
+See **[OPERATOR-GUIDE.md](./OPERATOR-GUIDE.md)** for day-to-day commands, workflows, RDV4 3.3 V notes, and safety acknowledgments.
+
+Also:
+
+- Command overview: [doc/emv_notes.md](../../emv_notes.md) (`emv terminal` section)
+- PCAP export notes: [doc/emv_pcap_format.md](../../emv_pcap_format.md)
+
+```bash
+./pm3 --offline -c 'emv terminal capabilities'
+./pm3 --offline -c 'emv terminal help'
+```


### PR DESCRIPTION
Split of #3385. Docs only under `doc/planning/emv-terminal-emulator/`.
Merge order: 1 → 2 → 3a → 3b → 4.
RDV4 sim is 3.3V only (5V cards may not work).
Fork review draft: https://github.com/andrew867/proxmark3/pull/18
