### PR TITLE
armsrc: resync BWM link baud after an AT32-only reset

### DIFF
--- a/armsrc/bwm_forward.c
+++ b/armsrc/bwm_forward.c
@@ -334,11 +334,15 @@ uint32_t bwm_read_ng(uint8_t *data, size_t len) {
 // send the request at the current baud, wait for that ack, then switch our own
 // UART4 to match. On timeout (old ESP without the command, or a lost ack) we
 // leave the link at the boot baud - it keeps working, just slower.
+//
+// The ESP keeps its baud across an AT32-only reset (bootloader, hw reset,
+// flash), so probe both rates first and adopt the one it answers at.
 // ---------------------------------------------------------------------------
 #define BWM_BAUD_ACK_WAIT_MS   300   // per-attempt wait for the ESP ack
 #define BWM_BAUD_ATTEMPTS      3     // resend attempts before giving up
 #define BWM_BAUD_VERIFY_MS     150   // per-probe wait for the GET_BAUD reply
 #define BWM_BAUD_VERIFY_TRIES  5     // GET_BAUD probes before declaring the switch failed
+#define BWM_BAUD_PROBE_ROUNDS  4     // boot/target probe pairs
 
 // Probe the ESP at the CURRENT baud with GET_UART_BAUD; true only if it answers,
 // i.e. it really is running at the baud we just switched to. Retried by the
@@ -370,8 +374,48 @@ static bool bwm_verify_baud(void) {
     return false;
 }
 
+// Switch to `baud` and probe up to `tries` times.
+static bool bwm_probe_at(uint32_t baud, int tries) {
+    bwm_uart_set_baud(baud);
+    SpinDelay(2);
+    for (int v = 0; v < tries; v++) {
+        if (bwm_verify_baud()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Reset framer, FIFO and flow control after a baud change.
+static void bwm_link_reset(void) {
+    s_p.state      = S_IDLE;
+    s_fifo_head    = 0;
+    s_fifo_tail    = 0;
+    s_fwd_inflight = 0;
+}
+
 bool bwm_fwd_negotiate_baud(uint32_t target) {
     if (target == 0 || target == bwm_uart_get_baud()) {
+        return false;
+    }
+    const uint32_t boot_baud = bwm_uart_get_baud();
+
+    // Locate the ESP: alternate so a cold-booted one (boot baud) and one that
+    // survived our reset (target baud) are both found.
+    bool at_boot = false, at_target = false;
+    for (int r = 0; r < BWM_BAUD_PROBE_ROUNDS && !at_boot && !at_target; r++) {
+        at_boot = bwm_probe_at(boot_baud, 1);
+        if (!at_boot) {
+            at_target = bwm_probe_at(target, 1);
+        }
+    }
+    if (at_target) {
+        bwm_link_reset();          // already at target
+        return true;
+    }
+    if (!at_boot) {
+        bwm_uart_set_baud(boot_baud);   // no ESP: stay at boot baud
+        bwm_link_reset();
         return false;
     }
 
@@ -400,43 +444,18 @@ bool bwm_fwd_negotiate_baud(uint32_t target) {
         for (int ms = 0; ms < BWM_BAUD_ACK_WAIT_MS; ms++) {
             bwm_pump();              // parser sets s_baud_ack on the SLAVE_RESP
             if (s_baud_ack) {
-                // ESP acked at the old baud and is committing to the new one.
-                // Switch our side and let it settle.
-                bwm_uart_set_baud(target);
-                SpinDelay(5);
-
-                // VERIFY the ESP is really at the new baud before trusting it. A
-                // lost or spurious ack must not leave the two ends at different
-                // bauds - that silently breaks every AT32<->ESP exchange (forward
-                // traffic, hw bwmwifi, ...). Retry so one dropped probe on a good
-                // link does not cause a needless fallback.
-                bool verified = false;
-                for (int v = 0; v < BWM_BAUD_VERIFY_TRIES; v++) {
-                    if (bwm_verify_baud()) {
-                        verified = true;
-                        break;
-                    }
+                // ESP acked and is switching; verify it before trusting the
+                // new baud, else fall back so both ends stay in sync.
+                bool verified = bwm_probe_at(target, BWM_BAUD_VERIFY_TRIES);
+                if (verified == false) {
+                    bwm_uart_set_baud(boot_baud);
                 }
-
-                s_p.state      = S_IDLE;   // fresh framer either way
-                s_fifo_head    = 0;
-                s_fifo_tail    = 0;
-                s_fwd_inflight = 0;
-
-                if (verified) {
-                    return true;
-                }
-
-                // Could not confirm the ESP at the new baud: fall back so the
-                // ends stay in sync. 460800 is the always-safe boot default.
-                bwm_uart_set_baud(BWM_UART_BAUD);
-                s_p.state    = S_IDLE;
-                s_fifo_head  = 0;
-                s_fifo_tail  = 0;
-                return false;
+                bwm_link_reset();
+                return verified;
             }
             SpinDelay(1);
         }
     }
+    bwm_link_reset();
     return false;   // no ack: stay at the boot baud, link still usable
 }

--- a/armsrc/bwm_forward.h
+++ b/armsrc/bwm_forward.h
@@ -92,10 +92,11 @@ uint32_t bwm_read_ng(uint8_t *data, size_t len);
 // >0 when raw bytes are waiting on the FPC USART (gate for receive_ng()).
 uint16_t bwm_fwd_rxdata_available(void);
 
-// Negotiate the ESP<->AT32 UART up to `target` baud (app_com cmd 1011), then
-// re-init UART4 to match. Returns true if the ESP acked and the link switched;
-// false (link left at the boot baud) on timeout or an unsupported rate. Must be
-// called once after bwm_uart_init(), before normal forward traffic starts.
+// Bring the ESP<->AT32 UART to `target` baud: adopt it if the ESP is already
+// there (its baud survives an AT32-only reset), else negotiate up via app_com
+// cmd 1011 and re-init UART4 to match. Returns true if the link runs at
+// `target`; false (left at the boot baud) if no ESP answered or the switch
+// could not be verified. Call once after bwm_uart_init().
 bool bwm_fwd_negotiate_baud(uint32_t target);
 
 #endif // __BWM_FORWARD_H


### PR DESCRIPTION
## Problem

On a PM5 with the BWM, the AT32<->ESP UART link stops working after any reset that restarts only the AT32: a bootloader round trip (`--flash`, `hw bootloader`), a firmware flash, or `hw reset`. `hw status` then reports `BWM link baud 460800` and every BWM command fails (`hw bwmwifi --status` -> "could not query BWM WiFi status"), while the ESP itself keeps running and its WiFi/TCP stays reachable. It only recovers once the BWM loses power (unplug USB, wake on battery).

Cause: the boot negotiation moves the ESP from 460800 to 921600, but that setting is runtime-only on the ESP and it is not reset when the AT32 restarts. The AT32 comes back at 460800, its set-baud request is garbage to an ESP listening at 921600, no ack arrives, and the AT32 stays at 460800 with the two ends mismatched.

## Change

`armsrc/bwm_forward.c`: `bwm_fwd_negotiate_baud()` now locates the ESP first by sending `GET_UART_BAUD` alternately at the boot baud and the target baud (4 rounds, 150 ms each). If the ESP answers at the target it is adopted as is; if it answers at the boot baud the existing set-baud handshake runs unchanged; if nothing answers the link stays at the boot baud as before. The verify/fallback tail of the handshake is factored into two small helpers (`bwm_probe_at`, `bwm_link_reset`) so the new path and the old one share it. No ESP firmware change needed.

`armsrc/bwm_forward.h`: doc comment updated.

## Behaviour change

- After an AT32-only reset the link comes back at 921600 instead of silently dropping to a mismatched 460800.
- Boot time with no BWM attached grows from ~0.9 s (3 x 300 ms set attempts) to ~1.2 s (4 x 2 x 150 ms probes). With a BWM present the first probe answers within a few ms.

## Testing

- `make fullimage` with `PLATFORM=PM5 PLATFORM_EXTRAS=BWM` and with `PLATFORM=PM3RDV4`: both warning-free (gcc). No client code touched, so clang/CMake/experimental_lib were not exercised.
- On hardware (PM5 + BWM, WiFi forward configured): reproduced the failure on current master, then with this change did a flash plus four bootloader round trips; `hw status` showed 921600 and `hw bwmwifi --status` answered after each. A cold power-up (ESP back at 460800) was also checked and negotiates up as before.
- Not tested: a BWM running firmware without the baud commands (falls into the "nothing answers" branch, same outcome as today).

## Checklist

- [x] Proper style of own code, no unrelated reformatting included
- [x] Builds warning-free with gcc; clang not applicable (firmware only)
- [x] Client build files unchanged (no client sources touched)
- [x] ARM firmware builds clean for RDV4 and PM5 platform configs
- [x] Platform-sensitive host code: none touched
- [x] Existing comments in touched files preserved (two verbose blocks in the rewritten handshake tail were condensed)
- [x] No command changes, `doc/commands.*` untouched
