### PR TITLE
fix: correct encrypted nonce length broken in 3762130c4

### DIFF
--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -1235,7 +1235,7 @@ void MifareAcquireEncryptedNonces(const mf_acquire_nonces_t *payload) {
     mf_nonces_resp_t *response = (mf_nonces_resp_t *)respbuf;
     response->cuid = cuid;
     response->num_nonces = num_nonces;
-    uint16_t noncelen = MIN((uint16_t)(num_nonces * 4), (uint16_t)(MFC_MAX_NONCES * 4));
+    uint16_t noncelen = (num_nonces / 2) * 9;
     memcpy(response->nonces, buf, noncelen);
     reply_ng(CMD_HF_MIFARE_ACQ_ENCRYPTED_NONCES, isOK, respbuf, sizeof(mf_nonces_resp_t) + noncelen);
     LED_B_OFF();


### PR DESCRIPTION
Updates the payload length calculation to account for the 9-byte structure of encrypted nonces (two 4-byte nonces + 1 parity byte). 

This prevents payload truncation which previously caused the client to read incomplete data and fail with errors like:
`[-] ⛔ No match for the First_Byte_Sum (105), is the card a genuine MFC Ev1?`