### PR TITLE
Making deprecated 'adapter_khz' no longer default just because incomp…

### DIFF
--- a/tools/jtag_openocd/board-at91sam7s.cfg
+++ b/tools/jtag_openocd/board-at91sam7s.cfg
@@ -29,6 +29,5 @@ sam7x.cpu configure -work-area-virt 0 -work-area-phys 0x00200000 -work-area-size
 flash bank sam7x.flash.0 at91sam7 0 0 0 0 sam7x.cpu 0 0 0 0 0 0 0 18432
 flash bank sam7x.flash.1 at91sam7 0 0 0 0 sam7x.cpu 1 0 0 0 0 0 0 18432
 transport select jtag
-# Since some 0.10.0 versions, "adapter_khz" is deprecated in favor of "adapter speed" but there are also some 0.10.0 not recognizing "adapter speed" so we'll stick to "adapter_khz" for now...
-# adapter speed 1000
-adapter_khz 1000
+# Some legacy 10.10.0 versions will need to stick to legacy "adapter_khz" instead "adapter speed"
+adapter speed 1000


### PR DESCRIPTION
…atible subvariant of 10yo legacy version (predating deprecation) exist somewhere