### PR TITLE
Check the file size when configuring the fpga.

### DIFF
--- a/common_arm/fpga/fpga_gw_jtag.c
+++ b/common_arm/fpga/fpga_gw_jtag.c
@@ -660,6 +660,7 @@ gowin_jtag_status_t gowin_jtag_flash_config_write(uint8_t *data, uint32_t data_l
     if (!data) return GOWIN_JTAG_ERROR_NULL_POINTER;
     if (detected_device == GW_DEVICE_UNKNOWN) return GOWIN_JTAG_ERROR_INVALID_IDCODE;
     if (m_flash_xpage_buf == NULL) return GOWIN_JTAG_ERROR_NULL_POINTER;
+    if (*tx_bytes_pos + data_length + m_flash_xpage_pos > tx_bytes_total) return GOWIN_JTAG_ERROR_OUT_OF_RANGE;
 
     // When xbuf already holds buffered data, we must first accumulate a full x-page before writing the data in xbuf
     if (data_length < 256 || m_flash_xpage_pos > 0) {

--- a/common_arm/fpga/fpga_hw_at32.c
+++ b/common_arm/fpga/fpga_hw_at32.c
@@ -285,8 +285,10 @@ static gowin_config_ctx_t gci = {
 
 int FpgaStartConfig(bool configSram, uint32_t fileLength) {
 
-    // TODO DXL: Check the file length is valid in this platform?
-    //  if not, return the PM3_EOVFLOW
+    // Check if the file length exceeds the maximum allowed size for FPGA bitstream files
+    if (fileLength > FPGA_BITSTREAM_FILE_SIZE_MAX) {
+        return PM3_ELENGTH;
+    }
 
     // Init jtag hardware link.
     gpio_fpga_download_setup();
@@ -306,8 +308,11 @@ int FpgaStartConfig(bool configSram, uint32_t fileLength) {
 
 int FpgaConfigWrite(uint8_t *data, uint32_t data_length) {
 
-    // TODO DXL: Check the data_length length is valid in this platform?
-    //  if not, return the PM3_EOVFLOW
+    // Check if the data length exceeds the remaining space in the configuration context
+    // When writing flash, the internal system will also check whether the number of caches plus the current number will overflow.
+    if (gci.tx_pos + data_length > gci.tx_total) {
+        return PM3_ELENGTH;
+    }
 
     gowin_jtag_config_write(data, data_length, &gci);
     if (gci.status != GOWIN_JTAG_OK) {

--- a/common_arm/fpga/fpga_hw_at32.h
+++ b/common_arm/fpga/fpga_hw_at32.h
@@ -6,6 +6,8 @@
 #include "at32f435_437_dma.h"
 #include "fpga_gw_jtag.h"
 
+#define FPGA_BITSTREAM_FILE_SIZE_MAX  (217 * 1024) // 217KB, the max size of bitstream file for GW1N-4(UV4) of PM5
+
 // The DMA memory address of AT32 does not self increment,
 // and there are no useful registers to know the initial set count value,
 // so we can only use one variable to store the set count value.


### PR DESCRIPTION
Currently, only file size needs to be checked; file format does not need to be checked at this time.