### PR TITLE
armsrc: fix the PM3GENERIC build broken by ab7729259

### DIFF
--- a/armsrc/sam_common.c
+++ b/armsrc/sam_common.c
@@ -316,7 +316,9 @@ out:
 void switch_clock_to_ticks(void) {
     StopTicks();
     StartTicks();
+#ifdef WITH_SMARTCARD
     sc_log_trace_reset();
+#endif
     trace_restart_timeline();
 }
 


### PR DESCRIPTION
## Problem

`master` does not link for `PLATFORM=PM3GENERIC`:

```
ld: obj/sam_common.o: in function `switch_clock_to_ticks':
sam_common.c: undefined reference to `sc_log_trace_reset'
```

`sam_common.c` is always compiled as part of `SRC_ISO14443a`, but `sc_log_trace_reset()` lives in `i2c.c`, which `armsrc/Makefile` only builds under `WITH_SMARTCARD`. `ab7729259` added the call to `switch_clock_to_ticks()`,
where it survives `--gc-sections`.

PM3RDV4 sets `-DWITH_SMARTCARD` and is unaffected. PM5 does not set it but links anyway, so PM3GENERIC is the configuration that breaks.

## Change

Guard the call with `#ifdef WITH_SMARTCARD`. The SAM is RDV4 hardware, so a build without smartcard support has no smartcard trace to reset — skipping it is correct, not just a way to quiet the linker.

## Behaviour change

None. `WITH_SMARTCARD` builds are unchanged; PM3GENERIC now links.

## Testing

`make -j fullimage bootrom` from a clean `armsrc`/`bootrom`, `arm-none-eabi-gcc` 13.3.1 on a macOS host:

| platform | master | patched |
|---|---|---|
| PM3GENERIC | **link error above** | builds |
| PM5 | builds | builds |
| PM3RDV4 | builds | builds |

The PM3GENERIC image was flashed to a generic Proxmark3 and exercised; normal.

Two platforms fail on master for unrelated reasons and are *not* addressed here: PM3ICOPYX (`GPIO_FPGA_ON` undeclared in `gpio_hw_at91.h`) and PM3ULTIMATE (fails at `obj/fpga_all.bit.z`).

Not tested: Linux, Windows/ProxSpace, and the CMake ARM path.

## Checklist

- [x] Proper style of own code, no unrelated reformatting. Note `make style` also wants to reformat two other hunks of this file that are not astyle-clean on master; left alone deliberately
- [x] Builds warning-free with `arm-none-eabi-gcc`
- [x] No client sources touched
- [x] ARM builds clean for PM3GENERIC, PM5, PM3RDV4
- [ ] Platform-sensitive code — this *is* the platform fix; macOS host only
- [x] Existing comments preserved
- [x] No commands changed, `doc/commands.*` unaffected

Fix and PR were drafted with Claude and have been human checked.