### PR TITLE
Fix ePassport disabled buttons drawing as three bands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `tools/ePassport` - a disabled button drew Kivy's banded disabled texture, which left its label unreadable (@pkilar)
 - Fixed `hf 14b` - a card asking for a waiting time extension of 4 or more left the timeout at zero, so any ISO14443-B card needing time to answer looked like it had stopped responding (@pkilar)
 - Fixed `hf mfdes chk` - now handles `-k` user supplied keys properly (@iceman1001)
 - Fixed `BigBuf_Clear_keep_EM()` - now also clear the trace length set (@iceman1001)

--- a/tools/ePassport/epassport/ui/app.kv
+++ b/tools/ePassport/epassport/ui/app.kv
@@ -7,6 +7,13 @@
 #:import ScanScreen epassport.ui.scan.ScanScreen
 #:import BinButton epassport.ui.widgets.binbutton.BinButton
 
+# Kivy's disabled button texture is pale at the edges and dark in the middle,
+# which stretches into three bands and leaves the label unreadable.  Keep the
+# normal background and let the dimmed text carry the disabled state.
+<Button>:
+    background_disabled_normal: "atlas://data/images/defaulttheme/button"
+    disabled_color: 1, 1, 1, 0.45
+
 <Root>:
     orientation: "vertical"
     canvas.before:


### PR DESCRIPTION
## Problem

At startup the **Delete dump** button is unreadable. It is disabled — no dump is loaded yet — and Kivy's stock disabled button texture is pale at the edges and dark in the middle. Stretched across a 110dp button the edges stay put while the middle grows, so it draws as three vertical bands, with the label sitting on the dark one and disappearing into it.

Every other toolbar button looks right only because it is enabled; the normal texture is uniform.

It is not specific to that button. Nine buttons across the app bind `disabled:` — Export…, Open folder, the camera button on the entry screen, Samples…, the bin button — and all band the same way whenever they are disabled.

## Change

Keep the normal background for the disabled state, and let the dimmed label carry it instead:

```
<Button>:
    background_disabled_normal: "atlas://data/images/defaulttheme/button"
    disabled_color: 1, 1, 1, 0.45
```

The text sits at 45% rather than Kivy's default 30%, which is faint against that grey. Applied as a `<Button>` rule so every disabled button is fixed rather than only the one that prompted it.

## Behaviour change

Disabled buttons now share the enabled background and are distinguished by their dimmed label instead of a different texture.

## Testing

Compared before and after at startup and on the FILES tab, where Export… and Open folder are disabled until a file is selected. **Delete dump** now matches **New read** and **Dumps…**, with the label clearly legible and clearly dimmed.

Checked the one button the rule could have harmed: the status-bar dump-path button sets `background_color: 0, 0, 0, 0`, and it stays invisible, since `background_color` multiplies the texture rather than replacing it.

- `python3 -m pytest tests/` — 323 passed, 2 skipped, unchanged.
- `black --check` clean.

Not tested here: Windows/ProxSpace and macOS. The rule is a Kivy default-theme atlas path and a colour, with nothing platform-specific about either.

## PR checklist

- [x] Proper style of own code, no unrelated reformatting included
- [ ] Builds warning-free with gcc; also tried with clang — n/a, no compiled code touched
- [ ] `client/Makefile`, `client/CMakeLists.txt`, `client/experimental_lib/CMakeLists.txt` all updated — n/a, no client sources changed
- [ ] ARM firmware builds clean for RDV4 and PM5 — n/a, no firmware changes
- [x] Platform-sensitive code reasoned about — a theme rule only
- [x] Existing comments in touched files preserved
- [ ] `doc/commands.md` / `doc/commands.json` regenerated — n/a, no commands changed
- [x] CHANGELOG entry added under `[unreleased]`
