### PR TITLE
Improve serialport send speed

### DIFF
--- a/client/src/cmdfpga.c
+++ b/client/src/cmdfpga.c
@@ -4,6 +4,7 @@
 #include "comms.h"
 #include "cmdfpga.h"
 #include "ui.h"
+#include "util_posix.h" // msclock
 
 static int CmdHelp(const char *Cmd);
 
@@ -53,11 +54,6 @@ static int CmdConfigFpga(const char *Cmd) {
         return PM3_EFILE;
     }
 
-    // TODO DXL Maybe length check for device model is required.
-    //  coming soon
-
-    // TODO DXL check response result is required
-
     struct {
         uint8_t sram_mode;
         uint32_t file_length;
@@ -69,6 +65,7 @@ static int CmdConfigFpga(const char *Cmd) {
     PrintAndLogEx(INFO, "Starting FPGA configuration in " _YELLOW_("%s"), sram_mode ? "SRAM" : "Flash");
 
     // Start fpga config by mode
+    uint64_t t_start = msclock();
     SendCommandNG(CMD_FPGA_BITSTREAM_CONFIG_START, (uint8_t *)&params, sizeof(params));
     // Wait for response before sending data
     if (WaitForResponseTimeout(CMD_FPGA_BITSTREAM_CONFIG_START, &resp, 15000) == false) {
@@ -123,7 +120,9 @@ static int CmdConfigFpga(const char *Cmd) {
         return resp.status;
     }
 
-    PrintAndLogEx(SUCCESS, "FPGA configuration successfully!");
+    uint64_t elapsed_ms = msclock() - t_start;
+    PrintAndLogEx(SUCCESS, "FPGA configuration successfully! Total time: " _YELLOW_("%.2f") " s (" _YELLOW_("%.0f") " ms)",
+                  (float)elapsed_ms / 1000.0f, (float)elapsed_ms);
     free(data);
     return PM3_SUCCESS;
 }

--- a/client/src/comms.c
+++ b/client/src/comms.c
@@ -100,7 +100,8 @@ bool WaitForTxIdle(uint32_t ms_timeout) {
         if (msclock() - start >= ms_timeout) {
             return false;
         }
-        msleep(1);
+        
+        xyield(); // just to avoid CPU busy loop
     }
 }
 
@@ -1149,8 +1150,8 @@ bool WaitForResponseTimeoutW(uint32_t cmd, PacketResponseNG *response, size_t ms
             PrintAndLogEx(INFO, "You can cancel this operation by pressing the pm3 button");
             show_warning = false;
         }
-        // just to avoid CPU busy loop:
-        msleep(1);
+
+        xyield(); // just to avoid CPU busy loop
     }
     return false;
 }

--- a/client/src/uart/uart_win32.c
+++ b/client/src/uart/uart_win32.c
@@ -29,6 +29,9 @@
 // The windows serial port implementation
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
 #include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -37,6 +40,8 @@ typedef struct {
     HANDLE hPort;          // Serial port handle
     DCB dcb;               // Device control settings
     COMMTIMEOUTS ct;       // Serial port time-out configuration
+    HANDLE hCommEvent;     // Event for the in-flight WaitCommEvent (EV_RXCHAR)
+    HANDLE hIoEvent;       // Event for the single in-flight overlapped read/write
     SOCKET hSocket;        // Socket handle
     RingBuffer *udpBuffer; // Buffer for UDP
 } serial_port_windows_t;
@@ -51,9 +56,21 @@ uint32_t newtimeout_value = 0;
 bool newtimeout_pending = false;
 uint8_t rx_empty_counter = 0;
 
-// Not implemented here: the win32 receive path would need an event object in
-// its wait instead of a pipe. Leaving it a no-op keeps that platform as it was.
-void uart_wakeup(void) { }
+// Manual-reset event set by uart_wakeup() to interrupt the comm thread's idle
+// WaitCommEvent(). Only the serial (USB-CDC/FPC) path ever creates this; TCP/UDP
+// keep their select() timeouts and are left untouched.
+static HANDLE hWakeEvent = NULL;
+
+// Interrupt a blocking serial wait so the comm thread can service a queued send
+// right away instead of waiting out the COMMTIMEOUTS. This is a *soft* signal:
+// it only wakes the comm thread's WaitCommEvent() wait; a pending data ReadFile()
+// is never cancelled, so in-flight bytes are not discarded. TCP/UDP are
+// unaffected: hWakeEvent is only ever a serial wake event.
+void uart_wakeup(void) {
+    if (hWakeEvent != NULL) {
+        SetEvent(hWakeEvent);
+    }
+}
 
 int uart_reconfigure_timeouts(uint32_t value) {
     newtimeout_value = value;
@@ -337,8 +354,17 @@ serial_port uart_open(const char *pcPortName, uint32_t speed, bool slient) {
 
     // Try to open the serial port
     // r/w,  none-share comport, no security, existing, no overlapping, no templates
-    sp->hPort = CreateFileA(acPortName, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+    // FILE_FLAG_OVERLAPPED is required for overlapped WaitCommEvent/ReadFile/WriteFile.
+    sp->hPort = CreateFileA(acPortName, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
     if (sp->hPort == INVALID_HANDLE_VALUE) {
+        uart_close(sp);
+        return INVALID_SERIAL_PORT;
+    }
+
+    sp->hCommEvent = CreateEvent(NULL, TRUE, FALSE, NULL); // manual reset, for WaitCommEvent
+    sp->hIoEvent   = CreateEvent(NULL, TRUE, FALSE, NULL); // manual reset, for ReadFile/WriteFile
+    hWakeEvent     = CreateEvent(NULL, TRUE, FALSE, NULL); // manual reset, for uart_wakeup()
+    if (sp->hCommEvent == NULL || sp->hIoEvent == NULL || hWakeEvent == NULL) {
         uart_close(sp);
         return INVALID_SERIAL_PORT;
     }
@@ -385,8 +411,19 @@ void uart_close(const serial_port sp) {
         WSACleanup();
     }
     RingBuf_destroy(spw->udpBuffer);
-    if (spw->hPort != INVALID_HANDLE_VALUE)
+    if (spw->hPort != INVALID_HANDLE_VALUE) {
         CloseHandle(spw->hPort);
+    }
+    if (spw->hCommEvent != NULL) {
+        CloseHandle(spw->hCommEvent);
+    }
+    if (spw->hIoEvent != NULL) {
+        CloseHandle(spw->hIoEvent);
+    }
+    if (spw->hSocket == INVALID_SOCKET && hWakeEvent != NULL) {
+        CloseHandle(hWakeEvent);
+        hWakeEvent = NULL;
+    }
     free(sp);
 }
 
@@ -426,23 +463,104 @@ uint32_t uart_get_speed(const serial_port sp) {
     return 0;
 }
 
+// Read data from the serial port after it has been reported available (via
+// ClearCommError or WaitCommEvent). Reuses hIoEvent for the single in-flight
+// overlapped operation in the comm thread.
+static int uart_read_serial(const serial_port_windows_t *spw, uint8_t *pbtRx, uint32_t pszMaxRxLen, uint32_t *pszRxLen) {
+    OVERLAPPED ov;
+    memset(&ov, 0, sizeof(ov));
+    ov.hEvent = spw->hIoEvent;
+    ResetEvent(ov.hEvent);
+
+    DWORD bytesRead = 0;
+    BOOL ok = ReadFile(spw->hPort, pbtRx, pszMaxRxLen, &bytesRead, &ov);
+    if (!ok && GetLastError() == ERROR_IO_PENDING) {
+        WaitForSingleObject(ov.hEvent, INFINITE);
+        ok = GetOverlappedResult(spw->hPort, &ov, &bytesRead, FALSE);
+    }
+    if (!ok) {
+        DWORD err = GetLastError();
+        *pszRxLen = 0;
+        if (err == ERROR_OPERATION_ABORTED) {
+            return PM3_ENODATA;
+        }
+        if (err == ERROR_FILE_NOT_FOUND) {
+            return PM3_EIO;
+        }
+        return PM3_ENOTTY;
+    }
+    *pszRxLen = bytesRead;
+    return PM3_SUCCESS;
+}
+
 int uart_receive(const serial_port sp, uint8_t *pbtRx, uint32_t pszMaxRxLen, uint32_t *pszRxLen) {
     const serial_port_windows_t *spw = (serial_port_windows_t *)sp;
     if (spw->hSocket == INVALID_SOCKET) {
         // serial port
         uart_reconfigure_timeouts_polling(sp);
 
-        int res = ReadFile(spw->hPort, pbtRx, pszMaxRxLen, (LPDWORD)pszRxLen, NULL);
-        if (res)
-            return PM3_SUCCESS;
-
-        int errorcode = GetLastError();
-
-        if (res == 0 && errorcode == 2) {
-            return PM3_EIO;
+        DWORD rx_timeout_ms = spw->ct.ReadTotalTimeoutConstant;
+        if (rx_timeout_ms == 0) {
+            rx_timeout_ms = UART_USB_CLIENT_RX_TIMEOUT_MS;
         }
 
-        return PM3_ENOTTY;
+        // Fast path: if bytes are already queued, read them without waiting. This
+        // also sidesteps WaitCommEvent's re-arm race, where data arriving between
+        // two waits would otherwise be missed.
+        DWORD comErrors;
+        COMSTAT comStat;
+        if (ClearCommError(spw->hPort, &comErrors, &comStat) && comStat.cbInQue > 0) {
+            return uart_read_serial(spw, pbtRx, pszMaxRxLen, pszRxLen);
+        }
+
+        // Nothing queued yet: wait for EV_RXCHAR or a wake signal.
+        SetCommMask(spw->hPort, EV_RXCHAR);
+        OVERLAPPED ov;
+        memset(&ov, 0, sizeof(ov));
+        ov.hEvent = spw->hCommEvent;
+        ResetEvent(ov.hEvent);
+        DWORD eventMask = 0;
+        BOOL ok = WaitCommEvent(spw->hPort, &eventMask, &ov);
+        if (!ok) {
+            DWORD err = GetLastError();
+            if (err != ERROR_IO_PENDING) {
+                *pszRxLen = 0;
+                if (err == ERROR_OPERATION_ABORTED) {
+                    return PM3_ENODATA;
+                }
+                return PM3_ENOTTY;
+            }
+
+            HANDLE handles[2] = {ov.hEvent, hWakeEvent};
+            DWORD waitRes = WaitForMultipleObjects(2, handles, FALSE, rx_timeout_ms);
+
+            if (waitRes == WAIT_TIMEOUT) {
+                // No data within the COMMTIMEOUTS window: abort the *wait* (not a
+                // data read) and report nothing, matching the old ReadFile timeout.
+                CancelIoEx(spw->hPort, &ov);
+                *pszRxLen = 0;
+                return PM3_SUCCESS;
+            }
+            if (waitRes == WAIT_OBJECT_0 + 1) {
+                // Woken to send: cancel the pending WaitCommEvent (the wait only),
+                // leaving any already-queued bytes in the driver buffer.
+                ResetEvent(hWakeEvent);
+                CancelIoEx(spw->hPort, &ov);
+                *pszRxLen = 0;
+                return PM3_ENODATA;
+            }
+            if (waitRes == WAIT_FAILED) {
+                CancelIoEx(spw->hPort, &ov);
+                *pszRxLen = 0;
+                return PM3_ENOTTY;
+            }
+            // EV_RXCHAR fired; finalize the wait.
+            DWORD dummy;
+            GetOverlappedResult(spw->hPort, &ov, &dummy, TRUE);
+        }
+
+        // Data is now available; read it.
+        return uart_read_serial(spw, pbtRx, pszMaxRxLen, pszRxLen);
     } else {
         // TCP or UDP
         uint32_t byteCount;  // FIONREAD returns size on 32b
@@ -567,13 +685,23 @@ int uart_receive(const serial_port sp, uint8_t *pbtRx, uint32_t pszMaxRxLen, uin
 int uart_send(const serial_port sp, const uint8_t *p_tx, const uint32_t len) {
     const serial_port_windows_t *spw = (serial_port_windows_t *)sp;
     if (spw->hSocket == INVALID_SOCKET) { // serial port
+        OVERLAPPED ov;
+        memset(&ov, 0, sizeof(ov));
+        ov.hEvent = spw->hIoEvent;
+        ResetEvent(ov.hEvent);
+
         DWORD txlen = 0;
-        int res = WriteFile(spw->hPort, p_tx, len, &txlen, NULL);
-        if (res)
+        BOOL ok = WriteFile(spw->hPort, p_tx, len, &txlen, &ov);
+        if (!ok && GetLastError() == ERROR_IO_PENDING) {
+            WaitForSingleObject(ov.hEvent, INFINITE);
+            ok = GetOverlappedResult(spw->hPort, &ov, &txlen, FALSE);
+        }
+
+        if (ok)
             return PM3_SUCCESS;
 
         int errorcode = GetLastError();
-        if (res == 0 && errorcode == 2) {
+        if (errorcode == ERROR_FILE_NOT_FOUND) {
             return PM3_EIO;
         }
         return PM3_ENOTTY;

--- a/common/util_posix.h
+++ b/common/util_posix.h
@@ -24,11 +24,13 @@
 #ifdef _WIN32
 # include <windows.h>
 # define sleep(n) Sleep(1000 *(n))
-# define msleep(n) Sleep((n))
+# define msleep(n) Sleep((n))       // Sleep(1) may wait 15ms, which is a feature of Windows.
+# define xyield() Sleep(0)          // avoid cpu busy, yield to other threads
 #else
-void msleep(uint32_t n);    // sleep n milliseconds
+void msleep(uint32_t n);            // sleep n milliseconds
+# define xyield() msleep(1)
 #endif // _WIN32
 
-uint64_t msclock(void);     // a milliseconds clock
-uint64_t usclock(void);     // a microseconds clock
+uint64_t msclock(void);            // a milliseconds clock
+uint64_t usclock(void);            // a microseconds clock
 #endif


### PR DESCRIPTION
* msleep(1) on Windows may is precision of 15ms.
   > https://news.ycombinator.com/item?id=1460529

* ReadFile's timeout is always 20ms(For SerialPort), and due to the single-threaded communication model, the sending queue is always processed only after receiving is complete. This results in an interval between each instruction being greater than 20ms (unless the ARM continuously responds with data, causing ReadFile to exit quickly).

For the first problem, our solution is to use Sleep(0) on Windows to yield CPU time slices, which avoids the fixed 15ms delay due to precision issues.

For the second problem, our solution is to use an event mechanism to prematurely end the receiving process while preserving buffer data (CancelIoEx alone cannot be used, as this may result in data loss).
> See: `uart_wakeup()`

After testing, after optimization, the interval between each instruction is now reduced to 1ms when SendCommandNG and WaitForResponseTimeout are used together, which is much less than the previous 30ms. This significantly improves the speed of HW FPGA configuration, from the original 13-16s to the current 3-4s.

Why is it named xyield()? This is to avoid conflicts with function names in other third-party libraries, or to avoid future conflicts with certain C/C++ keywords (yield is a very common keyword).
