### PR TITLE
fix(mifare): validate readable Key B before marking it found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 ## [unreleased][unreleased]
 - Added Proxmark5 (PM5/AT32) reporting in `hw version` / `hw status`: correct MCU (AT32F437), flash size and `PM5` target, instead of the AT91-decoded "Unknown / 32 KB / PM3 GENERIC". The device now also reports its on-chip flash size, appended to the `CMD_VERSION` reply in a backward-compatible way (@nemanjan00)
 - Fixed `hf mf dump` preserving readable sector trailer Key B data instead of overwriting it with values from the supplied key file (@oSPANNERo)
+- Fixed `hf mf chk` validating readable sector trailer Key B data before reporting it as a found key (@oSPANNERo)
 - Changed `magic_cards_notes.md` - documented the USCUID-UL helper scripts (`hf_mfu_uscuid` / `hf_mf_uscuid_prog`) and how to set the tag signature, replacing the outdated "No implemented commands" note (@c-barron)
 - Fixed `hf_mf_uscuid_prog.lua` - corrected the script name shown in its usage text (@c-barron)
 - Added `hf felica seacauth1` command

--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -2008,6 +2008,25 @@ static uint8_t chkKey_readb(struct chk_t *c, uint8_t *keyb) {
         }
         mifare_classic_halt(c->pcs);
     }
+    if (res != 0) {
+        return res;
+    }
+
+    // A readable Key B field may contain data rather than a usable key.
+    // Verify the extracted value as Key B and require subsequent memory access.
+    if (iso14443a_fast_select_card(c->uid, c->cl) == 0) {
+        return 2;
+    }
+
+    uint64_t key = bytes_to_num(keyb, 6);
+    res = mifare_classic_authex(c->pcs, c->cuid, c->block, MF_KEY_B, key, AUTH_FIRST, NULL, NULL);
+    if (res != 0) {
+        return res;
+    }
+
+    res = mifare_classic_readblock(c->pcs, c->block, data);
+    mifare_classic_halt(c->pcs);
+
     return res;
 }
 

--- a/client/src/cmdhfmf.c
+++ b/client/src/cmdhfmf.c
@@ -4597,11 +4597,18 @@ static int CmdHF14AMfChk(const char *Cmd) {
                 }
 
                 uint8_t *data = resp.data.asBytes;
-                key64 = bytes_to_num(data + 10, MIFARE_KEY_SIZE);
+                uint8_t keyB[MIFARE_KEY_SIZE] = {0};
+                memcpy(keyB, data + 10, MIFARE_KEY_SIZE);
+
+                key64 = bytes_to_num(keyB, MIFARE_KEY_SIZE);
                 if (key64) {
-                    PrintAndLogEx(NORMAL, "Data:%s", sprint_hex(data + 10, MIFARE_KEY_SIZE));
-                    e_sector[i].foundKey[1] = 1;
-                    e_sector[i].Key[1] = key64;
+                    PrintAndLogEx(NORMAL, "Data:%s", sprint_hex(keyB, MIFARE_KEY_SIZE));
+
+                    uint8_t verify[MFBLOCK_SIZE] = {0};
+                    if (mf_read_block(sectrail, MF_KEY_B, keyB, verify) == PM3_SUCCESS) {
+                        e_sector[i].foundKey[1] = 1;
+                        e_sector[i].Key[1] = key64;
+                    }
                 }
             }
             if (singleSector)


### PR DESCRIPTION
## Summary

`hf mf chk` could report six readable sector-trailer bytes as a recovered Key B without verifying that those bytes were actually usable as Key B.

This change validates readable Key B fields before marking them as found:

- firmware-side `chkKey_readb()` now reselects the tag, authenticates the extracted value as Key B, and requires a subsequent block read to succeed
- the client-side fallback now performs the same usable-Key-B check before setting `foundKey[1]`
- readable trailer bytes are still shown as `Data:` even when they are not a valid authentication key
- changelog updated

## Regression testing

Validated against three cases:

1. **Readable data-only Key B field**
   - trailer bytes: `E0E1E2E3E400`
   - direct Key B authentication fails
   - before: `hf mf chk` reported the value as found
   - after: Key A is found, Key B remains not found

2. **Readable and genuinely usable Key B field**
   - Key A: `7D45A5FB1913`
   - readable Key B: `A976669417CD`
   - Key B authentication and memory read succeed
   - after: both A and B are reported as found

3. **Ordinary protected Key B candidate**
   - Key A: `A0A1A2A3A401`
   - Key B: `B0B1B2B3B401`
   - existing protected-Key-B path still reports both keys correctly

Build tested with `make armsrc/all client/all` on PM3GENERIC / 512K hardware.