### PR TITLE
docs(bwm): fix stale hw bwm command references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `hw bwm` - doc and comment references still named the flat `hw bwmsetcap`/`bwmcharge`/`bwmautooff` commands from before the subgroup move (@xilni)
 - Added TA1=96 support via pwm to sim module `sim024.bin` - v4.66 (@antiklesys)
 - Added `hf mfu ndefformat` - NDEF format Ultralight/NTAG tags, restores the NXP factory Capability Container for the detected type (@0x6r1an0y)
 - Changed `lf hitag` - refactoring hitag2 operations and now they work much better (@iceman1001)

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -107,7 +107,7 @@ static bool s_autooff_setup = false;
 // Auto power-off on USB unplug. CRITICAL: only powers off on a USB-present -> absent
 // TRANSITION - i.e. the board was running on USB and the cable was pulled. A board that
 // booted on battery (button press, no USB) must NOT auto-off, or it could never be used
-// unplugged at all (and the hw bwmautooff toggle would be unreachable, since setting it
+// unplugged at all (and the hw bwm autooff toggle would be unreachable, since setting it
 // needs a client/USB). So we require having seen USB present at least once this session
 // before an absent reading triggers shutdown.
 static void bwm_autooff_check(void) {

--- a/armsrc/bwm_charger.c
+++ b/armsrc/bwm_charger.c
@@ -228,7 +228,7 @@ void bwm_print_battery_status(void) {
         // Capacity. FCC is the gauge's learned present full capacity; health = FCC/design.
         // NOTE: only meaningful once the gauge has run an Impedance Track learning cycle
         // (a full charge/discharge). Before that it is an unconverged estimate. If Design
-        // Capacity was never provisioned (hw bwmsetcap), the ratio is against the gauge
+        // Capacity was never provisioned (hw bwm setcap), the ratio is against the gauge
         // default, not the fitted cell - so it can read wildly wrong.
         uint16_t fcc = 0, design = 0;
         if (bwm_gauge_read16(BWM_GAUGE_FCC, &fcc) && fcc > 0) {
@@ -247,7 +247,7 @@ void bwm_print_battery_status(void) {
 // --- BQ27427 provisioning: set Design Capacity for the fitted cell -------------
 // One-time. The gauge ships with a ~1000+ mAh default profile, so RemainingCapacity
 // reads wrong for the fitted pack until Design Capacity is programmed. Invoked by the
-// `hw bwmsetcap` client command (CMD_PM5_BWM_SET_CAP) - deliberately NOT run at boot,
+// `hw bwm setcap` client command (CMD_PM5_BWM_SET_CAP) - deliberately NOT run at boot,
 // because a config-update cycle disrupts the Impedance Track learning cycle.
 // Per BQ27427 TRM (SLUUCD5): State subclass 82 (0x52), Design Capacity at offset 6
 // -> block addr 0x46 (MSB)/0x47 (LSB), big-endian. Assumes gauge UNSEALED (factory default).

--- a/armsrc/bwm_charger.h
+++ b/armsrc/bwm_charger.h
@@ -30,7 +30,7 @@
 #include "common.h"
 
 // Reference design capacity for the fitted cell (VXE 502540, 500 mAh / 3.7 V).
-// Used as the default target for `hw bwmsetcap` and as the fall-back divisor for
+// Used as the default target for `hw bwm setcap` and as the fall-back divisor for
 // the battery-health estimate.
 #define BWM_DEFAULT_DESIGN_CAP_MAH   500
 #define BWM_DEFAULT_VCHG_MV          4100   // default charge-voltage target (mV); snaps to 4095 (15mV step)
@@ -52,7 +52,7 @@ void bwm_detect_and_init(void);
 void bwm_print_battery_status(void);
 
 // One-time BQ27427 Design Capacity provisioning (CMD_PM5_BWM_SET_CAP /
-// `hw bwmsetcap`). Idempotent - returns true without a CFGUPDATE cycle if the
+// `hw bwm setcap`). Idempotent - returns true without a CFGUPDATE cycle if the
 // value is already correct. Assumes the gauge is UNSEALED (factory default).
 bool bwm_gauge_provision_capacity(uint16_t cap_mah);
 

--- a/client/pyscripts/pm5_battery_test.py
+++ b/client/pyscripts/pm5_battery_test.py
@@ -7,7 +7,7 @@ Polls `hw status` at a fixed interval and logs the fuel-gauge readings to CSV
 (plot with pm5_battery_test_graph.py).
 
 If not yet done, you should set up the gauge first for meaningful numbers:
-    hw bwmsetcap --cap 500  # your cell's mAh
+    hw bwm setcap --cap 500  # your cell's mAh
 then fully charge
 
 Usage:

--- a/doc/md/PM5_Start_Here/Getting_Started_With_PM5.md
+++ b/doc/md/PM5_Start_Here/Getting_Started_With_PM5.md
@@ -103,7 +103,7 @@ hf 14a read --drop
 
 ## Do this exactly once.
 * The very first time for a new battery:
-```hw bwmsetcap --cap 500```
+```hw bwm setcap --cap 500```
 * Do a full charge/discharge cycle for it to learn the real capacity.
 
 

--- a/include/pm3_cmd.h
+++ b/include/pm3_cmd.h
@@ -878,11 +878,11 @@ typedef struct {
 #define CMD_PM5_QC_TEST_HW 0x0177
 // PM5, set the antenna RGB LED colour (payload: r,g,b). Used by `hf/lf tune --rgb`.
 #define CMD_PM5_RGB_SET 0x0178
-// PM5, provision BWM fuel-gauge (BQ27427) Design Capacity. Used by `hw bwmsetcap`.
+// PM5, provision BWM fuel-gauge (BQ27427) Design Capacity. Used by `hw bwm setcap`.
 #define CMD_PM5_BWM_SET_CAP 0x0179
-// PM5, enable/disable BWM battery charging (AW32001E CEB). Used by `hw bwmcharge`.
+// PM5, enable/disable BWM battery charging (AW32001E CEB). Used by `hw bwm charge`.
 #define CMD_PM5_BWM_CHARGE_EN 0x017A
-// PM5, toggle automatic power-off on USB unplug. Used by `hw bwmautooff`.
+// PM5, toggle automatic power-off on USB unplug. Used by `hw bwm autooff`.
 #define CMD_PM5_BWM_AUTOOFF 0x017B
 #define CMD_PM5_BWM_WIFI    0x017C
 #define CMD_PM5_BWM_SET_VCHG 0x017D


### PR DESCRIPTION
docs got stale after bwm commands moved into a subgroup