### PR TITLE
fix: `hf mf fchk` with `--blk` does not print when keys are found

### DIFF
--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -4058,7 +4058,7 @@ static int CmdHF14AMfChk_fast(const char *Cmd) {
                 if (size == keycnt - i) {
                     lastChunk = true;
                 }
-                int res = mf_check_keys_fast_ex(sectorsCnt, firstChunk, lastChunk, strategy, size, keyBlock + (i * MIFARE_KEY_SIZE), e_sector, false, false, true, singleSectorParams);
+                int res = mf_check_keys_fast_ex(sectorsCnt, firstChunk, lastChunk, strategy, size, keyBlock + (i * MIFARE_KEY_SIZE), e_sector, false, false, false, singleSectorParams);
                 if (firstChunk)
                     firstChunk = false;
 


### PR DESCRIPTION
Issue: running `hf mf fchk` with `--blk` option (single block recovery mode) will not print results even when matching keys are found because it calls `mf_check_keys_fast_ex` with `quiet=true`.

Fix: Changed it to `quiet=false`.