### PR TITLE
QC tester behavior

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -3839,13 +3839,13 @@ static void PacketReceived(PacketCommandNG *packet) {
             break;
         }
 #ifdef PM5
-        case CMD_PM5_QC_TEST: {
+        case CMD_PM5_QC_TEST_HW: {
             uint8_t failed_item = 0;
             uint32_t timeout_ms = 0;
             if (packet->length >= sizeof(timeout_ms)) {
                 memcpy(&timeout_ms, packet->data.asBytes, sizeof(timeout_ms));
             }
-            reply_ng(CMD_PM5_QC_TEST, QCTestPM5(&failed_item, timeout_ms) ? PM3_SUCCESS : PM3_EFAILED, &failed_item, 1);
+            reply_ng(CMD_PM5_QC_TEST_HW, QCTestPM5(&failed_item, timeout_ms) ? PM3_SUCCESS : PM3_EFAILED, &failed_item, 1);
             break;
         }
         case CMD_PM5_RGB_SET: {

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1131,7 +1131,7 @@ static bool QCTestPM5(uint8_t *failed_item, uint32_t timeout_ms) {
     // 蜂鸣器 (PB13 使能, PC9 = TMR8_CH4 调制) 由通用 buzzer 模块驱动
     BuzzerSetup();
 
-    LEDsoff(); // 在开始测试之前线关闭所有LED
+    LEDsoff(); // 在开始测试之前先关闭所有LED
 
     *failed_item = 2;
     // 在开始测试之前，如果按钮是按下的，则认为失败，有可能按钮不良卡住了
@@ -1210,6 +1210,59 @@ out:
         I2C_BufferWrite(&data_u8, 1, 0x02, addr_ant << 1);
     }
     return result;
+}
+
+static int8_t QCTestPM5IO(uint16_t index, uint8_t status) {
+    // !!! No one is allowed to modify the definition and order of this list except DXL.
+    // Otherwise, the PM5 factory tester will fail to check.
+    struct qc_io_map {
+        crm_periph_clock_type gpio_clk;
+        gpio_type *gpio_group;
+        uint16_t gpio_pin;
+    } const qc_io_map[] = {
+        {.gpio_clk = CRM_GPIOA_PERIPH_CLOCK, .gpio_group = GPIOA, .gpio_pin = GPIO_PINS_14}, // SIGIN1-5x2P-SWD-CLK
+        {.gpio_clk = CRM_GPIOA_PERIPH_CLOCK, .gpio_group = GPIOA, .gpio_pin = GPIO_PINS_13}, // SIGIN2-5x2P-SWD-DIO
+        {.gpio_clk = CRM_GPIOA_PERIPH_CLOCK, .gpio_group = GPIOA, .gpio_pin = GPIO_PINS_3}, // SIGIN3-5x2P-UART_RX
+        {.gpio_clk = CRM_GPIOA_PERIPH_CLOCK, .gpio_group = GPIOA, .gpio_pin = GPIO_PINS_2}, // SIGIN4-5x2P-UART_TX
+        {.gpio_clk = CRM_GPIOA_PERIPH_CLOCK, .gpio_group = GPIOA, .gpio_pin = GPIO_PINS_7}, // SIGIN5-CEP-USB_RXP(MOSI)
+        {.gpio_clk = CRM_GPIOA_PERIPH_CLOCK, .gpio_group = GPIOA, .gpio_pin = GPIO_PINS_6}, // SIGIN6-CEP-USB_RXN(MISO)
+        {.gpio_clk = CRM_GPIOA_PERIPH_CLOCK, .gpio_group = GPIOA, .gpio_pin = GPIO_PINS_9}, // SIGIN7-CEP-USB_SBU(UART-1-line)
+        {.gpio_clk = CRM_GPIOA_PERIPH_CLOCK, .gpio_group = GPIOA, .gpio_pin = GPIO_PINS_11}, // SIGIN8-CEP-USB_DN
+        {.gpio_clk = CRM_GPIOA_PERIPH_CLOCK, .gpio_group = GPIOA, .gpio_pin = GPIO_PINS_4}, // SIGIN9-CEP-USB_TXP(CSN)
+        {.gpio_clk = CRM_GPIOA_PERIPH_CLOCK, .gpio_group = GPIOA, .gpio_pin = GPIO_PINS_12}, // SIGIN10-CEP-USB_DP
+        {.gpio_clk = CRM_GPIOA_PERIPH_CLOCK, .gpio_group = GPIOA, .gpio_pin = GPIO_PINS_5}, // SIGIN11-CEP-USB_TXN(CLK)
+    };
+    if (index >= ARRAYLEN(qc_io_map)) {
+        return PM3_EINVARG;
+    }
+    // For RXP/RXN/TXP/TXN
+    gpio_inter_usb_spi_role_setup();
+    Gpio_Inter_USB_SPI_Role_High();
+    // Enable the clock for the GPIO port and configure the pin as output
+    crm_periph_clock_enable(qc_io_map[index].gpio_clk, TRUE);
+    // Configure the GPIO pin as output or input based on the status parameter
+    gpio_init_type gpio_init_struct;
+    gpio_default_para_init(&gpio_init_struct);
+    gpio_init_struct.gpio_pins = qc_io_map[index].gpio_pin;
+    gpio_init_struct.gpio_mode = GPIO_MODE_OUTPUT;
+    // Set the GPIO pin state or RESET to default based on the status parameter( -> Preset <- )
+    if (status == 0) {
+        gpio_bits_reset(qc_io_map[index].gpio_group, qc_io_map[index].gpio_pin);
+    } else if (status == 1) {
+        gpio_bits_set(qc_io_map[index].gpio_group, qc_io_map[index].gpio_pin);
+    } else {
+        // Reset to Default state or MUX
+        if (index == 0 || index == 1) {
+            // SIGIN1-SWD-CLK or SIGIN2-SWD-DIO
+            gpio_init_struct.gpio_mode = GPIO_MODE_MUX;
+            gpio_init_struct.gpio_pull = index == 0 ?  GPIO_PULL_DOWN : GPIO_PULL_UP;
+            gpio_pin_mux_config(qc_io_map[index].gpio_group, qc_io_map[index].gpio_pin, GPIO_MUX_0);
+        } else {
+            gpio_init_struct.gpio_mode = GPIO_MODE_INPUT;
+        }
+    }
+    gpio_init(qc_io_map[index].gpio_group, &gpio_init_struct);
+    return PM3_SUCCESS;
 }
 
 #endif
@@ -3846,6 +3899,23 @@ static void PacketReceived(PacketCommandNG *packet) {
                 memcpy(&timeout_ms, packet->data.asBytes, sizeof(timeout_ms));
             }
             reply_ng(CMD_PM5_QC_TEST_HW, QCTestPM5(&failed_item, timeout_ms) ? PM3_SUCCESS : PM3_EFAILED, &failed_item, 1);
+            break;
+        }
+        case CMD_PM5_QC_TEST_IO: {
+            struct p {
+                uint32_t pwd;   // 0xDEADBEEF
+                uint16_t index; // index of the IO to test
+                uint8_t status; // 0 = low, 1 = high, 2 = float or RESET TO DEFAULT
+            } PACKED;
+            struct p *payload = (struct p *)packet->data.asBytes;
+            // !!! IMPORTANT !!!
+            // This password must not be written in the client software.
+            // Users should never use this command without knowing its purpose, otherwise it may damage the device.
+            if (payload->pwd != 0xDEADBEEF) {
+                reply_ng(CMD_PM5_QC_TEST_IO, PM3_EFAILED, NULL, 0);
+                break;
+            }
+            reply_ng(CMD_PM5_QC_TEST_IO, QCTestPM5IO(payload->index, payload->status), NULL, 0);
             break;
         }
         case CMD_PM5_RGB_SET: {

--- a/armsrc/at32_unit_test.c
+++ b/armsrc/at32_unit_test.c
@@ -1827,6 +1827,59 @@ void test_config_uart_tx2_to_dbgio(void) {
     gpio_init(GPIOA, &gpio_init_struct); // PA2_TX
 }
 
+#include "fpga_loader.h"
+#include "lfsampling.h"
+
+void test_max_power(void) {
+    FpgaResetComInterface();
+    FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
+
+    SpinDelay(100);
+    FpgaSetup24MHzClk();
+
+    uint8_t data;
+
+    // 开所有的灯
+    LED_A_ON();
+    LED_B_ON();
+    LED_C_ON();
+    LED_D_ON();
+    test_i2c_rgb_simple();
+
+    // 0x03 DischargeCurrentControl 寄存器
+    data = 0xE1; // 修改放电电流到 3A
+    I2C_BufferWrite(&data, 1, 0x03, 0x93);
+    // 0x05 ChargerTermination/TimerControl 寄存器
+    data = 0x1A; // 禁用定时器，正常为了安全可能需要在MainLoop喂狗
+    I2C_BufferWrite(&data, 1, 0x05, 0x93);
+
+#if 0
+    FpgaDownloadAndGo(FPGA_BITSTREAM_HF);
+    FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_READER);
+#else
+
+    // 开场
+    // FPGA_MAJOR_MODE_LF_READER | FPGA_LF_ADC_READER_FIELD
+    // FPGA_MAJOR_MODE_HF_READER
+    // FpgaWriteConfWord(FPGA_MAJOR_MODE_LF_READER | FPGA_LF_ADC_READER_FIELD);
+    LFSetupFPGAForADC(LF_DIVISOR_125, true);
+
+    gpio_fpga_mod_only_setup();
+    Gpio_SSC_DOUT_Low();
+
+    // 配置低频高Q
+    data = 0x87; // 0x87 = 10000111: 125k + 高Q + 开启两个LED
+    I2C_BufferWrite(&data, 1, 0x02, 0x51 << 1);
+
+#endif
+
+    // 调到最高输出电压
+    FpgaSendCommand(FPGA_CMD_SET_PWR_PWM_LOW_COUNT, 4095u & 0xFFF);
+
+    // 蜂鸣器持续响着
+    test_beep();
+}
+
 // 覆盖 UnitTestMain 实现单元测试
 void UnitTestMain(void);
 
@@ -1847,13 +1900,16 @@ void UnitTestMain(void) {
     // ------------------------------- 关闭所有的LED -------------------------------
     LEDsoff();
 
+    // ------------------------------- 功耗测试 -------------------------------
+    // test_max_power();
+
     // ------------------------------- 关闭FPGA输出 -------------------------------
     // 不然的话调试的时候也会很发热
     SpinDelay(500);
     FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
 
     // ------------------------------- 测试 配置UART TX2为DBGIO输出 -------------------------------
-    test_config_uart_tx2_to_dbgio();
+    // test_config_uart_tx2_to_dbgio();
 
     // ------------------------------- 测试 蓝牙电池套件UART通信 -------------------------------
     // test_bwm_uart();

--- a/armsrc/at32_unit_test.c
+++ b/armsrc/at32_unit_test.c
@@ -1050,18 +1050,23 @@ void test_beep(void) {
     }
 }
 
-void test_power_of_by_btn(void) {
+void test_power_off_by_btn(void) {
     usb_enable();
     SpinDelay(1000);
-    dxl_print_dbg("SystemStart\n");
+    // dxl_print_dbg("SystemStart\n");
     while (1) {
+        // 第一阶段，等按下
         if (is_btn_pressed()) {
+            // 第二阶段，等抬起
+            while (is_btn_pressed()) {}
+            // 第三阶段，等一会儿
+            SpinDelay(50);
             // 拉低直接关机
-            dxl_print_dbg("SystemOff\n");
+            // dxl_print_dbg("SystemOff\n");
             Gpio_ARM_Power_ON_Low();
             // 拉低关机的话，还会有一段PWR电容放电时间，此时我们应当让系统进入死循环，不再处理任何事情
             while (1) {
-                dxl_print_dbg("Waiting Power Off\n");
+                // dxl_print_dbg("Waiting Power Off\n");
             }
         }
     }
@@ -1880,6 +1885,21 @@ void test_max_power(void) {
     test_beep();
 }
 
+void test_nvic_reset(void) {
+    LED_A_ON();
+    SpinDelay(100);
+    LED_A_OFF();
+    LED_B_ON();
+    while (1) {
+        if (is_btn_pressed()) {
+            LED_B_OFF();
+            LED_C_ON();
+            while (is_btn_pressed()) {}
+            NVIC_SystemReset();
+        }
+    }
+}
+
 // 覆盖 UnitTestMain 实现单元测试
 void UnitTestMain(void);
 
@@ -1907,6 +1927,9 @@ void UnitTestMain(void) {
     // 不然的话调试的时候也会很发热
     SpinDelay(500);
     FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
+
+    // ------------------------------- 测试 NVIC 系统复位 -------------------------------
+    // test_nvic_reset();
 
     // ------------------------------- 测试 配置UART TX2为DBGIO输出 -------------------------------
     // test_config_uart_tx2_to_dbgio();
@@ -1942,7 +1965,7 @@ void UnitTestMain(void) {
     // test_i2c_ant_software();
 
     // ------------------------------- 测试按钮关机 -------------------------------
-    // test_power_of_by_btn();
+    // test_power_off_by_btn();
 
     // ------------------------------- 测试蜂鸣器 -------------------------------
     // usb_enable();

--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -2255,18 +2255,94 @@ static int CmdPM5QCTest(const char *Cmd) {
 
     CLIParserContext *ctx;
     CLIParserInit(&ctx, "hw qc_pm5", "QC Test for the PM5",
-                  "hw qc_pm5             -> run QC test with default 20 second timeout\n"
-                  "hw qc_pm5 -t 3        -> run QC test with a 3 second timeout");
+                  "hw qc_pm5                  -> run hardware QC test with default 20 second timeout\n"
+                  "hw qc_pm5 -t 3             -> run hardware QC test with a 3 second timeout\n"
+                  "hw qc_pm5 --iolow <index> --pwd <hex>   -> drive PM5 test IO <index> low\n"
+                  "hw qc_pm5 --iohigh <index> --pwd <hex>  -> drive PM5 test IO <index> high\n"
+                  "hw qc_pm5 --ioreset <index> --pwd <hex> -> reset PM5 test IO <index> to default");
 
     void *argtable[] = {
         arg_param_begin,
         arg_u64_0("t", "timeout", "<s>", "test sequence timeout in seconds (default 20)"),
+        arg_u64_0(NULL, "iolow", "<index>", "drive PM5 test IO <index> low"),
+        arg_u64_0(NULL, "iohigh", "<index>", "drive PM5 test IO <index> high"),
+        arg_u64_0(NULL, "ioreset", "<index>", "reset PM5 test IO <index> to default"),
+        arg_str0(NULL, "pwd", "<hex>", "QC test password in hex (required for IO tests)"),
         arg_param_end
     };
     CLIExecWithReturn(ctx, Cmd, argtable, true);
+
     uint32_t timeout_ms = arg_get_u32_def(ctx, 1, 20);
     timeout_ms *= 1000;
+
+    bool io_low = arg_get_u64_count(ctx, 2) > 0;
+    bool io_high = arg_get_u64_count(ctx, 3) > 0;
+    bool io_reset = arg_get_u64_count(ctx, 4) > 0;
+    int io_count = (io_low ? 1 : 0) + (io_high ? 1 : 0) + (io_reset ? 1 : 0);
+
+    uint16_t io_index = 0;
+    uint8_t io_status = 0;
+    if (io_low) {
+        io_index = (uint16_t)arg_get_u32(ctx, 2);
+        io_status = 0;
+    } else if (io_high) {
+        io_index = (uint16_t)arg_get_u32(ctx, 3);
+        io_status = 1;
+    } else if (io_reset) {
+        io_index = (uint16_t)arg_get_u32(ctx, 4);
+        io_status = 2;
+    }
+
+    uint8_t pwd[4];
+    int dlen = 0;
+    int res = CLIParamHexToBuf(arg_get_str(ctx, 5),  pwd, sizeof(pwd), &dlen);
     CLIParserFree(ctx);
+
+    if (io_count > 1) {
+        PrintAndLogEx(ERR, "only one of --iolow, --iohigh, --ioreset may be specified");
+        return PM3_EINVARG;
+    }
+
+    if (io_count == 1) {
+        if (res || dlen != sizeof(pwd)) {
+            PrintAndLogEx(ERR, "invalid password format, must be hex(8 chars)");
+            return PM3_EINVARG;
+        }
+
+        PrintAndLogEx(WARNING, _RED_("!!! WARNING: PM5 IO QC test drives the test IO pins directly !!!"));
+        PrintAndLogEx(WARNING, _RED_("!!! This can damage the device if used incorrectly !!!"));
+        PrintAndLogEx(WARNING, _RED_("!!! Only proceed if you know exactly what you are doing !!!"));
+        PrintAndLogEx(INFO, "PM5 IO QC test password: 0x%02X%02X%02X%02X", pwd[0], pwd[1], pwd[2], pwd[3]);
+
+        struct {
+            uint32_t pwd;   // QC password, verified by the device
+            uint16_t index; // index of the IO to test
+            uint8_t status; // 0 = low, 1 = high, 2 = float or RESET TO DEFAULT
+        } PACKED payload = {
+            .pwd = BYTES2UINT32_BE(pwd),
+            .index = io_index,
+            .status = io_status,
+        };
+
+        PrintAndLogEx(INFO, "Performing PM5 IO QC test (index %u, status %u)...", io_index, io_status);
+
+        clearCommandBuffer();
+        SendCommandNG(CMD_PM5_QC_TEST_IO, (uint8_t *)&payload, sizeof(payload));
+
+        PacketResponseNG resp;
+        if (WaitForResponseTimeout(CMD_PM5_QC_TEST_IO, &resp, 1000) == false) {
+            SendCommandNG(CMD_BREAK_LOOP, NULL, 0);
+            PrintAndLogEx(WARNING, "command execution time out");
+            return PM3_ETIMEOUT;
+        }
+
+        if (resp.status != PM3_SUCCESS) {
+            PrintAndLogEx(ERR, "failed to perform IO QC test on PM5 (wrong password?)");
+            return resp.status;
+        }
+        PrintAndLogEx(INFO, "PM5 IO QC test successful.");
+        return PM3_SUCCESS;
+    }
 
     if (timeout_ms == 0) {
         PrintAndLogEx(ERR, "timeout must be greater than zero");
@@ -2310,7 +2386,7 @@ static command_t CommandTable[] = {
     {"fpga", CmdFPGA, IfPm3Present, "Fpga commands"},
     {"fpgaoff", CmdFPGAOff, IfPm3Present, "Turn off FPGA on device"},
     {"ant_pm5", CmdPM5Ant, IfPm5StdAnt, "Control the antennal of pm5"},
-    {"qc_pm5", CmdPM5QCTest, IfPm5, "Perform QC test for the PM5"},
+    {"qc_pm5", CmdPM5QCTest, IfPm5, "Perform QC test (hardware or IO) for the PM5"},
     {"factorydata", CmdDeviceFactoryData, IfI2cEeprom, "Get/Set the factory data for Device"},
     {"lcd", CmdLCD, IfPm3Lcd, "Send command/data to LCD"},
     {"lcdreset", CmdLCDReset, IfPm3Lcd, "Hardware reset LCD"},

--- a/client/src/cmdhw.c
+++ b/client/src/cmdhw.c
@@ -2276,11 +2276,11 @@ static int CmdPM5QCTest(const char *Cmd) {
     PrintAndLogEx(INFO, "Performing QC test for the PM5...");
 
     clearCommandBuffer();
-    SendCommandNG(CMD_PM5_QC_TEST, (uint8_t *)&timeout_ms, sizeof(timeout_ms));
+    SendCommandNG(CMD_PM5_QC_TEST_HW, (uint8_t *)&timeout_ms, sizeof(timeout_ms));
 
     PacketResponseNG resp;
     // wait a bit longer than the device side sequence timeout, with headroom for RTC drift
-    if (WaitForResponseTimeout(CMD_PM5_QC_TEST, &resp, timeout_ms + (timeout_ms / 5) + 1000) == false) {
+    if (WaitForResponseTimeout(CMD_PM5_QC_TEST_HW, &resp, timeout_ms + (timeout_ms / 5) + 1000) == false) {
         SendCommandNG(CMD_BREAK_LOOP, NULL, 0);
         PrintAndLogEx(WARNING, "command execution time out");
         return PM3_ETIMEOUT;

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -871,6 +871,7 @@ typedef struct {
 #define CMD_EEPROM_FACTORY_INFO_READ 0x0172
 #define CMD_EEPROM_FACTORY_INFO_WRITE 0x0173
 // PM5, QC test for the hardware
+#define CMD_PM5_QC_TEST_IO 0x0176
 #define CMD_PM5_QC_TEST_HW 0x0177
 // PM5, set the antenna RGB LED colour (payload: r,g,b). Used by `hf/lf tune --rgb`.
 #define CMD_PM5_RGB_SET 0x0178

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -871,11 +871,10 @@ typedef struct {
 #define CMD_EEPROM_FACTORY_INFO_READ 0x0172
 #define CMD_EEPROM_FACTORY_INFO_WRITE 0x0173
 // PM5, QC test for the hardware
-#define CMD_PM5_QC_TEST 0x0177
+#define CMD_PM5_QC_TEST_HW 0x0177
 // PM5, set the antenna RGB LED colour (payload: r,g,b). Used by `hf/lf tune --rgb`.
 #define CMD_PM5_RGB_SET 0x0178
 // PM5, provision BWM fuel-gauge (BQ27427) Design Capacity. Used by `hw bwmsetcap`.
-#define CMD_PM5_BWM_SET_CAP 0x0179
 #define CMD_PM5_BWM_SET_CAP 0x0179
 // PM5, enable/disable BWM battery charging (AW32001E CEB). Used by `hw bwmcharge`.
 #define CMD_PM5_BWM_CHARGE_EN 0x017A


### PR DESCRIPTION
- The factory tester will automatically test whether each I/O is normal.
- Based on power consumption testing, it is currently known that the PM5 consumes approximately 600mA when the radio frequency and various LEDs such as RGB are enabled.
- For BWM, the current measured power consumption is approximately 110mA.