### PR TITLE
lf: restore the graph buffer length along with its contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `data modulation` - the 160 sample antenna settle trim was never undone, so the graph buffer stayed short for everything after it (@mfcarroll)
 - Fixed `lf t55xx detect` - PSK1 now detects at every bit rate and subcarrier. (@iceman1001)
 - Fixed `lf t55xx detect` - FSK was skipped entirely when the field-clock pair measured as neither legal pair, losing FSK1 at RF/32 and RF/40 and every variant at RF/16 (@iceman1001)
 - Fixed `lf t55xx dump/read` - blocks were extracted at a bit offset cached from the last `detect`  The offset is now anchored in graph samples (@iceman1001)

--- a/client/src/cmddata.c
+++ b/client/src/cmddata.c
@@ -2778,8 +2778,7 @@ static int try_detect_modulation(void) {
         clk = GetPskClock("", false);
         if (clk > 0) {
             // allow undo
-            buffer_savestate_t saveState = save_bufferS32(g_GraphBuffer, g_GraphTraceLen);
-            saveState.offset = g_GridOffset;
+            buffer_savestate_t saveState = save_graphbuffer();
             // skip first 160 samples to allow antenna to settle in (psk gets inverted occasionally otherwise)
             CmdLtrim("-i 160");
             if ((PSKDemod(0, 0, 6, false) == PM3_SUCCESS)) {
@@ -2791,8 +2790,7 @@ static int try_detect_modulation(void) {
                 tests[hits].carrier = GetPskCarrier(false);
             }
             //undo trim samples
-            restore_bufferS32(saveState, g_GraphBuffer);
-            g_GridOffset = saveState.offset;
+            restore_graphbuffer(saveState);
         }
     }
 

--- a/client/src/cmdlf.c
+++ b/client/src/cmdlf.c
@@ -1609,8 +1609,7 @@ static bool check_chiptype(bool getDeviceData) {
     }
 
     //Save the state of the Graph and Demod Buffers
-    buffer_savestate_t saveState_gb = save_bufferS32(g_GraphBuffer, g_GraphTraceLen);
-    saveState_gb.offset = g_GridOffset;
+    buffer_savestate_t saveState_gb = save_graphbuffer();
     buffer_savestate_t saveState_db = save_buffer8(g_DemodBuffer, g_DemodBufferLen);
     saveState_db.clock = g_DemodClock;
     saveState_db.offset = g_DemodStartIdx;
@@ -1683,12 +1682,12 @@ static bool check_chiptype(bool getDeviceData) {
 
     PrintAndLogEx(INFO, "Couldn't identify a chipset");
 out:
-    restore_buffer8(saveState_db, g_DemodBuffer);
+    // the detections above demodulate, so the length comes back with the contents
+    g_DemodBufferLen = restore_buffer8(saveState_db, g_DemodBuffer);
     g_DemodClock = saveState_db.clock;
     g_DemodStartIdx = saveState_db.offset;
 
-    restore_bufferS32(saveState_gb, g_GraphBuffer);
-    g_GridOffset = saveState_gb.offset;
+    restore_graphbuffer(saveState_gb);
 
     return retval;
 }

--- a/client/src/cmdlfti.c
+++ b/client/src/cmdlfti.c
@@ -89,8 +89,7 @@ int demodTI(bool verbose) {
         1, 1, 1, 1, 1, 1, 1, 1
     };
 
-    buffer_savestate_t saveState = save_bufferS32(g_GraphBuffer, g_GraphTraceLen);
-    saveState.offset = g_GridOffset;
+    buffer_savestate_t saveState = save_graphbuffer();
 
     int lowLen = ARRAYLEN(LowTone);
     int highLen = ARRAYLEN(HighTone);
@@ -278,8 +277,7 @@ int demodTI(bool verbose) {
 
 out:
     if (retval != PM3_SUCCESS) {
-        restore_bufferS32(saveState, g_GraphBuffer);
-        g_GridOffset = saveState.offset;
+        restore_graphbuffer(saveState);
     }
 
     return retval;

--- a/client/src/cmdlfvisa2000.c
+++ b/client/src/cmdlfvisa2000.c
@@ -84,8 +84,7 @@ static uint8_t visa_parity(uint32_t id) {
 //see ASKDemod for what args are accepted
 int demodVisa2k(bool verbose) {
     (void) verbose; // unused so far
-    buffer_savestate_t saveState = save_bufferS32(g_GraphBuffer, g_GraphTraceLen);
-    saveState.offset = g_GridOffset;
+    buffer_savestate_t saveState = save_graphbuffer();
 
     //CmdAskEdgeDetect("");
 
@@ -93,8 +92,7 @@ int demodVisa2k(bool verbose) {
     bool st = true;
     if (ASKDemod_ext(64, 0, 0, 0, false, false, false, 1, &st) != PM3_SUCCESS) {
         PrintAndLogEx(DEBUG, "DEBUG: Error - Visa2k: ASK/Manchester Demod failed");
-        restore_bufferS32(saveState, g_GraphBuffer);
-        g_GridOffset = saveState.offset;
+        restore_graphbuffer(saveState);
         return PM3_ESOFT;
     }
     size_t size = g_DemodBufferLen;
@@ -109,8 +107,7 @@ int demodVisa2k(bool verbose) {
         else
             PrintAndLogEx(DEBUG, "DEBUG: Error - Visa2k: ans: %d", ans);
 
-        restore_bufferS32(saveState, g_GraphBuffer);
-        g_GridOffset = saveState.offset;
+        restore_graphbuffer(saveState);
         return PM3_ESOFT;
     }
     setDemodBuff(g_DemodBuffer, 96, ans);
@@ -128,8 +125,7 @@ int demodVisa2k(bool verbose) {
     // test checksums
     if (chk != calc) {
         PrintAndLogEx(DEBUG, "DEBUG: error: Visa2000 checksum (%s) %x - %x\n", _RED_("fail"), chk, calc);
-        restore_bufferS32(saveState, g_GraphBuffer);
-        g_GridOffset = saveState.offset;
+        restore_graphbuffer(saveState);
         return PM3_ESOFT;
     }
     // parity
@@ -137,8 +133,7 @@ int demodVisa2k(bool verbose) {
     uint8_t chk_par = (raw3 & 0xFF0) >> 4;
     if (calc_par != chk_par) {
         PrintAndLogEx(DEBUG, "DEBUG: error: Visa2000 parity (%s) %x - %x\n", _RED_("fail"), chk_par, calc_par);
-        restore_bufferS32(saveState, g_GraphBuffer);
-        g_GridOffset = saveState.offset;
+        restore_graphbuffer(saveState);
         return PM3_ESOFT;
     }
     PrintAndLogEx(SUCCESS, "Visa2000 - Card " _GREEN_("%u") ", Raw: %08X%08X%08X", raw2,  raw1, raw2, raw3);

--- a/client/src/cmdlfzx8211.c
+++ b/client/src/cmdlfzx8211.c
@@ -41,8 +41,7 @@ static int CmdHelp(const char *Cmd);
 // see ASKDemod for what args are accepted
 int demodzx(bool verbose) {
     (void) verbose; // unused so far
-    buffer_savestate_t saveState = save_bufferS32(g_GraphBuffer, g_GraphTraceLen);
-    saveState.offset = g_GridOffset;
+    buffer_savestate_t saveState = save_graphbuffer();
 
     // CmdAskEdgeDetect("");
 
@@ -50,8 +49,7 @@ int demodzx(bool verbose) {
     bool st = true;
     if (ASKDemod_ext(64, 0, 0, 0, false, false, false, 1, &st) != PM3_SUCCESS) {
         PrintAndLogEx(DEBUG, "DEBUG: Error - ZX: ASK/Manchester Demod failed");
-        restore_bufferS32(saveState, g_GraphBuffer);
-        g_GridOffset = saveState.offset;
+        restore_graphbuffer(saveState);
         return PM3_ESOFT;
     }
     size_t size = g_DemodBufferLen;
@@ -66,8 +64,7 @@ int demodzx(bool verbose) {
         else
             PrintAndLogEx(DEBUG, "DEBUG: Error - ZX: ans: %d", ans);
 
-        restore_bufferS32(saveState, g_GraphBuffer);
-        g_GridOffset = saveState.offset;
+        restore_graphbuffer(saveState);
         return PM3_ESOFT;
     }
     setDemodBuff(g_DemodBuffer, 96, ans);

--- a/client/src/graph.c
+++ b/client/src/graph.c
@@ -648,3 +648,21 @@ size_t restore_buffer8(buffer_savestate_t saveState, uint8_t *dest) {
 
     return index;
 }
+
+// Save/restore the graph buffer as a unit: contents, length and grid offset.
+// A caller that drops restore_bufferS32()'s return leaves g_GraphTraceLen short.
+buffer_savestate_t save_graphbuffer(void) {
+    buffer_savestate_t saveState = save_bufferS32(g_GraphBuffer, g_GraphTraceLen);
+    saveState.offset = g_GridOffset;
+    return saveState;
+}
+
+void restore_graphbuffer(buffer_savestate_t saveState) {
+    size_t len = restore_bufferS32(saveState, g_GraphBuffer);
+    if (len == 0) {
+        // nothing was restored, so leave the buffer and its length alone
+        return;
+    }
+    g_GraphTraceLen = len;
+    g_GridOffset = saveState.offset;
+}

--- a/client/src/graph.h
+++ b/client/src/graph.h
@@ -67,6 +67,9 @@ size_t restore_buffer32(buffer_savestate_t saveState, uint32_t *dest);
 size_t restore_bufferS32(buffer_savestate_t saveState, int32_t *dest);
 size_t restore_buffer8(buffer_savestate_t saveState, uint8_t *dest);
 
+buffer_savestate_t save_graphbuffer(void);
+void restore_graphbuffer(buffer_savestate_t saveState);
+
 #define MAX_GRAPH_TRACE_LEN (40000 * 32)
 #define GRAPH_SAVE 1
 #define GRAPH_RESTORE 0

--- a/tools/pm3_tests.sh
+++ b/tools/pm3_tests.sh
@@ -468,6 +468,7 @@ while true; do
       if ! CheckExecute "data qrcode invalid hex" "$CLIENTBIN -c 'data qrcode -d zz' 2>&1" "QR data must contain only hex characters"; then break; fi
       if ! CheckExecute "data qrcode odd hex"     "$CLIENTBIN -c 'data qrcode -d a' 2>&1" "QR data must contain an even number of hex digits"; then break; fi
       if ! CheckExecute "data qrcode spaced hex"  "$CLIENTBIN -c 'data qrcode -d \"aa bb\"' 2>&1" "Spaces are not supported; encode a space byte as 20"; then break; fi
+      if ! CheckExecute "data modulation keeps trace" "$CLIENTBIN -c 'data load -f traces/lf_Q5_mod-psk1-32-4.pm3; data modulation; data autocorr -w 99999'" "smaller than trace \\( 20000 samples \\)"; then break; fi
       if ! CheckExecute "mfu pwdgen test"         "$CLIENTBIN -c 'hf mfu pwdgen --test'" "Selftest ok"; then break; fi
       if ! CheckExecute "mfu keygen test"         "$CLIENTBIN -c 'hf mfu keygen --uid 11223344556677'" "80 B1 C2 71 D8 A0"; then break; fi
       if ! CheckExecute "jooki encode test"       "$CLIENTBIN -c 'hf jooki encode --test'" "04 28 F4 DA F0 4A 81  \( ok \)"; then break; fi


### PR DESCRIPTION
Found during work on #3512, where the same type of error is an underlying cause.

## Problem

`restore_bufferS32()` returns the length it put back. Every graph-buffer caller dropped that
return, so `g_GraphTraceLen` kept whatever value the code between save and restore had left it at.
The samples come back; the length does not.

In `try_detect_modulation()` (`client/src/cmddata.c`) the code in between is the psk
antenna-settle trim, `CmdLtrim("-i 160")`. So `data modulation` hands the buffer's contents back
and leaves it 160 samples shorter than it found it — permanently, for everything the user runs
next. On three in-tree traces:

| trace | before `data modulation` | after, on master |
|---|---|---|
| `traces/lf_Q5_mod-psk1-32-4.pm3` | 20000 | 19840 |
| `traces/lf_Q5_mod-psk1.pm3` | 24000 | 23840 |
| `traces/lf_Indala-504278295.pm3` | 20000 | 19840 |

Those 160 samples are real signal, and the loss carries into whatever comes next. On a
12000-sample RF/32 psk1 capture: `data save` after `data modulation` writes 11840 samples instead
of 12000, and `data rawdemod --p1` returns 18 bits in its last word instead of 23 — exactly
`160 / 32` bits short.

Two more instances of the same dropped return:

- `check_chiptype()` (`client/src/cmdlf.c`) is on the `lf search` path. The detections it runs
  acquire their own samples, so the length it leaves behind belongs to the last chip it probed.
  Its demod-buffer save state loses the same way: `restore_buffer8()`'s return is
  `g_DemodBufferLen` and is also dropped, so the contents come back under a foreign length.
- `demodTI()` (`client/src/cmdlfti.c`) shortens by `convLen + 16` and restores on its error path
  only, so a failed TI demod leaves the buffer short.

`demodVisa2k()` and `demodzx()` never change the length, so they were correct by accident.

`test_scan()` and `t55xx_fallback_try()` in `client/src/cmdlft55xx.c` drop the same return around the
same 160-sample trim, and there it is not cosmetic: it defeats the graph-sample anchoring `detect`
already has and is a direct cause of the rotated blocks in #3512. That fix is submitted alongside
this PR as part of the #3512 series; it is not folded in here because it can only be *measured* on
top of the demodulator fixes in that series. The two do not overlap and either can merge first — if
this one lands first, that series can drop its hand-rolled pairing and call `restore_graphbuffer()`.

It is also why this is a wrapper rather than a one-line assignment: the same return has been dropped
at six of seven call sites, and twice with real consequences.

## Change

`save_graphbuffer()` / `restore_graphbuffer()` in `client/src/graph.c` pair the length and the
grid offset with the contents, so no call site has to remember them separately. The restore
leaves the buffer untouched when nothing was restored, which is what the failed-allocation path
already promises.

All seven graph-buffer sites move to the pair, including the two visa2000/zx8211 ones where it is
a no-op today — that is the point: the next `save`/`restore` around something that trims cannot
reintroduce this. `check_chiptype()`'s demod-buffer length is assigned from `restore_buffer8()`
in place; one site, and it is a different set of globals.

The self-test at `cmddata.c:3944` keeps calling `restore_bufferS32()` directly, since it restores
into a heap buffer and asserts on the return. That is also why the fix is not "have
`restore_bufferS32()` set `g_GraphTraceLen` itself" — it takes an arbitrary destination, and the
self-test would then clobber the user's trace length.

## Behaviour change

- `data modulation` no longer shortens the graph buffer. Identification output is unchanged —
  byte-for-byte identical on seven traces, four in tree and three saved captures.
- `lf search` no longer leaves `g_GraphTraceLen` and `g_DemodBufferLen` set from whichever chip
  `check_chiptype()` probed last.
- A failed `lf ti demod` restores the length it trimmed.

## Testing

New check in `tools/pm3_tests.sh`, offline and deterministic:

```
data load -f traces/lf_Q5_mod-psk1-32-4.pm3; data modulation; data autocorr -w 99999
```

must report 20000 samples. **Fails on master, passes with the commit** — verified both ways by
stashing the C change and rebuilding, not by reasoning.

Full suite green: 211 checks, 9 skipped as slow, 0 failures. `lf VISA2000 test` and
`lf T55 visa2000 test` cover one of the converted files; `lf INDALA test` and `lf SECURAKEY test`
cover the psk traces.

Build variants: `make client` (Apple clang 21, the default `cc` here), real GCC 16 with
`SKIPQT=1`, `SKIPREADLINE=1`, the CMake client, and `experimental_lib` — all warning-free bar the
pre-existing macOS `-bind_at_load` note. `astyle` produces no changes in the touched files.

No ARM build: `graph.c`/`graph.h` and the four command files are client-only, and nothing under
`armsrc/`, `bootrom/` or `common_arm/` includes them.

**Not tested:** Linux and Windows/ProxSpace. The change is a length assignment and two small
wrappers over existing code, with no platform-conditional paths, no filesystem or serial access
and no new dependencies. Qt is skipped in the GCC 16 run because the Qt framework headers do not
compile under GCC on macOS, which is pre-existing and unrelated.

**Net diff:** +39/−29 over nine files, one commit.

## Checklist

- [x] Proper style of own code, no unrelated reformatting included
- [x] Builds warning-free with the default compiler; also tried with GCC 16
- [x] No client sources added or removed, so no build definitions needed changing; Makefile,
      CMake and `experimental_lib` all built anyway
- [x] No ARM sources touched
- [x] No platform-sensitive code touched; macOS tested, Linux and Windows not, reasoned above
- [x] Existing comments in touched files preserved
- [x] New comments short and direct
- [x] No command signatures changed, so nothing to regenerate in `doc/`
