### PR TITLE
Client: Reflect PM5 in the CLI prompt

### DIFF
--- a/client/src/proxmark3.c
+++ b/client/src/proxmark3.c
@@ -350,10 +350,11 @@ static void prompt_set(void) {
 }
 
 static void prompt_compose(char *buf, size_t buflen, const char *promptctx, const char *promptdev, const char *promptnet, bool no_newline) {
+    const char *dev_name = IfPm5() ? "pm5" : "pm3";
     if (no_newline) {
-        snprintf(buf, buflen - 1, PROXPROMPT_COMPOSE, promptdev, promptnet, promptctx);
+        snprintf(buf, buflen - 1, PROXPROMPT_COMPOSE, promptdev, promptnet, promptctx, dev_name);
     } else {
-        snprintf(buf, buflen - 1, _CLR_LINE_ "\r" PROXPROMPT_COMPOSE, promptdev, promptnet, promptctx);
+        snprintf(buf, buflen - 1, _CLR_LINE_ "\r" PROXPROMPT_COMPOSE, promptdev, promptnet, promptctx, dev_name);
     }
 }
 

--- a/client/src/proxmark3.h
+++ b/client/src/proxmark3.h
@@ -24,7 +24,7 @@
 
 #define PROXPROMPT_MAX_SIZE 255
 
-#define PROXPROMPT_COMPOSE "[" "%s%s%s" "] pm3 --> "
+#define PROXPROMPT_COMPOSE "[" "%s%s%s" "] %s --> "
 
 #define PROXPROMPT_CTX_SCRIPTFILE  "|" _RL_GREEN_("script")
 #define PROXPROMPT_CTX_SCRIPTCMD   "|" _RL_GREEN_("script")


### PR DESCRIPTION
Follow-up to #3514 (client: default to PM5 when built for PLATFORM=PM5 and no device is connected)

In the CLI, the interactive prompt was hardcoded to pm3. It now shows pm5 when connected to a PM5 (or when the client is built for PM5 and running offline). 