### PR TITLE
Correct NLEN log message and empty record example

### DIFF
--- a/client/src/cmdhf14a.c
+++ b/client/src/cmdhf14a.c
@@ -4225,7 +4225,7 @@ int CmdHF14ANdefWrite(const char *Cmd) {
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "hf 14a ndefwrite",
                   "Write raw NDEF hex bytes to tag. This commands assumes tag already been NFC/NDEF formatted.\n",
-                  "hf 14a ndefwrite -d 0300FE      -> write empty record to tag\n"
+                  "hf 14a ndefwrite -d 0000        -> write empty record to tag\n"
                   "hf 14a ndefwrite -f myfilename\n"
                   "hf 14a ndefwrite -d 003fd1023a53709101195405656e2d55534963656d616e2054776974746572206c696e6b5101195502747769747465722e636f6d2f686572726d616e6e31303031\n"
                  );
@@ -4300,11 +4300,16 @@ int CmdHF14ANdefWrite(const char *Cmd) {
                 }
                 uint8_t tmp_raw[256];
                 memcpy(tmp_raw, raw, sizeof(tmp_raw));
+                // A NFC Type 4 Tag NDEF file starts with the NLEN field, a two byte
+                // big endian length of the NDEF message that follows.  It is not a
+                // TLV container, so there is no 0x03 tag byte here.
+                // raw[] is 256 bytes and the bounds check above caps bytes at 254,
+                // hence the high byte of NLEN is always zero.
                 raw[0] = 0x00;
                 raw[1] = bytes;
                 memcpy(raw + 2, tmp_raw, sizeof(raw) - 2);
                 bytes += 2;
-                PrintAndLogEx(SUCCESS, "Added generic message header (0x03)");
+                PrintAndLogEx(SUCCESS, "Added NDEF length prefix (NLEN)");
             }
         }
     }

--- a/client/src/cmdhf14a.c
+++ b/client/src/cmdhf14a.c
@@ -4300,12 +4300,7 @@ int CmdHF14ANdefWrite(const char *Cmd) {
                 }
                 uint8_t tmp_raw[256];
                 memcpy(tmp_raw, raw, sizeof(tmp_raw));
-                // A NFC Type 4 Tag NDEF file starts with the NLEN field, a two byte
-                // big endian length of the NDEF message that follows.  It is not a
-                // TLV container, so there is no 0x03 tag byte here.
-                // raw[] is 256 bytes and the bounds check above caps bytes at 254,
-                // hence the high byte of NLEN is always zero.
-                raw[0] = 0x00;
+                raw[0] = 0x00; // the high byte of NLEN is always zero.
                 raw[1] = bytes;
                 memcpy(raw + 2, tmp_raw, sizeof(raw) - 2);
                 bytes += 2;


### PR DESCRIPTION
`hf 14a ndefwrite` targets a NFC Type 4 Tag. The NDEF file there starts with NLEN (a two byte big endian message length), not a TLV container, so 0x03 is not needed.

The log message said otherwise, and the first help example (`0300FE`) was a Type 2 TLV empty record. On a Type 4 tag that parses as NLEN = 0x0300, i.e. 768 bytes. 

Fixed both, added a note. 