### PR TITLE
Set the stringop-overflow flags before add_subdirectory(deps)

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -292,6 +292,21 @@ if (NOT SKIPWHEREAMISYSTEM EQUAL 1)
     endif (WHEREAMI_INCLUDE_DIRS AND WHEREAMI_LIBRARIES)
 endif (NOT SKIPWHEREAMISYSTEM EQUAL 1)
 
+# These must be set BEFORE add_subdirectory(deps): CMake copies the
+# current variable scope into a subdirectory at that point, so flags set
+# further down never reach the bundled deps and jansson fails the
+# -Werror=stringop-overflow false positive on its own.
+# GCC 10 has issues with false positives on stringop-overflow,
+# let's disable them for now (cf https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92955, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94335)
+# beware these flags didn't exist for GCC < 7
+if(CMAKE_COMPILER_IS_GNUCXX)
+    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+    if (GCC_VERSION VERSION_GREATER 10.0 OR GCC_VERSION VERSION_EQUAL 10.0)
+        set(CMAKE_C_FLAGS "-Wno-stringop-overflow -Wno-error=stringop-overflow ${CMAKE_C_FLAGS}")
+        set(CMAKE_CXX_FLAGS "-Wno-stringop-overflow -Wno-error=stringop-overflow ${CMAKE_CXX_FLAGS}")
+    endif()
+endif(CMAKE_COMPILER_IS_GNUCXX)
+
 add_subdirectory(${PM3_ROOT}/client/deps deps)
 
 set (TARGET_SOURCES
@@ -872,17 +887,6 @@ if (MINGW)
     # link Winsock2
     set(ADDITIONAL_LNK ws2_32 ${ADDITIONAL_LNK})
 endif (MINGW)
-
-# GCC 10 has issues with false positives on stringop-overflow,
-# let's disable them for now (cf https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92955, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94335)
-# beware these flags didn't exist for GCC < 7
-if(CMAKE_COMPILER_IS_GNUCXX)
-    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-    if (GCC_VERSION VERSION_GREATER 10.0 OR GCC_VERSION VERSION_EQUAL 10.0)
-        set(CMAKE_C_FLAGS "-Wno-stringop-overflow -Wno-error=stringop-overflow ${CMAKE_C_FLAGS}")
-        set(CMAKE_CXX_FLAGS "-Wno-stringop-overflow -Wno-error=stringop-overflow ${CMAKE_CXX_FLAGS}")
-    endif()
-endif(CMAKE_COMPILER_IS_GNUCXX)
 
 target_include_directories(proxmark3 PRIVATE
         ${PM3_ROOT}/common

--- a/client/experimental_lib/CMakeLists.txt
+++ b/client/experimental_lib/CMakeLists.txt
@@ -212,6 +212,21 @@ if (NOT SKIPWHEREAMISYSTEM EQUAL 1)
     endif (WHEREAMI_INCLUDE_DIRS AND WHEREAMI_LIBRARIES)
 endif (NOT SKIPWHEREAMISYSTEM EQUAL 1)
 
+# These must be set BEFORE add_subdirectory(deps): CMake copies the
+# current variable scope into a subdirectory at that point, so flags set
+# further down never reach the bundled deps and jansson fails the
+# -Werror=stringop-overflow false positive on its own.
+# GCC 10 has issues with false positives on stringop-overflow,
+# let's disable them for now (cf https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92955, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94335)
+# beware these flags didn't exist for GCC < 7
+if(CMAKE_COMPILER_IS_GNUCXX)
+    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+    if (GCC_VERSION VERSION_GREATER 10.0 OR GCC_VERSION VERSION_EQUAL 10.0)
+        set(CMAKE_C_FLAGS "-Wno-stringop-overflow -Wno-error=stringop-overflow ${CMAKE_C_FLAGS}")
+        set(CMAKE_CXX_FLAGS "-Wno-stringop-overflow -Wno-error=stringop-overflow ${CMAKE_CXX_FLAGS}")
+    endif()
+endif(CMAKE_COMPILER_IS_GNUCXX)
+
 add_subdirectory(${PM3_ROOT}/client/deps deps)
 
 set (TARGET_SOURCES
@@ -705,17 +720,6 @@ if (MINGW)
     # link Winsock2
     set(ADDITIONAL_LNK ws2_32 ${ADDITIONAL_LNK})
 endif (MINGW)
-
-# GCC 10 has issues with false positives on stringop-overflow,
-# let's disable them for now (cf https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92955, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94335)
-# beware these flags didn't exist for GCC < 7
-if(CMAKE_COMPILER_IS_GNUCXX)
-    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-    if (GCC_VERSION VERSION_GREATER 10.0 OR GCC_VERSION VERSION_EQUAL 10.0)
-        set(CMAKE_C_FLAGS "-Wno-stringop-overflow -Wno-error=stringop-overflow ${CMAKE_C_FLAGS}")
-        set(CMAKE_CXX_FLAGS "-Wno-stringop-overflow -Wno-error=stringop-overflow ${CMAKE_CXX_FLAGS}")
-    endif()
-endif(CMAKE_COMPILER_IS_GNUCXX)
 
 target_include_directories(pm3rrg_rdv4 PRIVATE
         ${PM3_ROOT}/common


### PR DESCRIPTION
`client/CMakeLists.txt` disables the `stringop-overflow` false positive at line 882, but
`add_subdirectory(deps)` runs at line 295. CMake copies the calling scope into a subdirectory
at the point of the call, so flags set further down never reach the bundled deps and jansson
still hits `-Werror=stringop-overflow` on its own.

Moving the block above the call fixes it. Counted on current master, from the generated
`flags.make` of every deps target:

```
before:  0 of 17 deps targets have -Wno-error=stringop-overflow
after:  17 of 17
```

Same edit in `experimental_lib/CMakeLists.txt`, same ordering. ubuntu-cmake and macos-cmake
were green either way, since their compilers do not emit this one.

The Windows linker workaround that this PR originally carried is gone: master already
downgrades the ARM linker in `windows.yml`.
