### PR TITLE
Fix ePassport viewer segfault on startup

### DIFF
--- a/tools/ePassport/epassport/app.py
+++ b/tools/ePassport/epassport/app.py
@@ -32,17 +32,6 @@ if not _VERBOSE:
 os.environ.setdefault("OPENCV_LOG_LEVEL", "DEBUG" if _VERBOSE else "ERROR")
 os.environ.setdefault("OPENCV_VIDEOIO_DEBUG", "1" if _VERBOSE else "0")
 
-from kivy.config import Config  # noqa: E402
-
-# Set the minimum size here rather than on Window: assigning Window.minimum_*
-# warns while the other half of the pair is still zero, whichever order it is
-# done in.
-# Screen space is worth being careful with: the passport page scales as a
-# unit, so the window can go a long way down before anything stops being
-# readable.
-Config.set("graphics", "minimum_width", "760")
-Config.set("graphics", "minimum_height", "520")
-
 from kivy.app import App  # noqa: E402
 from kivy.clock import Clock  # noqa: E402
 from kivy.core.window import Window  # noqa: E402
@@ -70,9 +59,27 @@ log = logging.getLogger("epassport")
 #: What the window manager shows.
 APP_TITLE = "ePassport"
 
+#: The smallest window the passport page stays readable in.
+MIN_WINDOW_SIZE = (760, 520)
+
 #: How many files a full dump writes, for the progress bar's denominator when
 #: EF_COM has not been read yet.
 DEFAULT_EXPECTED_FILES = 9
+
+
+def apply_minimum_window_size(window) -> None:
+    """Constrain the window, once it exists.
+
+    Setting this through Config instead makes Kivy apply it inside
+    create_window(), where the resize recurses until the stack gives out.
+    """
+    minimum_width, minimum_height = MIN_WINDOW_SIZE
+    window.size = (
+        max(window.width, minimum_width),
+        max(window.height, minimum_height),
+    )
+    window.minimum_width = minimum_width
+    window.minimum_height = minimum_height
 
 
 class Root(BoxLayout):
@@ -139,8 +146,10 @@ class Pm3PassportApp(App):
     def _restore_window_size(self) -> None:
         """Reopen at the size the user last left, not a size we insist on."""
         width, height = self.settings.window_width, self.settings.window_height
-        if width >= 760 and height >= 520:
+        minimum_width, minimum_height = MIN_WINDOW_SIZE
+        if width >= minimum_width and height >= minimum_height:
             Window.size = (width, height)
+        apply_minimum_window_size(Window)
         Window.bind(on_resize=self._remember_window_size)
 
     def _remember_window_size(self, _window, width: int, height: int) -> None:
@@ -639,7 +648,11 @@ class _KivyNoise(logging.Filter):
     something the app never uses.
     """
 
-    NOISE = ("Cutbuffer", "Unable to find any valuable Cutbuffer provider")
+    NOISE = (
+        "Cutbuffer",
+        "Unable to find any valuable Cutbuffer provider",
+        "Both Window.minimum_width and Window.minimum_height",
+    )
 
     def filter(self, record: logging.LogRecord) -> bool:
         message = record.getMessage()
@@ -652,7 +665,11 @@ def _install_kivy_logging(verbose: bool) -> None:
 
     if verbose:
         return  # Kivy kept its own console handler
-    handler = logging.StreamHandler()
+    if sys.__stderr__ is None:
+        return  # pythonw and some frozen builds have no stderr
+    # Not sys.stderr: Kivy replaces it with a stream that feeds writes back
+    # in as warnings, so a handler on its own logger would loop.
+    handler = logging.StreamHandler(sys.__stderr__)
     handler.setFormatter(logging.Formatter("%(levelname)s kivy: %(message)s"))
     handler.addFilter(_KivyNoise())
     Logger.addHandler(handler)

--- a/tools/ePassport/tests/test_startup.py
+++ b/tools/ePassport/tests/test_startup.py
@@ -1,0 +1,69 @@
+"""Startup checks.  These run in a subprocess: importing the app builds the
+Kivy window, so a segfault would take the test session down with it."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+LAUNCHER = ROOT / "ePassport.py"
+
+
+@pytest.mark.skipif(
+    not (os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")),
+    reason="starting the app needs a display",
+)
+def test_the_launcher_starts() -> None:
+    """--help must not die on a signal."""
+    proc = subprocess.run(
+        [sys.executable, str(LAUNCHER), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env={**os.environ, "KIVY_NO_CONSOLELOG": "1"},
+    )
+    how = (
+        f"killed by signal {-proc.returncode}"
+        if proc.returncode < 0
+        else f"exited {proc.returncode}"
+    )
+    assert proc.returncode == 0, f"--help {how}\n{proc.stderr[-2000:]}"
+    assert "--dump" in proc.stdout
+
+
+@pytest.mark.skipif(
+    not (os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")),
+    reason="importing the app builds a window, which needs a display",
+)
+def test_a_kivy_warning_does_not_take_the_app_down_with_it() -> None:
+    """A Kivy warning must not loop through the stderr Kivy replaced."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; sys.path.insert(0, %r)\n" % str(ROOT)
+            + "from epassport.app import _install_kivy_logging\n"
+            + "from kivy.logger import Logger\n"
+            + "_install_kivy_logging(False)\n"
+            + "Logger.warning('an ordinary kivy warning')\n",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert proc.returncode == 0, f"exited {proc.returncode}\n{proc.stderr[-2000:]}"
+    assert "RecursionError" not in proc.stderr
+
+
+def test_the_window_minimum_is_not_pre_seeded_into_kivy_config() -> None:
+    """Read the source: importing the app to check is what crashed."""
+    source = (ROOT / "epassport" / "app.py").read_text()
+    assert not re.search(
+        r"""Config\.set\(\s*['"]graphics['"]\s*,\s*['"]minimum_""", source
+    ), "the minimum size must be set on Window, not pre-seeded into Config"


### PR DESCRIPTION
## Problem

`tools/ePassport` dies with SIGSEGV before drawing anything, on every entry point — `--help` included. No error, no traceback, no window.

The minimum window size is pre-seeded into Kivy's `Config`:

```python
Config.set("graphics", "minimum_width", "760")
Config.set("graphics", "minimum_height", "520")
```

`WindowBase.__init__` is the only place Kivy reads those, so they are applied from inside `WindowSDL.create_window()` while `Window.initialized` is still `False`. If the window SDL has just made is smaller than the minimum, SDL resizes it on the spot; the resize comes back through the SDL event filter into `EventLoop.idle()` (`kivy/core/window/window_sdl2.py:280`), which runs the clock and re-enters `create_window()`. Still not initialised, that call runs `setup_window()` again and resizes again — unbounded recursion until the C stack is exhausted.

A scaled HiDPI session is enough to get there. With sdl2-compat on SDL3 under Wayland sizes come back in logical points, so the 800x600 inherited from `~/.kivy/config.ini` arrives as a 500x375 window, under the 760x520 minimum. Confirmed either side of the threshold: a 500x375 minimum starts fine, 501x376 segfaults.

Reproduced on Arch, Python 3.14.7, Kivy 2.3.1, sdl2-compat 2.32.70 / SDL 3.4.14, Wayland at 1.6x scale.

## Change

`epassport/app.py`:

- Drop the two `Config.set(...)` calls and the now-unused `kivy.config` import.
- Add `MIN_WINDOW_SIZE` and `apply_minimum_window_size()`, called from `_restore_window_size()` once the window exists. Applying it after creation is the fix — post-init the same resize takes Kivy's cheap already-initialised branch instead of re-running `setup_window()`. Growing the window to the minimum first only avoids a visible jump.
- `MIN_WINDOW_SIZE` also replaces the duplicated `760`/`520` literals in `_restore_window_size()`.
- `_install_kivy_logging()` now writes to `sys.__stderr__`.

That last one is a second fault on the same path, exposed by fixing the first. `kivy.logger` replaces `sys.stderr` with a stream that feeds whatever is written to it back in as a warning, and cautions about exactly this (`kivy/logger.py:629` — *"If any logging handlers output to sys.stderr they should be configured BEFORE this reconfiguration is done to avoid loops."*). The app attached a bare `logging.StreamHandler()` to Kivy's own logger, so any warning `_KivyNoise` did not drop answered itself until the recursion limit stopped it — with stderr as the broken part, so nothing legible came out.

Not theoretical: this machine logs `MTD: Unable to open device "/dev/input/event11"` at startup, which killed the app as soon as the segfault was out of the way. Verified directly against the old handler.

`tests/test_startup.py` (new): the suite never imported the app or built a window, which is why 254 tests passed against a tool that could not start. The new checks run in a subprocess or read source deliberately — an in-process import takes the whole session down with a segfault rather than failing a test.

## Behaviour change

- A window that opens smaller than 760x520 is now grown to it. Previously the constraint was imposed while the window was being built (and crashed); for a setup where it worked, the end state is unchanged.
- One Kivy warning is now emitted at startup and filtered: setting `Window.minimum_width` and `minimum_height` in sequence makes Kivy complain while only half the pair is set. Added to `_KivyNoise`, so the console is as quiet as before.
- Kivy warnings now reach the console instead of crashing the app. On a machine that emits any, output that was previously absent will appear.

## Testing

- `python3 -m pytest tests/` — 257 passed, 2 skipped (was 254 passed, 2 skipped).
- `./ePassport.py --help` exits 0 (was SIGSEGV).
- Plain `./ePassport.py`, `--dump` against a generated sample, and `-v` all start and stay up.
- `black --check` clean.
- Net diff: +160/−15 over two files, one of them new.

Not tested here: Windows/ProxSpace and macOS, and X11 rather than Wayland. Low risk — the change is Python-only, swapping two `Config.set` calls for two property assignments on the same Kivy object and `StreamHandler()` for `StreamHandler(sys.__stderr__)`. Neither is platform-specific, and the `sys.__stderr__ is None` case (pythonw, some frozen builds) is handled explicitly.

Not tested: hardware. Nothing here reaches the `pm3` path.

No CHANGELOG entry, since `tools/ePassport` was itself added in the current `[unreleased]` cycle — this fixes something that has not shipped. Happy to add one if you would rather have it.

## PR checklist

- [x] Proper style of own code, no unrelated reformatting included
- [ ] Builds warning-free with gcc; also tried with clang — n/a, Python only, no compiled code touched
- [ ] `client/Makefile`, `client/CMakeLists.txt`, `client/experimental_lib/CMakeLists.txt` all updated — n/a, no client sources changed
- [ ] ARM firmware builds clean for RDV4 and PM5 — n/a, no `armsrc`/`bootrom`/`common_arm` changes
- [x] Platform-sensitive code reasoned about — tested on Linux/Wayland; untested platforms and why they are low risk are in Testing
- [x] Existing comments in touched files preserved — the one dropped described the `Config.set` calls this PR removes
- [ ] `doc/commands.md` / `doc/commands.json` regenerated — n/a, no client commands changed
