### PR TITLE
Fix ePassport FILES and LOG panes drawing nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `tools/ePassport` - FILES and LOG panes no longer go blank on long content, and picture files now show the picture (@pkilar)
 - Fixed `hf xerox view` - now rejects a dump file too small to contain the info blocks instead of reading past it (@munzzyy)
 - Changed NG frame layout to align better with 64bytes frames. From 512 -> 624bytes (@iceman1001)
 - Changed `hf plot` - converted to NG frame (@iceman1001)

--- a/tools/ePassport/epassport/emrtd/model.py
+++ b/tools/ePassport/epassport/emrtd/model.py
@@ -235,6 +235,14 @@ class PassportRecord:
                 return f
         return None
 
+    def image_for(self, name: str) -> bytes:
+        """The decoded PNG for a file that carries a picture, else empty."""
+        return {
+            "EF_DG2": self.portrait_png,
+            "EF_DG5": self.displayed_portrait_png,
+            "EF_DG7": self.signature_png,
+        }.get(name.upper(), b"")
+
     def has_dg(self, number: int) -> bool:
         f = self.file(f"EF_DG{number}")
         return f is not None and f.state == FileState.PRESENT

--- a/tools/ePassport/epassport/ui/tabs/pages.py
+++ b/tools/ePassport/epassport/ui/tabs/pages.py
@@ -246,6 +246,7 @@ class FilesPage(TabPage):
     files = ListProperty([])
     selected_name = StringProperty("")
     selected_data = ObjectProperty(b"")
+    selected_image = ObjectProperty(b"")
     status = StringProperty("")
     dump_dir = StringProperty("")
 
@@ -254,6 +255,7 @@ class FilesPage(TabPage):
         if record is None:
             self.files = []
             self.selected_data = b""
+            self.selected_image = b""
             return
         self.dump_dir = str(record.source_dir or "")
         self.files = [
@@ -267,6 +269,7 @@ class FilesPage(TabPage):
         else:
             self.selected_name = ""
             self.selected_data = b""
+            self.selected_image = b""
 
     def on_files(self, *_args) -> None:
         Clock.schedule_once(self._rebuild, 0)
@@ -300,6 +303,7 @@ class FilesPage(TabPage):
         entry = record.file(name)
         self.selected_name = name
         self.selected_data = entry.data if entry else b""
+        self.selected_image = record.image_for(name)
 
     def export_selected(self, destination: str) -> str:
         """Copy the selected file elsewhere.  Returns a status message."""

--- a/tools/ePassport/epassport/ui/tabs/tabs.kv
+++ b/tools/ePassport/epassport/ui/tabs/tabs.kv
@@ -1,6 +1,7 @@
 #:import theme epassport.ui.theme
 #:import HexView epassport.ui.widgets.hexview.HexView
 #:import LogPane epassport.ui.widgets.logpane.LogPane
+#:import Portrait epassport.ui.widgets.portrait.Portrait
 
 <BookTab>:
     font_name: theme.FONT_LABEL_BOLD
@@ -278,15 +279,24 @@
                     disabled: not root.dump_dir
                     on_release: app.open_dump_dir()
 
-        HexView:
-            id: hexview
-            data: root.selected_data
-            title: root.selected_name
-            available_width: self.width
+        BoxLayout:
+            orientation: "vertical"
+            spacing: dp(6)
+            Portrait:
+                png: root.selected_image
+                size_hint_y: None
+                height: dp(220) if root.selected_image else 0
+                opacity: 1 if root.selected_image else 0
+            HexView:
+                id: hexview
+                data: root.selected_data
+                title: root.selected_name
+                available_width: self.width
 
 <HexView>:
     orientation: "vertical"
     spacing: dp(4)
+    text_color: app.palette["log_text"]
     Label:
         text: (root.title + "   " + "{:,} bytes".format(root.byte_count)) if root.title else ""
         font_name: theme.FONT_LABEL_BOLD
@@ -305,16 +315,12 @@
             Rectangle:
                 pos: self.pos
                 size: self.size
-        Label:
-            text: root.text
-            font_name: theme.FONT_MONO
-            font_size: sp(11)
-            color: app.palette["log_text"]
+        GridLayout:
+            id: dump_box
+            cols: 1
             padding: dp(8), dp(8)
             size_hint: None, None
-            size: self.texture_size
-            halign: "left"
-            valign: "top"
+            size: self.minimum_size
 
 <LogPage>:
     orientation: "vertical"
@@ -342,6 +348,7 @@
         id: logpane
 
 <LogPane>:
+    text_color: app.palette["log_text"]
     ScrollView:
         id: scroller
         bar_width: dp(6)
@@ -351,16 +358,10 @@
             Rectangle:
                 pos: self.pos
                 size: self.size
-        Label:
-            text: root.text
-            markup: True
-            font_name: theme.FONT_MONO
-            font_size: sp(11)
-            color: app.palette["log_text"]
+        GridLayout:
+            id: log_box
+            cols: 1
             padding: dp(10), dp(8)
-            size_hint_y: None
-            size_hint_x: 1
-            height: self.texture_size[1]
-            text_size: self.width, None
-            halign: "left"
-            valign: "top"
+            size_hint: None, None
+            width: scroller.width
+            height: self.minimum_height

--- a/tools/ePassport/epassport/ui/widgets/hexview.py
+++ b/tools/ePassport/epassport/ui/widgets/hexview.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
-from kivy.properties import NumericProperty, ObjectProperty, StringProperty
+from kivy.clock import Clock
+from kivy.properties import (
+    ListProperty,
+    NumericProperty,
+    ObjectProperty,
+    StringProperty,
+)
 from kivy.uix.boxlayout import BoxLayout
+
+from .textblocks import ROWS_PER_BLOCK, split_blocks  # noqa: F401
 
 #: Beyond this the pane renders a prefix and says so - a 25 kB DG2 as one
 #: Label would stall the UI thread for seconds.
@@ -27,6 +35,13 @@ def hexdump(data: bytes, *, width: int = 16, limit: int = MAX_BYTES) -> str:
     return "\n".join(rows)
 
 
+def hexdump_blocks(
+    data: bytes, *, width: int = 16, limit: int = MAX_BYTES
+) -> list[str]:
+    """:func:`hexdump`, split into chunks that each fit one texture."""
+    return split_blocks(hexdump(data, width=width, limit=limit).splitlines())
+
+
 #: Row widths to try, widest first.  A hex dump must not wrap, so instead of
 #: letting it overflow we fit fewer bytes per row into a narrow pane.
 ROW_WIDTHS = (16, 8, 4)
@@ -38,7 +53,9 @@ class HexView(BoxLayout):
     data = ObjectProperty(b"")
     title = StringProperty("")
     byte_count = NumericProperty(0)
-    text = StringProperty("(no file selected)")
+    #: The dump, one entry per Label.  See :data:`ROWS_PER_BLOCK`.
+    blocks = ListProperty([])
+    text_color = ListProperty([1, 1, 1, 1])
     #: Width available for the dump, in pixels.  Set from the ``.kv`` rule.
     available_width = NumericProperty(0)
     row_bytes = NumericProperty(16)
@@ -54,7 +71,36 @@ class HexView(BoxLayout):
         width = self.fit_row_bytes(self.available_width)
         if width != self.row_bytes:
             self.row_bytes = width
-        self.text = hexdump(self.data or b"", width=width)
+        self.blocks = hexdump_blocks(self.data or b"", width=width)
+
+    def on_blocks(self, *_args) -> None:
+        Clock.schedule_once(self._render, -1)
+
+    def on_text_color(self, *_args) -> None:
+        Clock.schedule_once(self._render, -1)
+
+    def _render(self, *_args) -> None:
+        box = self.ids.get("dump_box")
+        if box is None:
+            return
+        from kivy.metrics import sp
+        from kivy.uix.label import Label
+
+        from .. import theme
+
+        box.clear_widgets()
+        for block in self.blocks:
+            label = Label(
+                text=block,
+                font_name=theme.FONT_MONO,
+                font_size=sp(11),
+                color=self.text_color,
+                halign="left",
+                valign="top",
+                size_hint=(None, None),
+            )
+            label.bind(texture_size=label.setter("size"))
+            box.add_widget(label)
 
     def fit_row_bytes(self, available: float) -> int:
         """Largest row width whose rendered line fits in ``available`` pixels."""

--- a/tools/ePassport/epassport/ui/widgets/logpane.py
+++ b/tools/ePassport/epassport/ui/widgets/logpane.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 from collections import deque
 
 from kivy.clock import Clock
-from kivy.properties import BooleanProperty, NumericProperty, StringProperty
+from kivy.properties import BooleanProperty, ListProperty, NumericProperty
 from kivy.uix.boxlayout import BoxLayout
+
+from .textblocks import split_blocks
+
+#: Log lines wrap, so a block covers more rows than it holds lines.
+#: Half of the hex dump's block leaves room for that.
+LOG_ROWS_PER_BLOCK = 256
 
 #: pm3 prefixes every line; colour them the way the client does.
 _PREFIX_COLOURS = {
@@ -26,7 +32,9 @@ class LogPane(BoxLayout):
 
     max_lines = NumericProperty(4000)
     autoscroll = BooleanProperty(True)
-    text = StringProperty("")
+    #: The log, one entry per Label.  See :mod:`.textblocks`.
+    blocks = ListProperty([])
+    text_color = ListProperty([1, 1, 1, 1])
 
     def __init__(self, **kwargs) -> None:
         self._lines: deque[str] = deque(maxlen=int(self.max_lines))
@@ -49,14 +57,54 @@ class LogPane(BoxLayout):
         pending, self._pending = self._pending, []
         for line in pending:
             self._lines.append(_markup(line))
-        self.text = "\n".join(self._lines)
+        self.blocks = split_blocks(list(self._lines), size=LOG_ROWS_PER_BLOCK)
         if self.autoscroll and "scroller" in self.ids:
             Clock.schedule_once(lambda *_: setattr(self.ids.scroller, "scroll_y", 0), 0)
 
     def clear(self) -> None:
         self._lines.clear()
         self._pending.clear()
-        self.text = ""
+        self.blocks = []
+
+    def on_blocks(self, *_args) -> None:
+        self._render()
+
+    def on_text_color(self, *_args) -> None:
+        self._render()
+
+    def _render(self) -> None:
+        """One Label per block, reusing them so only what changed re-renders."""
+        box = self.ids.get("log_box")
+        if box is None:
+            return
+        from kivy.metrics import sp
+        from kivy.uix.label import Label
+
+        from .. import theme
+
+        labels = list(reversed(box.children))  # children run newest-first
+        while len(labels) > len(self.blocks):
+            box.remove_widget(labels.pop())
+        while len(labels) < len(self.blocks):
+            label = Label(
+                markup=True,
+                font_name=theme.FONT_MONO,
+                font_size=sp(11),
+                color=self.text_color,
+                halign="left",
+                valign="top",
+                size_hint_y=None,
+                size_hint_x=1,
+            )
+            label.bind(
+                width=lambda inst, value: setattr(inst, "text_size", (value, None)),
+                texture_size=lambda inst, value: setattr(inst, "height", value[1]),
+            )
+            box.add_widget(label)
+            labels.append(label)
+        for label, block in zip(labels, self.blocks):
+            if label.text != block:
+                label.text = block
 
     @property
     def raw_text(self) -> str:

--- a/tools/ePassport/epassport/ui/widgets/textblocks.py
+++ b/tools/ePassport/epassport/ui/widgets/textblocks.py
@@ -1,0 +1,17 @@
+"""Splitting long text across Labels.
+
+A Label is drawn into a single texture, and OpenGL caps texture size at
+commonly 16384px.  A monospace line here is about 13px, so one Label past
+roughly 1260 lines silently fails to render and the pane draws nothing at
+all - no error with it.  Anything unbounded is split over several Labels.
+"""
+
+from __future__ import annotations
+
+#: Lines per Label.  Half the headroom of the smallest maximum we expect.
+ROWS_PER_BLOCK = 512
+
+
+def split_blocks(rows: list[str], *, size: int = ROWS_PER_BLOCK) -> list[str]:
+    """``rows`` grouped into chunks of at most ``size``, each joined."""
+    return ["\n".join(rows[at : at + size]) for at in range(0, len(rows), size)]

--- a/tools/ePassport/tests/test_dg_parse.py
+++ b/tools/ePassport/tests/test_dg_parse.py
@@ -200,3 +200,19 @@ def test_present_optional_groups_are_not_marked_missing(record) -> None:
         record.issuing_authority,
     ):
         assert not record.is_missing(value)
+
+
+def test_image_for_returns_the_decoded_picture(record) -> None:
+    """The FILES tab shows a picture for the files that carry one."""
+    assert record.image_for("EF_DG2").startswith(b"\x89PNG")
+    assert record.image_for("EF_DG7").startswith(b"\x89PNG")
+
+
+def test_image_for_is_case_insensitive_like_file_lookup(record) -> None:
+    assert record.image_for("ef_dg2") == record.image_for("EF_DG2")
+
+
+def test_image_for_is_empty_for_files_that_carry_no_picture(record) -> None:
+    assert record.image_for("EF_COM") == b""
+    assert record.image_for("EF_SOD") == b""
+    assert record.image_for("nonsense") == b""

--- a/tools/ePassport/tests/test_hexview.py
+++ b/tools/ePassport/tests/test_hexview.py
@@ -68,3 +68,34 @@ def test_fit_row_bytes_before_layout_assumes_the_widest(monkeypatch) -> None:
     monkeypatch.setattr(hexview, "measure_row_width", lambda n: 500.0)
     view = hexview.HexView.__new__(hexview.HexView)
     assert view.fit_row_bytes(0) == 16
+
+
+# ------------------------------------- splitting a dump the GPU can draw
+def test_a_long_dump_is_split_into_blocks_a_texture_can_hold() -> None:
+    """One Label per dump made a DG2 vanish.
+
+    A Label is drawn into a single texture, and a dump line is about 13px, so
+    past roughly 1260 lines the texture exceeds the 16384px OpenGL maximum,
+    fails to be created, and the pane draws nothing at all - no error either.
+    """
+    blocks = hexview.hexdump_blocks(bytes(40_000), width=16)
+    assert len(blocks) > 1
+    assert all(b.count("\n") + 1 <= hexview.ROWS_PER_BLOCK for b in blocks)
+
+
+def test_blocks_join_back_into_exactly_the_one_piece_dump() -> None:
+    data = bytes(range(256)) * 20
+    assert "\n".join(hexview.hexdump_blocks(data, width=16)) == hexdump(data, width=16)
+
+
+def test_a_short_dump_stays_a_single_block() -> None:
+    assert hexview.hexdump_blocks(b"ABC") == [hexdump(b"ABC")]
+
+
+def test_empty_input_is_still_one_block() -> None:
+    assert hexview.hexdump_blocks(b"") == ["(empty)"]
+
+
+def test_rows_per_block_leaves_headroom_under_the_texture_limit() -> None:
+    """16384px is the common maximum; a smaller one must not be marginal."""
+    assert hexview.ROWS_PER_BLOCK * 13 <= 16384 / 2

--- a/tools/ePassport/tests/test_logpane.py
+++ b/tools/ePassport/tests/test_logpane.py
@@ -1,0 +1,35 @@
+"""The pm3 log pane.
+
+Long text has to be split across several Labels: a Label is drawn into one
+texture, and OpenGL caps texture size at commonly 16384px.  A log line is
+about 13px, so the pane went blank somewhere past 1260 lines - and it holds
+4000, so a talkative dump lost its output entirely.
+"""
+
+from __future__ import annotations
+
+from epassport.ui.widgets import textblocks
+
+
+def test_a_long_log_is_split_into_blocks_a_texture_can_hold() -> None:
+    rows = [f"[+] line {i}" for i in range(4000)]
+    blocks = textblocks.split_blocks(rows)
+    assert len(blocks) > 1
+    assert all(b.count("\n") + 1 <= textblocks.ROWS_PER_BLOCK for b in blocks)
+
+
+def test_blocks_join_back_into_the_whole_log() -> None:
+    rows = [f"line {i}" for i in range(1500)]
+    assert "\n".join(textblocks.split_blocks(rows)) == "\n".join(rows)
+
+
+def test_a_short_log_stays_a_single_block() -> None:
+    assert textblocks.split_blocks(["one", "two"]) == ["one\ntwo"]
+
+
+def test_no_lines_is_no_blocks() -> None:
+    assert textblocks.split_blocks([]) == []
+
+
+def test_rows_per_block_leaves_headroom_under_the_texture_limit() -> None:
+    assert textblocks.ROWS_PER_BLOCK * 13 <= 16384 / 2


### PR DESCRIPTION
## Problem

In the FILES tab, clicking a file that holds a picture — EF_DG2, EF_DG7 — showed nothing at all: no image, no hex dump, and no error either.

Both the hex view and the log pane drew their text into a single Kivy `Label`, and a `Label` is one OpenGL texture, capped at commonly 16384px. A monospace line here is 13px, so past roughly 1260 lines the texture fails to be created and the pane draws nothing.

Measured on an RX 7900 (`GL_MAX_TEXTURE_SIZE` 16384):

```
 bytes  row  lines   texture
  6678   16    418     5434px   renders
 20000   16   1250    16250px   renders
 25000   16   1563    20319px   BLANK
  6678    4   1670    21710px   BLANK      (narrow pane)
```

A DG2 portrait is 15–25kB, which is 940–1560 dump lines at 16 bytes a row, and four times that in a narrow pane where the dump falls back to 4 bytes a row — so it was always over. The LOG pane holds 4000 lines and blanked the same way past ~1260:

```
  1260 log lines -> 16380px  renders
  2000 log lines -> 26000px  BLANK
  4000 log lines -> 52000px  BLANK
```

The 64kB cap already in the hex view guarded the wrong bound — it was sized for how long a `Label` takes to lay out, not for what the GPU will hold, and 64kB is three times past what can draw.

## Change

- `ui/widgets/textblocks.py` (new) — `split_blocks()` and the row-per-Label constant, with the texture reasoning in one place since two widgets need it.
- `ui/widgets/hexview.py` — `hexdump_blocks()` splits at 512 rows, and `HexView` renders one `Label` per block. `hexdump()` itself is unchanged.
- `ui/widgets/logpane.py` — same, at 256 rows because log lines wrap and so cover more rows than they hold. The pane reuses its `Label`s and only assigns the ones whose text actually changed, so streaming output still re-renders just the tail rather than the whole buffer each frame.
- `emrtd/model.py` — `PassportRecord.image_for()` returns the decoded PNG for EF_DG2/EF_DG5/EF_DG7. Nothing new is parsed; those are already decoded at load time for the data page.
- `ui/tabs/pages.py`, `ui/tabs/tabs.kv` — the FILES tab shows the picture above the dump for files that carry one, collapsing to zero height for those that don't.

512 rows is 6656px, well under half the 16384px maximum, so it still holds on hardware with a smaller one.

## Behaviour change

- A file carrying an image now shows it above the hex dump. The dump is still there underneath, so the bytes remain available — nothing is truncated that was not truncated before.
- Files and log content that previously drew nothing now draw. On a machine where these panes happened to stay under the limit, nothing changes.

## Testing

- `python3 -m pytest tests/` — 270 passed, 2 skipped (was 265 passed, 2 skipped).
- Checked on screen against a generated sample: EF_DG2 shows the portrait, EF_DG7 the signature, EF_SOD the dump at full height with no image, and the LOG tab renders a full 4000-line buffer as 16 Labels, tallest texture 3328px against the 16384px maximum.
- `black --check` clean.

Not tested here: Windows/ProxSpace and macOS, and X11 rather than Wayland. Low risk — this is Python only and the change is in how many `Label`s the text is spread over, with no platform-specific calls. Not tested: hardware; nothing here reaches the `pm3` path.

CHANGELOG entry added under `[unreleased]`.

## PR checklist

- [x] Proper style of own code, no unrelated reformatting included
- [ ] Builds warning-free with gcc; also tried with clang — n/a, Python only, no compiled code touched
- [ ] `client/Makefile`, `client/CMakeLists.txt`, `client/experimental_lib/CMakeLists.txt` all updated — n/a, no client sources changed
- [ ] ARM firmware builds clean for RDV4 and PM5 — n/a, no `armsrc`/`bootrom`/`common_arm` changes
- [x] Platform-sensitive code reasoned about — tested on Linux/Wayland; untested platforms and why they are low risk are in Testing
- [x] Existing comments in touched files preserved
- [ ] `doc/commands.md` / `doc/commands.json` regenerated — n/a, no client commands changed
