### PR TITLE
fix: heap overflow in pm3_grabbed_output_get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `pm3_grabbed_output_get` - heap overflow (@jonyen)
 - Fixed `hf iclass sam` - removed the old implementation (@iceman1001)
 - Fixed Proxmark5 (PM5/AT32) failing to re-enter the bootloader (@nemanjan00)
 - Fixed `hw fpga config` on Proxmark5 (PM5/AT32) now powers on the FPGA 24MHz clock (@nemanjan00)

--- a/client/src/pm3.c
+++ b/client/src/pm3.c
@@ -80,7 +80,7 @@ const char *pm3_name_get(pm3_device_t *dev) {
 const char *pm3_grabbed_output_get(pm3_device_t *dev) {
     if (g_grabbed_output.ptr != NULL) {
         char *tmp = g_grabbed_output.ptr;
-        tmp[g_grabbed_output.size] = 0;
+        tmp[g_grabbed_output.idx] = 0;
         g_grabbed_output.idx = 0;
         g_grabbed_output.size = 0;
         return tmp;


### PR DESCRIPTION
## Summary

`pm3_grabbed_output_get()` null-terminates the captured output one byte past the end of its heap allocation on every call.

The buffer is grown by `MAX_PRINT_BUFFER` at a time in `ui.c`, which tracks the number of bytes actually written in `g_grabbed_output.idx`, while `g_grabbed_output.size` holds the allocated capacity. The function terminated at `size` rather than `idx`, so it wrote a zero byte just past the last valid index of the allocation.

```c
const char *pm3_grabbed_output_get(pm3_device_t *dev) {
    if (g_grabbed_output.ptr != NULL) {
        char *tmp = g_grabbed_output.ptr;
-       tmp[g_grabbed_output.size] = 0;
+       tmp[g_grabbed_output.idx] = 0;
        ...
```

Terminating at `idx` is always in bounds: the grabber guarantees at least `MAX_PRINT_BUFFER` bytes of headroom before each write, so `idx` is strictly less than `size`.

## Impact

The interactive client mostly survives this because it calls the function only once or twice before exiting, so the corrupted `malloc` metadata is never reused. A long-running `libpm3` client that captures output on every command does not: the corruption surfaces later, far from its cause. I hit it as a `SIGTRAP` inside an unrelated AppKit autorelease pool while driving `libpm3` from a GUI.

## Reproduction

With the guard allocator, against real hardware:

```
MALLOC_STRICT_SIZE=1 MallocGuardEdges=1 \
  DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib ./pm3run <port> "hw version"
```

This crashes with `SIGSEGV` inside `pm3_grabbed_output_get` before the change and exits cleanly with identical captured output after it.

## Changes

- `client/src/pm3.c`: terminate at `idx` instead of `size`.
- `CHANGELOG.md`: added an entry under `[unreleased]`.
