### PR TITLE
doc(pm5): run `hf 14a read` before `hw fpga config` to power on the FPGA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `hw fpga config` on Proxmark5 (PM5/AT32) needing a prior reader command (e.g. `hf 14a read`) to work: it now powers on the FPGA (24MHz clock) itself at the start of the config, before driving the JTAG upload (@nemanjan00)
 - Added `--rgb` option to `hf tune` / `lf tune` (Proxmark5/PM5): mirrors the antenna tuning level on the antenna RGB LED (blue=low, green=mid, red=high, tracking the on-screen bar), for locating tags/implants by feel without watching the screen. Colour is computed client-side; the device gets a new `CMD_PM5_RGB_SET` handled by a dedicated AT32 RGB HAL module (`common_arm/rgb`), so other platforms are unaffected (@nemanjan00)
 - Fixed `hw version` / `hw status` showing a bogus FPGA image (`fpga_pm3_hf.ncd image 2s30vq100`) on Proxmark5 (PM5/AT32): PM5's Gowin FPGA bitstream is loaded externally and not compiled in, so the built-in Xilinx version info is meaningless there; the `[ FPGA ]` section (and the client FPGA "chip mismatch" check) are now suppressed for PM5 (@nemanjan00)
 - Fixed `hw status` [Model] section reporting "PM3 GENERIC" firmware on Proxmark5 (PM5/AT32); it now reports `PM5` (@nemanjan00)

--- a/common_arm/fpga/fpga_hw_at32.c
+++ b/common_arm/fpga/fpga_hw_at32.c
@@ -374,6 +374,11 @@ int FpgaStartConfig(bool configSram, uint32_t fileLength) {
     // TODO DXL: Check the file length is valid in this platform?
     //  if not, return the PM3_EOVFLOW
 
+    // Make sure the FPGA is clocked/powered before we drive its JTAG. Previously
+    // a reader command (e.g. `hf 14a read`) had to be run first to bring the FPGA
+    // up, otherwise `hw fpga config` had nothing to talk to. Do it here instead.
+    FpgaSetup24MHzClk();
+
     // Init jtag hardware link.
     gpio_fpga_download_setup();
 


### PR DESCRIPTION
`hw fpga config` uploads to the FPGA over JTAG, which needs the FPGA powered on. Add an `hf 14a read` before the config to bring the FPGA up (the existing read after flashing is kept to confirm the new image).