### PR TITLE
fix: FM11RF08S key recovery generates incorrect results when `nt == 0`

### DIFF
--- a/client/src/cmdhfmfsen.c
+++ b/client/src/cmdhfmfsen.c
@@ -943,42 +943,24 @@ static int fm11_generate_1nt_candidates(uint32_t uid, uint32_t nt, uint32_t nt_e
     return PM3_SUCCESS;
 }
 
-static uint16_t fm11_i_lfsr16[1 << 16] = {0};
-static uint16_t fm11_s_lfsr16[1 << 16] = {0};
-static uint16_t fm11_prev8_lfsr16[1 << 16] = {0};
-static uint16_t fm11_prev14_lfsr16[1 << 16] = {0};
+static uint16_t fm11_prev8_lfsr16[1 << 16];
+static uint16_t fm11_prev14_lfsr16[1 << 16];
 static bool fm11_lfsr16_ready = false;
-
-static uint16_t fm11_prev_lfsr16(uint16_t nonce);
 
 static void fm11_init_lfsr16_table(void) {
     if (fm11_lfsr16_ready) {
         return;
     }
+    uint16_t buffer[16] = { 0 };
     uint16_t x = 1;
-    for (uint16_t i = 1; i; ++i) {
-        fm11_i_lfsr16[(x & 0xff) << 8 | x >> 8] = i;
-        fm11_s_lfsr16[i] = (x & 0xff) << 8 | x >> 8;
+    for (uint32_t i = 0; i < 65536 + 16; ++i) {
+        fm11_prev8_lfsr16[buffer[(i + 8) % 16]] = buffer[i % 16];
+        fm11_prev14_lfsr16[buffer[(i + 14) % 16]] = buffer[i % 16];
+
         x = x >> 1 | (x ^ x >> 2 ^ x >> 3 ^ x >> 5) << 15;
-    }
-    for (uint32_t nonce = 0; nonce <= UINT16_MAX; nonce++) {
-        uint16_t p = nonce;
-        for (uint8_t i = 0; i < 8; i++) {
-            p = fm11_prev_lfsr16(p);
-        }
-        fm11_prev8_lfsr16[nonce] = p;
-        for (uint8_t i = 8; i < 14; i++) {
-            p = fm11_prev_lfsr16(p);
-        }
-        fm11_prev14_lfsr16[nonce] = p;
+        buffer[i % 16] = (x & 0xFF) << 8 | x >> 8;
     }
     fm11_lfsr16_ready = true;
-}
-
-static uint16_t fm11_prev_lfsr16(uint16_t nonce) {
-    uint16_t i = fm11_i_lfsr16[nonce];
-    i = (i == 1) ? 0xffff : i - 1;
-    return fm11_s_lfsr16[i];
 }
 
 static uint16_t fm11_compute_seednt16_nt32(uint32_t nt32, uint64_t key) {
@@ -3070,8 +3052,6 @@ int HFMFSENRecover(bool keep_nonces, bool no_oob, bool reader_mode, bool offline
                 fm11_sen_progress(nonce_count, activity, derived, 0);
             }
         }
-    }
-    {
     }
 
     uint32_t total_candidates = 0;

--- a/tools/mfc/card_only/staticnested_2x1nt_rf08s.c
+++ b/tools/mfc/card_only/staticnested_2x1nt_rf08s.c
@@ -18,15 +18,18 @@
 #include <string.h>
 #include <inttypes.h>
 
-uint16_t i_lfsr16[1 << 16] = {0};
-uint16_t s_lfsr16[1 << 16] = {0};
+uint16_t prev8_lfsr16[1 << 16];
+uint16_t prev14_lfsr16[1 << 16];
 
 static void init_lfsr16_table(void) {
+    uint16_t buffer[16] = { 0 };
     uint16_t x = 1;
-    for (uint16_t i = 1; i; ++i) {
-        i_lfsr16[(x & 0xff) << 8 | x >> 8] = i;
-        s_lfsr16[i] = (x & 0xff) << 8 | x >> 8;
+    for (uint32_t i = 0; i < 65536 + 16; ++i) {
+        prev8_lfsr16[buffer[(i + 8) % 16]] = buffer[i % 16];
+        prev14_lfsr16[buffer[(i + 14) % 16]] = buffer[i % 16];
+
         x = x >> 1 | (x ^ x >> 2 ^ x >> 3 ^ x >> 5) << 15;
+        buffer[i % 16] = (x & 0xFF) << 8 | x >> 8;
     }
 }
 
@@ -40,28 +43,25 @@ static void init_lfsr16_table(void) {
 //     return s_lfsr16[i];
 // }
 
-static uint16_t prev_lfsr16(uint16_t nonce) {
-    uint16_t i = i_lfsr16[nonce];
-    if (i == 1) {
-        i = 0xffff;
-    } else {
-        i--;
-    }
-    return s_lfsr16[i];
-}
+// static uint16_t prev_lfsr16(uint16_t nonce) {
+//     uint16_t i = i_lfsr16[nonce];
+//     if (i == 1) {
+//         i = 0xffff;
+//     } else {
+//         i--;
+//     }
+//     return s_lfsr16[i];
+// }
 
 static uint16_t compute_seednt16_nt32(uint32_t nt32, uint64_t key) {
     uint8_t a[] = {0, 8, 9, 4, 6, 11, 1, 15, 12, 5, 2, 13, 10, 14, 3, 7};
     uint8_t b[] = {0, 13, 1, 14, 4, 10, 15, 7, 5, 3, 8, 6, 9, 2, 12, 11};
-    uint16_t nt = nt32 >> 16;
-    uint8_t prev = 14;
-    for (uint8_t i = 0; i < prev; i++) {
-        nt = prev_lfsr16(nt);
-    }
-    uint8_t prevoff = 8;
-    bool odd = 1;
 
+    uint16_t nt = prev14_lfsr16[nt32 >> 16];
+
+    bool odd = 1;
     for (uint8_t i = 0; i < 6 * 8; i += 8) {
+
         if (odd) {
             nt ^= (a[(key >> i) & 0xF]);
             nt ^= (b[(key >> i >> 4) & 0xF]) << 4;
@@ -69,11 +69,9 @@ static uint16_t compute_seednt16_nt32(uint32_t nt32, uint64_t key) {
             nt ^= (b[(key >> i) & 0xF]);
             nt ^= (a[(key >> i >> 4) & 0xF]) << 4;
         }
+
         odd ^= 1;
-        prev += prevoff;
-        for (uint8_t j = 0; j < prevoff; j++) {
-            nt = prev_lfsr16(nt);
-        }
+        nt = prev8_lfsr16[nt];
     }
     return nt;
 }

--- a/tools/mfc/card_only/staticnested_2x1nt_rf08s_1key.c
+++ b/tools/mfc/card_only/staticnested_2x1nt_rf08s_1key.c
@@ -20,15 +20,18 @@ static uint32_t hex_to_uint32(const char *hex_str) {
     return (uint32_t)strtoul(hex_str, NULL, 16);
 }
 
-uint16_t i_lfsr16[1 << 16] = {0};
-uint16_t s_lfsr16[1 << 16] = {0};
+uint16_t prev8_lfsr16[1 << 16];
+uint16_t prev14_lfsr16[1 << 16];
 
 static void init_lfsr16_table(void) {
+    uint16_t buffer[16] = { 0 };
     uint16_t x = 1;
-    for (uint16_t i = 1; i; ++i) {
-        i_lfsr16[(x & 0xff) << 8 | x >> 8] = i;
-        s_lfsr16[i] = (x & 0xff) << 8 | x >> 8;
+    for (uint32_t i = 0; i < 65536 + 16; ++i) {
+        prev8_lfsr16[buffer[(i + 8) % 16]] = buffer[i % 16];
+        prev14_lfsr16[buffer[(i + 14) % 16]] = buffer[i % 16];
+
         x = x >> 1 | (x ^ x >> 2 ^ x >> 3 ^ x >> 5) << 15;
+        buffer[i % 16] = (x & 0xFF) << 8 | x >> 8;
     }
 }
 
@@ -42,29 +45,23 @@ static void init_lfsr16_table(void) {
 //     return s_lfsr16[i];
 // }
 
-static uint16_t prev_lfsr16(uint16_t nonce) {
-    uint16_t i = i_lfsr16[nonce];
-    if (i == 1) {
-        i = 0xffff;
-    } else {
-        i--;
-    }
-    return s_lfsr16[i];
-}
+// static uint16_t prev_lfsr16(uint16_t nonce) {
+//     uint16_t i = i_lfsr16[nonce];
+//     if (i == 1) {
+//         i = 0xffff;
+//     } else {
+//         i--;
+//     }
+//     return s_lfsr16[i];
+// }
 
 static uint16_t compute_seednt16_nt32(uint32_t nt32, uint64_t key) {
     uint8_t a[] = {0, 8, 9, 4, 6, 11, 1, 15, 12, 5, 2, 13, 10, 14, 3, 7};
     uint8_t b[] = {0, 13, 1, 14, 4, 10, 15, 7, 5, 3, 8, 6, 9, 2, 12, 11};
-    uint16_t nt = nt32 >> 16;
-    uint8_t prev = 14;
 
-    for (uint8_t i = 0; i < prev; i++) {
-        nt = prev_lfsr16(nt);
-    }
+    uint16_t nt = prev14_lfsr16[nt32 >> 16];
 
-    uint8_t prevoff = 8;
     bool odd = 1;
-
     for (uint8_t i = 0; i < 6 * 8; i += 8) {
 
         if (odd) {
@@ -76,11 +73,7 @@ static uint16_t compute_seednt16_nt32(uint32_t nt32, uint64_t key) {
         }
 
         odd ^= 1;
-        prev += prevoff;
-
-        for (uint8_t j = 0; j < prevoff; j++) {
-            nt = prev_lfsr16(nt);
-        }
+        nt = prev8_lfsr16[nt];
     }
     return nt;
 }


### PR DESCRIPTION
Issue: `prev_lfsr16` in `cmdhfmfsen.c` and `staticnested_2x1nt_rf08s*.c` maps nonce 0 to 0xFFFF when it should map to 0, generating incorrect results for `compute_seednt16_nt32` and failing to recover the key.

Fix: A new `init_lfsr16_table` implementation that correctly maps 0 to itself.