### PR TITLE
NULL-check fix

### DIFF
--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -3686,6 +3686,9 @@ b5,b6 = 00 - DESELECT
 */
 int iso14_apdu(uint8_t *cmd, uint16_t cmd_len, bool send_chaining, void *data, uint16_t data_len, uint8_t *res) {
     uint8_t *real_cmd = BigBuf_calloc(cmd_len + 4);
+    if (real_cmd == NULL) {
+        return -1;
+    }
 
     if (cmd_len) {
         // ISO 14443 APDU frame: PCB [CID] [NAD] APDU CRC PCB=0x02


### PR DESCRIPTION
iso14443a.c called BigBuf_calloc() and wrote to the result without checking it:

uint8_t *real_cmd = BigBuf_calloc(cmd_len + 4);
if (real_cmd == NULL) {
    return -1;
}
BigBuf_malloc returns NULL once s_bigbuf_hi - s_trace_len < chunksize. Since clear_trace() is never called anywhere in the SAM path — only from the four standalone 14a entry points — s_trace_len grows monotonically for the life of a session and can eventually starve that allocation. -1 matches the function's existing error convention, and callers already map apdu_len < 2 to PM3_ECARDEXCHANGE.

@iceman1001 please verify this