### PR TITLE
FeliCa SEAC improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Added `hf felica seacauth1` command
 - Added `lf trovan` commands to support Trovan Animal ID (@iceman1001)
 - Added `hf mf gdmgetblk/gdmgethidblk/gdmsethidblk/gdmsetuid/gdmwipe/gdmsetsig` (@0x6r1an0y)
 - Changed `hf mf gdmparsecfg/gdmsetblk` (@0x6r1an0y)

--- a/client/src/cmdhf.c
+++ b/client/src/cmdhf.c
@@ -222,6 +222,10 @@ int CmdHFSearch(const char *Cmd) {
             PrintAndLogEx(SUCCESS, "\nValid " _GREEN_("ISO 18092 / FeliCa tag") " found\n");
             success[FELICA] = true;
             res = PM3_SUCCESS;
+        } else if (info_felica_seac() == PM3_SUCCESS) {
+            PrintAndLogEx(SUCCESS, "Valid " _GREEN_("FeliCa SEAC tag") " found\n");
+            success[FELICA] = true;
+            res = PM3_SUCCESS;
         }
     }
 

--- a/client/src/cmdhffelica.c
+++ b/client/src/cmdhffelica.c
@@ -66,6 +66,9 @@
 #define FELICA_SEAC_POLL_TIMEOUT_MS 200U
 #define FELICA_SEAC_POLL_RETRY_COUNT 5U
 #define FELICA_SEAC_POLL_FRAME_LEN 5U
+#define FELICA_SEAC_IDM_LEN 8U
+#define FELICA_SEAC_CTX_LEN 2U
+#define FELICA_SEAC_POLL_RESPONSE_DATA_LEN (FELICA_SEAC_IDM_LEN + FELICA_SEAC_CTX_LEN)
 #define FELICA_REQUEST_SYSTEM_CODE_ATTEMPTS 5U
 #define FELICA_SYSTEM_CODE_MAX_COUNT 16U
 #define FELICA_DISCOVERED_SYSTEM_MAX_COUNT FELICA_SYSTEM_CODE_MAX_COUNT
@@ -1926,10 +1929,10 @@ static bool waitCmdFelica(bool iSelect, PacketResponseNG *resp, bool verbose) {
     return waitCmdFelicaEx(iSelect, resp, verbose, true, FELICA_DEFAULT_TIMEOUT_MS);
 }
 
-// SEAC responses appear to echo the full command payload before card-specific bytes.
-static bool get_seac_response_data(const PacketResponseNG *resp, const uint8_t *cmd_frame,
-                                   size_t cmd_frame_len, const uint8_t **response_data,
-                                   size_t *response_data_len) {
+// Poll response: 00 01 01 Selector IDm[8] CTX[2]
+static bool get_seac_poll_response_data(const PacketResponseNG *resp, const uint8_t *cmd_frame,
+                                        size_t cmd_frame_len, const uint8_t **response_data,
+                                        size_t *response_data_len) {
     if (resp == NULL || cmd_frame == NULL || response_data == NULL || response_data_len == NULL) {
         return false;
     }
@@ -1982,8 +1985,8 @@ static bool get_seac_response_data(const PacketResponseNG *resp, const uint8_t *
 
 static int info_seac(void) {
     static const uint8_t seac_poll_frames[][FELICA_SEAC_POLL_FRAME_LEN] = {
-        // {0x05, FELICA_POLLING_REQ, 0x01, 0x01, 0x0F},
-        {0x05, FELICA_POLLING_REQ, 0x01, 0x01, 0x01},
+        // LEN CMD  fixed  selector
+        {0x05, FELICA_SEAC_POLLING_CMD, 0x01, 0x01, 0x01},
     };
     const uint8_t seac_flags = FELICA_CONNECT | FELICA_CLEARTRACE | FELICA_RAW | FELICA_APPEND_CRC | FELICA_NO_SELECT;
 
@@ -1998,16 +2001,22 @@ static int info_seac(void) {
 
         const uint8_t *response_data = NULL;
         size_t response_data_len = 0;
-        if (get_seac_response_data(&resp, seac_poll_frames[i], sizeof(seac_poll_frames[i]),
-                                   &response_data, &response_data_len) == false) {
+        if (get_seac_poll_response_data(&resp, seac_poll_frames[i], sizeof(seac_poll_frames[i]),
+                                        &response_data, &response_data_len) == false ||
+                response_data_len != FELICA_SEAC_POLL_RESPONSE_DATA_LEN) {
             continue;
         }
+
+        const uint8_t *idm = response_data;
+        const uint8_t *ctx = response_data + FELICA_SEAC_IDM_LEN;
 
         PrintAndLogEx(NORMAL, "");
         PrintAndLogEx(INFO, "--- " _CYAN_("Tag Information") " ---------------------------");
         PrintAndLogEx(INFO, "Type........... " _YELLOW_("FeliCa SEAC"));
-        PrintAndLogEx(INFO, "IDSEAC......... " _YELLOW_("%s"),
-                      sprint_hex_inrow(response_data, response_data_len));
+        PrintAndLogEx(INFO, "IDm............ " _YELLOW_("%s"),
+                      sprint_hex_inrow(idm, FELICA_SEAC_IDM_LEN));
+        PrintAndLogEx(INFO, "CTX............ " _YELLOW_("%s"),
+                      sprint_hex_inrow(ctx, FELICA_SEAC_CTX_LEN));
         PrintAndLogEx(NORMAL, "");
         return PM3_SUCCESS;
     }
@@ -7928,12 +7937,13 @@ static command_t CommandTable[] = {
     {"list",            CmdHFFelicaList,                  AlwaysAvailable, "List ISO 18092/FeliCa history"},
     {"-----------",     CmdHelp,                          AlwaysAvailable, "----------------------- " _CYAN_("Operations") " -----------------------"},
     {"info",            CmdHFFelicaInfo,                  IfPm3Felica,     "Tag information"},
-    {"seacinfo",        CmdHFFelicaSeacInfo,              IfPm3Felica,     "FeliCa SEAC tag information"},
     {"raw",             CmdHFFelicaCmdRaw,                IfPm3Felica,     "Send raw hex data to tag"},
     {"rdbl",            CmdHFFelicaReadPlain,             IfPm3Felica,     "read block data from authentication-not-required Service."},
     {"reader",          CmdHFFelicaReader,                IfPm3Felica,     "Act like an ISO18092/FeliCa reader"},
     {"sniff",           CmdHFFelicaSniff,                 IfPm3Felica,     "Sniff ISO 18092/FeliCa traffic"},
     {"wrbl",            CmdHFFelicaWritePlain,            IfPm3Felica,     "write block data to an authentication-not-required Service."},
+    {"-----------",     CmdHelp,                          AlwaysAvailable, "----------------------- " _CYAN_("FeliCa SEAC") " -----------------------"},
+    {"seacinfo",        CmdHFFelicaSeacInfo,              IfPm3Felica,     "FeliCa SEAC tag information"},
     {"-----------",     CmdHelp,                          AlwaysAvailable, "----------------------- " _CYAN_("FeliCa Standard") " -----------------------"},
     {"dump",            CmdHFFelicaDump,                  IfPm3Felica,     "Wait for and try dumping FeliCa"},
     {"discnodes",       CmdHFFelicaDiscoverNodes,         IfPm3Felica,     "discover Area Code and Service Code nodes."},

--- a/client/src/cmdhffelica.c
+++ b/client/src/cmdhffelica.c
@@ -1981,7 +1981,7 @@ static bool get_seac_poll_response_data(const PacketResponseNG *resp, uint8_t se
     return true;
 }
 
-static int info_seac(void) {
+int info_felica_seac(void) {
     static const uint8_t seac_poll_frames[][FELICA_SEAC_POLL_FRAME_LEN] = {
         // LEN CMD  System Code  selector  Time Slot
         {0x06, FELICA_SEAC_POLLING_CMD, 0x01, 0x01, 0x01, FELICA_SEAC_POLL_TIME_SLOT},
@@ -2506,7 +2506,7 @@ static int CmdHFFelicaInfo(const char *Cmd) {
     CLIExecWithReturn(ctx, Cmd, argtable, true);
     CLIParserFree(ctx);
     int ret = info_felica(false);
-    return ret == PM3_SUCCESS ? ret : info_seac();
+    return ret == PM3_SUCCESS ? ret : info_felica_seac();
 }
 
 /**

--- a/client/src/cmdhffelica.c
+++ b/client/src/cmdhffelica.c
@@ -69,7 +69,10 @@
 #define FELICA_SEAC_POLL_TIME_SLOT 0x01U
 #define FELICA_SEAC_IDM_LEN 8U
 #define FELICA_SEAC_CTX_LEN 2U
+#define FELICA_SEAC_CHALLENGE_LEN 8U
+#define FELICA_SEAC_AUTH1_FRAME_LEN 21U
 #define FELICA_SEAC_POLL_RESPONSE_DATA_LEN (FELICA_SEAC_IDM_LEN + FELICA_SEAC_CTX_LEN)
+#define FELICA_SEAC_AUTH1_RESPONSE_DATA_LEN ((2U * FELICA_SEAC_CHALLENGE_LEN) + 1U)
 #define FELICA_REQUEST_SYSTEM_CODE_ATTEMPTS 5U
 #define FELICA_SYSTEM_CODE_MAX_COUNT 16U
 #define FELICA_DISCOVERED_SYSTEM_MAX_COUNT FELICA_SYSTEM_CODE_MAX_COUNT
@@ -1930,10 +1933,8 @@ static bool waitCmdFelica(bool iSelect, PacketResponseNG *resp, bool verbose) {
     return waitCmdFelicaEx(iSelect, resp, verbose, true, FELICA_DEFAULT_TIMEOUT_MS);
 }
 
-// Poll response: 00 01 01 Selector IDm[8] CTX[2]
-static bool get_seac_poll_response_data(const PacketResponseNG *resp, uint8_t selector,
-                                        const uint8_t **response_data,
-                                        size_t *response_data_len) {
+static bool get_seac_response_data(const PacketResponseNG *resp, uint8_t command, uint8_t selector,
+                                   const uint8_t **response_data, size_t *response_data_len) {
     if (resp == NULL || response_data == NULL || response_data_len == NULL) {
         return false;
     }
@@ -1964,8 +1965,8 @@ static bool get_seac_poll_response_data(const PacketResponseNG *resp, uint8_t se
         return false;
     }
 
-    // The response echoes CMD, System Code, and selector, but not the request's Time Slot.
-    const uint8_t expected_header[] = {FELICA_SEAC_POLLING_CMD, 0x01, 0x01, selector};
+    // The response echoes CMD, System Code, and selector.
+    const uint8_t expected_header[] = {command, 0x01, 0x01, selector};
     if (memcmp(resp->data.asBytes + 3, expected_header, sizeof(expected_header)) != 0) {
         return false;
     }
@@ -1981,45 +1982,82 @@ static bool get_seac_poll_response_data(const PacketResponseNG *resp, uint8_t se
     return true;
 }
 
-int info_felica_seac(void) {
-    static const uint8_t seac_poll_frames[][FELICA_SEAC_POLL_FRAME_LEN] = {
-        // LEN CMD  System Code  selector  Time Slot
-        {0x06, FELICA_SEAC_POLLING_CMD, 0x01, 0x01, 0x01, FELICA_SEAC_POLL_TIME_SLOT},
+static int poll_seac(uint8_t selector, uint8_t *idm, uint8_t *ctx) {
+    uint8_t poll_frame[FELICA_SEAC_POLL_FRAME_LEN] = {
+        FELICA_SEAC_POLL_FRAME_LEN, FELICA_SEAC_POLLING_CMD, 0x01, 0x01, selector, FELICA_SEAC_POLL_TIME_SLOT,
     };
     const uint8_t seac_flags = FELICA_CONNECT | FELICA_CLEARTRACE | FELICA_RAW | FELICA_APPEND_CRC | FELICA_NO_SELECT;
 
-    for (size_t i = 0; i < ARRAYLEN(seac_poll_frames); i++) {
-        PacketResponseNG resp;
-        if (send_felica_payload_with_retries(seac_flags, sizeof(seac_poll_frames[i]),
-                                             (uint8_t *)seac_poll_frames[i], false,
-                                             -1, FELICA_SEAC_POLL_TIMEOUT_MS, FELICA_SEAC_POLL_RETRY_COUNT,
-                                             0, false, &resp, NULL) != PM3_SUCCESS) {
-            continue;
-        }
-
-        const uint8_t *response_data = NULL;
-        size_t response_data_len = 0;
-        if (get_seac_poll_response_data(&resp, seac_poll_frames[i][4],
-                                        &response_data, &response_data_len) == false ||
-                response_data_len != FELICA_SEAC_POLL_RESPONSE_DATA_LEN) {
-            continue;
-        }
-
-        const uint8_t *idm = response_data;
-        const uint8_t *ctx = response_data + FELICA_SEAC_IDM_LEN;
-
-        PrintAndLogEx(NORMAL, "");
-        PrintAndLogEx(INFO, "--- " _CYAN_("Tag Information") " ---------------------------");
-        PrintAndLogEx(INFO, "Type........... " _YELLOW_("FeliCa SEAC"));
-        PrintAndLogEx(INFO, "IDm............ " _YELLOW_("%s"),
-                      sprint_hex_inrow(idm, FELICA_SEAC_IDM_LEN));
-        PrintAndLogEx(INFO, "CTX............ " _YELLOW_("%s"),
-                      sprint_hex_inrow(ctx, FELICA_SEAC_CTX_LEN));
-        PrintAndLogEx(NORMAL, "");
-        return PM3_SUCCESS;
+    PacketResponseNG resp;
+    int ret = send_felica_payload_with_retries(seac_flags, sizeof(poll_frame), poll_frame, false,
+                                               -1, FELICA_SEAC_POLL_TIMEOUT_MS, FELICA_SEAC_POLL_RETRY_COUNT,
+                                               0, false, &resp, NULL);
+    if (ret != PM3_SUCCESS) {
+        return ret;
     }
 
-    return PM3_ETIMEOUT;
+    const uint8_t *response_data = NULL;
+    size_t response_data_len = 0;
+    if (get_seac_response_data(&resp, FELICA_SEAC_POLLING_CMD, selector,
+                               &response_data, &response_data_len) == false ||
+            response_data_len != FELICA_SEAC_POLL_RESPONSE_DATA_LEN) {
+        return PM3_ESOFT;
+    }
+
+    memcpy(idm, response_data, FELICA_SEAC_IDM_LEN);
+    memcpy(ctx, response_data + FELICA_SEAC_IDM_LEN, FELICA_SEAC_CTX_LEN);
+    return PM3_SUCCESS;
+}
+
+static int auth1_seac(uint8_t selector, const uint8_t *idm, const uint8_t *challenge1a,
+                      uint8_t *challenge1b, uint8_t *challenge2a, uint8_t *trailer) {
+    uint8_t auth1_frame[FELICA_SEAC_AUTH1_FRAME_LEN] = {0};
+    auth1_frame[0] = (uint8_t)sizeof(auth1_frame);
+    auth1_frame[1] = FELICA_SEAC_AUTHENTICATION1_CMD;
+    auth1_frame[2] = 0x01;
+    auth1_frame[3] = 0x01;
+    auth1_frame[4] = selector;
+    memcpy(auth1_frame + 5, idm, FELICA_SEAC_IDM_LEN);
+    memcpy(auth1_frame + 5 + FELICA_SEAC_IDM_LEN, challenge1a, FELICA_SEAC_CHALLENGE_LEN);
+
+    const uint8_t seac_flags = FELICA_CONNECT | FELICA_CLEARTRACE | FELICA_RAW | FELICA_APPEND_CRC | FELICA_NO_SELECT;
+    PacketResponseNG resp;
+    int ret = send_felica_payload_with_retries(seac_flags, sizeof(auth1_frame), auth1_frame, false,
+                                               -1, FELICA_SEAC_POLL_TIMEOUT_MS, FELICA_SEAC_POLL_RETRY_COUNT,
+                                               0, false, &resp, NULL);
+    if (ret != PM3_SUCCESS) {
+        return ret;
+    }
+
+    const uint8_t *response_data = NULL;
+    size_t response_data_len = 0;
+    if (get_seac_response_data(&resp, FELICA_SEAC_AUTHENTICATION1_CMD, selector,
+                               &response_data, &response_data_len) == false ||
+            response_data_len != FELICA_SEAC_AUTH1_RESPONSE_DATA_LEN) {
+        return PM3_ESOFT;
+    }
+
+    memcpy(challenge1b, response_data, FELICA_SEAC_CHALLENGE_LEN);
+    memcpy(challenge2a, response_data + FELICA_SEAC_CHALLENGE_LEN, FELICA_SEAC_CHALLENGE_LEN);
+    *trailer = response_data[FELICA_SEAC_AUTH1_RESPONSE_DATA_LEN - 1U];
+    return PM3_SUCCESS;
+}
+
+int info_felica_seac(void) {
+    uint8_t idm[FELICA_SEAC_IDM_LEN] = {0};
+    uint8_t ctx[FELICA_SEAC_CTX_LEN] = {0};
+    int ret = poll_seac(0x01, idm, ctx);
+    if (ret != PM3_SUCCESS) {
+        return ret;
+    }
+
+    PrintAndLogEx(NORMAL, "");
+    PrintAndLogEx(INFO, "--- " _CYAN_("Tag Information") " ---------------------------");
+    PrintAndLogEx(INFO, "Type........... " _YELLOW_("FeliCa SEAC"));
+    PrintAndLogEx(INFO, "IDm............ " _YELLOW_("%s"), sprint_hex_inrow(idm, sizeof(idm)));
+    PrintAndLogEx(INFO, "CTX............ " _YELLOW_("%s"), sprint_hex_inrow(ctx, sizeof(ctx)));
+    PrintAndLogEx(NORMAL, "");
+    return PM3_SUCCESS;
 }
 
 
@@ -2507,6 +2545,72 @@ static int CmdHFFelicaInfo(const char *Cmd) {
     CLIParserFree(ctx);
     int ret = info_felica(false);
     return ret == PM3_SUCCESS ? ret : info_felica_seac();
+}
+
+static int CmdHFFelicaSeacAuth1(const char *Cmd) {
+    CLIParserContext *ctx;
+    CLIParserInit(&ctx, "hf felica seacauth1",
+                  "Send FeliCa SEAC Authentication1",
+                  "hf felica seacauth1\n"
+                  "hf felica seacauth1 --selector 0F\n"
+                  "hf felica seacauth1 --challenge 0001020304050607\n"
+                  "hf felica seacauth1 -s 0F -c FFFFFFFFFFFFFFFF");
+
+    void *argtable[] = {
+        arg_param_begin,
+        arg_str0("s", "selector", "<hex>", "selector, 1 byte (default 01)"),
+        arg_str0("c", "challenge", "<hex>", "Challenge1a, 8 bytes (default all zero)"),
+        arg_param_end
+    };
+    CLIExecWithReturn(ctx, Cmd, argtable, true);
+
+    uint8_t selector_data[1] = {0};
+    int selector_len = 0;
+    int ret = CLIParamHexToBuf(arg_get_str(ctx, 1), selector_data, sizeof(selector_data), &selector_len);
+    if (ret != PM3_SUCCESS || (selector_len != 0 && selector_len != (int)sizeof(selector_data))) {
+        CLIParserFree(ctx);
+        PrintAndLogEx(ERR, "Selector must be exactly 1 byte");
+        return PM3_EINVARG;
+    }
+
+    uint8_t challenge1a[FELICA_SEAC_CHALLENGE_LEN] = {0};
+    int challenge_len = 0;
+    ret = CLIParamHexToBuf(arg_get_str(ctx, 2), challenge1a, sizeof(challenge1a), &challenge_len);
+    CLIParserFree(ctx);
+    if (ret != PM3_SUCCESS || (challenge_len != 0 && challenge_len != (int)sizeof(challenge1a))) {
+        PrintAndLogEx(ERR, "Challenge1a must be exactly 8 bytes");
+        return PM3_EINVARG;
+    }
+
+    const uint8_t selector = selector_len == 0 ? 0x01 : selector_data[0];
+    uint8_t idm[FELICA_SEAC_IDM_LEN] = {0};
+    uint8_t seac_ctx[FELICA_SEAC_CTX_LEN] = {0};
+    ret = poll_seac(selector, idm, seac_ctx);
+    if (ret != PM3_SUCCESS) {
+        PrintAndLogEx(ERR, "No SEAC card response for selector %02X", selector);
+        return ret;
+    }
+
+    uint8_t challenge1b[FELICA_SEAC_CHALLENGE_LEN] = {0};
+    uint8_t challenge2a[FELICA_SEAC_CHALLENGE_LEN] = {0};
+    uint8_t trailer = 0;
+    ret = auth1_seac(selector, idm, challenge1a, challenge1b, challenge2a, &trailer);
+    if (ret != PM3_SUCCESS) {
+        PrintAndLogEx(ERR, "No valid SEAC Authentication1 response");
+        return ret;
+    }
+
+    PrintAndLogEx(NORMAL, "");
+    PrintAndLogEx(INFO, "--- " _CYAN_("SEAC Authentication1") " ----------------------");
+    PrintAndLogEx(INFO, "Selector....... " _YELLOW_("%02X"), selector);
+    PrintAndLogEx(INFO, "IDm............ " _YELLOW_("%s"), sprint_hex_inrow(idm, sizeof(idm)));
+    PrintAndLogEx(INFO, "CTX............ " _YELLOW_("%s"), sprint_hex_inrow(seac_ctx, sizeof(seac_ctx)));
+    PrintAndLogEx(INFO, "Challenge1a.... " _YELLOW_("%s"), sprint_hex_inrow(challenge1a, sizeof(challenge1a)));
+    PrintAndLogEx(INFO, "Challenge1b.... " _YELLOW_("%s"), sprint_hex_inrow(challenge1b, sizeof(challenge1b)));
+    PrintAndLogEx(INFO, "Challenge2a.... " _YELLOW_("%s"), sprint_hex_inrow(challenge2a, sizeof(challenge2a)));
+    PrintAndLogEx(INFO, "Trailer........ " _YELLOW_("%02X"), trailer);
+    PrintAndLogEx(NORMAL, "");
+    return PM3_SUCCESS;
 }
 
 /**
@@ -7926,6 +8030,8 @@ static command_t CommandTable[] = {
     {"reader",          CmdHFFelicaReader,                IfPm3Felica,     "Act like an ISO18092/FeliCa reader"},
     {"sniff",           CmdHFFelicaSniff,                 IfPm3Felica,     "Sniff ISO 18092/FeliCa traffic"},
     {"wrbl",            CmdHFFelicaWritePlain,            IfPm3Felica,     "write block data to an authentication-not-required Service."},
+    {"-----------",     CmdHelp,                          AlwaysAvailable, "----------------------- " _CYAN_("FeliCa SEAC") " -----------------------"},
+    {"seacauth1",       CmdHFFelicaSeacAuth1,             IfPm3Felica,     "FeliCa SEAC Authentication1"},
     {"-----------",     CmdHelp,                          AlwaysAvailable, "----------------------- " _CYAN_("FeliCa Standard") " -----------------------"},
     {"dump",            CmdHFFelicaDump,                  IfPm3Felica,     "Wait for and try dumping FeliCa"},
     {"discnodes",       CmdHFFelicaDiscoverNodes,         IfPm3Felica,     "discover Area Code and Service Code nodes."},

--- a/client/src/cmdhffelica.c
+++ b/client/src/cmdhffelica.c
@@ -65,7 +65,8 @@
 #define FELICA_POLLING_TIMEOUT_MS 100U
 #define FELICA_SEAC_POLL_TIMEOUT_MS 200U
 #define FELICA_SEAC_POLL_RETRY_COUNT 5U
-#define FELICA_SEAC_POLL_FRAME_LEN 5U
+#define FELICA_SEAC_POLL_FRAME_LEN 6U
+#define FELICA_SEAC_POLL_TIME_SLOT 0x01U
 #define FELICA_SEAC_IDM_LEN 8U
 #define FELICA_SEAC_CTX_LEN 2U
 #define FELICA_SEAC_POLL_RESPONSE_DATA_LEN (FELICA_SEAC_IDM_LEN + FELICA_SEAC_CTX_LEN)
@@ -1930,17 +1931,18 @@ static bool waitCmdFelica(bool iSelect, PacketResponseNG *resp, bool verbose) {
 }
 
 // Poll response: 00 01 01 Selector IDm[8] CTX[2]
-static bool get_seac_poll_response_data(const PacketResponseNG *resp, const uint8_t *cmd_frame,
-                                        size_t cmd_frame_len, const uint8_t **response_data,
+static bool get_seac_poll_response_data(const PacketResponseNG *resp, uint8_t selector,
+                                        const uint8_t **response_data,
                                         size_t *response_data_len) {
-    if (resp == NULL || cmd_frame == NULL || response_data == NULL || response_data_len == NULL) {
+    if (resp == NULL || response_data == NULL || response_data_len == NULL) {
         return false;
     }
 
     *response_data = NULL;
     *response_data_len = 0;
 
-    if (cmd_frame_len < 2 || resp->length < (3U + (cmd_frame_len - 1U) + 2U)) {
+    static const size_t response_header_len = 4U;
+    if (resp->length < (3U + response_header_len + 2U)) {
         return false;
     }
 
@@ -1953,8 +1955,7 @@ static bool get_seac_poll_response_data(const PacketResponseNG *resp, const uint
     }
 
     const size_t frame_len = resp->data.asBytes[2];
-    const size_t echoed_payload_len = cmd_frame_len - 1U;
-    if (frame_len <= (1U + echoed_payload_len)) {
+    if (frame_len <= (1U + response_header_len)) {
         return false;
     }
 
@@ -1963,17 +1964,14 @@ static bool get_seac_poll_response_data(const PacketResponseNG *resp, const uint
         return false;
     }
 
-    // Unlike standard FeliCa, SEAC keeps the response code equal to the request code.
-    if (resp->data.asBytes[3] != cmd_frame[1]) {
+    // The response echoes CMD, System Code, and selector, but not the request's Time Slot.
+    const uint8_t expected_header[] = {FELICA_SEAC_POLLING_CMD, 0x01, 0x01, selector};
+    if (memcmp(resp->data.asBytes + 3, expected_header, sizeof(expected_header)) != 0) {
         return false;
     }
 
-    if (memcmp(resp->data.asBytes + 3, cmd_frame + 1, echoed_payload_len) != 0) {
-        return false;
-    }
-
-    const size_t response_offset = 3U + echoed_payload_len;
-    const size_t response_len = frame_len - 1U - echoed_payload_len;
+    const size_t response_offset = 3U + response_header_len;
+    const size_t response_len = frame_len - 1U - response_header_len;
     if ((response_offset + response_len + 2U) > decoded_frame_len) {
         return false;
     }
@@ -1985,8 +1983,8 @@ static bool get_seac_poll_response_data(const PacketResponseNG *resp, const uint
 
 static int info_seac(void) {
     static const uint8_t seac_poll_frames[][FELICA_SEAC_POLL_FRAME_LEN] = {
-        // LEN CMD  fixed  selector
-        {0x05, FELICA_SEAC_POLLING_CMD, 0x01, 0x01, 0x01},
+        // LEN CMD  System Code  selector  Time Slot
+        {0x06, FELICA_SEAC_POLLING_CMD, 0x01, 0x01, 0x01, FELICA_SEAC_POLL_TIME_SLOT},
     };
     const uint8_t seac_flags = FELICA_CONNECT | FELICA_CLEARTRACE | FELICA_RAW | FELICA_APPEND_CRC | FELICA_NO_SELECT;
 
@@ -2001,7 +1999,7 @@ static int info_seac(void) {
 
         const uint8_t *response_data = NULL;
         size_t response_data_len = 0;
-        if (get_seac_poll_response_data(&resp, seac_poll_frames[i], sizeof(seac_poll_frames[i]),
+        if (get_seac_poll_response_data(&resp, seac_poll_frames[i][4],
                                         &response_data, &response_data_len) == false ||
                 response_data_len != FELICA_SEAC_POLL_RESPONSE_DATA_LEN) {
             continue;
@@ -2507,22 +2505,8 @@ static int CmdHFFelicaInfo(const char *Cmd) {
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
     CLIParserFree(ctx);
-    return info_felica(false);
-}
-
-static int CmdHFFelicaSeacInfo(const char *Cmd) {
-    CLIParserContext *ctx;
-    CLIParserInit(&ctx, "hf felica seacinfo",
-                  "Get info about FeliCa SEAC cards",
-                  "hf felica seacinfo");
-
-    void *argtable[] = {
-        arg_param_begin,
-        arg_param_end
-    };
-    CLIExecWithReturn(ctx, Cmd, argtable, true);
-    CLIParserFree(ctx);
-    return info_seac();
+    int ret = info_felica(false);
+    return ret == PM3_SUCCESS ? ret : info_seac();
 }
 
 /**
@@ -7942,8 +7926,6 @@ static command_t CommandTable[] = {
     {"reader",          CmdHFFelicaReader,                IfPm3Felica,     "Act like an ISO18092/FeliCa reader"},
     {"sniff",           CmdHFFelicaSniff,                 IfPm3Felica,     "Sniff ISO 18092/FeliCa traffic"},
     {"wrbl",            CmdHFFelicaWritePlain,            IfPm3Felica,     "write block data to an authentication-not-required Service."},
-    {"-----------",     CmdHelp,                          AlwaysAvailable, "----------------------- " _CYAN_("FeliCa SEAC") " -----------------------"},
-    {"seacinfo",        CmdHFFelicaSeacInfo,              IfPm3Felica,     "FeliCa SEAC tag information"},
     {"-----------",     CmdHelp,                          AlwaysAvailable, "----------------------- " _CYAN_("FeliCa Standard") " -----------------------"},
     {"dump",            CmdHFFelicaDump,                  IfPm3Felica,     "Wait for and try dumping FeliCa"},
     {"discnodes",       CmdHFFelicaDiscoverNodes,         IfPm3Felica,     "discover Area Code and Service Code nodes."},

--- a/client/src/cmdhffelica.h
+++ b/client/src/cmdhffelica.h
@@ -24,6 +24,7 @@
 
 int CmdHFFelica(const char *Cmd);
 int read_felica_uid(bool loop, bool verbose);
+int info_felica_seac(void);
 int send_request_service(uint8_t flags, uint16_t datalen, uint8_t *data, bool verbose);
 
 #endif

--- a/client/src/cmdhflist.c
+++ b/client/src/cmdhflist.c
@@ -2443,9 +2443,47 @@ void annotateLegic(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize) {
     }
 }
 
-void annotateFelica(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize) {
+static bool annotateFelicaSeac(char *exp, size_t size, const uint8_t *cmd, uint8_t cmdsize, bool is_response) {
+    if (cmdsize < 7 || cmd[4] != 0x01 || cmd[5] != 0x01 ||
+            (cmd[6] != 0x01 && cmd[6] < 0x0F)) {
+        return false;
+    }
+
+    const char *operation = NULL;
+    switch (cmd[3]) {
+        case FELICA_SEAC_POLLING_CMD:
+            operation = "POLLING";
+            break;
+        case FELICA_SEAC_AUTHENTICATION1_CMD:
+            operation = "AUTHENTICATION1";
+            break;
+        case FELICA_SEAC_AUTHENTICATION2_CMD:
+            operation = "AUTHENTICATION2";
+            break;
+        case FELICA_SEAC_WRITE_CMD:
+            operation = "WRITE";
+            break;
+        case FELICA_SEAC_READ_CMD:
+            operation = "READ";
+            break;
+        case FELICA_SEAC_EXTENDED_CMD:
+            operation = "EXTENDED";
+            break;
+        default:
+            return false;
+    }
+
+    snprintf(exp, size, "SEAC %s %s (SELECTOR %02X)", operation, is_response ? "RES" : "REQ", cmd[6]);
+    return true;
+}
+
+void annotateFelica(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize, bool is_response) {
     if (cmdsize < 4) {
         snprintf(exp, size, "?");
+        return;
+    }
+
+    if (annotateFelicaSeac(exp, size, cmd, cmdsize, is_response)) {
         return;
     }
 

--- a/client/src/cmdhflist.h
+++ b/client/src/cmdhflist.h
@@ -54,7 +54,7 @@ void annotateIclass(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize, bool 
 void annotateIso15693(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize);
 void annotateTopaz(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize);
 void annotateLegic(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize);
-void annotateFelica(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize);
+void annotateFelica(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize, bool is_response);
 void annotateIso7816(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize, bool is_response);
 void annotateCalypso(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize, bool is_response);
 void annotateIso14443b(char *exp, size_t size, uint8_t *cmd, uint8_t cmdsize, bool is_response);

--- a/client/src/cmdtrace.c
+++ b/client/src/cmdtrace.c
@@ -839,6 +839,9 @@ static uint16_t printTraceLine(uint16_t tracepos, uint16_t traceLen, uint8_t *tr
         case PROTO_HITAGS:
             annotateHitagS(explanation, sizeof(explanation), frame, (data_len * 8) - ((8 - parityBytes[0]) % 8), hdr->isResponse);
             break;
+        case FELICA:
+            annotateFelica(explanation, sizeof(explanation), frame, data_len, hdr->isResponse);
+            break;
         case PROTO_HITAGU:
             annotateHitagU(explanation, sizeof(explanation), frame, data_len, hdr->isResponse);
             break;
@@ -871,9 +874,6 @@ static uint16_t printTraceLine(uint16_t tracepos, uint16_t traceLen, uint8_t *tr
                 break;
             case ISO_15693:
                 annotateIso15693(explanation, sizeof(explanation), frame, data_len);
-                break;
-            case FELICA:
-                annotateFelica(explanation, sizeof(explanation), frame, data_len);
                 break;
             case LTO:
                 annotateLTO(explanation, sizeof(explanation), frame, data_len);

--- a/client/src/pm3line_vocabulary.h
+++ b/client/src/pm3line_vocabulary.h
@@ -257,6 +257,7 @@ const static vocabulary_t vocabulary[] = {
     { 1, "hf felica help" },
     { 1, "hf felica list" },
     { 0, "hf felica info" },
+    { 0, "hf felica seacauth1" },
     { 0, "hf felica raw" },
     { 0, "hf felica rdbl" },
     { 0, "hf felica reader" },

--- a/client/src/pm3line_vocabulary.h
+++ b/client/src/pm3line_vocabulary.h
@@ -257,7 +257,6 @@ const static vocabulary_t vocabulary[] = {
     { 1, "hf felica help" },
     { 1, "hf felica list" },
     { 0, "hf felica info" },
-    { 0, "hf felica seacinfo" },
     { 0, "hf felica raw" },
     { 0, "hf felica rdbl" },
     { 0, "hf felica reader" },

--- a/include/protocols.h
+++ b/include/protocols.h
@@ -897,6 +897,33 @@ ISO 7816-4 Basic interindustry commands. For command APDU's.
 #define EM4x05_PIGEON                   (1 << 26)
 
 
+// FeliCa SEAC protocol
+
+// Request:  CMD | 01 01 | Selector [| TIMESLOT]
+//           TIMESLOT masks the card's random response slot.
+//           Higher set bits may delay the response beyond the reader timeout.
+//           Observed: omitted~=38%, 00/01=100%, 0F=97%, 4F=50%, 64/65~=10%, FF=0%.
+// Response: CMD | 01 01 | Selector | IDm[8] | CTX[2]
+#define FELICA_SEAC_POLLING_CMD                         0x00
+
+// Request:  CMD | 01 01 | Selector | IDm[8] | Challenge1a[8]
+// Response: CMD | 01 01 | Selector | Challenge1b[8] | Challenge2a[8] | Trailer[1]
+#define FELICA_SEAC_AUTHENTICATION1_CMD                 0x01
+
+// Request:  CMD | 01 01 | Selector | Challenge2b[8]
+// Response: CMD | 01 01 | Selector | ProtectedIDi[8]
+#define FELICA_SEAC_AUTHENTICATION2_CMD                 0x02
+
+// Request/response: CMD | ProtectedBody[N]
+#define FELICA_SEAC_WRITE_CMD                           0x03
+
+// Request/response: CMD | ProtectedBody[N]
+#define FELICA_SEAC_READ_CMD                            0x04
+
+// Request/response: CMD | ProtectedBody[N]
+#define FELICA_SEAC_EXTENDED_CMD                        0xFF
+
+
 // FeliCa protocol
 
 #define FELICA_POLLING_REQ                              0x00


### PR DESCRIPTION
This PR makes the following changes related to FeliCa:
* Add command constants and descriptions for known SEAC commands;
* Improve stability of SEAC polling by configuring a proper timeslot parameter;
* Fold `hf felica seacinfo` into `hf felica info`;
* Add discovery of SEAC into `hf search`;
* Add SEAC command/response annotation to `hf felica list`.