### PR TITLE
Add default constructor to PictureItem class

### DIFF
--- a/client/src/proxguiqt.h
+++ b/client/src/proxguiqt.h
@@ -97,6 +97,7 @@ class SliderWidget : public QWidget {
  */
 class PictureItem {
   public:
+    PictureItem() = default;
     PictureItem(const QString &t, const QImage &i) : title(t), image(i) {}
     QString title;
     QImage image;


### PR DESCRIPTION
Changes to correctly shows multiple images in the image viewer have broken the build on:
compiler version:  cc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0
GUI support:       QT5 found, enabled (Qt version 5.12.8 in /usr/lib/x86_64-linux-gnu)

due to Qt 5's QVector implementation needing a default constructor to be defined.

Solution is to add a default constructor to PictureItem class