### PR TITLE
Add credit-based flow control to BWM app_com forwarding

### DIFF
--- a/armsrc/bwm_forward.c
+++ b/armsrc/bwm_forward.c
@@ -14,13 +14,15 @@
 #include "bwm_forward.h"
 
 #include "bwm_uart_at32.h"
-#include "pm3_cmd.h"
+#include "pm3_cmd.h"    // PM3_CMD_DATA_SIZE, PM3_* return codes
 #include "string.h"
 
 #ifndef MIN
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
+// CRC-16/CCITT-FALSE, byte-identical to the BWM firmware's crc16_ccitt()
+// (poly 0x1021, init 0xFFFF, MSB-first, no reflection, no xorout).
 static uint16_t bwm_crc16(const uint8_t *data, size_t len, uint16_t crc) {
     for (size_t i = 0; i < len; i++) {
         crc ^= (uint16_t)data[i] << 8;
@@ -35,18 +37,51 @@ static uint16_t bwm_crc16(const uint8_t *data, size_t len, uint16_t crc) {
     return crc;
 }
 
-#define BWM_TX_OVERHEAD   (2 + 2 + 2 + 2)
-#define BWM_TX_MAX_PAYLOAD (PM3_CMD_DATA_SIZE + 64)
+// ---------------------------------------------------------------------------
+// TX: wrap one reply frame into a SEND_FORWARD_DATA app_com frame.
+// A full NG/OLD frame is <= PM3_CMD_DATA_SIZE + a small header/postamble, well
+// under the BWM 4096-byte payload cap, so a single frame always suffices.
+// ---------------------------------------------------------------------------
+#define BWM_TX_OVERHEAD   (2 + 2 + 2 + 2)   // hdr + cmd + len + crc
+#define BWM_TX_MAX_PAYLOAD (PM3_CMD_DATA_SIZE + 64)   // NG/OLD frame ceiling
 #define BWM_TX_BUFSZ      (BWM_TX_OVERHEAD + BWM_TX_MAX_PAYLOAD)
 
+static void bwm_pump(void);   // fwd decl: TX gate pumps RX to collect credit grants
+
+// --- Flow control (credit window) ------------------------------------------
+// s_fc_granted: cumulative # of frames the ESP has authorized (updated from
+//   BWM_CMD_FLOW_CREDIT frames). s_fc_sent: cumulative # the ARM has sent.
+// Sending is allowed while (int16_t)(granted - sent) > 0; the signed diff is
+// wrap-safe. Grants are absolute/cumulative, so a lost credit frame self-corrects.
+static volatile uint16_t s_fc_granted = BWM_FC_INITIAL_CREDIT;
+static uint16_t          s_fc_sent    = 0;
+
+static inline bool bwm_fc_may_send(void) {
+    return (int16_t)(s_fc_granted - s_fc_sent) > 0;
+}
+
 int bwm_fwd_writebuffer_sync(const uint8_t *data, size_t len) {
-    static uint8_t frame[BWM_TX_BUFSZ];
+    static uint8_t frame[BWM_TX_BUFSZ];   // single-threaded bare-metal: static OK
 
     if (len > BWM_TX_MAX_PAYLOAD) {
-        len = BWM_TX_MAX_PAYLOAD;
+        len = BWM_TX_MAX_PAYLOAD;         // defensive; should never trigger
     }
 
     size_t idx = 0;
+    // Flow control: block until the ESP has granted credit for another frame.
+    // bwm_pump() drains the IRQ-filled RX ring, so grants are collected even
+    // while we sit inside a tight download loop (the reply_old firehose). The
+    // spin cap is a safety valve so a dead/disconnected ESP can't hard-hang us.
+    {
+        uint32_t spins = 0;
+        while (bwm_fc_may_send() == false) {
+            bwm_pump();
+            if (++spins > BWM_FC_STALL_SPINS) {
+                break;   // best-effort: proceed even without a fresh grant
+            }
+        }
+    }
+
     frame[idx++] = BWM_HDR_HOST_CMD_1;
     frame[idx++] = BWM_HDR_HOST_CMD_2;
     frame[idx++] = (uint8_t)(BWM_CMD_SEND_FORWARD_DATA & 0xFF);
@@ -61,10 +96,18 @@ int bwm_fwd_writebuffer_sync(const uint8_t *data, size_t len) {
     frame[idx++] = (uint8_t)(crc & 0xFF);
     frame[idx++] = (uint8_t)((crc >> 8) & 0xFF);
 
-    return bwm_uart_write(frame, idx);
+    int wr = bwm_uart_write(frame, idx);
+    s_fc_sent++;   // one forward frame consumed a credit
+    return wr;
 }
 
-#define BWM_DEFIFO_SZ     2048
+// ---------------------------------------------------------------------------
+// RX: persistent app_com de-framer. Feeds raw FPC bytes through a state machine
+// and pushes the payloads of valid DATA_FORWARD (0xD2 0xD3 / cmd 8089) frames
+// into a byte FIFO that bwm_read_ng() drains. Non-DATA_FORWARD frames (slave
+// responses, forwarded logs, cmd-error reports) are validated and discarded.
+// ---------------------------------------------------------------------------
+#define BWM_DEFIFO_SZ     2048            // >= one full NG frame's payload
 #define BWM_RXFRAME_MAX   (PM3_CMD_DATA_SIZE + 64)
 
 typedef enum {
@@ -74,32 +117,33 @@ typedef enum {
 typedef struct {
     bwm_state_t state;
     uint8_t     hdr1;
-    bool        is_bcast;
+    bool        is_bcast;     // header pair is 0xD2 0xD3
     uint16_t    cmd;
     uint16_t    len;
-    uint16_t    got;
-    uint16_t    crc_calc;
+    uint16_t    got;          // payload bytes received
+    uint16_t    crc_calc;     // running CRC over hdr..payload
     uint16_t    crc_recv;
     uint8_t     payload[BWM_RXFRAME_MAX];
 } bwm_parser_t;
 
 static bwm_parser_t s_p = { .state = S_IDLE };
 
+// De-framed payload ring
 static uint8_t  s_fifo[BWM_DEFIFO_SZ];
-static volatile uint16_t s_fifo_head = 0;
-static volatile uint16_t s_fifo_tail = 0;
+static volatile uint16_t s_fifo_head = 0;   // write
+static volatile uint16_t s_fifo_tail = 0;   // read
 
 static uint16_t fifo_count(void) {
     return (uint16_t)((s_fifo_head - s_fifo_tail) & (BWM_DEFIFO_SZ - 1));
 }
-static inline void fifo_push(uint8_t b) {
+static void fifo_push(uint8_t b) {
     uint16_t next = (uint16_t)((s_fifo_head + 1) & (BWM_DEFIFO_SZ - 1));
-    if (next != s_fifo_tail) {
+    if (next != s_fifo_tail) {              // drop on overflow rather than corrupt
         s_fifo[s_fifo_head] = b;
         s_fifo_head = next;
     }
 }
-static inline uint8_t fifo_pop(void) {
+static uint8_t fifo_pop(void) {
     uint8_t b = s_fifo[s_fifo_tail];
     s_fifo_tail = (uint16_t)((s_fifo_tail + 1) & (BWM_DEFIFO_SZ - 1));
     return b;
@@ -109,6 +153,8 @@ static void bwm_reset_frame(bwm_parser_t *p) {
     p->state = S_IDLE;
 }
 
+// Update running CRC one byte at a time (mirrors the streaming update in the
+// BWM firmware parser).
 static void crc_step(bwm_parser_t *p, uint8_t byte) {
     p->crc_calc = bwm_crc16(&byte, 1, p->crc_calc);
 }
@@ -121,12 +167,14 @@ static void bwm_feed_byte(bwm_parser_t *p, uint8_t byte) {
             } else if (byte == BWM_HDR_SLAVE_RESP_1) {
                 p->hdr1 = byte; p->is_bcast = false; p->state = S_HDR2;
             }
+            // any other byte: stay idle (resync)
             break;
 
         case S_HDR2: {
             bool ok = (p->is_bcast  && byte == BWM_HDR_SLAVE_BCAST_2) ||
                       (!p->is_bcast && byte == BWM_HDR_SLAVE_RESP_2);
             if (!ok) {
+                // header mismatch: reset and re-examine this byte as a potential SOF
                 p->state = S_IDLE;
                 bwm_feed_byte(p, byte);
                 return;
@@ -144,7 +192,7 @@ static void bwm_feed_byte(bwm_parser_t *p, uint8_t byte) {
             p->len |= (uint16_t)byte << 8;
             crc_step(p, byte);
             p->got = 0;
-            if (p->len > BWM_RXFRAME_MAX) {
+            if (p->len > BWM_RXFRAME_MAX) {            // oversized -> drop frame
                 bwm_reset_frame(p);
             } else {
                 p->state = (p->len == 0) ? S_CRC_LO : S_PAYLOAD;
@@ -162,12 +210,17 @@ static void bwm_feed_byte(bwm_parser_t *p, uint8_t byte) {
         case S_CRC_LO:  p->crc_recv = byte;                 p->state = S_CRC_HI; break;
         case S_CRC_HI:
             p->crc_recv |= (uint16_t)byte << 8;
-            if (p->crc_recv == p->crc_calc &&
-                    p->is_bcast && p->cmd == BWM_CMD_DATA_FORWARD) {
-                for (uint16_t i = 0; i < p->len; i++) {
-                    fifo_push(p->payload[i]);
+            if (p->crc_recv == p->crc_calc && p->is_bcast) {
+                if (p->cmd == BWM_CMD_DATA_FORWARD) {
+                    for (uint16_t i = 0; i < p->len; i++) {
+                        fifo_push(p->payload[i]);
+                    }
+                } else if (p->cmd == BWM_CMD_FLOW_CREDIT && p->len >= 2) {
+                    // absolute cumulative grant from the ESP
+                    s_fc_granted = (uint16_t)(p->payload[0] | ((uint16_t)p->payload[1] << 8));
                 }
             }
+            // valid non-DATA_FORWARD frames and CRC failures alike: just resync
             bwm_reset_frame(p);
             break;
 
@@ -177,6 +230,7 @@ static void bwm_feed_byte(bwm_parser_t *p, uint8_t byte) {
     }
 }
 
+// Pull whatever raw framed bytes are waiting and run them through the parser.
 static void bwm_pump(void) {
     uint8_t scratch[64];
     uint16_t avail = bwm_uart_rx_available();
@@ -196,6 +250,8 @@ uint16_t bwm_fwd_rxdata_available(void) {
     if (fifo_count() > 0) {
         return fifo_count();
     }
+    // No de-framed payload yet, but raw frame bytes may be waiting; pump once so
+    // receive_ng()'s gate reflects real forward data.
     bwm_pump();
     return fifo_count();
 }
@@ -204,6 +260,9 @@ uint32_t bwm_read_ng(uint8_t *data, size_t len) {
     if (len == 0) {
         return 0;
     }
+
+    // Same bounded-retry budget shape as bwm_uart_read(); USART_SLOW_LINK (set
+    // for the BWM/BLE link) widens it so a slow round-trip doesn't time out.
     uint32_t tryconstant = 0;
 #ifdef USART_SLOW_LINK
     tryconstant = 50000;

--- a/armsrc/bwm_forward.h
+++ b/armsrc/bwm_forward.h
@@ -8,29 +8,71 @@
 //
 // See LICENSE.txt for the text of the license.
 //-----------------------------------------------------------------------------
+// Proxmark5 Battery Wireless Module (BWM) transport shim.
+//
+// The BWM (ESP32-C2, RfidResearchGroup/Proxmark5_BWM_esp32) bridges the AT32
+// host <-> BLE/WiFi. Its ESP<->AT32 UART link does NOT carry raw PacketCommandNG;
+// it uses a framed "app_com" protocol. Transparent host<->wireless traffic rides
+// inside that framing:
+//
+//   AT32 -> ESP (our reply, toward wireless host):
+//       [0x7C 0xC7] cmd=APP_CMD_SEND_FORWARD_DATA(5000) len(LE) payload CRC16(LE)
+//   ESP -> AT32 (command from wireless host):
+//       [0xD2 0xD3] cmd=APP_BROADCAST_DATA_FORWARD(8089) len(LE) payload CRC16(LE)
+//
+//   Frame = HDR1 HDR2 | CMD(LE16) | LEN(LE16) | PAYLOAD[LEN] | CRC(LE16)
+//   CRC   = CRC-16/CCITT-FALSE (poly 0x1021, init 0xFFFF, MSB-first, no xorout)
+//           over HDR..PAYLOAD. (NOT compute_crc(CRC_14443_A) - different CRC.)
+//
+// This shim wraps outgoing NG/OLD reply bytes into a SEND_FORWARD_DATA frame and
+// de-frames incoming DATA_FORWARD frames back into a raw NG byte stream, so the
+// stock reply_ng()/receive_ng() paths work unchanged over the BWM link.
+//
+// Enabled by -DWITH_BWM_FORWARD (implies WITH_FPC_USART_HOST).
+//-----------------------------------------------------------------------------
 
 #ifndef __BWM_FORWARD_H
 #define __BWM_FORWARD_H
 
 #include "common.h"
 
-#define BWM_HDR_HOST_CMD_1     0x7C
+// app_com framing constants (verified against BWM firmware app_cmd_uart.[ch] /
+// app_com_defs.h).
+#define BWM_HDR_HOST_CMD_1     0x7C   // AT32 -> ESP  (host command)
 #define BWM_HDR_HOST_CMD_2     0xC7
-#define BWM_HDR_SLAVE_BCAST_1  0xD2
+#define BWM_HDR_SLAVE_BCAST_1  0xD2   // ESP  -> AT32 (slave broadcast)
 #define BWM_HDR_SLAVE_BCAST_2  0xD3
-#define BWM_HDR_SLAVE_RESP_1   0x2D
+#define BWM_HDR_SLAVE_RESP_1   0x2D   // ESP  -> AT32 (slave response, skipped here)
 #define BWM_HDR_SLAVE_RESP_2   0x3D
 
-#define BWM_CMD_SEND_FORWARD_DATA   5000
-#define BWM_CMD_DATA_FORWARD        8089
+#define BWM_CMD_SEND_FORWARD_DATA   5000   // host cmd: payload -> BLE/WiFi endpoint
+#define BWM_CMD_DATA_FORWARD        8089   // slave bcast: payload came from endpoint
+#define BWM_CMD_FLOW_CREDIT         8092   // slave bcast: payload = uint16 cumulative granted-frame count (LE)
+
+// Flow control (credit window). The ESP grants the ARM permission to send a
+// bounded number of forward frames; it advances the cumulative grant as it
+// drains frames to BLE. Sizing: BWM_FC_INITIAL_CREDIT frames must fit inside the
+// ESP's UART RX FIFO + BLE mbuf pool so an in-flight window never overflows.
+#define BWM_FC_INITIAL_CREDIT       8      // frames the ARM may send before the first grant
+#ifndef BWM_FC_STALL_SPINS
+#define BWM_FC_STALL_SPINS          200000
+#endif // safety valve: give up waiting for credit (avoid hard hang)
 
 #define BWM_CRC16_POLY  0x1021
 #define BWM_CRC16_INIT  0xFFFF
 
+// Wrap `len` raw reply bytes (a whole PacketResponseNG/OLD frame) into one
+// SEND_FORWARD_DATA app_com frame and write it synchronously to the FPC USART.
+// Returns PM3_SUCCESS or the underlying usart error. Drop-in for the FPC
+// usart_writebuffer_sync() call in reply_ng_internal()/reply_old().
 int bwm_fwd_writebuffer_sync(const uint8_t *data, size_t len);
 
+// De-framed read: returns up to `len` raw NG bytes recovered from inbound
+// DATA_FORWARD frames, blocking-with-timeout exactly like usart_read_ng().
+// Drop-in for usart_read_ng() as the receive_ng() read callback.
 uint32_t bwm_read_ng(uint8_t *data, size_t len);
 
+// >0 when raw bytes are waiting on the FPC USART (gate for receive_ng()).
 uint16_t bwm_fwd_rxdata_available(void);
 
-#endif
+#endif // __BWM_FORWARD_H


### PR DESCRIPTION
Fixes bulk BigBuf downloads over BWM/BLE (mem dump, traces, lf read ≤40000): the un-paced reply_old firehose overruns the ESP (no UART flow control) → dropped frames → Got 0 samples. 

Adds a cumulative credit window (new APP_BROADCAST_FLOW_CREDIT frame) so the ARM only sends what the ESP can drain to BLE. 