### PR TITLE
lf t55xx: correctly report the psk2/psk3 ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `lf t55xx detect` - a psk3 tag read back as psk2 with a block 0 one bit out, and a freshly wiped psk2 tag was reported as psk3 on no evidence; the two are now reported as ambiguous where the waveform cannot separate them, and block 0 is narrowed using the subcarrier, the broadcast period and whether password mode is in use (@mfcarroll)
 - Added doc/md/PM5_Start_Here/Getting_Started_With_PM5.md now exists as a starting point for those who have their PM5 (@innocentbystanderproxmark)
 - Fixed `tools/ePassport` - the personal number read from the MRZ optional-data field showed a filler character where a space belonged, and a document number longer than nine characters left its overflow there (@pkilar)
 - Fixed `tools/ePassport` - the detail tabs named the files their data came from as fixed text, so a document without EF_DG11 was told otherwise, and the personal-number caption wrapped (@pkilar)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `lf t55xx detect` - dropped the psk3 candidates, which run the same demodulation as the psk2 one beside them and so can never match a psk3 tag, only fire on demodulation errors (@mfcarroll)
 - Fixed `lf t55xx detect` - a psk3 tag read back as psk2 with a block 0 one bit out, and a freshly wiped psk2 tag was reported as psk3 on no evidence; the two are now reported as ambiguous where the waveform cannot separate them, and block 0 is narrowed using the subcarrier, the broadcast period and whether password mode is in use (@mfcarroll)
 - Added doc/md/PM5_Start_Here/Getting_Started_With_PM5.md now exists as a starting point for those who have their PM5 (@innocentbystanderproxmark)
 - Fixed `tools/ePassport` - the personal number read from the MRZ optional-data field showed a filler character where a space belonged, and a document number longer than nine characters left its overflow there (@pkilar)

--- a/client/src/cmdlft55xx.c
+++ b/client/src/cmdlft55xx.c
@@ -1202,7 +1202,9 @@ static void t55xx_psk_coherent(int fitclk, uint8_t clk, t55xx_conf_block_t *test
 
     if (n >= 32) {
 
-        for (int variant = 0; variant < 4 && *hits == before; variant++) {
+        // three variants, not four: inverting does not move a stream's
+        // transitions, so a fourth barely differed from variant 2
+        for (int variant = 0; variant < 3 && *hits == before; variant++) {
 
             const bool inverted = ((variant & 1) != 0);
 
@@ -1217,7 +1219,7 @@ static void t55xx_psk_coherent(int fitclk, uint8_t clk, t55xx_conf_block_t *test
             setDemodBuff(work, n, 0);
             setClockGrid((uint32_t)(got_clk + 0.5), got_phase);
 
-            static const uint8_t modes[4] = { DEMOD_PSK1, DEMOD_PSK1, DEMOD_PSK2, DEMOD_PSK3 };
+            static const uint8_t modes[3] = { DEMOD_PSK1, DEMOD_PSK1, DEMOD_PSK2 };
 
             int bitRate = 0;
             if (test(modes[variant], &tests[*hits].offset, &bitRate, clk, &tests[*hits].Q5) == false) {
@@ -1776,20 +1778,13 @@ bool t55xxTryDetectModulationEx(uint8_t downlink_mode, bool print_config, uint32
                     ++hits;
                 }
             } // inverse waves does not affect this demod
-            // PSK3 - needs a call to psk1TOpsk2.
-            if (PSKDemod(0, 0, 6, false) == PM3_SUCCESS) {
-                psk1TOpsk2(g_DemodBuffer, g_DemodBufferLen);
-                if (test(DEMOD_PSK3, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
-                    tests[hits].modulation = DEMOD_PSK3;
-                    tests[hits].psk_carrier = t55xx_observed_psk_carrier();
-                    tests[hits].bitrate = bitRate;
-                    tests[hits].inverted = false;
-                    tests[hits].block0 = PackBits(tests[hits].offset, 32, g_DemodBuffer);
-                    tests[hits].ST = false;
-                    tests[hits].downlink_mode = downlink_mode;
-                    ++hits;
-                }
-            } // inverse waves does not affect this demod
+
+            // no psk3 candidate here on purpose: it would demodulate the same
+            // as psk2 and only differ in the test() constant, which wants two
+            // adjacent ones - and this demod recovers rising edges, which are
+            // never adjacent.  psk3 is reached by ruling psk2 out instead, see
+            // t55xx_psk3_resolve()
+
             //undo trim samples
             restore_bufferS32(saveState, g_GraphBuffer);
             g_GridOffset = saveState.offset;

--- a/client/src/cmdlft55xx.c
+++ b/client/src/cmdlft55xx.c
@@ -55,9 +55,12 @@
 
 #define T55XX_PSK3_MAX_CAND 32
 
-static size_t t55xx_psk3_block0_candidates(uint32_t observed, uint8_t clk, uint32_t *out, size_t max);
+static size_t t55xx_psk3_block0_candidates(uint32_t observed, uint8_t clk, uint8_t carrier, uint32_t *out, size_t max);
 static bool t55xx_config_psk3_ambiguous(void);
 static bool t55xx_psk3_probe(bool usepwd, uint32_t password, uint8_t downlink_mode);
+static uint8_t t55xx_measure_broadcast_blocks(bool usepwd, uint32_t password, uint8_t downlink_mode);
+static uint8_t t55xx_measure_broadcast_blocks_once(bool usepwd, uint32_t password, uint8_t downlink_mode);
+static size_t t55xx_psk3_resolve(uint8_t nblk, uint32_t *only);
 
 // Default configuration
 static t55xx_conf_block_t config = {
@@ -982,6 +985,9 @@ static int CmdT55xxDetect(const char *Cmd) {
 
     // detect called so clear data blocks
     T55x7_ClearAllBlockData();
+    config.broadcast_blocks = 0;
+    config.psk3_favoured = false;
+    config.pwd_known = false;
 
     // sanity check.
     if (SanityOfflineCheck(use_gb) != PM3_SUCCESS)
@@ -1014,7 +1020,7 @@ static int CmdT55xxDetect(const char *Cmd) {
                         if (AcquireData(T55x7_PAGE0, T55x7_CONFIGURATION_BLOCK, (try_with_pwd && usepwd), password, m) == false)
                             continue;
 
-                        if (t55xxTryDetectModulationEx(m, T55XX_PrintConfig, 0, (try_with_pwd && usepwd) ? password : -1) == false)
+                        if (t55xxTryDetectModulationEx(m, T55XX_DontPrintConfig, 0, (try_with_pwd && usepwd) ? password : -1) == false)
                             continue;
 
                         found = true;
@@ -1032,7 +1038,7 @@ static int CmdT55xxDetect(const char *Cmd) {
                     }
 
                     if (AcquireData(T55x7_PAGE0, T55x7_CONFIGURATION_BLOCK, usepwd, password, downlink_mode)) {
-                        found = t55xxTryDetectModulationEx(downlink_mode, T55XX_PrintConfig, 0, (usepwd) ? password : -1);
+                        found = t55xxTryDetectModulationEx(downlink_mode, T55XX_DontPrintConfig, 0, (usepwd) ? password : -1);
                     }
                 }
 
@@ -1049,24 +1055,65 @@ static int CmdT55xxDetect(const char *Cmd) {
             usewake = !usewake;
         } while (found == false && usewake);
     } else {
-        found = t55xxTryDetectModulation(downlink_mode, T55XX_PrintConfig);
+        found = t55xxTryDetectModulation(downlink_mode, T55XX_DontPrintConfig);
     }
 
+    // password mode gates direct access, so a live detect tells us which mode
+    // the tag is in.  set before the narrowing below, which uses it
+    config.pwd_known = (found && use_gb == false);
+
+    uint8_t nblk = 0;
+    bool psk2_out = false, favoured = false;
+
     // With a tag on the antenna the psk2 / psk3 ambiguity can be settled rather
-    // than merely reported: read a few data blocks and apply the adjacent ones
-    // invariant.  It needs the card, so it is skipped offline, where the single
-    // saved block 0 buffer cannot answer the question either way.
+    // than merely reported: measure the broadcast period, or read a few data
+    // blocks and apply the adjacent ones invariant.  It needs the card, so it
+    // is skipped offline, where the single saved block 0 buffer cannot answer
+    // the question either way.
     if (found && use_gb == false && t55xx_config_psk3_ambiguous()) {
 
-        if (t55xx_psk3_probe(config.usepwd, config.pwd, config.downlink_mode)) {
+        // the broadcast period constrains maxblock, which narrows block 0
+        nblk = t55xx_measure_broadcast_blocks(config.usepwd, config.pwd, config.downlink_mode);
+        config.broadcast_blocks = nblk;
+
+        // ruling psk2 out beats the probe's weighing, so try it first
+        uint32_t only = 0;
+        const size_t nleft = (nblk != 0) ? t55xx_psk3_resolve(nblk, &only) : 0;
+
+        if (nleft) {
+            psk2_out = true;
             config.modulation = DEMOD_PSK3;
-            PrintAndLogEx(SUCCESS, "Data blocks agree this is " _GREEN_("psk3") ", not psk2 - block 0 is one of the words listed above");
+
+            // one word left, so report it rather than the collapsed image
+            if (nleft == 1) {
+                config.block0 = only;
+            }
+
+        } else {
+            // the probe only leans, so it does not get to name the modulation
+            favoured = t55xx_psk3_probe(config.usepwd, config.pwd, config.downlink_mode);
+            config.psk3_favoured = favoured;
         }
 
         // put the configuration block back in the demod buffer, so anything
-        // reading it after us sees block 0 rather than the last probed block
+        // reading it after us sees block 0 rather than whatever we last read
         if (AcquireData(T55x7_PAGE0, T55x7_CONFIGURATION_BLOCK, config.usepwd, config.pwd, config.downlink_mode)) {
             DecodeT55xxBlock();
+        }
+    }
+
+    if (found) {
+
+        printConfiguration(config);
+
+        if (nblk) {
+            PrintAndLogEx(SUCCESS, "Broadcast repeats every " _GREEN_("%u") " block(s), so maxblock is a multiple of %u", nblk, nblk);
+        }
+
+        if (psk2_out) {
+            PrintAndLogEx(SUCCESS, "psk2 " _RED_("ruled out") " - the psk2 reading of block 0 carries a maxblock contradicted by the broadcast");
+        } else if (favoured) {
+            PrintAndLogEx(SUCCESS, "Data blocks favour " _GREEN_("psk3") " over psk2, but do not settle it");
         }
     }
 
@@ -1092,6 +1139,13 @@ static bool block0_repeats_at_stride(uint8_t offset) {
         return false;
     }
     return (PackBits(offset, 32, g_DemodBuffer) == PackBits((uint8_t)(offset + 32), 32, g_DemodBuffer));
+}
+
+// psk subcarrier in field clocks, or 0 when it could not be measured, so
+// callers can skip the constraint rather than filter on a bad reading
+static uint8_t t55xx_observed_psk_carrier(void) {
+    const int fc = GetPskCarrier(false);
+    return (fc == 2 || fc == 4 || fc == 8) ? (uint8_t)fc : 0;
 }
 
 static void t55xx_psk_coherent(int fitclk, uint8_t clk, t55xx_conf_block_t *tests, uint8_t *hits, uint8_t downlink_mode) {
@@ -1171,6 +1225,7 @@ static void t55xx_psk_coherent(int fitclk, uint8_t clk, t55xx_conf_block_t *test
             }
 
             tests[*hits].modulation = modes[variant];
+            tests[*hits].psk_carrier = t55xx_observed_psk_carrier();
             tests[*hits].bitrate = bitRate;
             tests[*hits].inverted = inverted;
             tests[*hits].block0 = PackBits(tests[*hits].offset, 32, g_DemodBuffer);
@@ -1357,6 +1412,7 @@ static bool t55xx_fallback_try(pm3_mod_t mod, pm3_enc_t enc, int fc_hi, int fc_l
             psk1TOpsk2(g_DemodBuffer, g_DemodBufferLen);
             if (test(DEMOD_PSK2, &tests[*hits].offset, &bitRate, clk, &tests[*hits].Q5)) {
                 tests[*hits].modulation = DEMOD_PSK2;
+                tests[*hits].psk_carrier = t55xx_observed_psk_carrier();
                 tests[*hits].bitrate = bitRate;
                 tests[*hits].inverted = false;
                 tests[*hits].block0 = PackBits(tests[*hits].offset, 32, g_DemodBuffer);
@@ -1574,7 +1630,7 @@ static void t55xx_detect_fallback(t55xx_conf_block_t *tests, uint8_t *hits, uint
 
 bool t55xxTryDetectModulationEx(uint8_t downlink_mode, bool print_config, uint32_t wanted_conf, uint64_t pwd) {
 
-    t55xx_conf_block_t tests[15];
+    t55xx_conf_block_t tests[15] = {0};
     int bitRate = 0, clk = 0, firstClockEdge = 0;
     uint8_t hits = 0, fc1 = 0, fc2 = 0, ans = 0;
 
@@ -1711,6 +1767,7 @@ bool t55xxTryDetectModulationEx(uint8_t downlink_mode, bool print_config, uint32
                 psk1TOpsk2(g_DemodBuffer, g_DemodBufferLen);
                 if (test(DEMOD_PSK2, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
                     tests[hits].modulation = DEMOD_PSK2;
+                    tests[hits].psk_carrier = t55xx_observed_psk_carrier();
                     tests[hits].bitrate = bitRate;
                     tests[hits].inverted = false;
                     tests[hits].block0 = PackBits(tests[hits].offset, 32, g_DemodBuffer);
@@ -1724,6 +1781,7 @@ bool t55xxTryDetectModulationEx(uint8_t downlink_mode, bool print_config, uint32
                 psk1TOpsk2(g_DemodBuffer, g_DemodBufferLen);
                 if (test(DEMOD_PSK3, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
                     tests[hits].modulation = DEMOD_PSK3;
+                    tests[hits].psk_carrier = t55xx_observed_psk_carrier();
                     tests[hits].bitrate = bitRate;
                     tests[hits].inverted = false;
                     tests[hits].block0 = PackBits(tests[hits].offset, 32, g_DemodBuffer);
@@ -1752,6 +1810,7 @@ bool t55xxTryDetectModulationEx(uint8_t downlink_mode, bool print_config, uint32
         config.block0 = tests[0].block0;
         config.Q5 = tests[0].Q5;
         config.ST = tests[0].ST;
+        config.psk_carrier = tests[0].psk_carrier;
         config.downlink_mode = downlink_mode;
         if (pwd != -1) {
             config.usepwd = true;
@@ -1784,6 +1843,7 @@ bool t55xxTryDetectModulationEx(uint8_t downlink_mode, bool print_config, uint32
                 config.block0 = tests[i].block0;
                 config.Q5 = tests[i].Q5;
                 config.ST = tests[i].ST;
+                config.psk_carrier = tests[i].psk_carrier;
                 config.downlink_mode = tests[i].downlink_mode;
 
                 if (pwd != -1) {
@@ -1866,24 +1926,53 @@ static bool t55xx_config_psk3_ambiguous(void) {
     const uint8_t clk = basic[config.bitrate & 0x07];
 
     uint32_t cand[T55XX_PSK3_MAX_CAND];
-    return (t55xx_psk3_block0_candidates(config.block0, clk, cand, ARRAYLEN(cand)) > 0);
+    return (t55xx_psk3_block0_candidates(config.block0, clk, config.psk_carrier, cand, ARRAYLEN(cand)) > 0);
 }
 
-#define T55XX_PSK3_PROBE_BLOCKS 7
 #define T55XX_PSK3_PROBE_TRIES  3
 #define T55XX_PSK3_PROBE_MIN    3
+
+typedef struct {
+    uint8_t page;
+    uint8_t blk;
+} t55xx_probe_block_t;
+
+// blocks the probe samples.  page 1 is writable so it is not trustworthy trace
+// data, just more blocks in which an adjacent pair can turn up
+static const t55xx_probe_block_t t55xx_psk3_probe_blocks[] = {
+    { T55x7_PAGE0, 1 }, { T55x7_PAGE0, 2 }, { T55x7_PAGE0, 3 }, { T55x7_PAGE0, 4 },
+    { T55x7_PAGE0, 5 }, { T55x7_PAGE0, 6 }, { T55x7_PAGE0, 7 },
+    { T55x7_PAGE1, T55x7_TRACE_BLOCK1 }, { T55x7_PAGE1, T55x7_TRACE_BLOCK2 },
+    { T55x7_PAGE1, 3 },
+};
+
+// evidence threshold as a probability scaled by 65536.  one percent
+#define T55XX_PSK3_PROBE_MAX_P  655
+
+// P(32 bit word with k one bits has no cyclically adjacent pair) * 65536,
+// (32 / (32 - k)) * C(32 - k, k) / C(32, k).  zero from k = 15, adjacency
+// forced.  zeroes score 1.0, so a wiped tag proves nothing
+static const uint32_t t55xx_p_no_adjacent[] = {
+    65536, 65536, 61308, 53274, 42646, 31138, 20493, 11980,
+    6110,  2657,   956,   273,    59,     9,     1,     0
+};
 
 static bool t55xx_psk3_probe(bool usepwd, uint32_t password, uint8_t downlink_mode) {
 
     size_t usable = 0, clean = 0;
+    uint64_t prob = 65536;
 
-    for (uint8_t b = 1; b <= T55XX_PSK3_PROBE_BLOCKS; b++) {
+    for (size_t i = 0; i < ARRAYLEN(t55xx_psk3_probe_blocks); i++) {
+
+        const uint8_t page = t55xx_psk3_probe_blocks[i].page;
+        const uint8_t blk = t55xx_psk3_probe_blocks[i].blk;
 
         bool got = false, ok = false;
+        uint32_t seen = 0;
 
         for (uint8_t t = 0; t < T55XX_PSK3_PROBE_TRIES; t++) {
 
-            if (AcquireData(T55x7_PAGE0, b, usepwd, password, downlink_mode) == false) {
+            if (AcquireData(page, blk, usepwd, password, downlink_mode) == false) {
                 continue;
             }
             if (DecodeT55xxBlock() == false) {
@@ -1896,6 +1985,7 @@ static bool t55xx_psk3_probe(bool usepwd, uint32_t password, uint8_t downlink_mo
             }
 
             got = true;
+            seen = val;
 
             if (t55xx_has_adjacent_ones(val) == false) {
                 ok = true;
@@ -1910,10 +2000,149 @@ static bool t55xx_psk3_probe(bool usepwd, uint32_t password, uint8_t downlink_mo
         usable++;
         if (ok) {
             clean++;
+
+            const uint32_t k = bitcount32(seen);
+            const uint32_t bp = (k < ARRAYLEN(t55xx_p_no_adjacent)) ? t55xx_p_no_adjacent[k] : 0;
+            prob = (prob * bp) / 65536;
         }
     }
 
-    return (usable >= T55XX_PSK3_PROBE_MIN && clean == usable);
+    // every readable block has to be clean - one adjacent pair disproves psk3 -
+    // and the one bits present have to make that a surprise, not a given
+    return (usable >= T55XX_PSK3_PROBE_MIN && clean == usable && prob <= T55XX_PSK3_PROBE_MAX_P);
+}
+
+// regular-read cycles blocks 1 to MAXBLK, so the stream repeats every
+// MAXBLK * 32 bits.  returns that block count, or 0 when it cannot be measured.
+// blocks holding the same word repeat sooner, so this is a divisor of MAXBLK
+// rather than MAXBLK itself.  needs two full periods, so 6 or 7 read as
+// unmeasurable
+static uint8_t t55xx_measure_broadcast_blocks_once(bool usepwd, uint32_t password, uint8_t downlink_mode) {
+
+    // the acquisition misses often enough to be worth a couple of retries
+    bool got = false;
+    for (uint8_t t = 0; t < T55XX_PSK3_PROBE_TRIES && got == false; t++) {
+        if (AcquireData(T55x7_PAGE0, REGULAR_READ_MODE_BLOCK, usepwd, password, downlink_mode) == false) {
+            continue;
+        }
+        if (DecodeT55xxBlock() == false) {
+            continue;
+        }
+        got = (g_DemodBufferLen >= 64);
+    }
+
+    if (got == false) {
+        return 0;
+    }
+
+    for (uint8_t n = 1; n <= 7; n++) {
+
+        const size_t stride = (size_t)n * 32;
+
+        // two full periods, or it is not a demonstrated repeat
+        if (g_DemodBufferLen < stride * 2) {
+            break;
+        }
+
+        const size_t cmp = g_DemodBufferLen - stride;
+        size_t bad = 0;
+        for (size_t i = 0; i < cmp; i++) {
+            if (g_DemodBuffer[i] != g_DemodBuffer[i + stride]) {
+                bad++;
+            }
+        }
+
+        // the stream carries the odd bit error, so this cannot want an exact
+        // repeat - but the allowance has to be absolute, not proportional: a
+        // real difference between blocks recurs every period, bit errors do not
+        if (bad <= 2) {
+            // a one block period rules nothing out, and also catches an
+            // acquisition that never left block 0.  report it as unmeasured
+            return (n > 1) ? n : 0;
+        }
+    }
+
+    return 0;
+}
+
+// believing a spurious period is expensive - it excludes psk2 and can name the
+// wrong word - so require two attempts to agree
+#define T55XX_PSK3_PERIOD_TRIES 4
+
+static uint8_t t55xx_measure_broadcast_blocks(bool usepwd, uint32_t password, uint8_t downlink_mode) {
+
+    uint8_t seen = 0;
+
+    for (uint8_t t = 0; t < T55XX_PSK3_PERIOD_TRIES; t++) {
+
+        const uint8_t n = t55xx_measure_broadcast_blocks_once(usepwd, password, downlink_mode);
+
+        // an attempt that could not measure at all says nothing either way
+        if (n == 0) {
+            continue;
+        }
+
+        if (seen == 0) {
+            seen = n;
+            continue;
+        }
+
+        if (seen == n) {
+            return n;
+        }
+
+        // measured twice and disagreed, nothing here says which is wrong
+        return 0;
+    }
+
+    return 0;
+}
+
+// the broadcast period constrains maxblock, and so every reading of block 0,
+// the psk2 one included.  returns 0 when psk2 still fits, otherwise how many
+// words block 0 could be, with *only set when that is exactly one
+static size_t t55xx_psk3_resolve(uint8_t nblk, uint32_t *only) {
+
+    static const uint8_t basic[] = {8, 16, 32, 40, 50, 64, 100, 128};
+
+    uint32_t cand[T55XX_PSK3_MAX_CAND];
+    size_t n = t55xx_psk3_block0_candidates(config.block0, basic[config.bitrate & 0x07],
+                                            config.psk_carrier, cand, ARRAYLEN(cand));
+    if (n == 0) {
+        return 0;
+    }
+
+    const uint8_t seen = (config.block0 >> 5) & 0x07;
+    const bool psk2_fits = (seen != 0) && ((seen % nblk) == 0);
+
+    size_t kept = 0;
+    for (size_t i = 0; i < n; i++) {
+        const uint8_t mb = (cand[i] >> 5) & 0x07;
+
+        // a measured period rules out ST, which would add four bit periods
+        if (((cand[i] >> 3) & 1) != 0) {
+            continue;
+        }
+
+        // and the password bit has to match the mode the detect succeeded in
+        if (config.pwd_known && ((((cand[i] >> 4) & 1) != 0) != config.usepwd)) {
+            continue;
+        }
+        if (mb != 0 && (mb % nblk) == 0) {
+            cand[kept++] = cand[i];
+        }
+    }
+
+    // nothing left means the measurement is what is wrong, not every reading
+    if (psk2_fits || kept == 0) {
+        return 0;
+    }
+
+    if (kept == 1) {
+        *only = cand[0];
+    }
+
+    return kept;
 }
 
 void printT55xxBlock(uint8_t blockNum, bool page1) {
@@ -2260,10 +2489,11 @@ int CmdT55xxSpecial(const char *Cmd) {
 // the bit rate the demodulation settled on?
 //
 // Only rules that are certainly true are applied - master key, the fixed zero
-// bits, the bit rate, modulation field 3 and a psk carrier that exists.  A
-// candidate list one entry too long is harmless; one that has dropped the real
-// word is not, so nothing merely probable is tested here.
-static bool t55xx_psk3_block0_plausible(uint32_t b, uint8_t clk) {
+// bits, the bit rate, modulation field 3, a psk carrier that exists and, where
+// it was measured, the one the tag is transmitting on.  A candidate list one
+// entry too long is harmless; one that has dropped the real word is not, so
+// nothing merely probable is tested here.
+static bool t55xx_psk3_block0_plausible(uint32_t b, uint8_t clk, uint8_t carrier) {
 
     const uint8_t master = (uint8_t)((b >> 28) & 0x0F);
     const bool xmode = (((b >> 17) & 1) != 0) && (master == 0x6 || master == 0x9);
@@ -2291,6 +2521,16 @@ static bool t55xx_psk3_block0_plausible(uint32_t b, uint8_t clk) {
         return false;
     }
 
+    // the subcarrier was measured off the same waveform, so a candidate naming
+    // a different one is not this tag's word.  0 = not measured
+    if (carrier != 0) {
+        // 4th entry is the reserved carrier 11, which matches no real subcarrier
+        static const uint8_t pskcf[] = {2, 4, 8, 0};
+        if (pskcf[(b >> 10) & 0x03] != carrier) {
+            return false;
+        }
+    }
+
     if (xmode) {
         return (EM4x05_GET_BITRATE((b >> 18) & 0x3F) == clk);
     }
@@ -2299,7 +2539,7 @@ static bool t55xx_psk3_block0_plausible(uint32_t b, uint8_t clk) {
     return (basic[(b >> 18) & 0x07] == clk);
 }
 
-static size_t t55xx_psk3_block0_candidates(uint32_t observed, uint8_t clk, uint32_t *out, size_t max) {
+static size_t t55xx_psk3_block0_candidates(uint32_t observed, uint8_t clk, uint8_t carrier, uint32_t *out, size_t max) {
 
     if (out == NULL || max == 0 || observed == 0) {
         return 0;
@@ -2337,7 +2577,7 @@ static size_t t55xx_psk3_block0_candidates(uint32_t observed, uint8_t clk, uint3
             }
         }
 
-        if (t55xx_psk3_block0_plausible(d, clk)) {
+        if (t55xx_psk3_block0_plausible(d, clk, carrier)) {
 
             bool dup = false;
             for (size_t i = 0; i < found; i++) {
@@ -2372,23 +2612,56 @@ static size_t t55xx_psk3_block0_candidates(uint32_t observed, uint8_t clk, uint3
 }
 
 int printConfiguration(t55xx_conf_block_t b) {
-    PrintAndLogEx(INFO, " Chip type......... " _GREEN_("%s"), (b.Q5) ? "Q5/T5555" : "T55x7");
-    PrintAndLogEx(INFO, " Modulation........ " _GREEN_("%s"), GetSelectedModulationStr(b.modulation));
-    PrintAndLogEx(INFO, " Bit rate.......... %s", GetBitRateStr(b.bitrate, (b.block0 & T55x7_X_MODE && (b.block0 >> 28 == 6 || b.block0 >> 28 == 9))));
-    PrintAndLogEx(INFO, " Inverted.......... %s", (b.inverted) ? _GREEN_("Yes") : "No");
-    PrintAndLogEx(INFO, " Offset............ %d", b.offset);
-    PrintAndLogEx(INFO, " Seq. terminator... %s", (b.ST) ? _GREEN_("Yes") : "No");
-    PrintAndLogEx(INFO, " Block0............ %08X %s", b.block0, GetConfigBlock0Source(b.block0Status));
 
-    if (b.modulation == DEMOD_PSK2 && b.Q5 == false) {
+    // psk3 changes phase on the rising edge, so the psk2 demod both share keeps
+    // only the leading bit of each run of ones.  a word with a legal psk3
+    // pre-image is consistent with either, so work that out before printing
+    uint32_t cand[T55XX_PSK3_MAX_CAND];
+    size_t ncand = 0;
+
+    if ((b.modulation == DEMOD_PSK2 || b.modulation == DEMOD_PSK3) && b.Q5 == false) {
 
         static const uint8_t basic[] = {8, 16, 32, 40, 50, 64, 100, 128};
         const uint8_t clk = basic[b.bitrate & 0x07];
 
-        uint32_t cand[T55XX_PSK3_MAX_CAND];
-        size_t n = t55xx_psk3_block0_candidates(b.block0, clk, cand, ARRAYLEN(cand));
+        ncand = t55xx_psk3_block0_candidates(b.block0, clk, b.psk_carrier, cand, ARRAYLEN(cand));
 
-        for (size_t i = 1; i < n; i++) {
+        // password mode gates the direct access block 0 was read with, so
+        // candidates disagreeing with the mode we got in are not this tag's
+        if (b.pwd_known) {
+            size_t kept = 0;
+            for (size_t i = 0; i < ncand; i++) {
+                if ((((cand[i] >> 4) & 1) != 0) == b.usepwd) {
+                    cand[kept++] = cand[i];
+                }
+            }
+            if (kept) {
+                ncand = kept;
+            }
+        }
+
+        // drop candidates whose maxblock could not have produced the measured
+        // period.  none left means the measurement is wrong, so keep the lot
+        if (b.broadcast_blocks) {
+            size_t kept = 0;
+            for (size_t i = 0; i < ncand; i++) {
+                const uint8_t mb = (cand[i] >> 5) & 0x07;
+                // ST adds four bit periods per cycle, so a whole number of 32
+                // bit blocks rules it out.  leans on the measurement, not on
+                // config.ST, which the psk paths hardcode rather than detect
+                if (((cand[i] >> 3) & 1) != 0) {
+                    continue;
+                }
+                if (mb != 0 && (mb % b.broadcast_blocks) == 0) {
+                    cand[kept++] = cand[i];
+                }
+            }
+            if (kept) {
+                ncand = kept;
+            }
+        }
+
+        for (size_t i = 1; i < ncand; i++) {
             uint32_t v = cand[i];
             size_t j = i;
             while (j > 0 && cand[j - 1] > v) {
@@ -2397,13 +2670,45 @@ int printConfiguration(t55xx_conf_block_t b) {
             }
             cand[j] = v;
         }
+    }
 
-        if (n > 0) {
-            PrintAndLogEx(INFO, " psk3 ambiguity.... this read is also consistent with a " _YELLOW_("psk3") " tag holding");
-            for (size_t i = 0; i < n; i++) {
-                PrintAndLogEx(INFO, "                    %08X", cand[i]);
-            }
+    PrintAndLogEx(INFO, " Chip type......... " _GREEN_("%s"), (b.Q5) ? "Q5/T5555" : "T55x7");
+
+    if (ncand > 0 && b.modulation == DEMOD_PSK2) {
+        // the probe weighs modulation, not any one word
+        PrintAndLogEx(INFO, " Modulation........ " _YELLOW_("PSK2 or PSK3") " ( ambiguous%s )",
+                      (b.psk3_favoured) ? ", psk3 favoured" : "");
+    } else {
+        PrintAndLogEx(INFO, " Modulation........ " _GREEN_("%s"), GetSelectedModulationStr(b.modulation));
+    }
+
+    PrintAndLogEx(INFO, " Bit rate.......... %s", GetBitRateStr(b.bitrate, (b.block0 & T55x7_X_MODE && (b.block0 >> 28 == 6 || b.block0 >> 28 == 9))));
+    PrintAndLogEx(INFO, " Inverted.......... %s", (b.inverted) ? _GREEN_("Yes") : "No");
+    PrintAndLogEx(INFO, " Offset............ %d", b.offset);
+    PrintAndLogEx(INFO, " Seq. terminator... %s", (b.ST) ? _GREEN_("Yes") : "No");
+    // list the words block 0 could be.  where psk3 is settled the demodulated
+    // value is the collapsed image, which the tag cannot hold, so it is left out
+    if (ncand > 0 && b.modulation == DEMOD_PSK2) {
+
+        // both readings live: demodulated word under psk2, candidates under psk3
+        PrintAndLogEx(INFO, " Block0............ " _YELLOW_("ambiguous, one of:"));
+        PrintAndLogEx(INFO, "                    %08X " _YELLOW_("( psk2 )"), b.block0);
+
+        for (size_t i = 0; i < ncand; i++) {
+            PrintAndLogEx(INFO, "                    %08X " _YELLOW_("( psk3 )"), cand[i]);
         }
+
+    } else if (ncand > 0) {
+
+        // psk3 settled, more than one word still fits it
+        PrintAndLogEx(INFO, " Block0............ " _YELLOW_("ambiguous, one of:"));
+
+        for (size_t i = 0; i < ncand; i++) {
+            PrintAndLogEx(INFO, "                    %08X", cand[i]);
+        }
+
+    } else {
+        PrintAndLogEx(INFO, " Block0............ %08X %s", b.block0, GetConfigBlock0Source(b.block0Status));
     }
 
     PrintAndLogEx(INFO, " Downlink mode..... %s", GetDownlinkModeStr(b.downlink_mode));

--- a/client/src/cmdlft55xx.h
+++ b/client/src/cmdlft55xx.h
@@ -158,6 +158,10 @@ typedef struct {
     } bitrate;
     bool Q5;
     bool ST;
+    uint8_t psk_carrier;    // observed psk subcarrier in field clocks, 2/4/8. 0 = not measured
+    uint8_t broadcast_blocks; // measured blocks per regular-read cycle. 0 = not measured
+    bool psk3_favoured;      // data blocks lean psk3, but do not settle it
+    bool pwd_known;         // usepwd below reflects a live detect, not a default
     bool usepwd;
     uint32_t pwd;
     enum {


### PR DESCRIPTION
Two commits. The first fixes what detect claims about psk2/psk3 and narrows block 0 using observable properties of the tag. The second removes the psk3 candidates from detect, which can only ever misfire. They are independent.

## Problem

Per the ATA5577C table psk3 is *"phase change on rising edge of input"*. The client demodulates psk2 and psk3 with the same `PSKDemod()` + `psk1TOpsk2()` pair, and `psk1TOpsk2()` marks every phase transition — which against a psk3 waveform *are* the rising edges. So what comes back is the rising-edge image of the tag's word: **every run of 1's collapses to its leading 1.**

The psk3 modulation field is `0b00011`, and collapsing that `11` to `10` gives `0b00010`, psk2. A psk3 tag therefore _always_ presents as psk2, one bit out:

```
lf t55xx write -b 0 -d 00083040
lf t55xx detect
  Modulation........ PSK2
  Block0............ 00082040 (auto detect)     # written 00083040, xor = bit 12
```

`t55xx_psk3_block0_candidates()` already enumerates the psk3 words a read is consistent with. Two things around it overstated the result:

1. **The modulation line named psk2 as fact** whenever that candidate set was non-empty — exactly when detect structurally cannot tell the two apart from the waveform alone. And `printConfiguration()` ran before the probe, so a tag the probe went on to resolve was printed as psk2 and contradicted three lines later.

2. **`t55xx_psk3_probe()` concluded psk3 from vacuous evidence.** It accepted when no readable data block held cyclically adjacent ones — but a block of zeroes satisfies that for free and reads back identically either way. A freshly wiped, genuinely psk2 tag was reported as psk3. Reproduced on hardware and on 2 of the 21 psk2 configs in a full sweep.

## Change

All in `client/src/cmdlft55xx.c` plus one struct field. No demodulation code is touched.

- **Weight the probe's evidence.** A clean block argues for psk3 only in proportion to the one bits it carries. Using P(a 32-bit word with k ones has no cyclically adjacent pair) = `(32/(32-k))·C(32-k,k)/C(32,k)`, require the product across probed blocks below 1%. A zero block scores 1.0 and contributes nothing.
- **Sample page 1 as well as page 0.** Three more blocks an adjacent pair of 1's can turn up in, providing additional opportunities to disprove psk3.
- **Apply the subcarrier already being measured.** The filter checked bit rate against the observed clock but only rejected the reserved value for the PSK carrier field, so candidates survived despite naming a subcarrier the tag demonstrably is not using. `GetPskCarrier()` already exists and `try_detect_modulation()` already calls it. Takes the list from 8 to 4 on the test tag.
- **Narrow by the broadcast period.** Regular-read cycles blocks 1..MAXBLK, so the stream repeats every MAXBLK x 32 bits — and MAXBLK lives in block 0. That constrains *every* reading of block 0, the psk2 one included, so where the psk2 reading's MAXBLK cannot produce the measured period, psk2 is **excluded outright** rather than weighed.
- **Rule out the sequence terminator where the period allows it.** ST inserts four bit periods at the start of each regular-read cycle, so a tag with it set cannot produce a period that is a whole number of 32-bit blocks. Having measured one at all therefore excludes ST, and candidates carrying that bit are dropped. Note: this leans on the measurement, not on `config.ST`, which the psk paths hardcode to `false` rather than detect — pruning on that would only confirm an assumption.
- **Rule out the password bit.** Password mode gates direct access, and direct access is how detect reads block 0 — so a detect that got there without a password says the tag is not in password mode, and one that needed a password says it is. Candidates disagreeing with whichever succeeded are dropped. Verified on hardware in both directions: with PWD set, a passwordless detect fails outright rather than returning something wrong, so the inference does not inherit the misfire risk the other heuristics carry. This one costs nothing, being a property of the detect that already happened.
- **Report the answer, not the working.** `Block0` with `(auto detect)` is already an inference from observed properties; once further properties rule that inference out it should stop being presented as the config word. `Block0` now reports the words it could be: one value with `(auto detect)` where the evidence pins it, otherwise `ambiguous, one of:` and an indented list, tagged `( psk2 )` / `( psk3 )` where the possibilities disagree about the modulation. Once psk3 is settled, the demodulated value is not printed at all — it is the collapsed image the candidates were derived from, which the tag cannot be holding, so it is working rather than result. This also retires the separate `psk3 ambiguity....` line, which existed only to carry what the `Block0` field now says itself. Detect prints once, after the card-side narrowing, so the list is final when it appears.
- **The probe no longer names the modulation.** It weighs rather than rules out, so it reports a leaning and leaves the reading ambiguous; only the broadcast exclusion sets psk3. Previously a heuristic could assert `PSK3` while `Block0` still showed the psk2 reading — two claims that cannot both be true.

## Behaviour change

- A psk2-classified tag with a legal psk3 pre-image prints `PSK2 or PSK3 ( ambiguous )`. Words containing adjacent ones have no pre-image and are unaffected, so this appears only where the ambiguity is real.
- `Block0` can now print several values, or a word that was never demodulated directly — the one the evidence pins the tag to. Where psk3 is settled but not pinned it still holds the collapsed image, which is not a claim about the config word but the observation the candidate list is derived from: printConfiguration() recomputes that list from it on every call, so a later lf t55xx config needs it. Nothing outside this file reads the field.
- The probe declines on empty or very sparse data blocks where it previously answered psk3, and no longer sets `config.modulation` at all.
- Detect prints its config block once, after narrowing. Consequence: where detection finds several candidate modulations it still reports the count and which was selected, but no longer prints a table per candidate. That path did not occur once in ~350 detects across the sweeps.
- Extra card reads on tags where the ambiguity path runs: the period measurement retries up to four times, and the probe reads up to nine blocks with up to three tries each. The subcarrier and password constraints cost nothing, both being properties of work already done. The path runs only when detect landed on psk2 *and* a psk3 pre-image exists, so nothing else pays.

## Second commit: dropping the psk3 candidates from detect

Both psk3 entries — one in `t55xxTryDetectModulationEx()`, one as the fourth variant in `t55xx_psk_coherent()` — run the same demodulation as the psk2 entry beside them and differ only in the constant handed to `test()`. `test()` accepts a word only when that word's own modulation field matches the constant, so the psk3 entry needs a recovered word whose field reads 3.

Field 3 is `00011`, so it needs two adjacent set bits. What this demodulation recovers is the data's rising edges, and a rising edge needs a 0 before the 1, so no two of them are ever adjacent. The words it produces can never carry field 3, and so the psk3 entries can never match the case they were written for.

What they can do is match on a demodulation error, and then name psk3 plus a block 0 the tag does not hold. The coherent variant also inverted before `psk1TOpsk2()`, and inverting a stream does not move its transitions, so it barely differed from the psk2 variant before it.

**The cost, honestly:** a tag that only these branches matched now comes out as psk2, or as undetected where no offset yields a plausible psk2 word. The narrowing in the first commit cannot rescue that — it engages only once detect has already landed on psk2. Four runs of `00082840`, the recurring misfire, gave psk2 three times and nothing once.

## Limitations

- **psk3 is not uniquely decodable.** Verified on hardware: with a psk3 config, writing `00000003` and `00000002` to block 1 both read back as the same word. So "implement psk3 demodulation properly" is not available as a fix.
- **The adjacent-ones probe can only disprove psk3, never confirm it.** Finding an adjacent pair is proof the tag is not psk3; not finding one is weak evidence, always — hence a threshold rather than a verdict. The broadcast test is the other way round, which is why it is tried first and short-circuits the probe.
- **It stays a heuristic where it is used.** A psk2 tag whose blocks hold `AAAAAAAA` still reads as favouring psk3, because such a tag genuinely is indistinguishable from a psk3 tag holding a pre-image of it.
- **ST is not detected on the psk path, and this does not fix that.** The psk paths set `config.ST = false` unconditionally, so `Seq. terminator... No` is an unimplemented default presented as an observation — on a tag written with ST set it is simply wrong. Detecting it properly is not a small job: measured on device, a psk3 tag with ST enabled has no periodic structure in its demodulated stream at any stride from 32 to 250 bits, against a 0.7%-vs-25% margin on the same tag with ST off. ST switches modulation off for two of its four bit periods, which for psk is a subcarrier dropout that destroys the phase reference rather than merely displacing the data — which is presumably what the datasheet means by ST being "not suitable" for psk. Worth its own issue rather than this PR.
- **Block 0 is not always pinned.** Where the broadcast period does not measure, or measures a divisor that rules nothing out, the list stays as several words. Nothing here writes to the tag to resolve that, and the constraints that do apply are only as good as the measurements behind them.

## Testing

Generic Proxmark3, `PLATFORM=PM3GENERIC`, T5577, macOS/clang. Firmware rebuilt and flashed from this tree; the branch touches no `armsrc` code, so the device runs what is behaviourally master's firmware for both sides of the comparison.

Every bit-rate and subcarrier config word for ten modulations — 119 words — swept on device against the stock client and the patched one: wipe, write four data blocks, write the config, detect, read the blocks back.

**The metric changed with the output.** Detect no longer always prints a single `Block0` value, so "block 0 read back equals what was written" no longer applies directly. The comparable question is whether the written word is **among the words detect says block 0 could be** — which is what stock's `psk3 ambiguity` list was already claiming, so it scores both sides on the same basis.

| modulation | stock | patched |
|---|---|---|
| ASK | 8/8 | 7/8 |
| Biphase | 7/8 | 7/8 |
| DIRECT/NRZ | 7/8 | 7/8 |
| FSK1 | 5/8 | 5/8 |
| FSK2 | 6/8 | 6/8 |
| FSK1a | 6/8 | 6/8 |
| FSK2a | 6/8 | 6/8 |
| PSK1 | 16/21 | 17/21 |
| PSK2 | 16/21 | 15/21 |
| PSK3 | 6/21 | 5/21 |

Every difference is ±1. A previously measured noise floor on this bench — the same sweep run twice against an unchanged binary — was 7 differing configs in 111, so these are inside it. Rows failing on both sides are the RF/8 bit rate, which fails
for every modulation here.

**What the patch is for.** Configs where detect claimed psk3 on the strength of the data-block probe:

| true modulation | stock | patched |
|---|---|---|
| PSK2 · 21 configs | 3 | **0** |
| PSK3 · 21 configs | 5 | 3 |

The psk2 row is the false-positive fault. The psk3 row falling is the intended conservatism — those configs are swept with mostly-zero data blocks, exactly the case with no evidence. A later repeat of the psk sweep showed 1 rather than 0 in the psk2 row, on `00142040`, a config whose block 0 read is corrupt in that run; repeating it four times on a settled tag gives a correct read and no verdict every time.

Configs where detect *named* psk3 outright, which the second commit removes:

| | stock | patched |
|---|---|---|
| configs detect names psk3 | `00041040`, `00082840` | **none** |

Worth noting `00041040` is a **psk1** config. The misfire was never confined to the psk2/psk3 pair.

**And what the narrowing is worth.** Measured with the tag held fixed and only the build varied, since a sweep average is dominated by how often the period measurement fires rather than by the constraints themselves. Tag holding `00083060`:

| after | words offered for block 0 |
|---|---|
| stock | 8 |
| subcarrier constraint | 4 |
| broadcast period | 3 |
| sequence terminator | 2 |
| password bit | **1** |

That last one is the true word. The two the terminator left, `00083060` and `00083070`, differ only in the password bit, and the detect that read block 0 did so without a password — which under password mode it could not have. Across the psk sweep 3 of the 10 detected psk3 configs come down to a single word this way.

The period measurement is the least dependable part, and every failure mode is a refusal to narrow rather than a wrong narrowing: it needs the acquisition to succeed (hence retries), it returns a divisor of MAXBLK where neighbouring blocks hold the same word, two full periods must fit in the demodulated stream so MAXBLK 6 or 7 is out of reach, and a one-block period is reported as unmeasured because it rules nothing out. It is believed only once two attempts agree, up to four attempts. On the test tag it measured on 9 of 10 consecutive detects; the tenth simply did not narrow. So the same tag can give slightly different output between runs, always in the direction of claiming less.

`make client/check` green. `cmdlft55xx.c` compiles clean under Apple clang and Homebrew gcc 16 with the project's `-Werror` set. `astyle` with the repo's flags is a no-op on the diff.

**Not tested:** Linux, Windows/ProxSpace, the CMake client and `experimental_lib` builds, a full client link under gcc. The change adds no files, symbols or build inputs, so the three client build systems have nothing to keep in sync.

**Note on the in-tree LF suite:** `client/luascripts/tests/lf_t55xx_*.lua` and `client/lualibs/t55xx_config.lua` call `core.console(cmd, true, true)` expecting the output back as a string, but `l_CmdConsole()` in `client/src/scripting.c` takes only the command and returns no values, so they abort immediately. Looks like a gap left by 2dbd4836c, unrelated to this PR, but it is why the sweeps were driven externally.

## Checklist

- [x] Proper style of own code, no unrelated reformatting
- [x] Builds warning-free with clang; **not** linked with gcc here
- [x] No client build-file changes needed (no files or deps added)
- [x] No `armsrc`/`bootrom`/`common_arm` changes
- [ ] Platform-sensitive code — n/a, no serial/filesystem/OS-conditional code touched
- [x] Existing comments preserved
- [x] No command definitions changed, `doc/commands.*` unaffected

Claude was used extensively in researching this issue, and drafting of the code and PR. Everything has been human reviewed and edited.