### PR TITLE
Add CopyKEY M+ tags

### DIFF
--- a/doc/magic_cards_notes.md
+++ b/doc/magic_cards_notes.md
@@ -783,6 +783,7 @@ Here is how the IC can be configured:
   * MF-8 (RU)
   * MF-3 (RU) - not susceptible to "field reset bug", a way to detect [OTP](#fuid) chips.
   * MF-3.2 (RU) - static nonce `01200145`, potentially fixed chip which can bypass Iron Logic's filters.
+  * M+ (CopyKEY) - chips presented as a universal alternative to more advanced Chinese ICs; only real difference is presence of rewritable sectors 16+17 and block 255 (readable after any auth)
 `
 ### Identify
 


### PR DESCRIPTION
Not much to explain about them really

The tags actually have two new sectors to copy signatures, even though frankly NOBODY checks them other than ICT (and even then, the things have the mfc clone style prng, so if a reader checks that + signature, it'll be obvious since there must be a trng)

There don't appear to be any special commands of any kind at all
All settings done by the X6 cloner are just writes to ACL changing sectors as needed