### PR TITLE
To expand crm_ertc_clock_select() in at32_bpr_write_dt1() for reduce code size

### DIFF
--- a/common_arm/sys/sys_hw_at32.c
+++ b/common_arm/sys/sys_hw_at32.c
@@ -68,7 +68,8 @@ static void at32_bpr_write_dt1(uint32_t data) {
 
     // Select and enable an ERTC clock so the write-protection register is
     // writable at the full APB frequency.
-    crm_ertc_clock_select(CRM_ERTC_CLOCK_HEXT_DIV_20);
+    CRM->cfg_bit.ertcdiv = ((CRM_ERTC_CLOCK_HEXT_DIV_20 & 0x1F0) >> 4);
+    CRM->bpdc_bit.ertcsel = (CRM_ERTC_CLOCK_HEXT_DIV_20 & 0xF);
     CRM->bpdc_bit.ertcen = TRUE;
 
     ERTC->wp = SYS_SIMPLE_RESET_BPR_UNLOCK_KEY1;


### PR DESCRIPTION
Always to use register calls to reduce the performance loss, and reduce code size.