### PR TITLE
fix(pm5): terminate packet-aligned AT32 USB CDC writes with ZLP

### DIFF
--- a/common_arm/usb/usb_cdc_at32.c
+++ b/common_arm/usb/usb_cdc_at32.c
@@ -508,6 +508,21 @@ int usb_write(const uint8_t *data, const size_t len) {
         //  Have a cup of tea?
     }
 
+    // End a packet-aligned CDC transfer with a zero-length packet. Without
+    // this short packet, a host read larger than this reply can remain pending.
+    // Use the low-level sender: usb_write() intentionally rejects len == 0.
+    // Keep this in the synchronous path, not the asynchronous sample stream.
+    if ((len % USBD_CDC_IN_MAXPACKET_SIZE) == 0) {
+        if (usb_vcp_send_data(udev, (uint8_t *) data, 0) != SUCCESS) {
+            return PM3_EIO;
+        }
+        while (pcdc->g_tx_completed != 1) {
+            if (usb_check() == false) {
+                return PM3_EIO;
+            }
+        }
+    }
+
     return PM3_SUCCESS;
 }
 


### PR DESCRIPTION
## Summary

Addresses #3606 

Send a zero-length packet after synchronous AT32 USB-CDC writes whose total length is an exact multiple of the bulk-IN endpoint's 64-byte maximum packet size.

This fixes deterministic PM5 USB replies that otherwise do not complete on Windows, including:

```text
hw ping --len 52   # NG reply = 64 bytes
hw ping --len 116  # NG reply = 128 bytes
```

The change is intentionally limited to `usb_write()`. The asynchronous sample-stream path and PM3 framing are unchanged.

## Root cause

PM5's AT32 CDC bulk-IN endpoint uses a 64-byte max packet size. `usb_write()` currently sends exactly `len` bytes and returns after `g_tx_completed`.

When `len` is a multiple of 64, the transfer ends with a full packet and the AT32 path does not send a terminating short packet/ZLP. On the affected Windows USB-CDC path, the host read remains pending.

Sending a ZLP after packet-aligned synchronous writes terminates the transfer without changing the PM3 payload.

## Hardware test

Base revision physically reproduced: `23d6f67dc8a3096bdebde069e4e18e0133830fd7`.

Before:

```text
hw ping --len 51 -> PASS
hw ping --len 52 -> FAIL
hw ping --len 53 -> PASS
hw version       -> stops after "[ Model ]"
```

After applying only this change and rebuilding the PM5 application:

```text
hw ping --len 51  -> PASS
hw ping --len 52  -> PASS
hw ping --len 53  -> PASS
hw ping --len 116 -> PASS
hw version        -> complete PM5/ARM/Hardware output
```

Client and patched application were built from the same modified tree. The bootloader was not changed during the validation.

## Scope

Changed:

- `common_arm/usb/usb_cdc_at32.c`
- synchronous `usb_write()` only