### PR TITLE
feat(pm5): `hf tune --rgb` / `lf tune --rgb` - antenna RGB as a tuning meter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Added `--rgb` option to `hf tune` / `lf tune` (Proxmark5/PM5): mirrors the antenna tuning level on the antenna RGB LED (blue=low, green=mid, red=high, tracking the on-screen bar), for locating tags/implants by feel without watching the screen. Colour is computed client-side; the device gets a new `CMD_PM5_RGB_SET` handled by a dedicated AT32 RGB HAL module (`common_arm/rgb`), so other platforms are unaffected (@nemanjan00)
 - Fixed `hw version` / `hw status` showing a bogus FPGA image (`fpga_pm3_hf.ncd image 2s30vq100`) on Proxmark5 (PM5/AT32): PM5's Gowin FPGA bitstream is loaded externally and not compiled in, so the built-in Xilinx version info is meaningless there; the `[ FPGA ]` section (and the client FPGA "chip mismatch" check) are now suppressed for PM5 (@nemanjan00)
 - Fixed `hw status` [Model] section reporting "PM3 GENERIC" firmware on Proxmark5 (PM5/AT32); it now reports `PM5` (@nemanjan00)
 - Added Proxmark5 (PM5/AT32) reporting in `hw version` / `hw status`: correct MCU (AT32F437), flash size and `PM5` target, instead of the AT91-decoded "Unknown / 32 KB / PM3 GENERIC". The device now also reports its on-chip flash size, appended to the `CMD_VERSION` reply in a backward-compatible way (@nemanjan00)

--- a/armsrc/CMakeLists.txt
+++ b/armsrc/CMakeLists.txt
@@ -37,6 +37,7 @@ set(INC_DIRS
         ../include
         ../common_arm
         ../common_arm/rssi
+        ../common_arm/rgb
         ../common_arm/ticks
         ../common_arm/usb
         ../common_arm/flash_data
@@ -57,6 +58,7 @@ if (PM5)
     set(SRC_GPIO ../common_arm/gpio/gpio_hw_at32.c)
     set(SRC_WDT ../common_arm/wdt/wdt_hw_at32.c)
     set(SRC_RSSI ../common_arm/rssi/rssi_hw_at32.c)
+    set(SRC_RGB ../common_arm/rgb/rgb_hw_at32.c)
     set(SRC_SYS ../common_arm/sys/sys_hw_at32.c)
     set(SRC_FLASH_DATA ../common_arm/flash_data/flashmem_hw_at32.c)
     set(SRC_USB_CDC ../common_arm/usb/usb_cdc_at32.c)
@@ -67,6 +69,7 @@ else ()
     set(SRC_GPIO ../common_arm/gpio/gpio_hw_at91.c)
     set(SRC_WDT ../common_arm/wdt/wdt_hw_at91.c)
     set(SRC_RSSI ../common_arm/rssi/rssi_hw_at91.c)
+    set(SRC_RGB "")
     set(SRC_SYS ../common_arm/sys/sys_hw_at91.c)
     set(SRC_FLASH_DATA ../common_arm/flash_data/flashmem_hw_at91.c)
     set(SRC_USB_CDC ../common_arm/usb/usb_cdc_at91.c)
@@ -268,6 +271,7 @@ set(THUMBSRC
         string.c
         BigBuf.c
         ${SRC_RSSI}
+        ${SRC_RGB}
         ${SRC_TICKS}
         ${SRC_GPIO}
         ${SRC_WDT}

--- a/armsrc/Makefile
+++ b/armsrc/Makefile
@@ -45,6 +45,7 @@ ifeq ($(PLATFORM),PM5)
     SRC_GPIO       = ../common_arm/gpio/gpio_hw_at32.c
     SRC_WDT        = ../common_arm/wdt/wdt_hw_at32.c
     SRC_RSSI       = ../common_arm/rssi/rssi_hw_at32.c
+    SRC_RGB        = ../common_arm/rgb/rgb_hw_at32.c
     SRC_SYS        = ../common_arm/sys/sys_hw_at32.c
     SRC_FPGA       = ../common_arm/fpga/fpga_hw_at32.c ../common_arm/fpga/fpga_gw_jtag.c
     SRC_USB_CDC    = ../common_arm/usb/usb_cdc_at32.c
@@ -60,6 +61,7 @@ else
     SRC_GPIO       = ../common_arm/gpio/gpio_hw_at91.c
     SRC_WDT        = ../common_arm/wdt/wdt_hw_at91.c
     SRC_RSSI       = ../common_arm/rssi/rssi_hw_at91.c
+    SRC_RGB        =
     SRC_SYS        = ../common_arm/sys/sys_hw_at91.c
     SRC_FPGA       = ../common_arm/fpga/fpga_hw_at91.c
     SRC_USB_CDC    = ../common_arm/usb/usb_cdc_at91.c
@@ -177,6 +179,7 @@ THUMBSRC = start.c \
     $(SRC_STANDALONE) \
     $(SRC_ZX) \
     $(SRC_RSSI) \
+    $(SRC_RGB) \
 	$(SRC_TICKS) \
 	$(SRC_GPIO) \
 	$(SRC_WDT) \

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -29,6 +29,7 @@
 #include "fpga_loader.h"
 #include "fpga_apis.h"
 #include "rssi_apis.h"
+#include "rgb_apis.h"
 #include "string.h"
 #include "printf.h"
 #include "legicrf.h"
@@ -3621,6 +3622,18 @@ static void PacketReceived(PacketCommandNG *packet) {
         case CMD_PM5_QC_TEST: {
             uint8_t failed_item = 0;
             reply_ng(CMD_PM5_QC_TEST, QCTestPM5(&failed_item) ? PM3_SUCCESS : PM3_EFAILED, &failed_item, 1);
+            break;
+        }
+        case CMD_PM5_RGB_SET: {
+            // Set the antenna RGB LED colour (used by `hf/lf tune --rgb`).
+            struct p {
+                uint8_t r;
+                uint8_t g;
+                uint8_t b;
+            } PACKED;
+            struct p *payload = (struct p *)packet->data.asBytes;
+            RgbLedSet(payload->r, payload->g, payload->b);
+            reply_ng(CMD_PM5_RGB_SET, PM3_SUCCESS, NULL, 0);
             break;
         }
 #endif

--- a/client/src/cmdhf.c
+++ b/client/src/cmdhf.c
@@ -21,6 +21,7 @@
 #include "cmdparser.h"      // command_t
 #include "cliparser.h"      // parse
 #include "comms.h"          // clearCommandBuffer
+#include "util.h"           // set_rgb
 #include "lfdemod.h"        // computeSignalProperties
 #include "cmdhf14a.h"       // ISO14443-A
 #include "cmdhf14b.h"       // ISO14443-B
@@ -298,6 +299,22 @@ int CmdHFSearch(const char *Cmd) {
     return res;
 }
 
+// Mirror an antenna tuning level on the PM5 antenna RGB LED. `volt` is scaled
+// relative to the running peak (`v_max`), so the colour tracks the on-screen bar:
+// blue = low, green = mid, red = high.
+static void tune_rgb_update(uint32_t volt, uint32_t v_max) {
+    uint32_t t = (v_max > 0) ? (volt * 510 / v_max) : 0;
+    if (t > 510) {
+        t = 510;
+    }
+    if (t < 255) {          // blue -> green
+        set_rgb(0, (uint8_t)t, (uint8_t)(255 - t));
+    } else {                // green -> red
+        t -= 255;
+        set_rgb((uint8_t)t, (uint8_t)(255 - t), 0);
+    }
+}
+
 int CmdHFTune(const char *Cmd) {
 
     CLIParserContext *ctx;
@@ -315,6 +332,7 @@ int CmdHFTune(const char *Cmd) {
         arg_lit0(NULL, "mix", "mixed style"),
         arg_lit0(NULL, "value", "values style"),
         arg_lit0("v", "verbose", "verbose output"),
+        arg_lit0(NULL, "rgb", "(PM5) mirror the tuning level on the antenna RGB LED"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
@@ -323,7 +341,13 @@ int CmdHFTune(const char *Cmd) {
     bool is_mix = arg_get_lit(ctx, 3);
     bool is_value = arg_get_lit(ctx, 4);
     bool verbose = arg_get_lit(ctx, 5);
+    bool use_rgb = arg_get_lit(ctx, 6);
     CLIParserFree(ctx);
+
+    if (use_rgb && (IfPm5() == false)) {
+        PrintAndLogEx(WARNING, "`--rgb` is only supported on Proxmark5; ignoring");
+        use_rgb = false;
+    }
 
     if ((is_bar + is_mix + is_value) > 1) {
         PrintAndLogEx(ERR, "Select only one output style");
@@ -397,6 +421,12 @@ int CmdHFTune(const char *Cmd) {
             v_count++;
         }
         print_progress(volt, v_max, style);
+        if (use_rgb) {
+            tune_rgb_update(volt, v_max);
+        }
+    }
+    if (use_rgb) {
+        set_rgb(0, 0, 0); // turn the LED off on exit
     }
     mode[0] = 3;
 

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -28,6 +28,7 @@
 
 #include "cmdparser.h"      // command_t
 #include "comms.h"
+#include "util.h"           // set_rgb
 #include "commonutil.h"     // ARRAYLEN
 #include "lfdemod.h"        // device/client demods of LF signals
 #include "ui.h"             // for show graph controls
@@ -107,6 +108,22 @@ int lfsim_wait_check(uint32_t cmd) {
     return PM3_SUCCESS;
 }
 
+// Mirror an antenna tuning level on the PM5 antenna RGB LED. `volt` is scaled
+// relative to the running peak (`v_max`), so the colour tracks the on-screen bar:
+// blue = low, green = mid, red = high.
+static void tune_rgb_update(uint32_t volt, uint32_t v_max) {
+    uint32_t t = (v_max > 0) ? (volt * 510 / v_max) : 0;
+    if (t > 510) {
+        t = 510;
+    }
+    if (t < 255) {          // blue -> green
+        set_rgb(0, (uint8_t)t, (uint8_t)(255 - t));
+    } else {                // green -> red
+        t -= 255;
+        set_rgb((uint8_t)t, (uint8_t)(255 - t), 0);
+    }
+}
+
 static int CmdLFTune(const char *Cmd) {
 
     CLIParserContext *ctx;
@@ -128,6 +145,7 @@ static int CmdLFTune(const char *Cmd) {
         arg_lit0(NULL, "mix", "mixed style"),
         arg_lit0(NULL, "value", "values style"),
         arg_lit0("v", "verbose", "verbose output"),
+        arg_lit0(NULL, "rgb", "(PM5) mirror the tuning level on the antenna RGB LED"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
@@ -139,7 +157,13 @@ static int CmdLFTune(const char *Cmd) {
     bool is_mix = arg_get_lit(ctx, 5);
     bool is_value = arg_get_lit(ctx, 6);
     bool verbose = arg_get_lit(ctx, 7);
+    bool use_rgb = arg_get_lit(ctx, 8);
     CLIParserFree(ctx);
+
+    if (use_rgb && (IfPm5() == false)) {
+        PrintAndLogEx(WARNING, "`--rgb` is only supported on Proxmark5; ignoring");
+        use_rgb = false;
+    }
 
     if (divisor < 19) {
         PrintAndLogEx(ERR, "divisor must be between 19 and 255");
@@ -232,6 +256,12 @@ static int CmdLFTune(const char *Cmd) {
             v_count++;
         }
         print_progress(volt, v_max, style);
+        if (use_rgb) {
+            tune_rgb_update(volt, v_max);
+        }
+    }
+    if (use_rgb) {
+        set_rgb(0, 0, 0); // turn the LED off on exit
     }
 
     params[0] = 3;

--- a/client/src/util.c
+++ b/client/src/util.c
@@ -33,6 +33,8 @@
 #include <time.h> // Mingw
 
 #include "ui.h"     // PrintAndLog
+#include "comms.h"  // SendCommandNG / WaitForResponseTimeout (set_rgb)
+#include "pm3_cmd.h" // CMD_PM5_RGB_SET
 
 #define UTIL_BUFFER_SIZE_SPRINT 8196
 // global client debug variable
@@ -2047,4 +2049,16 @@ int str_copy_without_whitespace(const char *src, char *dst, size_t dst_size, siz
     dst[out] = '\0';
     *dst_len = out;
     return PM3_SUCCESS;
+}
+
+void set_rgb(uint8_t r, uint8_t g, uint8_t b) {
+    struct {
+        uint8_t r;
+        uint8_t g;
+        uint8_t b;
+    } PACKED payload = { r, g, b };
+    clearCommandBuffer();
+    SendCommandNG(CMD_PM5_RGB_SET, (uint8_t *)&payload, sizeof(payload));
+    PacketResponseNG resp;
+    WaitForResponseTimeout(CMD_PM5_RGB_SET, &resp, 200);
 }

--- a/client/src/util.h
+++ b/client/src/util.h
@@ -231,4 +231,10 @@ void str_unescape_newlines_inplace(char *s);
  */
 int str_copy_without_whitespace(const char *src, char *dst, size_t dst_size, size_t *dst_len);
 
+/**
+ * @brief Set the antenna RGB LED colour (Proxmark5). No-op reply on devices
+ * without an RGB LED. Sends CMD_PM5_RGB_SET and waits briefly for the ack.
+ */
+void set_rgb(uint8_t r, uint8_t g, uint8_t b);
+
 #endif

--- a/common_arm/Makefile.common
+++ b/common_arm/Makefile.common
@@ -43,12 +43,12 @@ OBJDIR = obj
 
 INCLUDE = -I../include -I../common_arm -I../common_fpga -I../common -I.
 INCLUDE += -I../common_arm/flash_code -I../common_arm/flash_data -I../common_arm/fpga -I../common_arm/gpio
-INCLUDE += -I../common_arm/rssi -I../common_arm/sys -I../common_arm/ticks -I../common_arm/usb -I../common_arm/wdt
+INCLUDE += -I../common_arm/rssi -I../common_arm/rgb -I../common_arm/sys -I../common_arm/ticks -I../common_arm/usb -I../common_arm/wdt
 
 # Also search prerequisites in the common directory (for usb.c), the fpga directory (for fpga.bit), and the lz4 directory
 VPATH = . ../common_arm ../common ../common/crapto1 ../common/mbedtls ../common/lz4 ../fpga ../armsrc/Standalone ../common/hitag2
 VPATH += ../common_arm/flash_code ../common_arm/flash_data ../common_arm/fpga ../common_arm/gpio
-VPATH += ../common_arm/rssi ../common_arm/sys ../common_arm/ticks ../common_arm/usb ../common_arm/wdt
+VPATH += ../common_arm/rssi ../common_arm/rgb ../common_arm/sys ../common_arm/ticks ../common_arm/usb ../common_arm/wdt
 
 INCLUDES = ../include/proxmark3_arm.h ../include/at91sam7s512.h ../include/config_gpio.h ../include/pm3_cmd.h
 

--- a/common_arm/rgb/rgb_apis.h
+++ b/common_arm/rgb/rgb_apis.h
@@ -1,0 +1,15 @@
+#ifndef RGB_APIS_H_
+#define RGB_APIS_H_
+
+#include "common.h"
+
+//-----------------------------------------------------------------------------
+// Antenna RGB LED control.
+//
+// Only implemented on platforms that actually have an RGB LED (currently PM5,
+// driven by an I2C RGB controller). Other platforms don't build this module, so
+// callers must guard usage accordingly (e.g. the CMD_PM5_RGB_SET handler).
+//-----------------------------------------------------------------------------
+void RgbLedSet(uint8_t r, uint8_t g, uint8_t b);
+
+#endif // RGB_APIS_H_

--- a/common_arm/rgb/rgb_hw_at32.c
+++ b/common_arm/rgb/rgb_hw_at32.c
@@ -1,0 +1,22 @@
+#include "rgb_apis.h"
+#include "i2c.h"        // RGB LED is driven over I2C
+#include "ticks_apis.h" // I2C timing needs ticks running
+
+// PM5 antenna RGB LED, driven by an I2C RGB controller (7-bit address 0x48).
+// Register map (from the QC/bring-up code):
+//   0x02 = index (which LED)
+//   0x01 = count (number of LEDs on the string; must be set or nothing lights)
+//   0x03 = data  (3 bytes RGB888 per LED)
+#define RGB_I2C_ADDR   (0x48 << 1) // 8-bit address form expected by the I2C_* API
+#define RGB_REG_COUNT  0x01
+#define RGB_REG_INDEX  0x02
+#define RGB_REG_DATA   0x03
+
+void RgbLedSet(uint8_t r, uint8_t g, uint8_t b) {
+    uint8_t rgb[3] = { r, g, b };
+    StartTicks();
+    I2C_init(true);
+    I2C_WriteByte(0, RGB_REG_INDEX, RGB_I2C_ADDR); // address LED index 0
+    I2C_WriteByte(1, RGB_REG_COUNT, RGB_I2C_ADDR); // 1 LED on the string
+    I2C_BufferWrite(rgb, sizeof(rgb), RGB_REG_DATA, RGB_I2C_ADDR);
+}

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -637,6 +637,8 @@ typedef struct {
 #define CMD_EEPROM_FACTORY_INFO_WRITE 0x0173
 // PM5, QC test for the hardware
 #define CMD_PM5_QC_TEST 0x0177
+// PM5, set the antenna RGB LED colour (payload: r,g,b). Used by `hf/lf tune --rgb`.
+#define CMD_PM5_RGB_SET 0x0178
 
 // For low-frequency tags
 #define CMD_LF_TI_READ 0x0202


### PR DESCRIPTION
Adds an opt-in `--rgb` flag to the continuous `hf tune` / `lf tune` commands that mirrors the antenna tuning level on the PM5 antenna RGB LED: blue = low, green = mid, red = high, tracking the on-screen bar so you can find coupling (e.g. an implant) by feel without watching the screen.