### PR TITLE
lf idteck demod: report only what the tag actually holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project uses the changelog in accordance with [keepchangelog](http://keepachangelog.com/). Please use this to write notable changes, which is not the same as git commit log...
 
 ## [unreleased][unreleased]
+- Fixed `lf idteck demod` - without `--raw` it decoded a zeroed stack buffer instead of the graphbuffer, always reporting card id 0 (@mfcarroll)
+- Fixed `lf idteck demod` - a raw frame without the Idteck preamble printed `No genuine IDTECK found` and then announced a tag anyway (@mfcarroll)
+- Changed `lf idteck demod` - no longer prints an HID H10301 credential built from the Idteck card id (@mfcarroll)
 - Added `trace clear` - clears the tracebuffer (@iceman1001)
 - Changed `trace save -1` - now downloads from device by default (@iceman1001)
 - Added `hf 14a antifuzz --coll` - the UID collides from the 9th bit (@iceman1001)

--- a/client/src/cmdlfidteck.c
+++ b/client/src/cmdlfidteck.c
@@ -33,7 +33,6 @@
 #include "protocols.h"   // T55x7 defines
 #include "cmdlft55xx.h"  // verifywrite
 #include "generator.h"
-#include "wiegand_formats.h"
 
 static int CmdHelp(const char *Cmd);
 
@@ -104,12 +103,13 @@ int demodIdteck(uint8_t *raw, bool verbose) {
         raw2 = bytes_to_num(raw + 4, 4);
     }
 
-    // got a good demod
-    uint32_t id = 0;
-
     if (raw1 != 0x4944544B) {
         PrintAndLogEx(FAILED, "No genuine IDTECK found");
+        return PM3_ESOFT;
     }
+
+    // got a good demod
+    uint32_t id = 0;
 
     // parity check (TBD)
 
@@ -135,13 +135,6 @@ int demodIdteck(uint8_t *raw, bool verbose) {
                   (chksum == calc) ? _GREEN_("ok") : _RED_("fail")
                  );
 
-    wiegand_message_t packed = {
-        .Bot = id,
-        .Mid = 0,
-        .Top = 0,
-        .Length = 26
-    };
-    HIDUnpack(0, &packed);
     return PM3_SUCCESS;
 }
 
@@ -163,7 +156,8 @@ static int CmdIdteckDemod(const char *Cmd) {
     uint8_t raw[8] = {0};
     CLIGetHexWithReturn(ctx, 1, raw, &raw_len);
     CLIParserFree(ctx);
-    return demodIdteck(raw, true);
+    // no --raw given, demod the graphbuffer instead
+    return demodIdteck((raw_len == 0) ? NULL : raw, true);
 }
 
 static int CmdIdteckClone(const char *Cmd) {

--- a/tools/pm3_tests.sh
+++ b/tools/pm3_tests.sh
@@ -539,6 +539,12 @@ while true; do
       if ! CheckExecute "lf GPROXII test"            "$CLIENTBIN -c 'data load -f traces/lf_GProx_36_30_14489.pm3; lf search -1'" "Guardall G-Prox II ID found"; then break; fi
       if ! CheckExecute "lf HID Prox test"           "$CLIENTBIN -c 'data load -f traces/lf_HID-proxCardII-05512-11432784-1.pm3;lf search -1'" "HID Prox ID found"; then break; fi
       if ! CheckExecute "lf IDTECK test"             "$CLIENTBIN -c 'data load -f traces/lf_IDTECK_4944544BAC40E069.pm3; lf search -1'" "Idteck ID found"; then break; fi
+      if ! CheckExecute "lf IDTECK test 2"           "$CLIENTBIN -c 'data load -f traces/lf_IDTECK_4944544BAC40E069.pm3; lf idteck demod'" \
+                                                              "Card ID 6938688 \( 0x69E040 \) Raw: 4944544BAC40E069"; then break; fi
+      if ! CheckExecute "lf IDTECK raw test"         "$CLIENTBIN -c 'lf idteck demod --raw 4944544B351FBE4B'" \
+                                                              "Card ID 4963871 \( 0x4BBE1F \) Raw: 4944544B351FBE4B"; then break; fi
+      if ! CheckExecute "lf IDTECK reject test"      "if ! $CLIENTBIN -c 'lf idteck demod --raw DEADBEEFDEADBEEF' 2>&1 | grep -q 'IDTECK Tag Found'; then echo OK; fi" "OK"; then break; fi
+      if ! CheckExecute "lf IDTECK no wiegand test"  "if ! $CLIENTBIN -c 'lf idteck demod --raw 4944544B351FBE4B' 2>&1 | grep -q 'H10301'; then echo OK; fi" "OK"; then break; fi
       if ! CheckExecute "lf INDALA test"             "$CLIENTBIN -c 'data load -f traces/lf_Indala-504278295.pm3;lf search -1'" "Indala ID found"; then break; fi
       if ! CheckExecute "lf KERI test"               "$CLIENTBIN -c 'data load -f traces/lf_Keri.pm3;lf search -1'" "Pyramid ID found"; then break; fi
       if ! CheckExecute "lf NEXWATCH test"           "$CLIENTBIN -c 'data load -f traces/lf_NEXWATCH_Quadrakey-521512301.pm3;lf search -1 '" "NexWatch ID found"; then break; fi


### PR DESCRIPTION
## Problem

Three separate ways `lf idteck demod` reported a credential that is not on the tag.

**1. Without `--raw` it never looked at the graphbuffer.** `CmdIdteckDemod` always passed its
local `raw[8]` to `demodIdteck()`, never `NULL`, so the `raw == NULL` signal path was
unreachable from the command and `raw_len` was read and then ignored. A bare `lf idteck demod`
decoded a zero-filled stack array:

```
pm3 --> data load -f traces/lf_IDTECK_4944544B351FBE4B.pm3
[+] loaded 44451 samples
pm3 --> lf idteck demod
[-] No genuine IDTECK found
[+] IDTECK Tag Found: Card ID 0 ( 0x000000 ) Raw: 0000000000000000  chksum 0x00 ( ok )
```

That is the first example in the command's own help, and it has reported card id 0 for every
tag since `--raw` was added in 49f07a39d.

**2. A rejected frame was announced as a tag anyway.** `raw1 != 0x4944544B` printed a failure
and then fell through to the success line - two contradictory lines, the green one last:

```
pm3 --> lf idteck demod --raw DEADBEEFDEADBEEF
[-] No genuine IDTECK found
[+] IDTECK Tag Found: Card ID 15711917 ( 0xEFBEAD ) Raw: DEADBEEFDEADBEEF  chksum 0xDE ( fail )
```

**3. An HID H10301 credential was fabricated from the Idteck card id.** The id went into a
26-bit `wiegand_message_t` and through `HIDUnpack(0, ...)`, hardcoded to `FormatTable[0]`,
H10301:

```
pm3 --> lf t55xx wipe
...
pm3 --> lf idteck clone -r 4944544B55667788
...
pm3 --> lf search
[+] IDTECK Tag Found: Card ID 8943462 ( 0x887766 ) Raw: 4944544B55667788  chksum 0x55 ( fail )
[+] [H10301  ] HID H10301 26-bit                FC: 68  CN: 15283  parity ( fail )
[+] Valid Idteck ID found!
```

An H10301 frame carries 26 bits **on the wire**: even parity, 8 bit facility code, 16 bit card
number, odd parity. An Idteck card id is 24 bits, so `.Bot = id` with `.Length = 26` widens it
and bits 24 and 25 are zeros the client invented. Two things follow.

**The split is off by one.** The id lands at bits 23..0, so the code reads the id's own LSB as
H10301's parity bit. Even in the one case where a wiegand view could carry meaning - an Idteck
reader emitting Wiegand-26 to a panel - the id would be the payload at bits 24..1, and the
fields come out differently:

| raw | card id | printed today | that panel would read |
|---|---|---|---|
| `4944544B55667788` | 8943462 | FC 68, CN 15283, parity ( fail ) | FC 136, CN 30566 |
| `4944544B351FBE4B` | 4963871 | FC 37, CN 57103, parity ( ok ) | FC 75, CN 48671 |
| `4944544BAC40E069` | 6938688 | FC 52, CN 61472, parity ( fail ) | FC 105, CN 57408 |

**The parity flag cannot warn anyone, because an Idteck tag has no parity bit** - `ParityValid`
compares against bit 25, one of those invented zeros. `Unpack_H10301()` returns `true` for any
26-bit message and never gates on the result, so the line prints for every tag, reading `ok` for
exactly 4194304 of 16777216 card ids: 25.00%, two coin flips, no information. Rows 2 and 3 are
the Idteck traces committed to this repo, and row 2 is also the example in the help text - so a
user following the documentation sees a parity-clean HID credential that does not exist.

The same widening caps reported FC at 127 where H10301 allows 255.

## Change

`client/src/cmdlfidteck.c`, -12/+6.

- `CmdIdteckDemod()` passes `NULL` when `--raw` was not given, reaching the graphbuffer path
  `demodIdteck()` already implements and `lf idteck reader` already uses.
- `demodIdteck()` returns `PM3_ESOFT` on a preamble mismatch instead of falling through.
- The `wiegand_message_t` / `HIDUnpack()` block goes, with the `wiegand_formats.h` include that
  arrived with it and has no other user in the file.

Removed rather than gated on parity: the flag checks an invented bit, so gating would keep
exactly the quarter of tags whose fabricated credential looks *most* trustworthy. Nothing is
lost either way - the line above still prints card id, raw frame and checksum, and `wiegand
decode` is there for anyone wanting to try a format against those bits deliberately.

`tools/pm3_tests.sh` gains four tests beside the existing `lf IDTECK test`; `CHANGELOG.md` three
entries.

## Behaviour change

- `lf idteck demod` with no `--raw` now demodulates the graphbuffer instead of always printing
  card id 0. Anything parsing that zero is reading a bug.
- `lf idteck demod --raw <non-Idteck>` now prints only `No genuine IDTECK found` and returns
  `PM3_ESOFT`, without the `IDTECK Tag Found` line.
- The `[H10301 ]` line is gone from `lf search`, `lf idteck reader` and `lf idteck demod`.
- `lf search` and `lf idteck reader` are otherwise untouched. `detectIdteck()` matches the full
  32-bit preamble, so `raw1` is always `0x4944544B` on the signal path and the new early return
  cannot fire there; `Valid Idteck ID found!` still prints.

## Testing

macOS 15 / arm64, default `make client` (readline, QT6, Python 3.14).

- **Regression sweep.** `lf search -1` over all 99 committed `traces/lf_*.pm3`, on separately
  built before and after clients. The diff is two lines, both removed H10301 lines. Nothing else
  in the corpus moved.
- **Offline.** `tools/pm3_tests.sh client` green. The new tests were run first against a build
  of the unpatched file: `lf IDTECK test 2`, `lf IDTECK reject test` and `lf IDTECK no wiegand
  test` fail there, one per defect; `lf IDTECK raw test` passes on both as a baseline guard.
- **Hardware.** T5577 on a PM3 Easy at `00081040 / 4944544B / 55667788`. `lf search` and `lf
  idteck reader` report `Card ID 8943462 ( 0x887766 ) Raw: 4944544B55667788` with no H10301
  line, `Valid Idteck ID found!` still prints, and `lf idteck demod` reads the tag rather than
  reporting zero.
- **Compilers.** Apple clang 21.0.0 `-Werror` clean via the normal build, GCC 16.2.0 `-Werror`
  clean on `cmdlfidteck.c`. `astyle` with the project flags reports the file unchanged.
- **Not tested here:** Linux, Windows/ProxSpace, the CMake client and `experimental_lib`. The
  change is three lines of plain C in one client file with no new headers, platform calls or
  build-system changes, so those paths carry the same risk as any client edit.
- `armsrc` untouched. `doc/commands.*` not regenerated - no command, argument or help text
  changed.

## Checklist

- [x] Proper style of own code, no unrelated reformatting included
- [x] Builds warning-free with gcc; also tried with clang
- [x] `client/Makefile` / `CMakeLists.txt` / `experimental_lib` - n/a, no files added or removed
- [x] ARM firmware builds clean for RDV4 and PM5 - n/a, `armsrc` untouched
- [x] Platform-sensitive code reasoned about / tested - macOS tested, see Testing
- [x] Existing comments in touched files preserved
- [x] New comments short and direct, no restated code or PR prose
- [x] `doc/commands.md` / `doc/commands.json` regenerated - n/a, no commands changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
👤 Human reviewed and edited :)
