### PR TITLE
R&Y: Nomeclature updates to `felica_system_code_list.json`

### DIFF
--- a/client/resources/felica/felica_system_code_list.json
+++ b/client/resources/felica/felica_system_code_list.json
@@ -449,9 +449,9 @@
     "description": "Default system code used by FeliCa Lite/Lite-S tags",
     "services": [
       {
-        "name": "Konami",
-        "type": "e-amusement",
-        "description": "Konami E-amusement",
+        "name": "Konami e-amusement pass",
+        "type": "arcade",
+        "description": "Konami e-amusement pass (AIC)",
         "nodes": [
           {
             "code": "0b00",
@@ -475,9 +475,9 @@
         ]
       },
       {
-        "name": "Aime",
-        "type": "e-amusement",
-        "description": "AIME E-amusement",
+        "name": "Sega Aime",
+        "type": "arcade",
+        "description": "Sega Aime (AIC)",
         "nodes": [
           {
             "code": "0b00",
@@ -488,9 +488,9 @@
         ]
       },
       {
-        "name": "NESiCA",
-        "type": "e-amusement",
-        "description": "NESiCA E-amusement",
+        "name": "Taito NESiCA",
+        "type": "arcade",
+        "description": "Taito NESiCA (AIC)",
         "nodes": [
           {
             "code": "0b00",
@@ -501,9 +501,9 @@
         ]
       },
       {
-        "name": "Bandai Namco Pasport",
-        "type": "e-amusement",
-        "description": "Bandai Namco Pasport E-amusement",
+        "name": "Bandai Namco Passport",
+        "type": "arcade",
+        "description": "Bandai Namco Passport (AIC)",
         "nodes": [
           {
             "code": "0b00",


### PR DESCRIPTION
# Updates
1. Changed `type` from `e-amusement` to `arcade` for:
    - Bandai Namco Passport
    - Konami e-amusement pass
    - Sega Aime
    - Taito NESiCA
2. Updated `description` to include the full name and `(AIC)` annotation to note that this information only applies to the Amusement IC Card variants as opposed to MFC/ICODE SLI/MFC/MFU, respectively.

-r&y.