### PR TITLE
Add API check to Android spinlock shim

### DIFF
--- a/client/src/cmdparser.c
+++ b/client/src/cmdparser.c
@@ -30,7 +30,7 @@
 # include "pthread_spin_lock_shim.h"  // spinlock shim for OSX ..
 #endif
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__) && __ANDROID_API__ < 24
 //Spinlock patch for building with Android NDK
 
 typedef pthread_mutex_t pthread_spinlock_t;


### PR DESCRIPTION
Android spinlock shim not needed on modern (API 24+) Android, this fixes compiling on Termux