### PR TITLE
BWM: negotiate ESP/AT32 UART baud up from 460800

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -586,6 +586,9 @@ static void SendStatus(uint32_t wait) {
 #if defined(PM5) && defined(WITH_BWM_STATUS)
     bwm_print_battery_status();
 #endif
+#ifdef WITH_BWM_FORWARD
+    Dbprintf("  BWM link baud....... " _YELLOW_("%u") " bps", bwm_uart_get_baud());
+#endif
     printConnSpeed(wait);
     DbpString(_CYAN_("Various"));
 

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -24,6 +24,7 @@
 #include "usb_cdc_apis.h"
 #ifdef WITH_BWM_FORWARD
 #include "bwm_uart_at32.h"
+#include "bwm_forward.h"   // bwm_fwd_negotiate_baud()
 #include "bwm_wifi.h"
 #endif
 #include "proxmark3_arm.h"
@@ -700,10 +701,11 @@ static void SendCapabilities(void) {
         capabilities.baudrate = g_usart_baudrate;
 #endif
 #ifdef WITH_BWM_FORWARD
-    // BWM link runs at a fixed baud; report it so the client's timeout math
-    // (communication_delay: 12000000 / uart_speed) doesn't divide by zero.
+    // Report the negotiated link baud so the client's timeout math
+    // (communication_delay: 12000000 / uart_speed) matches reality and never
+    // divides by zero.
     if (g_reply_via_fpc)
-        capabilities.baudrate = BWM_UART_BAUD;
+        capabilities.baudrate = bwm_uart_get_baud();
 #endif
 
 #ifdef RDV4
@@ -4011,6 +4013,9 @@ void __attribute__((noreturn)) AppMain(void) {
 
 #ifdef WITH_BWM_FORWARD
     bwm_uart_init();         // AT32 UART4 <-> BWM app_com link; AFTER usb_enable()
+    // Negotiate the link up from the boot baud; harmless no-op if the ESP is
+    // older or the target is unreachable (stays at BWM_UART_BAUD).
+    bwm_fwd_negotiate_baud(BWM_UART_BAUD_TARGET);
 #endif
 
 #ifdef WITH_BWM_CHARGERKICK

--- a/armsrc/bwm_forward.c
+++ b/armsrc/bwm_forward.c
@@ -15,6 +15,7 @@
 
 #include "bwm_uart_at32.h"
 #include "pm3_cmd.h"    // PM3_CMD_DATA_SIZE, PM3_* return codes
+#include "ticks_apis.h" // SpinDelay
 #include "string.h"
 
 #ifndef MIN
@@ -53,6 +54,10 @@ static void bwm_pump(void);   // fwd decl: TX gate pumps RX to collect forward-f
 // send, decremented when a SLAVE_RESP echoing cmd=SEND_FORWARD_DATA arrives.
 // We may send while it is below BWM_FC_WINDOW; at the cap we wait for an ack.
 static volatile int16_t s_fwd_inflight = 0;
+
+// Set true by the parser when a SLAVE_RESP echoing BWM_CMD_SET_UART_BAUD arrives
+// (the ESP's ack for a baud-set request). Consumed by bwm_fwd_negotiate_baud().
+static volatile bool s_baud_ack = false;
 
 int bwm_fwd_writebuffer_sync(const uint8_t *data, size_t len) {
     static uint8_t frame[BWM_TX_BUFSZ];   // single-threaded bare-metal: static OK
@@ -236,6 +241,9 @@ static void bwm_feed_byte(bwm_parser_t *p, uint8_t byte) {
                     if (s_fwd_inflight > 0) {
                         s_fwd_inflight--;
                     }
+                } else if ((p->is_bcast == false) && p->cmd == BWM_CMD_SET_UART_BAUD) {
+                    // SLAVE_RESP ack for a baud-set request (see negotiate below)
+                    s_baud_ack = true;
                 }
             }
             // valid non-DATA_FORWARD frames and CRC failures alike: just resync
@@ -308,4 +316,64 @@ uint32_t bwm_read_ng(uint8_t *data, size_t len) {
             }
     }
     return out;
+}
+
+
+// ---------------------------------------------------------------------------
+// Runtime baud negotiation.
+// The ESP boots at BWM_UART_BAUD and accepts a HOST_CMD (cmd 1011) carrying a
+// u32 LE target baud. Its handler test-switches, rolls back, acks at the OLD
+// baud with a SLAVE_RESP echoing cmd 1011, then commits to the new baud. So we
+// send the request at the current baud, wait for that ack, then switch our own
+// UART4 to match. On timeout (old ESP without the command, or a lost ack) we
+// leave the link at the boot baud - it keeps working, just slower.
+// ---------------------------------------------------------------------------
+#define BWM_BAUD_ACK_WAIT_MS   300   // per-attempt wait for the ESP ack
+#define BWM_BAUD_ATTEMPTS      3     // resend attempts before giving up
+
+bool bwm_fwd_negotiate_baud(uint32_t target) {
+    if (target == 0 || target == bwm_uart_get_baud()) {
+        return false;
+    }
+
+    // Build the SET_UART_BAUD host-command frame once (payload = u32 LE baud).
+    uint8_t frame[2 + 2 + 2 + 4 + 2];
+    size_t idx = 0;
+    frame[idx++] = BWM_HDR_HOST_CMD_1;
+    frame[idx++] = BWM_HDR_HOST_CMD_2;
+    frame[idx++] = (uint8_t)(BWM_CMD_SET_UART_BAUD & 0xFF);
+    frame[idx++] = (uint8_t)((BWM_CMD_SET_UART_BAUD >> 8) & 0xFF);
+    frame[idx++] = (uint8_t)(4 & 0xFF);
+    frame[idx++] = (uint8_t)((4 >> 8) & 0xFF);
+    frame[idx++] = (uint8_t)(target & 0xFF);
+    frame[idx++] = (uint8_t)((target >> 8) & 0xFF);
+    frame[idx++] = (uint8_t)((target >> 16) & 0xFF);
+    frame[idx++] = (uint8_t)((target >> 24) & 0xFF);
+    uint16_t crc = bwm_crc16(frame, idx, BWM_CRC16_INIT);
+    frame[idx++] = (uint8_t)(crc & 0xFF);
+    frame[idx++] = (uint8_t)((crc >> 8) & 0xFF);
+
+    for (int attempt = 0; attempt < BWM_BAUD_ATTEMPTS; attempt++) {
+        s_baud_ack = false;
+        s_p.state = S_IDLE;          // drop any half-frame before we listen
+        bwm_uart_write(frame, idx);
+
+        for (int ms = 0; ms < BWM_BAUD_ACK_WAIT_MS; ms++) {
+            bwm_pump();              // parser sets s_baud_ack on the SLAVE_RESP
+            if (s_baud_ack) {
+                // ESP acked at the old baud and is committing to the new one.
+                // Switch our side and let both settle before any traffic.
+                bwm_uart_set_baud(target);
+                SpinDelay(5);
+                // Fresh start on the faster link: clear framer + de-fifo + window.
+                s_p.state    = S_IDLE;
+                s_fifo_head  = 0;
+                s_fifo_tail  = 0;
+                s_fwd_inflight = 0;
+                return true;
+            }
+            SpinDelay(1);
+        }
+    }
+    return false;   // no ack: stay at the boot baud, link still usable
 }

--- a/armsrc/bwm_forward.h
+++ b/armsrc/bwm_forward.h
@@ -47,6 +47,10 @@
 
 #define BWM_CMD_SEND_FORWARD_DATA   5000   // host cmd: payload -> BLE/WiFi endpoint
 #define BWM_CMD_DATA_FORWARD        8089   // slave bcast: payload came from endpoint
+// System command: set the ESP<->AT32 UART baud (app_com_defs.h, enum @1000).
+// SET is a HOST_CMD carrying u32 LE baud; the ESP replies with a SLAVE_RESP
+// echoing this cmd (len 0) at the OLD baud, then commits to the new baud.
+#define BWM_CMD_SET_UART_BAUD       1011
 // Flow control (ack window) - ARM-side only, no BWM firmware change required.
 // The ESP already replies to every forward frame with a SLAVE_RESP echoing
 // cmd=SEND_FORWARD_DATA, and it sends that ack only *after* app_ble_send() has
@@ -76,5 +80,11 @@ uint32_t bwm_read_ng(uint8_t *data, size_t len);
 
 // >0 when raw bytes are waiting on the FPC USART (gate for receive_ng()).
 uint16_t bwm_fwd_rxdata_available(void);
+
+// Negotiate the ESP<->AT32 UART up to `target` baud (app_com cmd 1011), then
+// re-init UART4 to match. Returns true if the ESP acked and the link switched;
+// false (link left at the boot baud) on timeout or an unsupported rate. Must be
+// called once after bwm_uart_init(), before normal forward traffic starts.
+bool bwm_fwd_negotiate_baud(uint32_t target);
 
 #endif // __BWM_FORWARD_H

--- a/armsrc/bwm_uart_at32.c
+++ b/armsrc/bwm_uart_at32.c
@@ -9,6 +9,13 @@
 // See LICENSE.txt for the text of the license.
 //-----------------------------------------------------------------------------
 // AT32F435 UART4 driver for the Proxmark5 BWM link - see bwm_uart_at32.h.
+//
+// RX is serviced by circular DMA (DMA1 channel 2) rather than a per-byte
+// RX interrupt. The old RDBF ISR dropped bytes on overrun as soon as the
+// main loop was busy (FPGA / USB) - fine at 460800, fatal at higher bauds,
+// where the dropped byte becomes an app_com CRC-16 failure and a stall.
+// Circular DMA lets the controller sink every byte independent of CPU load,
+// so BWM_UART_BAUD can be raised to lift BLE/WiFi transfer rates.
 //-----------------------------------------------------------------------------
 
 #include "bwm_uart_at32.h"
@@ -18,10 +25,10 @@
 #include "at32f435_437_crm.h"
 #include "at32f435_437_gpio.h"
 #include "at32f435_437_usart.h"
+#include "at32f435_437_dma.h"
 #include "at32f435_437_misc.h"
 
 #define BWM_UART            UART4
-#define BWM_UART_IRQn       UART4_IRQn
 #define BWM_UART_GPIO       GPIOA
 #define BWM_UART_TX_PIN     GPIO_PINS_0
 #define BWM_UART_RX_PIN     GPIO_PINS_1
@@ -29,12 +36,24 @@
 #define BWM_UART_RX_SRC     GPIO_PINS_SOURCE1
 #define BWM_UART_MUX        GPIO_MUX_8
 
+// SSC already owns DMA1 channel 1 (see fpga_hw_at32.c); UART4 RX uses channel 2.
+#define BWM_DMA_CHANNEL     DMA1_CHANNEL2
+#define BWM_DMA_MUX_CHANNEL DMA1MUX_CHANNEL2
+
+// Power-of-two so head/tail wrap with a mask. DMA target buffer.
 #define BWM_RX_RING_SZ      4096
 static volatile uint8_t  s_rx_ring[BWM_RX_RING_SZ];
-static volatile uint16_t s_rx_head = 0;
-static volatile uint16_t s_rx_tail = 0;
+static volatile uint16_t s_rx_tail = 0;   // software read cursor; head comes from DMA
 
 static volatile bool s_inited = false;
+
+// Bytes the DMA controller has written so far, wrapped into the ring.
+// The channel's DTCNT counts DOWN from buffer_size and reloads to buffer_size
+// at wrap (loop mode), so head = size - remaining, always in [0, size-1].
+static inline uint16_t bwm_uart_rx_head(void) {
+    return (uint16_t)((BWM_RX_RING_SZ - dma_data_number_get(BWM_DMA_CHANNEL))
+                      & (BWM_RX_RING_SZ - 1));
+}
 
 void bwm_uart_init(void) {
     if (s_inited) {
@@ -60,29 +79,36 @@ void bwm_uart_init(void) {
     usart_transmitter_enable(BWM_UART, TRUE);
     usart_receiver_enable(BWM_UART, TRUE);
 
-    s_rx_head = 0;
+    // --- RX via circular DMA (mirror of the SSC RX setup in fpga_hw_at32.c) ---
     s_rx_tail = 0;
 
-    usart_interrupt_enable(BWM_UART, USART_RDBF_INT, TRUE);
-    nvic_irq_enable(BWM_UART_IRQn, 2, 0);
+    crm_periph_clock_enable(CRM_DMA1_PERIPH_CLOCK, TRUE);
+
+    dma_reset(BWM_DMA_CHANNEL);
+
+    dma_init_type dma_init_struct;
+    dma_default_para_init(&dma_init_struct);
+    dma_init_struct.buffer_size           = BWM_RX_RING_SZ;
+    dma_init_struct.direction             = DMA_DIR_PERIPHERAL_TO_MEMORY;
+    dma_init_struct.peripheral_base_addr  = (uint32_t) & (BWM_UART->dt);
+    dma_init_struct.peripheral_inc_enable = FALSE;
+    dma_init_struct.memory_base_addr      = (uint32_t)s_rx_ring;
+    dma_init_struct.memory_inc_enable     = TRUE;
+    dma_init_struct.peripheral_data_width = DMA_PERIPHERAL_DATA_WIDTH_BYTE;
+    dma_init_struct.memory_data_width     = DMA_MEMORY_DATA_WIDTH_BYTE;
+    dma_init_struct.loop_mode_enable      = TRUE;   // circular: reloads at count 0
+    // MEDIUM: single-byte requests, must not starve the SSC bulk channel (HIGH).
+    dma_init_struct.priority              = DMA_PRIORITY_MEDIUM;
+    dma_init(BWM_DMA_CHANNEL, &dma_init_struct);
+
+    dmamux_enable(DMA1, TRUE);
+    dmamux_init(BWM_DMA_MUX_CHANNEL, DMAMUX_DMAREQ_ID_UART4_RX);
+
+    usart_dma_receiver_enable(BWM_UART, TRUE);
+    dma_channel_enable(BWM_DMA_CHANNEL, TRUE);
 
     usart_enable(BWM_UART, TRUE);
     s_inited = true;
-}
-
-void UART4_IRQHandler(void) {
-    if (usart_flag_get(BWM_UART, USART_RDBF_FLAG) != RESET) {
-        uint8_t b = (uint8_t)usart_data_receive(BWM_UART);
-        uint16_t next = (uint16_t)((s_rx_head + 1) & (BWM_RX_RING_SZ - 1));
-        if (next != s_rx_tail) {
-            s_rx_ring[s_rx_head] = b;
-            s_rx_head = next;
-        }
-    }
-    if (usart_flag_get(BWM_UART, USART_ROERR_FLAG) != RESET) {
-        usart_flag_clear(BWM_UART, USART_ROERR_FLAG);
-        (void)usart_data_receive(BWM_UART);
-    }
 }
 
 int bwm_uart_write(const uint8_t *data, size_t len) {
@@ -97,12 +123,13 @@ int bwm_uart_write(const uint8_t *data, size_t len) {
 }
 
 uint16_t bwm_uart_rx_available(void) {
-    return (uint16_t)((s_rx_head - s_rx_tail) & (BWM_RX_RING_SZ - 1));
+    return (uint16_t)((bwm_uart_rx_head() - s_rx_tail) & (BWM_RX_RING_SZ - 1));
 }
 
 uint32_t bwm_uart_read(uint8_t *data, size_t len) {
+    uint16_t head = bwm_uart_rx_head();
     uint32_t n = 0;
-    while (n < len && s_rx_tail != s_rx_head) {
+    while (n < len && s_rx_tail != head) {
         data[n++] = s_rx_ring[s_rx_tail];
         s_rx_tail = (uint16_t)((s_rx_tail + 1) & (BWM_RX_RING_SZ - 1));
     }

--- a/armsrc/bwm_uart_at32.c
+++ b/armsrc/bwm_uart_at32.c
@@ -45,7 +45,8 @@
 static volatile uint8_t  s_rx_ring[BWM_RX_RING_SZ];
 static volatile uint16_t s_rx_tail = 0;   // software read cursor; head comes from DMA
 
-static volatile bool s_inited = false;
+static volatile bool     s_inited = false;
+static volatile uint32_t s_cur_baud = BWM_UART_BAUD;
 
 // Bytes the DMA controller has written so far, wrapped into the ring.
 // The channel's DTCNT counts DOWN from buffer_size and reloads to buffer_size
@@ -55,13 +56,14 @@ static inline uint16_t bwm_uart_rx_head(void) {
                       & (BWM_RX_RING_SZ - 1));
 }
 
-void bwm_uart_init(void) {
-    if (s_inited) {
-        return;
-    }
-
+// Bring UART4 + circular RX DMA up at `baud`. Safe to call repeatedly: on a
+// re-config it tears the channel down first, so the ring restarts empty (which
+// also discards bytes straddling a baud switch). Mirrors the SSC RX setup in
+// fpga_hw_at32.c.
+static void bwm_uart_configure(uint32_t baud) {
     crm_periph_clock_enable(CRM_GPIOA_PERIPH_CLOCK, TRUE);
     crm_periph_clock_enable(CRM_UART4_PERIPH_CLOCK, TRUE);
+    crm_periph_clock_enable(CRM_DMA1_PERIPH_CLOCK, TRUE);
 
     gpio_init_type gpio_init_struct;
     gpio_default_para_init(&gpio_init_struct);
@@ -74,15 +76,17 @@ void bwm_uart_init(void) {
     gpio_pin_mux_config(BWM_UART_GPIO, BWM_UART_TX_SRC, BWM_UART_MUX);
     gpio_pin_mux_config(BWM_UART_GPIO, BWM_UART_RX_SRC, BWM_UART_MUX);
 
-    usart_init(BWM_UART, BWM_UART_BAUD, USART_DATA_8BITS, USART_STOP_1_BIT);
+    // Quiesce before reconfiguring (matters on the re-config path).
+    dma_channel_enable(BWM_DMA_CHANNEL, FALSE);
+    usart_enable(BWM_UART, FALSE);
+
+    usart_init(BWM_UART, baud, USART_DATA_8BITS, USART_STOP_1_BIT);
     usart_parity_selection_config(BWM_UART, USART_PARITY_NONE);
     usart_transmitter_enable(BWM_UART, TRUE);
     usart_receiver_enable(BWM_UART, TRUE);
 
-    // --- RX via circular DMA (mirror of the SSC RX setup in fpga_hw_at32.c) ---
+    // --- RX via circular DMA ---
     s_rx_tail = 0;
-
-    crm_periph_clock_enable(CRM_DMA1_PERIPH_CLOCK, TRUE);
 
     dma_reset(BWM_DMA_CHANNEL);
 
@@ -108,7 +112,26 @@ void bwm_uart_init(void) {
     dma_channel_enable(BWM_DMA_CHANNEL, TRUE);
 
     usart_enable(BWM_UART, TRUE);
+    s_cur_baud = baud;
+}
+
+void bwm_uart_init(void) {
+    if (s_inited) {
+        return;
+    }
+    bwm_uart_configure(BWM_UART_BAUD);
     s_inited = true;
+}
+
+void bwm_uart_set_baud(uint32_t baud) {
+    if (baud == 0 || baud == s_cur_baud) {
+        return;
+    }
+    bwm_uart_configure(baud);
+}
+
+uint32_t bwm_uart_get_baud(void) {
+    return s_cur_baud;
 }
 
 int bwm_uart_write(const uint8_t *data, size_t len) {

--- a/armsrc/bwm_uart_at32.h
+++ b/armsrc/bwm_uart_at32.h
@@ -14,11 +14,27 @@
 
 #include "common.h"
 
-#define BWM_UART_BAUD   460800
+// Boot/default baud. Must match UART_BAUD_RATE_DEFAULT in the ESP firmware
+// (Proxmark5_BWM_esp32). The link comes up here, then the ARM negotiates up to
+// BWM_UART_BAUD_TARGET at runtime via app_com cmd 1011 - the ESP is designed to
+// be told, not reflashed (the SET command is explicitly non-persistent).
+#define BWM_UART_BAUD          460800
+
+// Target baud to negotiate after link-up. 0 disables negotiation (stay at
+// BWM_UART_BAUD). Bounded by the ESP's CONFIG_SOC_UART_BITRATE_MAX and PA0/PA1
+// signal integrity; validate on hardware before raising further.
+#ifndef BWM_UART_BAUD_TARGET
+#define BWM_UART_BAUD_TARGET   921600
+#endif
 
 void bwm_uart_init(void);
 
-void UART4_IRQHandler(void);
+// Re-init UART4 + RX DMA at a new baud (used by the runtime baud negotiation).
+// Discards any bytes already in the RX ring.
+void bwm_uart_set_baud(uint32_t baud);
+
+// Baud the link is currently running at (updated by bwm_uart_set_baud).
+uint32_t bwm_uart_get_baud(void);
 
 int bwm_uart_write(const uint8_t *data, size_t len);
 

--- a/armsrc/bwm_uart_at32.h
+++ b/armsrc/bwm_uart_at32.h
@@ -14,14 +14,11 @@
 
 #include "common.h"
 
-// Must match UART_BAUD_RATE_DEFAULT in the ESP firmware
-// (Proxmark5_BWM_esp32: components/app_uart_cmd/app_cmd_uart.h). Both ends
-// step together. RX is DMA-serviced, so this can be raised well past 460800;
-// the ceiling is the ESP's CONFIG_SOC_UART_BITRATE_MAX and PA0/PA1 signal
-// integrity. Validate on hardware before pushing beyond 921600.
-#define BWM_UART_BAUD   921600
+#define BWM_UART_BAUD   460800
 
 void bwm_uart_init(void);
+
+void UART4_IRQHandler(void);
 
 int bwm_uart_write(const uint8_t *data, size_t len);
 

--- a/armsrc/bwm_uart_at32.h
+++ b/armsrc/bwm_uart_at32.h
@@ -14,11 +14,14 @@
 
 #include "common.h"
 
-#define BWM_UART_BAUD   460800
+// Must match UART_BAUD_RATE_DEFAULT in the ESP firmware
+// (Proxmark5_BWM_esp32: components/app_uart_cmd/app_cmd_uart.h). Both ends
+// step together. RX is DMA-serviced, so this can be raised well past 460800;
+// the ceiling is the ESP's CONFIG_SOC_UART_BITRATE_MAX and PA0/PA1 signal
+// integrity. Validate on hardware before pushing beyond 921600.
+#define BWM_UART_BAUD   921600
 
 void bwm_uart_init(void);
-
-void UART4_IRQHandler(void);
 
 int bwm_uart_write(const uint8_t *data, size_t len);
 


### PR DESCRIPTION
All BLE and WiFi traffic funnels through the ESP-AT32 UART, so its baud caps effective transfer rate.

This raises it at runtime instead of leaving it pinned at the 460800 boot rate.

default target is 921600;
`make PLATFORM=PM5 PLATFORM_EXTRAS=BWM`

raise/lower the target (bounded by the ESP
`make PLATFORM=PM5 PLATFORM_EXTRAS=BWM APP_CFLAGS="-DBWM_UART_BAUD_TARGET=2000000"`

disable negotiation, stay at 460800
`make PLATFORM=PM5 PLATFORM_EXTRAS=BWM APP_CFLAGS="-DBWM_UART_BAUD_TARGET=0"`

hw status will show the negotiated link speed
`  BWM link baud....... 921600 bps`