### PR TITLE
Name the ePassport files each detail tab actually drew from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `tools/ePassport` - the PERSONAL tab's personal-number caption wrapped, dropping the source onto a line of its own (@pkilar)
 - Added `tools/ePassport` - EF_DG13 is decoded, and a Polish document's PESEL is shown as the personal number when it carries no EF_DG11 (@pkilar)
 - Fixed `tools/ePassport` - a disabled button drew Kivy's banded disabled texture, which left its label unreadable (@pkilar)
 - Fixed `hf 14b` - a card asking for a waiting time extension of 4 or more left the timeout at zero, so any ISO14443-B card needing time to answer looked like it had stopped responding (@pkilar)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
-- Fixed `tools/ePassport` - the PERSONAL tab's personal-number caption wrapped, dropping the source onto a line of its own (@pkilar)
+- Fixed `tools/ePassport` - the detail tabs named the files their data came from as fixed text, so a document without EF_DG11 was told otherwise, and the personal-number caption wrapped (@pkilar)
 - Added `tools/ePassport` - EF_DG13 is decoded, and a Polish document's PESEL is shown as the personal number when it carries no EF_DG11 (@pkilar)
 - Fixed `tools/ePassport` - a disabled button drew Kivy's banded disabled texture, which left its label unreadable (@pkilar)
 - Fixed `hf 14b` - a card asking for a waiting time extension of 4 or more left the timeout at zero, so any ISO14443-B card needing time to answer looked like it had stopped responding (@pkilar)

--- a/tools/ePassport/epassport/app.py
+++ b/tools/ePassport/epassport/app.py
@@ -263,9 +263,11 @@ class Pm3PassportApp(App):
                 box.add_widget(plate)
             else:
                 cls, title = {
-                    1: (PersonalPage, "Additional personal details  ·  EF_DG11"),
-                    2: (IssuerPage, "Additional document details  ·  EF_DG12"),
-                    3: (SecurityPage, "Document security  ·  EF_SOD, EF_DG14, EF_DG15"),
+                    # The files are appended by the page itself, from what
+                    # the document actually turned out to carry.
+                    1: (PersonalPage, "Additional personal details"),
+                    2: (IssuerPage, "Additional document details"),
+                    3: (SecurityPage, "Document security"),
                     4: (FilesPage, "Dumped files"),
                     5: (LogPage, "pm3 client output"),
                 }[index]

--- a/tools/ePassport/epassport/emrtd/model.py
+++ b/tools/ePassport/epassport/emrtd/model.py
@@ -294,6 +294,38 @@ class PassportRecord:
             "EF_DG7": self.signature_png,
         }.get(name.upper(), b"")
 
+    def has_file(self, name: str) -> bool:
+        entry = self.file(name)
+        return entry is not None and entry.state == FileState.PRESENT
+
+    @property
+    def personal_files(self) -> list[str]:
+        """The files the PERSONAL tab drew from, in file order.
+
+        Naming them beats a fixed caption: plenty of documents carry no DG11,
+        and the personal number can arrive from the MRZ or from DG13 instead.
+        """
+        out = []
+        if self.personal_number_source == "MRZ":
+            out.append("EF_DG1")
+        if self.has_dg(11):
+            out.append("EF_DG11")
+        if self.personal_number_source == "DG13":
+            out.append("EF_DG13")
+        return out
+
+    @property
+    def document_files(self) -> list[str]:
+        """The files the ISSUER tab drew from."""
+        return ["EF_DG12"] if self.has_dg(12) else []
+
+    @property
+    def security_files(self) -> list[str]:
+        """The files the SECURITY tab drew from."""
+        return [
+            name for name in ("EF_SOD", "EF_DG14", "EF_DG15") if self.has_file(name)
+        ]
+
     def has_dg(self, number: int) -> bool:
         f = self.file(f"EF_DG{number}")
         return f is not None and f.state == FileState.PRESENT

--- a/tools/ePassport/epassport/ui/tabs/pages.py
+++ b/tools/ePassport/epassport/ui/tabs/pages.py
@@ -51,10 +51,15 @@ class DetailPage(TabPage):
 
 
 def _personal_number_label(record) -> str:
-    """Name the source when it is not DG11, so the row is not misread."""
+    """Name the source when it is not DG11, so the row is not misread.
+
+    Without the "from" it fits the caption column: dp(190) holds 167px of
+    "Personal number (DG13)" but not the 203px the longer wording needs, and
+    a caption that wraps drops the source onto a line of its own.
+    """
     source = record.personal_number_source
     if source in ("MRZ", "DG13"):
-        return f"Personal number (from {source})"
+        return f"Personal number ({source})"
     return "Personal number"
 
 

--- a/tools/ePassport/epassport/ui/tabs/pages.py
+++ b/tools/ePassport/epassport/ui/tabs/pages.py
@@ -50,6 +50,17 @@ class DetailPage(TabPage):
             box.add_widget(KeyValueRow(key=key, value=value, palette=self.palette))
 
 
+def _titled(base: str, record, files: list[str]) -> str:
+    """The tab header: what the tab shows, then the files it came from.
+
+    With nothing read there is no document to describe, so the header stays
+    the bare description rather than reporting an absence.
+    """
+    if record.is_empty:
+        return base
+    return f"{base}  ·  {', '.join(files)}" if files else f"{base}  ·  none present"
+
+
 def _personal_number_label(record) -> str:
     """Name the source when it is not DG11, so the row is not misread.
 
@@ -71,6 +82,9 @@ class PersonalPage(DetailPage):
         if record is None:
             self.set_rows([])
             return
+        self.title = _titled(
+            "Additional personal details", record, record.personal_files
+        )
         p = record.personal
         self.set_rows(
             [
@@ -114,6 +128,9 @@ class IssuerPage(DetailPage):
         if record is None:
             self.set_rows([])
             return
+        self.title = _titled(
+            "Additional document details", record, record.document_files
+        )
         d = record.document
         self.set_rows(
             [
@@ -192,6 +209,7 @@ class SecurityPage(TabPage):
             self.rows, self.hashes = [], []
             self.headline = "No document loaded."
             return
+        self.title = _titled("Document security", record, record.security_files)
         sod = record.sod
         if not sod.available:
             self.headline = sod.message or "EF_SOD could not be inspected."

--- a/tools/ePassport/tests/test_tab_sources.py
+++ b/tools/ePassport/tests/test_tab_sources.py
@@ -1,0 +1,74 @@
+"""Which files each detail tab actually drew from.
+
+The tab headers named their files as fixed text - "Additional personal
+details  ·  EF_DG11" - so a document without DG11 was told its details came
+from a file it does not carry, and the SECURITY header listed EF_DG15 whether
+or not it was there.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from epassport.emrtd import dg, tlv
+from epassport.emrtd.model import PassportRecord
+from epassport.emrtd.mrz import Checked, Mrz
+
+
+def _pesel_dg13(digits: str = "10030912345") -> bytes:
+    return tlv.encode(
+        0x6D, tlv.encode(0x5C, b"\x5f\x70") + tlv.encode(0x5F70, digits.encode())
+    )
+
+
+def _polish_record() -> PassportRecord:
+    """DG13 and no DG11, the shape that exposed this."""
+    record = PassportRecord()
+    blank = Checked("")
+    record.mrz = Mrz(
+        kind="TD3",
+        lines=[],
+        document_number=blank,
+        date_of_birth=blank,
+        date_of_expiry=blank,
+        composite=blank,
+        nationality="POL",
+        optional_data=Checked(""),
+    )
+    record.optional = dg.parse_dg13(_pesel_dg13())
+    return record
+
+
+def test_personal_names_dg11_when_the_document_carries_it(td3: Path) -> None:
+    assert "EF_DG11" in dg.load_dump(td3).personal_files
+
+
+def test_personal_names_dg13_when_that_is_where_the_number_came_from() -> None:
+    record = _polish_record()
+    assert record.personal_files == ["EF_DG13"]
+    assert "EF_DG11" not in record.personal_files
+
+
+def test_personal_names_nothing_when_nothing_fed_it(tmp_path: Path) -> None:
+    assert dg.load_dump(tmp_path).personal_files == []
+
+
+def test_document_follows_dg12(td3: Path, td1: Path) -> None:
+    assert dg.load_dump(td3).document_files == ["EF_DG12"]
+    assert dg.load_dump(td1).document_files == []
+
+
+def test_security_lists_only_the_files_that_are_there(td3: Path) -> None:
+    files = dg.load_dump(td3).security_files
+    assert "EF_SOD" in files
+    assert files == [f for f in ("EF_SOD", "EF_DG14", "EF_DG15") if f in files]
+
+
+def test_security_drops_a_missing_dg15(tmp_path: Path, td3: Path) -> None:
+    import shutil
+
+    for name in ("EF_SOD.bin", "EF_DG14.bin"):
+        shutil.copy(td3 / name, tmp_path / name)
+    files = dg.load_dump(tmp_path).security_files
+    assert "EF_DG15" not in files
+    assert "EF_DG14" in files


### PR DESCRIPTION
## Problem

The detail tabs named the files their data came from as fixed text, set once when the page was built:

```python
1: (PersonalPage, "Additional personal details  ·  EF_DG11"),
2: (IssuerPage,   "Additional document details  ·  EF_DG12"),
3: (SecurityPage, "Document security  ·  EF_SOD, EF_DG14, EF_DG15"),
```

A Polish passport ships EF_DG13 and no EF_DG11, so all three headers were wrong on the same document:

| Tab | Claimed | Actually present |
|---|---|---|
| PERSONAL | `EF_DG11` | absent — the details came from EF_DG13 |
| ISSUER | `EF_DG12` | absent |
| SECURITY | `EF_SOD, EF_DG14, EF_DG15` | no EF_DG15 |

The same document showed a second, smaller problem: `Personal number (from DG13)` renders 203px against a `dp(190)` caption column, so it wrapped and left `DG13)` on a line of its own.

## Change

`personal_files`, `document_files` and `security_files` report which files fed each tab, and the pages compose their header from them. They sit on the record rather than in the widgets so they can be tested without a display, which is how the rest of the suite is built.

Result:

| | Before | After |
|---|---|---|
| Polish PERSONAL | `· EF_DG11` | `· EF_DG13` |
| Polish ISSUER | `· EF_DG12` | `· none present` |
| Polish SECURITY | `· EF_SOD, EF_DG14, EF_DG15` | `· EF_SOD, EF_DG14` |
| US PERSONAL | `· EF_DG11` | `· EF_DG1, EF_DG11` |
| no document | `· EF_DG11` | `Additional personal details` |

And the caption drops its "from": `Personal number (DG13)` is 167px and fits, against 140px for the longest caption already in that tab.

Two decisions worth a reviewer's eye:

- **PERSONAL names `EF_DG1` when the number came from the MRZ**, that being the file which supplied it, rather than crediting DG11 for a value DG11 did not provide. This is why the US passport gains it.
- **With nothing read the header stays the bare description.** The record is an empty `PassportRecord` at startup rather than `None`, so an earlier cut announced an absence on a chip nobody had read. "none present" rather than "nothing on this chip", since the app opens offline dumps too.

## Behaviour change

Detail tab headers name the files the loaded document actually carries, instead of a fixed list. With no document loaded they show the description alone. The personal-number caption reads `Personal number (DG13)` rather than `Personal number (from DG13)`.

The data page is untouched: its caption is a different widget whose default label, `PERSONAL No. / No. PERSONNEL`, is longer than the `(FROM DG13)` variant, so that field already accommodates it.

## Testing

- `python3 -m pytest tests/` — 329 passed, 2 skipped (was 323 passed, 2 skipped); six new tests cover the source properties, including a document with DG13 and no DG11, and one with EF_DG14 but no EF_DG15.
- Checked on screen against a Polish document (DG13, no DG11/DG12), a US one (DG11 + DG12), and with no document loaded.
- `black --check` clean.

Not tested here: Windows/ProxSpace and macOS. Python only, no platform-specific calls.

## PR checklist

- [x] Proper style of own code, no unrelated reformatting included
- [ ] Builds warning-free with gcc — n/a, Python only
- [ ] `client/*` build files updated — n/a, no client sources changed
- [ ] ARM firmware builds clean — n/a, no firmware changes
- [x] Platform-sensitive code reasoned about — parsing and labels only
- [x] Existing comments in touched files preserved
- [ ] `doc/commands.md` / `doc/commands.json` regenerated — n/a
- [x] CHANGELOG entry added under `[unreleased]`
