### PR TITLE
Fix pm3line fallback for ProxSpace/MinGW builds

### DIFF
--- a/client/src/pm3line.c
+++ b/client/src/pm3line.c
@@ -186,15 +186,23 @@ char *pm3line_read(const char *s) {
     return linenoise(s);
 #else
     printf("%s", s);
-    char *answer = NULL;
-    size_t anslen = 0;
-    int ret;
-    if ((ret = getline(&answer, &anslen, stdin)) < 0) {
-        // TODO this happens also when kbd_enter_pressed() is used, with a key pressed or not
-        printf("DEBUG: getline returned %i", ret);
-        free(answer);
-        answer = NULL;
+    // MinGW/ProxSpace builds do not provide getline() in this fallback path.
+    char input[1024] = {0};
+    if (fgets(input, sizeof(input), stdin) == NULL) {
+        return NULL;
     }
+
+    size_t len = strlen(input);
+    while (len > 0 && (input[len - 1] == '\n' || input[len - 1] == '\r')) {
+        input[--len] = '\0';
+    }
+
+    char *answer = calloc(len + 1, sizeof(char));
+    if (answer == NULL) {
+        return NULL;
+    }
+
+    memcpy(answer, input, len);
     return answer;
 #endif
 }


### PR DESCRIPTION
This restores the non-readline fallback in pm3line.c to use fgets() instead of getline().
Why:
- getline() is not declared in the ProxSpace/MinGW build used for static client binaries.
- The fallback path is only for builds without readline/linenoise, so this keeps the client portable without changing normal interactive behavior.
Scope:
- Only client/src/pm3line.c
- No kgh tool changes in this PR, see the separate PR 