### PR TITLE
Remove swap_clocks()

### DIFF
--- a/armsrc/sam_common.c
+++ b/armsrc/sam_common.c
@@ -115,39 +115,15 @@ out:
     return res;
 }
 
-
-static inline void swap_clock_counters(volatile unsigned int *a, unsigned int *b) {
-    unsigned int c = *a;
-    *a = *b;
-    *b = c;
-}
-
-/**
- * @brief Swaps the timer counter values.
- *
- * AT91SAM7S512 has a single Timer-Counter, that is reused in clocks Ticks
- * and CountSspClk. This function stops the current clock and restores previous
- * values. It is used to switch between different clock sources.
- * It probably makes communication timing off, but at least makes it work.
- */
-static void swap_clocks(void) {
-    static unsigned int tc0, tc1, tc2 = 0;
-    StopTicks();
-    swap_clock_counters(&(AT91C_BASE_TC0->TC_CV), &tc0);
-    swap_clock_counters(&(AT91C_BASE_TC1->TC_CV), &tc1);
-    swap_clock_counters(&(AT91C_BASE_TC2->TC_CV), &tc2);
-}
-
 void switch_clock_to_ticks(void) {
-    swap_clocks();
+    StopTicks();
     StartTicks();
 }
 
 void switch_clock_to_countsspclk(void) {
-    swap_clocks();
+    StopTicks();
     StartCountSspClk();
 }
-
 
 /**
  * @brief Sends a payload to the SAM

--- a/common_arm/ticks/ticks_hw_at91.c
+++ b/common_arm/ticks/ticks_hw_at91.c
@@ -413,7 +413,23 @@ void ResetTicks(void) {
 void StopTicks(void) {
     AT91C_BASE_TC0->TC_CCR = AT91C_TC_CLKDIS;
     AT91C_BASE_TC1->TC_CCR = AT91C_TC_CLKDIS;
-    AT91C_BASE_TC2->TC_CCR = AT91C_TC_CLKDIS; // TODO StartTicks() did not use TC2, is this code worthless?
+    AT91C_BASE_TC2->TC_CCR = AT91C_TC_CLKDIS;
+
+    // TODO DXL StartTicks() did not use TC2, is this code worthless?
+    //  In some places, StartCountSspClk() is called after StopTicks(), so it seems necessary to disable timers completely.
+    //  In that case, the role of StopTicks() is not limited to being paired with StartTicks(),
+    //  but is a general release function for all ticks modules.
+    //  ---
+    //  Do we need to provide a StopXXX for each StartXXXX?
+    //  Such as:
+    //    * StartTicks -> StopTicks
+    //    * StartCountSspClk -> StopCountSspClk
+    //    * StartTickCount -> StopTickCount
+    //    * StartCountUS -> StopCountUS
+    //    * StartPrecisionCounter -> StopPrecisionCounter
+    //    * StartLoEdgeCapture -> StopLoEdgeCapture
+    //    * StartTimestamp -> StopTimestamp
+    //  It seems best for everyone(api) to do their own job.
 }
 
 uint32_t GetTicks(void) {


### PR DESCRIPTION
It seems that swap_clocks() has no real effect. It can be safely deleted.

Not to mention that AT91C_BASE_TC0->TC_CV is marked as a read-only register in the manual. And both StartTicks & StartCountSspClk will reset the timer, causing TC_CV to be cleared.

If it's truly unnecessary code (or at least doesn't provide any benefit), then it seems I can remove it without having to consider implementing HAL here.