### PR TITLE
proxmark3 classic doesn't have JTAG RST lines routed at all so there …

### DIFF
--- a/tools/jtag_openocd/board-at91sam7s.cfg
+++ b/tools/jtag_openocd/board-at91sam7s.cfg
@@ -1,6 +1,7 @@
 ## Chipset configuration section
 # use combined on interfaces or targets that can't set TRST/SRST separately
-reset_config srst_only srst_pulls_trst
+#reset_config srst_only srst_pulls_trst
+reset_config none #proxmark3 classic doesn't have JTAG RST lines routed at all
 
 jtag newtap sam7x cpu -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id 0x3f0f0f0f
 


### PR DESCRIPTION
…is no reason to having those enabled/generating warning in OpenOCD