### PR TITLE
fix PM5 lock-up after hf search: restart TMR5 before low-batt I2C poll

### DIFF
--- a/armsrc/bwm_charger.c
+++ b/armsrc/bwm_charger.c
@@ -478,6 +478,14 @@ void bwm_lowbatt_check(void) {
     }
     last_tick = GetTickCount();
 
+    // The I2C bit-bang uses WaitUS()/WaitTicks(), which busy-waits on the TMR5
+    // free-running counter. A command handler run just before this poll (e.g. the
+    // LEGIC probe in `hf search`) can leave TMR5 stopped via StopTicks(); WaitTicks()
+    // would then loop forever and the device would appear to lock up (WDT_HIT() is a
+    // no-op on AT32). Restart the counter first, exactly as RgbLedSet() does before
+    // its own idle-loop I2C access.
+    StartTicks();
+
     uint8_t sysstat = 0;
     if (I2C_BufferReadRaw(&sysstat, 1, BWM_CHG_REG_SYSSTAT, BWM_CHG_ADDR) <= 0) {
         return;   // no BWM / I2C error - stay quiet


### PR DESCRIPTION
On PM5 the device locks up and needs a manual power-cycle within ~30 s of `hf search`, or of any command whose handler ends in StopTicks() (the LEGIC probe in hf search is one). The idle-loop low-battery poll bwm_lowbatt_check() reads the BWM charger/gauge over the bit-banged I2C, which busy-waits on the TMR5 free-running counter via WaitUS()/WaitTicks(). If the preceding command left TMR5 stopped, WaitTicks() spins in `while (GetTicks() < ticks)` forever, and WDT_HIT() is a no-op on AT32 so nothing recovers it.

This is reachable by default since the PM5 low-batt beep/shutdown was enabled (d35ddce2). The earlier idle-loop I2C user, the power LED, was fine because RgbLedSet() calls StartTicks() first. This does the same at the top of the poll.

Tested on PM5 hardware: hf search no longer hangs.

Companion to #3582; both touch bwm_lowbatt_check() so whichever lands second needs a trivial rebase. They are otherwise independent.