### PR TITLE
Fix PM5 auto-off leaving the board unable to power back on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `PM5 auto-off` - no longer powers the board into a state it can't be woken from (@nemanjan00)
 - Fixed `tools/ePassport` - FILES and LOG panes no longer go blank on long content, and picture files now show the picture (@pkilar)
 - Fixed `hf xerox view` - now rejects a dump file too small to contain the info blocks instead of reading past it (@munzzyy)
 - Changed NG frame layout to align better with 64bytes frames. From 512 -> 624bytes (@iceman1001)

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -110,9 +110,20 @@ static bool s_autooff_setup = false;
 // unplugged at all (and the hw bwmautooff toggle would be unreachable, since setting it
 // needs a client/USB). So we require having seen USB present at least once this session
 // before an absent reading triggers shutdown.
+#ifndef PM5_AUTOOFF_CONFIRMATIONS
+// Consecutive absent samples required before powering off (x PM5_AUTOOFF_POLL_MS).
+// This is the grace period the comment above has always promised, and it is not only
+// glitch rejection: pulling VBUS puts the BWM charger into Battery Discharge Mode, and
+// BATFET is only turned fully on as part of that transition. Releasing the power latch
+// 250ms in leaves the charger mid-transition and the board will not power on again -
+// waiting lets DISCHG settle first.
+#define PM5_AUTOOFF_CONFIRMATIONS  20      // 20 x 250ms = 5s
+#endif
+
 static void bwm_autooff_check(void) {
     static uint32_t last_tick = 0;
     static bool usb_was_present = false;   // have we seen USB present since boot?
+    static uint8_t absent = 0;             // consecutive USB-absent samples
 
     if (g_autooff_enabled == false) {
         return;
@@ -130,12 +141,18 @@ static void bwm_autooff_check(void) {
     // Gpio_VUSB_Read() == true means USB power present.
     if (Gpio_VUSB_Read()) {
         usb_was_present = true;   // latch: USB has been present this session
+        absent = 0;               // present again -> restart the grace period
         return;
     }
 
     // USB absent. Only power off if USB had previously been present (a real unplug).
     // If it booted on battery and never saw USB, leave it running.
     if (usb_was_present == false) {
+        return;
+    }
+
+    // Require the absence to persist before acting on it.
+    if (++absent < PM5_AUTOOFF_CONFIRMATIONS) {
         return;
     }
 


### PR DESCRIPTION
bwm_autooff_check() released the power latch on the first VUSB-absent sample, ~250ms after VBUS was pulled. With a BWM fitted that lands while the AW32001E is still transitioning into Battery Discharge Mode, where BATFET is only turned fully on as part of that transition. The board powered down mid-transition and could then not be brought back up by button or by USB insertion - it looked dead until the cell was physically re-inserted.

Require the absence to persist for 5s (20 consecutive 250ms samples) before acting, resetting the count whenever USB reappears. This is the grace period the function's own comment already described, and it also means a single spurious low reading on PC2 - a floating input, configured GPIO_PULL_NONE - can no longer power down a working device.

The 5s figure is empirical rather than derived from a datasheet settling time. Other users report auto-off working on their boards, so this makes a marginal path robust rather than fixing something broken everywhere.