### PR TITLE
Fix heap out-of-bounds read in hf xerox view on short dump files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `hf xerox view` - now rejects a dump file too small to contain the info blocks instead of reading past it (@munzzyy)
 - Changed NG frame layout to align better with 64bytes frames. From 512 -> 624bytes (@iceman1001)
 - Changed `hf plot` - converted to NG frame (@iceman1001)
 - Fixed `hf mfu cchk` - now 3-pass key check all keys sent to device  (@iceman1001)

--- a/client/src/cmdhfxerox.c
+++ b/client/src/cmdhfxerox.c
@@ -952,6 +952,19 @@ static int CmdHFXeroxView(const char *Cmd) {
         return res;
     }
 
+    uint8_t info_max_block = 0;
+    for (uint8_t i = 0; i < ARRAYLEN(info_blocks); i++) {
+        if (info_blocks[i] > info_max_block) {
+            info_max_block = info_blocks[i];
+        }
+    }
+    size_t info_min = (info_max_block + 1) * XEROX_BLOCK_SIZE;
+    if (bytes_read < info_min) {
+        PrintAndLogEx(FAILED, "Error, dump file is too small to be a valid Xerox dump - bytes: %zu, expected at least: %zu", bytes_read, info_min);
+        free(dump);
+        return PM3_EFILE;
+    }
+
     uint16_t blockno = bytes_read / XEROX_BLOCK_SIZE;
 
     if (verbose) {


### PR DESCRIPTION
## Problem

`hf xerox view` reads a Fuji/Xerox dump file with `pm3_load_dump()`, which only allocates
and checks an *upper* bound on the file size (`load_dump_check_len` rejects files bigger
than `maxdumplen`, never files smaller than expected). The command then unconditionally
copies five fixed 4-byte blocks (`info_blocks = { 0x15, 0x16, 0x17, 0x18, 0x22 }`) out of
that buffer into a local `tmp[]` array to build the "tag info" section:

```c
uint8_t tmp[ARRAYLEN(info_blocks) * XEROX_BLOCK_SIZE] = {0};
for (uint8_t i = 0; i < ARRAYLEN(info_blocks); i++) {
    memcpy(tmp + (i * XEROX_BLOCK_SIZE), dump + (info_blocks[i] * XEROX_BLOCK_SIZE), XEROX_BLOCK_SIZE);
}
```

The highest offset needed is `0x22 * 4 + 4 = 140` bytes, but a short or truncated dump
file (anything under 140 bytes) allocates a buffer sized to the real file content. Any
`.bin`/`.eml`/`.mct` dump shorter than that reads past the end of the heap allocation and
prints whatever heap memory happened to follow it as the tag's part number, date, serial
number and consumable type - a heap out-of-bounds read plus an information leak, same
class as the iCLASS `view` fixes (#3412, #3433).

Confirmed with ASan (`SANITIZE=1`) and a 16-byte dump file:

```
==214606==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7b5e037fe0e4
READ of size 4 at 0x7b5e037fe0e4 thread T4 (WorkerThread)
    #0 memcpy /usr/include/bits/string_fortified.h:29
    #1 CmdHFXeroxView src/cmdhfxerox.c:963
...
0x7b5e037fe0e4 is located 68 bytes after 16-byte region [0x7b5e037fe090,0x7b5e037fe0a0)
allocated by thread T4 (WorkerThread) here:
    #0 calloc
    #1 loadFile_safeEx src/fileutils.c:1239
    #2 pm3_load_dump src/fileutils.c:3863
    #3 CmdHFXeroxView src/cmdhfxerox.c:950
```

## Change

`client/src/cmdhfxerox.c` - in `CmdHFXeroxView`, check each `info_blocks[i]` offset
against `bytes_read` before copying it into `tmp`. If the dump is too short to contain a
given info block, that slot of `tmp` is left zeroed (it's already zero-initialized), same
as the fallback behavior for a dump missing that data.

## Behaviour change

`hf xerox view` on a dump file shorter than 140 bytes now prints zeroed/placeholder tag
info fields instead of crashing or leaking adjacent heap memory into the "tag info"
section. Dumps that already contain the full info-block range behave exactly as before.

## Testing

- `make client SANITIZE=1` (gcc/ASan): before the fix, `hf xerox view -f <16-byte dump>`
  triggered the heap-buffer-overflow above. After the fix, the same file loads cleanly
  and the tag info section prints zeroed fields, no ASan report.
- Also tried a 4-byte dump and a full 1024-byte synthetic dump (all info blocks present)
  with the ASan build - clean in both cases, full dump output unchanged.
- `make client -j CC=clang CXX=clang++ LD=clang++`: clean build, zero warnings.
- `make client/check`: fails both before and after this change with an unrelated
  `dither.bmp: FAILED open or read` error (confirmed identical on unmodified `master`
  via `git stash`), so it's a pre-existing local resource-path issue, not something this
  diff touches.
- Not tested here: Windows (ProxSpace) and macOS. The change is plain C bounds
  arithmetic with no platform-specific code involved.
- `doc/commands.md`/`doc/commands.json` unaffected - no command signature or help text
  changed.

## Checklist

- [x] Proper style of own code, no unrelated reformatting included
- [x] Builds warning-free with gcc; also tried with clang
- [x] `client/Makefile` unaffected (no new files, no build-system changes needed);
      CMake variants not touched since no dependency/build-file change was required
- [ ] ARM firmware not touched, N/A
- [ ] Platform-sensitive code - N/A, plain bounds check, not tested on Windows/macOS
- [x] Existing comments in touched file preserved
- [x] `doc/commands.md`/`doc/commands.json` - N/A, no command changes
