### PR TITLE
lf: fix silently rotated and inverted blocks in the t55xx read path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Fixed `lf t55xx detect` - PSK1 now detects at every bit rate and subcarrier. (@iceman1001)
 - Fixed `lf t55xx detect` - FSK was skipped entirely when the field-clock pair measured as neither legal pair, losing FSK1 at RF/32 and RF/40 and every variant at RF/16 (@iceman1001)
 - Fixed `lf t55xx detect` - the block 0 rotation was picked by scan order; the measured broadcast period now settles it (@mfcarroll)
+- Fixed `lf t55xx detect` - the psk antenna-settle trim left the graph 160 samples short, so the graph-sample anchor was discarded on most block reads (@mfcarroll)
 - Fixed `lf psk demod` - lead-in samples were accepted as a phase shift, complementing the rest of the word (@mfcarroll)
 - Fixed `lf fsk demod` - a leading run too short to be a bit was forced to one, fabricating a bit and shifting the word (@mfcarroll)
 - Fixed `lf nrz demod` - the samples before the first level change were counted as bits, rotating the word whenever that edge moved (@mfcarroll)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 ## [unreleased][unreleased]
 - Fixed `lf t55xx detect` - PSK1 now detects at every bit rate and subcarrier. (@iceman1001)
 - Fixed `lf t55xx detect` - FSK was skipped entirely when the field-clock pair measured as neither legal pair, losing FSK1 at RF/32 and RF/40 and every variant at RF/16 (@iceman1001)
+- Fixed `lf t55xx detect` - the block 0 rotation was picked by scan order; the measured broadcast period now settles it (@mfcarroll)
 - Fixed `lf psk demod` - lead-in samples were accepted as a phase shift, complementing the rest of the word (@mfcarroll)
 - Fixed `lf fsk demod` - a leading run too short to be a bit was forced to one, fabricating a bit and shifting the word (@mfcarroll)
 - Fixed `lf nrz demod` - the samples before the first level change were counted as bits, rotating the word whenever that edge moved (@mfcarroll)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 ## [unreleased][unreleased]
 - Fixed `lf t55xx detect` - PSK1 now detects at every bit rate and subcarrier. (@iceman1001)
 - Fixed `lf t55xx detect` - FSK was skipped entirely when the field-clock pair measured as neither legal pair, losing FSK1 at RF/32 and RF/40 and every variant at RF/16 (@iceman1001)
+- Fixed `lf psk demod` - lead-in samples were accepted as a phase shift, complementing the rest of the word (@mfcarroll)
 - Fixed `lf fsk demod` - a leading run too short to be a bit was forced to one, fabricating a bit and shifting the word (@mfcarroll)
 - Fixed `lf nrz demod` - the samples before the first level change were counted as bits, rotating the word whenever that edge moved (@mfcarroll)
 - Fixed `lf t55xx dump/read` - blocks were extracted at a bit offset cached from the last `detect`  The offset is now anchored in graph samples (@iceman1001)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 ## [unreleased][unreleased]
 - Fixed `lf t55xx detect` - PSK1 now detects at every bit rate and subcarrier. (@iceman1001)
 - Fixed `lf t55xx detect` - FSK was skipped entirely when the field-clock pair measured as neither legal pair, losing FSK1 at RF/32 and RF/40 and every variant at RF/16 (@iceman1001)
+- Fixed `lf fsk demod` - a leading run too short to be a bit was forced to one, fabricating a bit and shifting the word (@mfcarroll)
 - Fixed `lf nrz demod` - the samples before the first level change were counted as bits, rotating the word whenever that edge moved (@mfcarroll)
 - Fixed `lf t55xx dump/read` - blocks were extracted at a bit offset cached from the last `detect`  The offset is now anchored in graph samples (@iceman1001)
 - Fixed `lf t55xx write --verify` - a successful write could be reported as a validation failure, both from the rotated read above and from the pre-write config decoding the post-write signal into garbage (@iceman1001)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 ## [unreleased][unreleased]
 - Fixed `lf t55xx detect` - PSK1 now detects at every bit rate and subcarrier. (@iceman1001)
 - Fixed `lf t55xx detect` - FSK was skipped entirely when the field-clock pair measured as neither legal pair, losing FSK1 at RF/32 and RF/40 and every variant at RF/16 (@iceman1001)
+- Fixed `lf nrz demod` - the samples before the first level change were counted as bits, rotating the word whenever that edge moved (@mfcarroll)
 - Fixed `lf t55xx dump/read` - blocks were extracted at a bit offset cached from the last `detect`  The offset is now anchored in graph samples (@iceman1001)
 - Fixed `lf t55xx write --verify` - a successful write could be reported as a validation failure, both from the rotated read above and from the pre-write config decoding the post-write signal into garbage (@iceman1001)
 - Fixed `lf t55xx detect` - the automatic detect after a block 0 write reported a password that was never supplied (@iceman1001)

--- a/client/src/cmdlft55xx.c
+++ b/client/src/cmdlft55xx.c
@@ -61,6 +61,8 @@ static bool t55xx_psk3_probe(bool usepwd, uint32_t password, uint8_t downlink_mo
 static uint8_t t55xx_measure_broadcast_blocks(bool usepwd, uint32_t password, uint8_t downlink_mode);
 static uint8_t t55xx_measure_broadcast_blocks_once(bool usepwd, uint32_t password, uint8_t downlink_mode);
 static size_t t55xx_psk3_resolve(uint8_t nblk, uint32_t *only);
+static bool t55xx_block0_rotation_ambiguous(void);
+static bool t55xx_resolve_block0_rotation(uint8_t nblk);
 
 // Default configuration
 static t55xx_conf_block_t config = {
@@ -1247,12 +1249,32 @@ static int CmdT55xxDetect(const char *Cmd) {
         }
     }
 
+    // Several rotations of the word can read as a configuration and detect takes the first the
+    // scan reaches.  The broadcast period is the tag's own answer to which is real
+    bool rerotated = false;
+
+    if (found && use_gb == false && t55xx_block0_rotation_ambiguous()) {
+
+        if (nblk == 0) {
+            nblk = t55xx_measure_broadcast_blocks(config.usepwd, config.pwd, config.downlink_mode);
+            config.broadcast_blocks = nblk;
+        }
+
+        if (nblk) {
+            rerotated = t55xx_resolve_block0_rotation(nblk);
+        }
+    }
+
     if (found) {
 
         printConfiguration(config);
 
         if (nblk) {
             PrintAndLogEx(SUCCESS, "Broadcast repeats every " _GREEN_("%u") " block(s), so maxblock is a multiple of %u", nblk, nblk);
+        }
+
+        if (rerotated) {
+            PrintAndLogEx(SUCCESS, "Block 0 " _GREEN_("re-anchored") " - the first reading was a rotation the broadcast period contradicts");
         }
 
         if (psk2_out) {
@@ -2565,6 +2587,167 @@ static void windows_build(t55_windows_t *w) {
     }
 }
 
+// the checks a 32 bit word has to pass to be a configuration block for `mode` at
+// `clk`, independent of where in a demodulation it was found
+static bool t55xx_block0_plausible(uint32_t block0, uint8_t mode, uint8_t clk, int *fndBitRate) {
+
+    uint8_t safer    = (block0 >> 28) & 0x0F;   //master key
+    uint8_t resv     = (block0 >> 24) & 0x0F;   //was 7 // should be only 4 bits if extended mode
+    // 2nibble must be zeroed.
+
+    if (resv > 0x00) {
+        return false;
+    }
+
+    // The master key is 0, or 6 or 9 to select extended mode
+    if (safer != 0x0 && safer != 0x6 && safer != 0x9) {
+        return false;
+    }
+
+    int bitRate      = (block0 >> 18) & 0x3F;   //bit rate (includes extended mode part of rate)
+    uint8_t extend   = (block0 >> 17) & 0x01;   //bit 15 extended mode
+    uint8_t modread  = (block0 >> 12) & 0x1F;
+    //pskcr  = (block0 >> 10) & 0x03;  //could check psk cr
+    //bit 24, 30, 31 are otp, fast write and inverse data - all settable, so no help here
+
+    // Bit 14 selects extended mode, and extended mode only exists under master key 6 or 9.
+    // Set with any other key the word is not a valid configuration
+    if (extend && safer != 0x6 && safer != 0x9) {
+        return false;
+    }
+
+    //if extended mode
+    bool extMode = ((safer == 0x6 || safer == 0x9) && extend) ? true : false;
+
+    if (extMode == false) {
+
+        if (bitRate > 7) {
+            return false;
+        }
+
+        if (testBitRate(bitRate, clk) == false) {
+            return false;
+        }
+
+    } else { //extended mode bitrate = same function to calc bitrate as em4x05
+        if (EM4x05_GET_BITRATE(bitRate) != clk) {
+            return false;
+        }
+    }
+
+    //test modulation
+    if (testModulation(mode, modread) == false) {
+        return false;
+    }
+
+    if (fndBitRate) {
+        *fndBitRate = bitRate;
+    }
+    return true;
+}
+
+// true when the maxblock and sequence terminator in `block0` could have produced
+// an `nblk` block broadcast period
+static bool t55xx_block0_fits_period(uint32_t block0, uint8_t nblk) {
+
+    // ST adds four bit periods per cycle, so a whole number of 32
+    // bit blocks rules it out.  leans on the measurement, not on
+    // config.ST, which the psk paths hardcode rather than detect
+    if (((block0 >> 3) & 1) != 0) {
+        return false;
+    }
+
+    const uint8_t mb = (block0 >> 5) & 0x07;
+    return (mb != 0 && (mb % nblk) == 0);
+}
+
+// how many distinct rotations of `block0` read as a configuration for `mode` at `clk`.  more than
+// one means detect's answer was scan order, not evidence.  `nblk` 0 skips the period constraint
+static size_t t55xx_block0_rotations(uint32_t block0, uint8_t mode, uint8_t clk, uint8_t nblk, uint32_t *only) {
+
+    uint32_t seen[32] = {0};
+    size_t n = 0;
+
+    for (uint8_t r = 0; r < 32; r++) {
+
+        const uint32_t v = (r == 0) ? block0 : ((block0 << r) | (block0 >> (32 - r)));
+
+        if (t55xx_block0_plausible(v, mode, clk, NULL) == false) {
+            continue;
+        }
+
+        if (nblk != 0 && t55xx_block0_fits_period(v, nblk) == false) {
+            continue;
+        }
+
+        // a word that is its own rotation offers the same value twice
+        bool dup = false;
+        for (size_t i = 0; i < n; i++) {
+            if (seen[i] == v) {
+                dup = true;
+                break;
+            }
+        }
+        if (dup) {
+            continue;
+        }
+
+        seen[n++] = v;
+    }
+
+    if (n == 1 && only != NULL) {
+        *only = seen[0];
+    }
+    return n;
+}
+
+// the clock the detected bit rate names, for the rotation helpers above
+static uint8_t t55xx_config_clock(void) {
+    static const uint8_t basic[] = {8, 16, 32, 40, 50, 64, 100, 128};
+    return basic[config.bitrate & 0x07];
+}
+
+// more than one rotation of the detected block 0 reads as a configuration
+static bool t55xx_block0_rotation_ambiguous(void) {
+
+    if (config.Q5 || config.block0 == 0) {
+        return false;
+    }
+
+    return (t55xx_block0_rotations(config.block0, config.modulation, t55xx_config_clock(), 0, NULL) > 1);
+}
+
+// Settle which rotation is real with the tag's own broadcast period and re-anchor on it.  Nothing
+// surviving means the measurement disagrees with every reading, so leave the detected word alone
+static bool t55xx_resolve_block0_rotation(uint8_t nblk) {
+
+    uint32_t only = 0;
+    if (t55xx_block0_rotations(config.block0, config.modulation, t55xx_config_clock(), nblk, &only) != 1) {
+        return false;
+    }
+
+    if (only == config.block0) {
+        return false;
+    }
+
+    // measuring the period left a regular read in the demod buffer
+    if (AcquireData(T55x7_PAGE0, T55x7_CONFIGURATION_BLOCK, config.usepwd, config.pwd, config.downlink_mode) == false) {
+        return false;
+    }
+
+    if (DecodeT55xxBlock() == false) {
+        return false;
+    }
+
+    if (t55xx_stream_holds(only) == false) {
+        return false;
+    }
+
+    // keep the offset t55xx_stream_holds just anchored
+    SetConfigWithBlock0Ex(only, config.offset, config.Q5);
+    return true;
+}
+
 static bool test_scan(uint8_t mode, uint8_t *offset, int *fndBitRate, uint8_t clk,
                       uint16_t start, uint16_t end, const t55_windows_t *w,
                       uint16_t need, bool need_stride) {
@@ -2581,58 +2764,8 @@ static bool test_scan(uint8_t mode, uint8_t *offset, int *fndBitRate, uint8_t cl
             continue;
         }
 
-        uint8_t safer    = PackBits(si, 4, g_DemodBuffer);
-        si += 4;     //master key
-        uint8_t resv     = PackBits(si, 4, g_DemodBuffer);
-        si += 4;     //was 7 & +=7+3 // should be only 4 bits if extended mode
-        // 2nibble must be zeroed.
-
-        if (resv > 0x00) {
-            continue;
-        }
-
-        // The master key is 0, or 6 or 9 to select extended mode
-        if (safer != 0x0 && safer != 0x6 && safer != 0x9) {
-            continue;
-        }
-
-        int bitRate      = PackBits(si, 6, g_DemodBuffer);
-        si += 6;     //bit rate (includes extended mode part of rate)
-        uint8_t extend   = PackBits(si, 1, g_DemodBuffer);
-        si += 1;     //bit 15 extended mode
-        uint8_t modread  = PackBits(si, 5, g_DemodBuffer);
-        si += 5 + 2 + 1;
-        //uint8_t pskcr   = PackBits(si, 2, g_DemodBuffer); si += 2+1;  //could check psk cr
-        //uint8_t nml01    = PackBits(si, 1, g_DemodBuffer); si += 1+5;   //bit 24, 30, 31 could be tested for 0 if not extended mode
-        //uint8_t nml02    = PackBits(si, 2, g_DemodBuffer); si += 2;
-
-        // Bit 14 selects extended mode, and extended mode only exists under master key 6 or 9.
-        // Set with any other key the word is not a valid configuration
-        if (extend && safer != 0x6 && safer != 0x9) {
-            continue;
-        }
-
-        //if extended mode
-        bool extMode = ((safer == 0x6 || safer == 0x9) && extend) ? true : false;
-
-        if (extMode == false) {
-
-            if (bitRate > 7) {
-                continue;
-            }
-
-            if (testBitRate(bitRate, clk) == false) {
-                continue;
-            }
-
-        } else { //extended mode bitrate = same function to calc bitrate as em4x05
-            if (EM4x05_GET_BITRATE(bitRate) != clk) {
-                continue;
-            }
-        }
-
-        //test modulation
-        if (testModulation(mode, modread) == false) {
+        int bitRate = 0;
+        if (t55xx_block0_plausible(PackBits(si, 32, g_DemodBuffer), mode, clk, &bitRate) == false) {
             continue;
         }
 
@@ -2910,14 +3043,7 @@ int printConfiguration(t55xx_conf_block_t b) {
         if (b.broadcast_blocks) {
             size_t kept = 0;
             for (size_t i = 0; i < ncand; i++) {
-                const uint8_t mb = (cand[i] >> 5) & 0x07;
-                // ST adds four bit periods per cycle, so a whole number of 32
-                // bit blocks rules it out.  leans on the measurement, not on
-                // config.ST, which the psk paths hardcode rather than detect
-                if (((cand[i] >> 3) & 1) != 0) {
-                    continue;
-                }
-                if (mb != 0 && (mb % b.broadcast_blocks) == 0) {
+                if (t55xx_block0_fits_period(cand[i], b.broadcast_blocks)) {
                     cand[kept++] = cand[i];
                 }
             }

--- a/client/src/cmdlft55xx.c
+++ b/client/src/cmdlft55xx.c
@@ -82,6 +82,13 @@ static t55xx_memory_item_t cardmem[T55x7_BLOCK_COUNT] = {{0}};
 // Regular read mode cycles several blocks and a buffer loaded from a file could be either
 static bool s_block_read_capture = false;
 
+// samples dropped from the head of a capture before psk demodulation
+#define T55XX_PSK_SETTLE_TRIM 160
+
+// non-zero while the capture is trimmed, so an anchor recorded inside the trim
+// still names an untrimmed sample
+static int32_t s_sample_bias = 0;
+
 // A block read repeats one 32 bit word for as long as the field is on.
 // `offset` is a bit index into a demod buffer that no longer exists once the next acquisition lands,
 // and the demodulators do not all start on the same bit:
@@ -90,16 +97,36 @@ static bool s_block_read_capture = false;
 static void t55xx_anchor(t55xx_conf_block_t *c, uint8_t offset) {
     c->offset = offset;
     c->anchor_valid = (g_DemodClock > 0);
-    c->anchor_sample = g_DemodStartIdx + ((int32_t)offset * g_DemodClock);
-    c->anchor_tracelen = (int32_t)g_GraphTraceLen;
+    c->anchor_sample = g_DemodStartIdx + ((int32_t)offset * g_DemodClock) + s_sample_bias;
+    c->anchor_tracelen = (int32_t)g_GraphTraceLen + s_sample_bias;
 }
 
 // records a detect candidate against the demodulation that is loaded right now
 static void t55xx_record_hit(t55xx_conf_block_t *t) {
     t->block0 = PackBits(t->offset, 32, g_DemodBuffer);
     t->anchor_valid = (g_DemodClock > 0);
-    t->anchor_sample = g_DemodStartIdx + ((int32_t)t->offset * g_DemodClock);
-    t->anchor_tracelen = (int32_t)g_GraphTraceLen;
+    t->anchor_sample = g_DemodStartIdx + ((int32_t)t->offset * g_DemodClock) + s_sample_bias;
+    t->anchor_tracelen = (int32_t)g_GraphTraceLen + s_sample_bias;
+}
+
+// skip first 160 samples to allow antenna to settle in (psk gets inverted occasionally otherwise)
+static buffer_savestate_t t55xx_psk_trim_head(void) {
+    buffer_savestate_t st = save_bufferS32(g_GraphBuffer, g_GraphTraceLen);
+    st.offset = g_GridOffset;
+
+    char ltrim[16];
+    snprintf(ltrim, sizeof(ltrim), "-i %d", T55XX_PSK_SETTLE_TRIM);
+    CmdLtrim(ltrim);
+
+    s_sample_bias = T55XX_PSK_SETTLE_TRIM;
+    return st;
+}
+
+static void t55xx_psk_untrim_head(buffer_savestate_t st) {
+    s_sample_bias = 0;
+    // restore_bufferS32 returns the length it put back; dropping it leaves the trim in place
+    g_GraphTraceLen = restore_bufferS32(st, g_GraphBuffer);
+    g_GridOffset = st.offset;
 }
 
 // the bit offset to read a block at in the demod buffer loaded right now
@@ -1617,9 +1644,7 @@ static bool t55xx_fallback_try(pm3_mod_t mod, pm3_enc_t enc, int fc_hi, int fc_l
 
     if (mod == PM3_MOD_PSK) {
 
-        buffer_savestate_t saveState = save_bufferS32(g_GraphBuffer, g_GraphTraceLen);
-        saveState.offset = g_GridOffset;
-        CmdLtrim("-i 160");
+        buffer_savestate_t saveState = t55xx_psk_trim_head();
 
         for (int inv = 0; inv < 2; inv++) {
             if (PSKDemod(fitclk, inv, PM3_T55_FALLBACK_MAXERR, false) != PM3_SUCCESS) {
@@ -1653,8 +1678,7 @@ static bool t55xx_fallback_try(pm3_mod_t mod, pm3_enc_t enc, int fc_hi, int fc_l
             }
         }
 
-        restore_bufferS32(saveState, g_GraphBuffer);
-        g_GridOffset = saveState.offset;
+        t55xx_psk_untrim_head(saveState);
 
         if (*hits == before && coherent_ok) {
             t55xx_psk_coherent(fitclk, clk, tests, hits, downlink_mode);
@@ -2002,10 +2026,7 @@ bool t55xxTryDetectModulationEx(uint8_t downlink_mode, bool print_config, uint32
         clk = GetPskClock("", false);
         if (clk > 0) {
             // allow undo
-            buffer_savestate_t saveState = save_bufferS32(g_GraphBuffer, g_GraphTraceLen);
-            saveState.offset = g_GridOffset;
-            // skip first 160 samples to allow antenna to settle in (psk gets inverted occasionally otherwise)
-            CmdLtrim("-i 160");
+            buffer_savestate_t saveState = t55xx_psk_trim_head();
             if ((PSKDemod(0, 0, 6, false) == PM3_SUCCESS) && test(DEMOD_PSK1, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
                 tests[hits].modulation = DEMOD_PSK1;
                 tests[hits].bitrate = bitRate;
@@ -2041,8 +2062,7 @@ bool t55xxTryDetectModulationEx(uint8_t downlink_mode, bool print_config, uint32
             } // inverse waves does not affect this demod
 
             //undo trim samples
-            restore_bufferS32(saveState, g_GraphBuffer);
-            g_GridOffset = saveState.offset;
+            t55xx_psk_untrim_head(saveState);
             // t55xx_search_config_psk(g_GraphBuffer, 1);
             // t55xx_search_config_psk(g_GraphBuffer, 2);
         }

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -1902,18 +1902,31 @@ int nrzRawDemod(uint8_t *dest, size_t *size, int *clk, const int *invert, int *s
         if (dest[i] <= low)  bit = 0;
         dest[i] = bit;
     }
-    //now demod based on clock (rf/32 = 32 1's for one 1 bit, 32 0's for one 0 bit)
+    // start on the first level change: it is the earliest sample known to be a
+    // bit boundary.  counting the samples before it as bits rotated the stream
+    // whenever that edge moved by one, and left startIdx naming no sample
     size_t lastBit = 0;
     size_t numBits = 0;
+    bool anchored = false;
     for (i = 21; i < *size - 20; i++) {
+
+        bool edge = (dest[i] != dest[i - 1]);
+
+        if (anchored == false) {
+            if (edge == false) {
+                continue;
+            }
+            *startIdx = (int)i;
+            if (g_debugMode == 2) prnt("DEBUG NRZ: startIdx %i", *startIdx);
+            lastBit = i - 1;
+            anchored = true;
+            continue;
+        }
+
         //if transition detected or large number of same bits - store the passed bits
-        if (dest[i] != dest[i - 1] || (i - lastBit) == (10 * *clk)) {
+        if (edge || (i - lastBit) == (10 * *clk)) {
             memset(dest + numBits, dest[i - 1] ^ *invert, (i - lastBit + (*clk / 4)) / *clk);
             numBits += (i - lastBit + (*clk / 4)) / *clk;
-            if (lastBit == 0) {
-                *startIdx = i - (numBits * *clk);
-                if (g_debugMode == 2) prnt("DEBUG NRZ: startIdx %i", *startIdx);
-            }
             lastBit = i - 1;
         }
     }

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -547,13 +547,16 @@ size_t pskFindFirstPhaseShift(const uint8_t *samples, size_t size, uint8_t *curP
 
     uint16_t avgWaveVal = 0, lastAvgWaveVal;
     size_t i = waveStart, waveEnd, waveLenCnt, firstFullWave;
+    // waveStart starts as wherever the caller began looking, so the first length is part of a wave,
+    // not a wave, and judging it accepts a shift that is not there.  Baseline on the first peak.
+    bool wave_from_peak = false;
     for (; i < loopCnt; i++) {
         // find peak // was "samples[i] + fc" but why?  must have been used to weed out some wave error... removed..
         if (samples[i] < samples[i + 1] && samples[i + 1] >= samples[i + 2]) {
             waveEnd = i + 1;
             if (g_debugMode == 2) prnt("DEBUG PSK: waveEnd: %zu, waveStart: %zu", waveEnd, waveStart);
             waveLenCnt = waveEnd - waveStart;
-            if (waveLenCnt > fc && waveStart > fc && !(waveLenCnt > fc + 8)) { //not first peak and is a large wave but not out of whack
+            if (wave_from_peak && waveLenCnt > fc && waveStart > fc && !(waveLenCnt > fc + 8)) { //not first peak and is a large wave but not out of whack
                 lastAvgWaveVal = avgWaveVal / (waveLenCnt);
                 firstFullWave = waveStart;
                 *fullWaveLen = waveLenCnt;
@@ -562,6 +565,7 @@ size_t pskFindFirstPhaseShift(const uint8_t *samples, size_t size, uint8_t *curP
                 return firstFullWave;
             }
             waveStart = i + 1;
+            wave_from_peak = true;
             avgWaveVal = 0;
         }
         avgWaveVal += samples[i + 2];
@@ -2161,14 +2165,22 @@ int pskRawDemod_ext(uint8_t *dest, size_t *size, int *clock, const int *invert, 
         i = findModStart(dest, *size, fc);
         //find first phase shift
         firstFullWave = pskFindFirstPhaseShift(dest, *size, &curPhase, i, fc, &fullWaveLen);
-        if (firstFullWave == 0) {
-            // no phase shift detected - could be all 1's or 0's - doesn't matter where we start
-            // so skip a little to ensure we are past any Start Signal
-            firstFullWave = 160;
-            memset(dest, curPhase, firstFullWave / *clock);
-        } else {
-            memset(dest, curPhase ^ 1, firstFullWave / *clock);
-        }
+    }
+
+    // A first shift less than a bit period in is lead-in, not data.  Counting it toggles curPhase
+    // once too often, and the emitted bit is the running phase, so the rest of the word inverts.
+    const size_t bit_period = (size_t)(*clock);
+    if (firstFullWave != 0 && firstFullWave < bit_period) {
+        curPhase = *invert;
+        fullWaveLen = 0;
+        firstFullWave = pskFindFirstPhaseShift(dest, *size, &curPhase, bit_period, fc, &fullWaveLen);
+    }
+
+    if (firstFullWave == 0) {
+        // no phase shift detected - could be all 1's or 0's - doesn't matter where we start
+        // so skip a little to ensure we are past any Start Signal
+        firstFullWave = 160;
+        memset(dest, curPhase, firstFullWave / *clock);
     } else {
         memset(dest, curPhase ^ 1, firstFullWave / *clock);
     }

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -2051,6 +2051,13 @@ static size_t aggregate_bits(uint8_t *dest, size_t size, uint8_t clk, uint8_t in
             // 0->1 crossing
             n = (n * fchigh + hclk) / clk;
 
+        // A leading run that rounds to no bits is lead-in, not data.  Forcing it to one fabricates
+        // a bit and shifts the word; mid-stream a zero would lose a bit the tag did send.
+        if (n == 0 && numBits == 0) {
+            lastval = dest[i];
+            continue;
+        }
+
         if (n == 0)
             n = 1;
 


### PR DESCRIPTION
Fixes #3512.

This builds on the recent `lf t55xx` work. The graph sample anchoring (ea2909702) is untouched, the fifth commit here just lets it run. It resolved on 1 of 6 dumps before and 6 of 6 after. The psk1 and FSK detect fixes (78b4d4ef0, e121e3f0a) are what these measurements sit on top of, and the extend check (e121e3f0a) is folded into a shared helper rather than dropped, so the tie break judges candidates by the same rules `detect` does.

Worth noting that the fifth commit could call the shared helper from #3614. Happy to rebase and add that, I just wanted to keep this able to stand alone rather than stacking so the entire picture was visible.

## Problem

`lf t55xx dump` and `lf t55xx rdbl` return silently corrupted blocks — a rotation, or a complement, of
what the tag holds, with nothing marking it wrong. `--verify` reports good writes as failures, and
`restore` can write rotated data back permanently.

Three of the five commits are the same mistake in a different demodulator: **the acquisition opens
before the tag answers, and those lead-in samples were treated as data.** One fabricated bit shifts
every bit after it, and in psk — where the emitted bit is the running phase — it complements them too.

- **`nrzRawDemod`** counted the samples before the first level change as bits. The count sat on a
  rounding boundary: the first edge lands on sample 438 or 439 between acquisitions, and
  `(438-319+8)/32` is 3 while `(439-319+8)/32` is 4. One sample of jitter, one bit of rotation.
  `startIdx` came from the same count, so it held `i % clk` and could name no sample.
- **psk, two ways.** `pskFindFirstPhaseShift` judged its first measured length, but `waveStart` starts
  as wherever the caller began looking — so that length is part of a wave, not a wave, and any gap
  beating `fc` was taken as a shift. Separately `pskRawDemod_ext` trusted a shift under one bit period
  in. Over 54 block reads, every inverted word had exactly one extra phase toggle.
- **`aggregate_bits`** sized each run in bits then forced a zero to one — right mid-stream, wrong on
  the leading run, where a single subcarrier wave rounds to no bits and became one anyway.

The other two are client-side. **`test_scan`** answers with the first offset that passes its checks,
but a block read repeats one 32-bit word so every offset yields a rotation and several can pass. A live
buffer carried both `00080040`, the word on the tag, and `00080001`, its `ror19` — both master key 0,
reserved 0, RF/32, direct. Which one detect reported was scan order.

And **the psk antenna-settle trim was never fully undone.** `test_scan` and `t55xx_fallback_try` drop
160 samples off the head of a capture before demodulating psk, then restore it — but
`restore_bufferS32()` returns the length it put back and no caller assigned that return, so
`g_GraphTraceLen` stayed at the trimmed length for the rest of `detect`. That left the sample-space
anchoring the previous work added unable to engage: `t55xx_demod_offset()` only resolves when
`config.anchor_tracelen` equals `g_GraphTraceLen`, and detect recorded 11840 against the 12000 every
block read acquires, so the guard never matched and a dump fell back to `config.offset` — a bit index
into a demod buffer that no longer exists, which is the case its own comment warns about. A candidate
found inside the trim was also recorded 160 samples left of where a later read would look for it. 160
samples is `160 / clk` bits, which is the rotation size seen at every rate.

## Change

**`common/lfdemod.c`** — one commit per demodulator.

- `nrzRawDemod` starts the bitstream at the first level change and reports that sample. A level change
  can only fall on a bit boundary, so it is the earliest sample known to be one.
- `pskFindFirstPhaseShift` lets the first peak set the baseline and judges from the second;
  `pskRawDemod_ext` discards a shift under a bit period in and looks again from a bit period in.
- `aggregate_bits` skips a leading run that rounds to nothing.

**`client/src/cmdlft55xx.c`** — when more than one rotation of block 0 reads as a configuration, the
measured broadcast period settles it: maxblock has to account for what regular read mode cycles
through. No structural check can, because every bit of block 0 is a real field and the three the scan
skips are settable — `00080001` is a *valid* configuration, just not that tag's. Reuses
`t55xx_measure_broadcast_blocks()` and the maxblock constraint `printConfiguration()` already applies
to psk2/psk3 pre-images, factored into shared helpers rather than written twice.

The trim is now wrapped in `t55xx_psk_trim_head()` / `t55xx_psk_untrim_head()`, which assign the
restored length back to `g_GraphTraceLen` and hold a sample bias while trimmed so an anchor recorded
inside it still names an untrimmed sample. Both halves are needed: without the length the resolution
never engages, and without the bias it engages against a frame 160 samples off.

**Related PRs, submitted alongside this one.** #3614 fixes the same dropped
`restore_bufferS32()` return client-wide, adding `save_graphbuffer()` / `restore_graphbuffer()`;
the fifth commit here pairs the trim by hand instead. The two do not overlap — different files, no
shared hunks — and either can merge first. #3613 is the harness whose `ror5` / `unstable`
vocabulary the numbers below are reported in.

## Behaviour change

- `lf t55xx detect` performs **one extra acquisition** when more than one rotation of block 0 is
  plausible, and prints a line when it re-anchors as a result. It can now report a **different block 0**
  on such a tag — the one the broadcast period agrees with, rather than whichever the scan met first.
- **The demodulated bitstream from nrz, psk and fsk starts in a different place** — the fabricated
  leading bits are gone — and **`startIdx` now means the graph sample the first bit sits on** for nrz
  and fsk, which it previously did not. Psk already reported that: `startIdx` there is
  `(firstFullWave mod clk) + 2`, and the fabricated bits occupy exactly the samples back to it, so the
  two were already one convention. Nothing in tree depends on the old behaviour: the tag decoders search for a
  preamble, and `lf t55xx detect` searches the buffer it just demodulated. Out-of-tree code reading
  `g_DemodBuffer` or `startIdx` directly will see it.
- On a marginal signal a read that used to answer with a wrong word may now **not answer at all**. A
  missing block is visible; a rotated one is not.

## Testing

Measured against `master` `088408353` on **eight T5577s**: five Invengo dual-frequency fobs
(`0x45`, ATA5577M1), two Silicon Craft coins and one Silicon Craft fob whose blocks 3–6 are
unimplemented. Built in dedicated git worktrees from each head, with both binaries confirmed to have
no pending recompiles and no object older than its source. Every comparison alternates the two builds
in one sitting — single runs on a marginal tag swing widely enough to invent a difference that is
not there.

Both builds were also identified on the device before measuring, so the numbers cannot be from the
wrong binary: with the tag in psk1, `lf t55xx detect` followed by `data autocorr -w 99999` reports
11840 samples on `master` and 12000 on this branch — every tag, every time. In ASK it reads 12000 on
both, because `detect` never enters the psk branch that trims.

**Six modulations, two dumps each, scored field-by-field against an ASK/Manchester reference dump**
(manchester, fsk2a at two frame lengths, psk1, direct, biphase). Three interleaved rounds per tag:

| tag | `master`, fields corrupted per round | this branch |
|---|---|---|
| Invengo 1 | 30 of 129, 21 of 121, 21 of 126 | **0 of 132, ×3** |
| Invengo 2 | 10 of 126, 17 of 123, 27 of 125 | **0 of 132, ×3** |
| Invengo 3 | 20 of 124, 7 of 122, 17 of 124 | **0 of 132, ×3** |
| Invengo 4 | 7 of 129, 17 of 127, 5 of 126 | **0 of 132, ×3** |
| Invengo 5 | 17 of 126, 17 of 132, 29 of 129 | **0 of 132, ×3** |
| copper coin | 0 of 132, ×3 | 0 of 132, ×3 |
| white coin | 2, 1, 1 of 132 — all `inverted` | **0 of 132, ×3** |
| orange fob | 0 of 84, ×3 | 0 of 84, ×3 |

24 sweeps, **3024 scored fields, not one corrupted** on this branch, against 266 on `master`. No
overlap on any tag that shows the fault at all.

**Two tags show nothing on this instrument** — the copper coin and the orange fob are already clean
on `master`, and are reported as the nulls they are. The fault is silicon- and
configuration-dependent, and a tag that does not exhibit it is not made worse.

On `master` psk1 and direct come back *intermittent* on most rounds — the two dumps of the same tag
disagree with each other — and every modulation is repeatable on this branch. The scorable field
count differs because a block that fails to read cannot be scored: `master` loses up to 11 fields per
round that way. The orange fob scores 84 rather than 132 because its unimplemented blocks are
excluded.

**`dump` eight times with a `detect` before each**, psk1 at RF/32, against a written payload whose
every word has 32 distinct rotations. Two interleaved rounds per tag:

| tag | `master` | this branch |
|---|---|---|
| Invengo 1 | 0 of 8 dumps clean (34+17, 29+18 wrong+unread of 56) | **8 of 8, 0 wrong, ×2** |
| Invengo 2 | 0 of 8 (23+17, 25+19) | **8 of 8, 0 wrong, ×2** |
| Invengo 3 | 0 of 8 (26+21, 29+16) | **8 of 8, 0 wrong, ×2** |
| Invengo 4 | 0 of 8 (30+11, 31+15) | **8 of 8, 0 wrong, ×2** |
| Invengo 5 | 0 of 8 (34+5, 37+0) | **8 of 8, 0 wrong, ×2** |
| copper coin | 8 of 8, ×2 | 8 of 8, ×2 |
| white coin | 2 of 8 and 1 of 8; 8 wrong of 56 both rounds, **all `inverted`** | **8 of 8, 0 wrong, ×2** |
| orange fob | 8 of 8, ×2 (blocks 1, 2, 7 — the rest unimplemented) | 8 of 8, ×2 |

**128 dumps on this branch, every one field-for-field clean.** On `master`, 35 of 128 — and none at
all on any Invengo.

`master`'s errors are a mixture of inverted words, rotations, logical shifts and unexplained, with
the rotations `ror5`-dominated — `160 / 32 = 5`, the trim signature at this bit rate. Two cases are
worth singling out:

- **Invengo 5, round 2**: 37 of 56 fields wrong with **nothing unread** — every one a silently
  corrupted answer rather than a failed read.
- **The white coin**: `master`'s only fault is `inverted`, 8 complemented words per round with
  nothing else and nothing unread. That is the psk lead-in polarity fault on its own, isolated from
  any boundary rotation — the two halves of the demod fix showing up separately.

Built warning-free with `make client` on Apple clang 21 and on GCC 16 (the latter with `SKIPQT=1`,
because the Qt framework headers do not compile under GCC on macOS — pre-existing and unrelated),
`SKIPREADLINE=1`, the CMake client, `experimental_lib`, and `bootrom armsrc` for `PLATFORM=PM3RDV4`,
`PM5`, `PM3GENERIC` and `PM3ULTIMATE` — `lfdemod.c` compiles into firmware, though nothing there calls
the changed functions. Two pre-existing warnings remain and are byte-identical on `master`: the macOS
`-bind_at_load` note, and a bootrom RWX LOAD-segment note from the ARM linker on PM5.
`tools/pm3_tests.sh` green — 210 checks with 9 skipped as slow, and 164 of 167 on the `client` subset
alone — including every path through the changed demodulators. `astyle` produces no further changes.

**Not tested:** Linux and Windows/ProxSpace — all measured on macOS. The changed code is integer
arithmetic over sample buffers with no platform-conditional paths, no filesystem or serial access and
no new dependencies, so the exposure is what both compilers already checked.

**Downlink modes.** Fixed-bit-length and long leading reference were both exercised on psk1 and
direct — 28 and 84 fields each, all clean. `--r2` (leading zero) and `--r3` (1 of 4) could not be:
`detect` fails outright on the tags available, and does so identically on `master`, so that is a
pre-existing limitation rather than anything this changes.

**Q5/T5555 needs no hardware to reason about.** The client Q5 path is untouched — `testQ5` is not in
the diff, `test()` still tries the scan then Q5 in the same order, and the rotation tie-break returns
early on `config.Q5` because the Q5 block 0 layout differs. So a Q5 behaves exactly as it does today,
and simply does not gain the tie-break. The three demod fixes do reach a Q5, as they would any tag,
but they are modulation-level and were verified across six modulations; the chip type is not a
variable in them.

**ASK was audited and deliberately left alone.** `askdemod_ext` derives `startIdx` from a detected
clock start and adds `(clk / 2) * alignPos` when the manchester decoder realigns — the compensating
step the other three lacked. That is why manchester and biphase never slipped, and it needs no change.
It is the reference for how the others now behave. The raw demod surface is those four families and no
others: `manrawdecode`, `BiphaseRawDecode` and `DetectST` search for alignment, and `detectAWID`,
`HIDdemodFSK` and `detectIOProx` work on already-demodulated streams.

**`tests/lf_t55xx_writetest.lua`** — the in-tree harness writes a configuration and four data blocks,
detects, reads them back and compares, which is exactly this bug class. Run on PSK1, three
interleaved rounds per build on every tag:

| tag | `master`, blocks correct per run | mean | this branch | mean |
|---|---|---|---|---|
| Invengo 1 | 3, 0, 3 of 84 | 2.0 | **47, 47, 47** | **47.0** |
| Invengo 2 | 7, 2, 8 | 5.7 | **30, 34, 37** | **33.7** |
| Invengo 3 | 8, 5, 9 | 7.3 | **47, 43, 46** | **45.3** |
| Invengo 4 | 4, 5, 2 | 3.7 | **35, 36, 34** | **35.0** |
| Invengo 5 | 9, 9, 13 | 10.3 | **49, 49, 48** | **48.7** |
| copper coin | 6, 7, 6 | 6.3 | **23, 27, 23** | **24.3** |
| white coin | 12, 14, 14 | 13.3 | **48, 47, 48** | **47.7** |
| orange fob † | 14, 14, 12 | 13.3 | **34, 34, 34** | **34.0** |

**No overlap on any of the eight tags** — the best `master` round anywhere (14) is below the worst
branch round anywhere (23). Configurations fully correct: **0 of 21 on `master`** on 23 of the 24
rounds and 1 of 21 on the other, against **5–10 of 21** on this branch (the orange fob excepted, see below.)

Unlike the other two instruments, this one separates the builds on **every** tag, including the two
that show nothing on a six-modulation sweep. It sweeps all 21 psk1 configurations rather than one, so
it reaches the marginal bit rates where the fault lives.

† The orange fob's blocks 3 and 4 are unimplemented and always read `00000000`, so they can never
pass and its ceiling is **42, not 84** — read it as `master` 14 of 42 against **34 of 42**. Its
0-of-21 configuration count on both arms is that same structural limit, not a detection failure. For
the same reason the `shl1`/`shr1` it reports on both arms are dead blocks reading as zero rather than
demodulation shifts (`80000000` shifted left once, and `00000001` shifted right once, are both zero),
and this tag is excluded from the shift counts below.

The improved harness — #3613 — is what named the largest remaining fault and made it fixable.
With only the first four commits in place, the read-back failures were mostly
*deterministic rotations* whose size tracked the bit rate: ror5 at RF/32, ror4 at RF/40, ror3 at
RF/50, ror2 at RF/100 — that is `round(160 / clk)`. Those are **multi-bit** rotations, so unlike the
1-bit residuals discussed below they cannot be a single misplaced bit; and they reproduced round
after round in the same configuration. That signature is what led to the fifth commit, and it is gone
from the numbers above.

The 160 is **not** `pskRawDemod_ext`'s no-shift fallback, which is a coincidence of value.
`test_scan` and `t55xx_fallback_try` trim 160 samples off the head of the capture before demodulating
psk, and the undo dropped `restore_bufferS32()`'s return value, so `g_GraphTraceLen` stayed short. The
graph-sample anchor was then recorded in a frame 160 samples left of the one block reads use, and its
`anchor_tracelen` guard never matched, so the resolution was skipped altogether. It is in `master`
too, and it is what stops `master`'s own graph-sample anchoring from taking effect.

It is the fifth commit here rather than a separate PR, because it can only be *measured* on top of the
other four: against `master` alone the read-back is dominated by non-repeatable demod errors (153
`unstable` classifications pooled over three rounds) and the deterministic rotation barely appears —
`ror5` twice, against twelve times once the demod commits are in. A deterministic rotation only becomes
visible, and only becomes fixable, once the noise ahead of it is gone.

**That also says plainly what is not fixed.** Pooled per configuration over 20 rounds per build
across the seven tags with all blocks implemented, this branch is **better on all 21 configurations,
level on none and worse on none** — but the improvement is very unevenly distributed:

| region | `master`, mean blocks of 4 | this branch |
|---|---|---|
| RF/32–RF/100 at an RF/2 subcarrier (5 configs) | 0.45–0.60 | **4.00 — every block, all 20 runs, every tag** |
| RF/128 at an RF/2 subcarrier | 0.75 | **3.00, and exactly 3.00 in all 20 runs** |
| the RF/4 subcarrier column | 0.35–0.75 | 1.35–2.45, but swinging 0 to 4 between runs |
| RF/16, any subcarrier | 0.35–0.40 | 0.45–1.65 |
| RF/8 anywhere, and RF/40 at RF/8 | 0.00–0.05 | 0.05–0.50 — still effectively unreadable |

So 23 to 49 of 84 is a large improvement rather than a fix. Where these commits apply the result is
exact and repeatable — five configurations return every block on every tag in every run, and RF/128
at RF/2 returns the same 3 of 4 in all 20. Where the signal is marginal they help and no more.

What remains is a *different* fault: 9–35 of the failures per round classify as `unstable` — three
reads of the same block disagreeing with each other — a non-repeatable demodulation error, not a
boundary that moved. It is what makes the RF/4 column swing between 0 and 4. The fault these commits
*do* address — a word boundary that moved — falls, pooled over the same 20 rounds, from **197 named
rotations to 12**.

Those last 12 are worth being precise about, because they are **not** surviving boundary faults. The
harness payload is `b1 = 00000000`, `b2 = aa5500ff`, `b3 = 80000000`, `b4 = 00000001`. Only `b2` can
prove a rotation: it has 16 bits set, so nothing but an actual boundary shift reproduces one of its
rotations. `b3` and `b4` hold a *single set bit*, so any one-bit demodulation error is
indistinguishable from a 1-bit rotation.

| | `b2` (16 bits set) | `b3`/`b4` (one bit set) | in the RF/2 column |
|---|---|---|---|
| `master` | **59** | 138 | 64 |
| this branch | **0** | 12 | **0** |

So on the only block where a rotation is unambiguous, this branch has **none** — 59 to zero. All 12
residuals sit on single-bit words, in the RF/4 and RF/8 subcarrier columns where `unstable` dominates,
and none is reproducible across rounds in the same configuration. They are one-bit errors from the
marginal-signal fault above, which the classifier can only describe as a rotation.

The three instruments disagree on purpose. The modulation sweep and the repeated `dump` both use one
configuration per modulation at moderate bit rates, where these commits do the most good, and two
tags show no fault there at all. The harness sweeps all 21 psk1 configurations including the broken
ones, and separates the builds on every tag. All three belong here: the first two say the reported
bug is gone, the third says how much of the wider problem is not.

No *offline* regression test is possible: the faults only show where an absolute bit offset is carried
*between* captures, which is what `dump` does across twelve acquisitions. One saved graph buffer cannot
express it, `detect -1` self-corrects, and the tag decoders are shift-insensitive — which is why
`pm3_tests.sh` stays green either way. Saved captures live on a separate tooling branch as offline
material.

**Net diff:** +266/−83 over five commits, three files.

## Checklist

- [x] Proper style of own code, no unrelated reformatting included
- [x] Builds warning-free with gcc; also tried with clang
- [x] No client sources added or removed, so no build definitions needed changing; Makefile, CMake and
      `experimental_lib` all built anyway
- [x] ARM firmware builds clean for RDV4 and PM5
- [x] No platform-sensitive code touched; macOS tested, Linux and Windows not, reasoned above
- [x] Existing comments in touched files preserved
- [x] New comments short and direct
- [x] No command signatures changed, so nothing to regenerate in `doc/`
