### PR TITLE
Fix standalone mode button trigger on non-PM5 platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed standalone modes - the one second button hold trigger was a no-op on all non-PM5 platforms, leaving `hw standalone` over USB as the only entry point (@ShawInnes)
 - Added `sim022.bin` - enabled burst mode transfers, which allows us to do TA1=96 in speeds (@iceman1001)
 - Fixed `hf felica liteauth` - empty long option names for `-c` and `-k` made argtable read past the string (found by ASAN on `--fulltext`) (@Msprg)
 - Added `sim020.bin` - v4.60 of sim module firmware, better T=0 handling and clock etu handling (@iceman1001)

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -3907,11 +3907,11 @@ void __attribute__((noreturn)) AppMain(void) {
             * So this is the trigger to execute a standalone mod.  Generic entrypoint by following the standalone/standalone.h headerfile
             * All standalone mod "main loop" should be the RunMod() function.
             */
-            // allow_send_wtx = false;
-            // RunMod();
-            // allow_send_wtx = true;
-
-#ifdef PM5 // TODO DXL Test long press to device shutdown, temporarily blocking standalone mod
+#ifndef PM5
+            allow_send_wtx = false;
+            RunMod();
+            allow_send_wtx = true;
+#else // TODO DXL Test long press to device shutdown, temporarily blocking standalone mod
 
             /*
             StartTicks();


### PR DESCRIPTION
Fixes #3543.

## Problem

The one second button hold that starts a standalone mode is currently a no-op on every platform except PM5. `armsrc/appmain.c:3903`:

```c
        button_status = BUTTON_HELD(1000);
        if (button_status == BUTTON_HOLD) {
            // allow_send_wtx = false;
            // RunMod();
            // allow_send_wtx = true;

#ifdef PM5 // TODO DXL Test long press to device shutdown, temporarily blocking standalone mod
            ... PM5 power-off code ...
#endif
        }
```

`RunMod()` is commented out unconditionally while only the new PM5 power-off code sits behind `#ifdef PM5`, so on non-PM5 builds the whole `BUTTON_HOLD` body compiles to an empty block. That leaves `case CMD_STANDALONE:` (`appmain.c:3508`) as the only remaining entry point, i.e. `hw standalone` from the client over USB — which defeats the purpose of standalone modes.

It produces no compiler warning, since an empty `if` body is valid C.

Introduced in e3511c535 ("Used HAL layer") from the PM5 HAL work in #3449. The same hunk is in the original unsquashed commit 24f2569 on that branch, so it predates the manual merge / history rewrite. The intent looks like it was to fence the *new* PM5 gesture behind a guard — the same commit uses `#ifndef PM5` correctly elsewhere — and the "temporarily blocking standalone mod" comment reads as bench-test scaffolding.

## Fix

Restore the call under `#ifndef PM5` and move the PM5 power-off code to the `#else` branch, matching the guard style used elsewhere in that commit. The `TODO DXL` comment is preserved on the `#else`.

## Verification

Built with `arm-none-eabi-gcc 13.3.1`, checking `bl <RunMod>` call sites in `armsrc/obj/fullimage.stage1.elf`:

| Build | RunMod call sites | Result |
|---|---|---|
| `PLATFORM=PM3RDV4` `STANDALONE=HF_MATTYRUN` | 2 (AppMain + CMD_STANDALONE) | fixed |
| `PLATFORM=PM3GENERIC` `STANDALONE=LF_SAMYRUN` | 2 (AppMain + CMD_STANDALONE) | fixed |
| `PLATFORM=PM5` | 1 (CMD_STANDALONE only) | unchanged |

PM5 is unaffected: it keeps exactly one call site and retains its long-press power-off path (`Gpio_ARM_Power_ON_Low()` at `appmain.c:3967`, inlined via `STATIC_FORCE_INLINE`).

Verified on RDV4.01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)