### PR TITLE
hf 14b: scale the WTX timeout, not the shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `hf 14b` - a card asking for a waiting time extension of 4 or more left the timeout at zero, so any ISO14443-B card needing time to answer looked like it had stopped responding (@pkilar)
 - Fixed `hf mfdes chk` - now handles `-k` user supplied keys properly (@iceman1001)
 - Fixed `BigBuf_Clear_keep_EM()` - now also clear the trace length set (@iceman1001)
 - Fixed `BTADDON` - rx ring reported empty when filled to exactly its size, silently dropping 1kB of received data; now read straight from the PDC banks (@iceman1001)

--- a/armsrc/iso14443b.c
+++ b/armsrc/iso14443b.c
@@ -1719,11 +1719,12 @@ int iso14443b_apdu(uint8_t const *msg, size_t msg_len, bool send_chaining, void 
             // byte1 - WTXM [1..59].
             uint8_t wtxm = data_bytes[1] & 0x3F;
 
-            // command FWT = FWT * WTXM
-            uint32_t fwt_temp = (s_iso14b_fwt * wtxm);
+            // command FWT = FWT * WTXM.  (32 << fwi) is the FWT in ETUs; scaling
+            // the shift instead overflows it at wtxm 4 and leaves a timeout of 0.
+            uint32_t fwt_temp = (32 << s_iso14b_fwt) * wtxm;
 
             // temporarily increase timeout
-            iso14b_set_timeout((32 << fwt_temp));
+            iso14b_set_timeout(fwt_temp);
 
             // Transmit WTX back
             data_bytes[1] = wtxm;


### PR DESCRIPTION
## Problem

A card that cannot answer within FWT replies with an S(WTX) block carrying a multiplier, and ISO 14443-4 has the timeout become **FWT × WTXM** for that exchange. `iso14443b_apdu()` scaled the shift instead of the timeout:

```c
uint32_t fwt_temp = (s_iso14b_fwt * wtxm);
iso14b_set_timeout((32 << fwt_temp));
```

`(32 << fwi)` *is* the FWT in ETUs — the form `iso14b_set_fwt()` uses at `iso14443b.c:503`, the same expression at `iso14443b.c:112`, and what the client prints in `hf 14b info` at `cmdhf14b.c:460`. So this computed `32 << (fwi × wtxm)`.

With the `fwi` of 8 an ePassport reports:

| WTXM | `32 << (8 × WTXM)` | Result |
|---|---|---|
| 1 | `32 << 8` = 8192 | correct by accident |
| 2 | `32 << 16` = 2097152 | 256× too long |
| **≥ 4** | `32 << 32` | shift past the width of a `uint32_t` — undefined, and 0 on ARM |

A timeout of 0 makes the following `Get14443bAnswerFromTag()` fail immediately, `iso14443b_apdu()` returns `PM3_ECARDEXCHANGE`, and the client reports:

```
APDU: no APDU response
```

which reads as a card that has left the field, when in fact it was answering normally and we stopped listening.

## How it showed up

A Polish ePassport that would not read. `hf 14b info` fingerprinted it fine, and every short command answered:

```
00A4020C02011C                                    -> 9000   SELECT EF.CardAccess
00A404001400112233445566778899AABBCCDDEEFF00112233 -> 6A81   25-byte SELECT
00EE000000                                        -> 6D00   unsupported instruction
00220000                                          -> 6700   bare MSE
0022000003830101                                  -> 6A86   MSE, other P1/P2
0022C1A412800A04007F0007020204020183010184010C    -> (silence)
```

Only `MSE:Set AT` with P1P2 `C1 A4` was silent — the one command in the exchange that starts the PACE ECDH setup, and therefore the only one that ever asks for more time. Frame length, the optional `84` domain-parameter object and the MRZ-vs-CAN password reference were all ruled out by the commands above before the WTX path was suspected.

Older passports read because they ask for a smaller multiplier, where the wrong formula still lands on a usable number.

## Change

One line of arithmetic, plus a comment saying why it is written that way:

```c
uint32_t fwt_temp = (32 << s_iso14b_fwt) * wtxm;
iso14b_set_timeout(fwt_temp);
```

## Behaviour change

ISO14443-B cards that request a waiting time extension of 4 or more are now waited for instead of being abandoned. Cards requesting 1 are unaffected; those requesting 2 or 3 previously got a timeout hundreds of times longer than asked for and now get the correct one.

## Testing

Built and flashed to an **RDV4** (`PLATFORM=PM3RDV4`), tested against the document that reproducibly failed:

- The `MSE:Set AT` that returned nothing now answers `9000`.
- `hf emrtd dump` completes in 3 seconds: `Authentication with PACE successful ( ECDH, Generic Mapping, 3DES-CBC-CBC, NIST P-256 (secp256r1) )`, with EF_COM, DG1, DG2, DG13, DG14 and EF_SOD all read.
- Every EF_SOD data-group hash matches; DG3 correctly shows as not checked, being EAC-protected.
- The two older ePassports that already read still read.

Not tested here: PM5 and PM3 Easy, and non-passport Type B cards. Low risk — the change is confined to the S(WTX) branch of `iso14443b_apdu()`, is platform-independent arithmetic, and cards that never request WTX do not reach it.

This may be related to the timeouts in #3563, though that report is on PM5 and predates this being looked at, so I would not assume they are the same fault.