### PR TITLE
hf felica liteauth: use NULL instead of "" for options without a long name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `hf felica liteauth` - empty long option names for `-c` and `-k` made argtable read past the string (found by ASAN on `--fulltext`) (@Msprg)
 - Added `sim020.bin` - v4.60 of sim module firmware, better T=0 handling and clock etu handling (@iceman1001)
 - Fixed `hf seos sam` - now have a invalid pacs guard (@iceman1001)
 - Changed i2c comms to auto-negotiation and use ATR-keyed rate cache for speedier smart card comms (@iceman1001)

--- a/client/src/cmdhffelica.c
+++ b/client/src/cmdhffelica.c
@@ -8999,9 +8999,9 @@ static int CmdHFFelicaAuthenticationLite(const char *Cmd) {
     void *argtable[] = {
         arg_param_begin,
         arg_str0(NULL, "key", "<hex>", "set card key, 16 bytes"),
-        arg_str0("c", "", "<hex>", "set random challenge, 16 bytes"),
+        arg_str0("c", NULL, "<hex>", "set random challenge, 16 bytes"),
         arg_str0(NULL, "idm", "<hex>", "set custom IDm"),
-        arg_lit0("k", "", "keep signal field ON after receive"),
+        arg_lit0("k", NULL, "keep signal field ON after receive"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);


### PR DESCRIPTION
`hf felica liteauth` declares its `-c` and `-k` options with `""` as the long option name instead of `NULL`, which every other command uses. argtable scans that field with `strchr`, so the empty literal is read one byte past its end. AddressSanitizer reports it as a `global-buffer-overflow` in `arg_parse` whenever the command's help is generated — e.g. on every `proxmark3 --fulltext` (which `make commands` uses):

```
==6811==ERROR: AddressSanitizer: global-buffer-overflow ...
    #0 __interceptor_strchr
    #1 arg_parse
    #2 CLIParserParseArg
    #3 CLIParserParseStringEx
    #4 CmdHFFelicaAuthenticationLite src/cmdhffelica.c:9007
    #5 dumpCommandsRecursive src/cmdparser.c:488
```

Fix: `"" -> NULL` on both lines. No behaviour change; `hf felica liteauth -h` still lists `-c <hex>` and `-k`.

Verified with a `SANITIZE=1` build: `--fulltext` reports 1 ASAN error before, 0 after. A grep over `client/src` shows these were the only two empty long option names.

Found while running ASAN over the client for #3539; independent of that PR.
