### PR TITLE
client: default to PM5 when built for PLATFORM=PM5 and no device is connected

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -574,6 +574,10 @@ if (APPLE)
     endif()
 endif (APPLE)
 
+if(PLATFORM STREQUAL "PM5")
+    add_definitions("-DDEFAULT_PM5")
+endif()
+
 if ((NOT SKIPQT EQUAL 1) AND (Qt5_FOUND OR Qt6_FOUND))
     set(CMAKE_AUTOMOC ON)
     set(CMAKE_AUTORCC ON)

--- a/client/Makefile
+++ b/client/Makefile
@@ -30,6 +30,10 @@ ifeq ($(PLATFORM),PM3ICOPYX)
   INCLUDES += -DICOPYX
 endif
 
+ifeq ($(PLATFORM),PM5)
+  INCLUDES += -DDEFAULT_PM5
+endif
+
 INSTALLBIN = proxmark3
 INSTALLSHARE = cmdscripts lualibs luascripts pyscripts resources dictionaries
 

--- a/client/src/cmdparser.c
+++ b/client/src/cmdparser.c
@@ -123,8 +123,13 @@ bool IfPm3FpcUsartFromUsb(void) {
 }
 
 bool IfPm5(void) {
-    if (IfPm3Present() == false)
+    if (IfPm3Present() == false) {
+#ifdef DEFAULT_PM5
+        return true;    // client built for PM5 -> assume PM5 when offline
+#else
         return false;
+#endif
+    }
     return g_pm3_capabilities.is_pm5;
 }
 


### PR DESCRIPTION
When the client is built with PLATFORM=PM5 but run offline, it previously fell back to generic PM3 behavior. 

This makes a PM5-built client assume PM5 while offline, so the banner and commands reflect what the client was compiled for.